### PR TITLE
Added onNavigate event

### DIFF
--- a/NavigationJS/Navigation.ts
+++ b/NavigationJS/Navigation.ts
@@ -428,9 +428,9 @@
 
     export class StateController {
         static crumbs: Array<Crumb>;
-        private static NAVIGATED_HANDLER_ID = 'navigatedHandlerId';
-        private static navigatedHandlerId: number = 1;
-        private static navigatedHandlers: { [index: string]: (oldState: State, state: State, data: any) => void } = {};
+        private static NAVIGATE_HANDLER_ID = 'navigateHandlerId';
+        private static navigateHandlerId: number = 1;
+        private static navigateHandlers: { [index: string]: (oldState: State, state: State, data: any) => void } = {};
 
         static setStateContext(state: State, url: string) {
             var oldState = StateContext.state;
@@ -456,22 +456,22 @@
             if (oldState && oldState !== state)
                 oldState.dispose();
             state.navigated(StateContext.data);
-            for (var id in this.navigatedHandlers) {
-                this.navigatedHandlers[id](oldState, state, StateContext.data);
+            for (var id in this.navigateHandlers) {
+                this.navigateHandlers[id](oldState, state, StateContext.data);
             }
         }
 
-        static onNavigated(handler: (oldState: State, state: State, data: any) => void) {
-            if (!handler[this.NAVIGATED_HANDLER_ID]) {
-                var id = this.NAVIGATED_HANDLER_ID + this.navigatedHandlerId++;
-                handler[this.NAVIGATED_HANDLER_ID] = id;
-                this.navigatedHandlers[id] = handler;
+        static onNavigate(handler: (oldState: State, state: State, data: any) => void) {
+            if (!handler[this.NAVIGATE_HANDLER_ID]) {
+                var id = this.NAVIGATE_HANDLER_ID + this.navigateHandlerId++;
+                handler[this.NAVIGATE_HANDLER_ID] = id;
+                this.navigateHandlers[id] = handler;
             }
         }
 
-        static offNavigated(handler: (oldState: State, state: State, data: any) => void) {
-            delete this.navigatedHandlers[handler[this.NAVIGATED_HANDLER_ID]];
-            delete handler[this.NAVIGATED_HANDLER_ID];
+        static offNavigate(handler: (oldState: State, state: State, data: any) => void) {
+            delete this.navigateHandlers[handler[this.NAVIGATE_HANDLER_ID]];
+            delete handler[this.NAVIGATE_HANDLER_ID];
         } 
 
         static navigate(action: string, toData?: any) {

--- a/NavigationJS/Test/Navigation.Test.ts
+++ b/NavigationJS/Test/Navigation.Test.ts
@@ -1480,6 +1480,28 @@
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s4']);
     });
 
+    QUnit.test('NavigatingNavigateTest', function (assert) {
+        Navigation.StateController.navigate('d0');
+        var link = Navigation.StateController.getNavigationLink('t0');
+        Navigation.StateController.navigate('t0');
+        Navigation.StateController.navigate('t0');
+        var disposed = 0, navigating, navigated10, navigated01;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s2'].dispose = () => disposed++;
+        Navigation.StateInfoConfig.dialogs['d1'].states['s0'].navigating = (data, url, navigate) => {
+            navigating = true;
+            Navigation.StateController.navigateLink(link);
+        }
+        Navigation.StateInfoConfig.dialogs['d1'].states['s0'].navigated = () => navigated10 = true;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s1'].navigated = () => navigated01 = true;
+        Navigation.StateController.navigate('d1');
+        assert.strictEqual(disposed, 1);
+        assert.strictEqual(navigating, true);
+        assert.strictEqual(navigated10, undefined);
+        assert.strictEqual(navigated01, true);
+        assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+    });
+
     QUnit.test('OnNavigatedTest', function (assert) {
         var oldStates: Array<State> = [];
         var states: Array<State> = [];

--- a/NavigationJS/Test/Navigation.Test.ts
+++ b/NavigationJS/Test/Navigation.Test.ts
@@ -1526,16 +1526,18 @@
     });
 
     QUnit.test('OnNavigatedMultipleTest', function (assert) {
-        var oldStates: Array<State> = [];
-        var states: Array<State> = [];
+        var oldStates1: Array<State> = [];
+        var states1: Array<State> = [];
+        var oldStates2: Array<State> = [];
+        var states2: Array<State> = [];
         Navigation.StateController.navigate('d0');
         var navigatedHandler1 = (oldState, state, data) => {
-            oldStates.push(oldState);
-            states.push(state);
+            oldStates1.push(oldState);
+            states1.push(state);
         };
         var navigatedHandler2 = (oldState, state, data) => {
-            oldStates.push(oldState);
-            states.push(state);
+            oldStates2.push(oldState);
+            states2.push(state);
         };
         Navigation.StateController.onNavigated(navigatedHandler1);
         Navigation.StateController.onNavigated(navigatedHandler2);
@@ -1544,16 +1546,18 @@
         Navigation.StateController.navigate('d1');
         Navigation.StateController.offNavigated(navigatedHandler1);
         Navigation.StateController.offNavigated(navigatedHandler2);
-        assert.equal(oldStates[0], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
-        assert.equal(states[0], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
-        assert.equal(oldStates[1], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
-        assert.equal(states[1], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
-        assert.equal(oldStates[2], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
-        assert.equal(states[2], Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
-        assert.equal(oldStates[3], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
-        assert.equal(states[3], Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
-        assert.equal(oldStates.length, 4);
-        assert.equal(states.length, 4);
+        assert.equal(oldStates1[0], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
+        assert.equal(states1[0], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+        assert.equal(oldStates2[0], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
+        assert.equal(states2[0], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+        assert.equal(oldStates1[1], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+        assert.equal(states1[1], Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
+        assert.equal(oldStates2[1], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+        assert.equal(states2[1], Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
+        assert.equal(oldStates1.length, 2);
+        assert.equal(states1.length, 2);
+        assert.equal(oldStates2.length, 2);
+        assert.equal(states2.length, 2);
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
     });
 
@@ -1574,6 +1578,40 @@
         assert.equal(states[0], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
         assert.equal(oldStates.length, 1);
         assert.equal(states.length, 1);
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
+    });
+
+    QUnit.test('OffNavigatedMultipleTest', function (assert) {
+        var oldStates1: Array<State> = [];
+        var states1: Array<State> = [];
+        var oldStates2: Array<State> = [];
+        var states2: Array<State> = [];
+        Navigation.StateController.navigate('d0');
+        var navigatedHandler1 = (oldState, state, data) => {
+            oldStates1.push(oldState);
+            states1.push(state);
+        };
+        var navigatedHandler2 = (oldState, state, data) => {
+            oldStates2.push(oldState);
+            states2.push(state);
+        };
+        Navigation.StateController.onNavigated(navigatedHandler1);
+        Navigation.StateController.onNavigated(navigatedHandler2);
+        var link = Navigation.StateController.getNavigationLink('t0');
+        Navigation.StateController.navigateLink(link);
+        Navigation.StateController.offNavigated(navigatedHandler1);
+        Navigation.StateController.navigate('d1');
+        Navigation.StateController.offNavigated(navigatedHandler2);
+        assert.equal(oldStates1[0], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
+        assert.equal(states1[0], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+        assert.equal(oldStates2[0], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
+        assert.equal(states2[0], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+        assert.equal(oldStates2[1], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+        assert.equal(states2[1], Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
+        assert.equal(oldStates1.length, 1);
+        assert.equal(states1.length, 1);
+        assert.equal(oldStates2.length, 2);
+        assert.equal(states2.length, 2);
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
     });
 

--- a/NavigationJS/Test/Navigation.Test.ts
+++ b/NavigationJS/Test/Navigation.Test.ts
@@ -1547,6 +1547,30 @@
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
     });
 
+    QUnit.test('OnOffNavigatedDuplicateTest', function (assert) {
+        var oldStates: Array<State> = [];
+        var states: Array<State> = [];
+        Navigation.StateController.navigate('d0');
+        var navigatedHandler = (oldState, state, data) => {
+            oldStates.push(oldState);
+            states.push(state);
+        };
+        Navigation.StateController.onNavigated(navigatedHandler);
+        Navigation.StateController.offNavigated(navigatedHandler);
+        Navigation.StateController.onNavigated(navigatedHandler);
+        var link = Navigation.StateController.getNavigationLink('t0');
+        Navigation.StateController.navigateLink(link);
+        Navigation.StateController.navigate('d1');
+        Navigation.StateController.offNavigated(navigatedHandler);
+        assert.equal(oldStates[0], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
+        assert.equal(states[0], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+        assert.equal(oldStates[1], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+        assert.equal(states[1], Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
+        assert.equal(oldStates.length, 2);
+        assert.equal(states.length, 2);
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
+    });
+
     QUnit.test('OnNavigatedCopyTest', function (assert) {
         var oldStates: Array<State> = [];
         var states: Array<State> = [];
@@ -1626,6 +1650,7 @@
         Navigation.StateController.onNavigated(navigatedHandler);
         var link = Navigation.StateController.getNavigationLink('t0');
         Navigation.StateController.navigateLink(link);
+        Navigation.StateController.offNavigated(navigatedHandler);
         Navigation.StateController.offNavigated(navigatedHandler);
         Navigation.StateController.navigate('d1');
         assert.equal(oldStates[0], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);

--- a/NavigationJS/Test/Navigation.Test.ts
+++ b/NavigationJS/Test/Navigation.Test.ts
@@ -1525,6 +1525,38 @@
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
     });
 
+    QUnit.test('OnNavigatedCopyTest', function (assert) {
+        var oldStates: Array<State> = [];
+        var states: Array<State> = [];
+        Navigation.StateController.navigate('d0');
+        var navigatedHandler1 = (oldState, state, data) => {
+            oldStates.push(oldState);
+            states.push(state);
+        };
+        var navigatedHandler2 = (oldState, state, data) => {
+            oldStates.push(oldState);
+            states.push(state);
+        };
+        Navigation.StateController.onNavigated(navigatedHandler1);
+        Navigation.StateController.onNavigated(navigatedHandler2);
+        var link = Navigation.StateController.getNavigationLink('t0');
+        Navigation.StateController.navigateLink(link);
+        Navigation.StateController.navigate('d1');
+        Navigation.StateController.offNavigated(navigatedHandler1);
+        Navigation.StateController.offNavigated(navigatedHandler2);
+        assert.equal(oldStates[0], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
+        assert.equal(states[0], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+        assert.equal(oldStates[1], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
+        assert.equal(states[1], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+        assert.equal(oldStates[2], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+        assert.equal(states[2], Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
+        assert.equal(oldStates[3], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+        assert.equal(states[3], Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
+        assert.equal(oldStates.length, 4);
+        assert.equal(states.length, 4);
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
+    });
+
     QUnit.test('OnNavigatedMultipleTest', function (assert) {
         var oldStates1: Array<State> = [];
         var states1: Array<State> = [];

--- a/NavigationJS/Test/Navigation.Test.ts
+++ b/NavigationJS/Test/Navigation.Test.ts
@@ -1502,7 +1502,7 @@
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
     });
 
-    QUnit.test('OnNavigatedTest', function (assert) {
+    QUnit.test('OnNavigateTest', function (assert) {
         var oldStates: Array<State> = [];
         var states: Array<State> = [];
         Navigation.StateController.navigate('d0');
@@ -1510,11 +1510,11 @@
             oldStates.push(oldState);
             states.push(state);
         };
-        Navigation.StateController.onNavigated(navigatedHandler);
+        Navigation.StateController.onNavigate(navigatedHandler);
         var link = Navigation.StateController.getNavigationLink('t0');
         Navigation.StateController.navigateLink(link);
         Navigation.StateController.navigate('d1');
-        Navigation.StateController.offNavigated(navigatedHandler);
+        Navigation.StateController.offNavigate(navigatedHandler);
         assert.equal(oldStates[0], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
         assert.equal(states[0], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
         assert.equal(oldStates[1], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
@@ -1524,7 +1524,7 @@
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
     });
 
-    QUnit.test('OnNavigatedDuplicateTest', function (assert) {
+    QUnit.test('OnNavigateDuplicateTest', function (assert) {
         var oldStates: Array<State> = [];
         var states: Array<State> = [];
         Navigation.StateController.navigate('d0');
@@ -1532,12 +1532,12 @@
             oldStates.push(oldState);
             states.push(state);
         };
-        Navigation.StateController.onNavigated(navigatedHandler);
-        Navigation.StateController.onNavigated(navigatedHandler);
+        Navigation.StateController.onNavigate(navigatedHandler);
+        Navigation.StateController.onNavigate(navigatedHandler);
         var link = Navigation.StateController.getNavigationLink('t0');
         Navigation.StateController.navigateLink(link);
         Navigation.StateController.navigate('d1');
-        Navigation.StateController.offNavigated(navigatedHandler);
+        Navigation.StateController.offNavigate(navigatedHandler);
         assert.equal(oldStates[0], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
         assert.equal(states[0], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
         assert.equal(oldStates[1], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
@@ -1547,7 +1547,7 @@
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
     });
 
-    QUnit.test('OnOffNavigatedDuplicateTest', function (assert) {
+    QUnit.test('OnOffNavigateDuplicateTest', function (assert) {
         var oldStates: Array<State> = [];
         var states: Array<State> = [];
         Navigation.StateController.navigate('d0');
@@ -1555,13 +1555,13 @@
             oldStates.push(oldState);
             states.push(state);
         };
-        Navigation.StateController.onNavigated(navigatedHandler);
-        Navigation.StateController.offNavigated(navigatedHandler);
-        Navigation.StateController.onNavigated(navigatedHandler);
+        Navigation.StateController.onNavigate(navigatedHandler);
+        Navigation.StateController.offNavigate(navigatedHandler);
+        Navigation.StateController.onNavigate(navigatedHandler);
         var link = Navigation.StateController.getNavigationLink('t0');
         Navigation.StateController.navigateLink(link);
         Navigation.StateController.navigate('d1');
-        Navigation.StateController.offNavigated(navigatedHandler);
+        Navigation.StateController.offNavigate(navigatedHandler);
         assert.equal(oldStates[0], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
         assert.equal(states[0], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
         assert.equal(oldStates[1], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
@@ -1571,7 +1571,7 @@
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
     });
 
-    QUnit.test('OnNavigatedCopyTest', function (assert) {
+    QUnit.test('OnNavigateCopyTest', function (assert) {
         var oldStates: Array<State> = [];
         var states: Array<State> = [];
         Navigation.StateController.navigate('d0');
@@ -1583,13 +1583,13 @@
             oldStates.push(oldState);
             states.push(state);
         };
-        Navigation.StateController.onNavigated(navigatedHandler1);
-        Navigation.StateController.onNavigated(navigatedHandler2);
+        Navigation.StateController.onNavigate(navigatedHandler1);
+        Navigation.StateController.onNavigate(navigatedHandler2);
         var link = Navigation.StateController.getNavigationLink('t0');
         Navigation.StateController.navigateLink(link);
         Navigation.StateController.navigate('d1');
-        Navigation.StateController.offNavigated(navigatedHandler1);
-        Navigation.StateController.offNavigated(navigatedHandler2);
+        Navigation.StateController.offNavigate(navigatedHandler1);
+        Navigation.StateController.offNavigate(navigatedHandler2);
         assert.equal(oldStates[0], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
         assert.equal(states[0], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
         assert.equal(oldStates[1], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
@@ -1603,7 +1603,7 @@
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
     });
 
-    QUnit.test('OnNavigatedMultipleTest', function (assert) {
+    QUnit.test('OnNavigateMultipleTest', function (assert) {
         var oldStates1: Array<State> = [];
         var states1: Array<State> = [];
         var oldStates2: Array<State> = [];
@@ -1617,13 +1617,13 @@
             oldStates2.push(oldState);
             states2.push(state);
         };
-        Navigation.StateController.onNavigated(navigatedHandler1);
-        Navigation.StateController.onNavigated(navigatedHandler2);
+        Navigation.StateController.onNavigate(navigatedHandler1);
+        Navigation.StateController.onNavigate(navigatedHandler2);
         var link = Navigation.StateController.getNavigationLink('t0');
         Navigation.StateController.navigateLink(link);
         Navigation.StateController.navigate('d1');
-        Navigation.StateController.offNavigated(navigatedHandler1);
-        Navigation.StateController.offNavigated(navigatedHandler2);
+        Navigation.StateController.offNavigate(navigatedHandler1);
+        Navigation.StateController.offNavigate(navigatedHandler2);
         assert.equal(oldStates1[0], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
         assert.equal(states1[0], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
         assert.equal(oldStates2[0], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
@@ -1639,7 +1639,7 @@
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
     });
 
-    QUnit.test('OffNavigatedTest', function (assert) {
+    QUnit.test('OffNavigateTest', function (assert) {
         var oldStates: Array<State> = [];
         var states: Array<State> = [];
         Navigation.StateController.navigate('d0');
@@ -1647,11 +1647,11 @@
             oldStates.push(oldState);
             states.push(state);
         };
-        Navigation.StateController.onNavigated(navigatedHandler);
+        Navigation.StateController.onNavigate(navigatedHandler);
         var link = Navigation.StateController.getNavigationLink('t0');
         Navigation.StateController.navigateLink(link);
-        Navigation.StateController.offNavigated(navigatedHandler);
-        Navigation.StateController.offNavigated(navigatedHandler);
+        Navigation.StateController.offNavigate(navigatedHandler);
+        Navigation.StateController.offNavigate(navigatedHandler);
         Navigation.StateController.navigate('d1');
         assert.equal(oldStates[0], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
         assert.equal(states[0], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
@@ -1660,7 +1660,7 @@
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
     });
 
-    QUnit.test('OffNavigatedMultipleTest', function (assert) {
+    QUnit.test('OffNavigateMultipleTest', function (assert) {
         var oldStates1: Array<State> = [];
         var states1: Array<State> = [];
         var oldStates2: Array<State> = [];
@@ -1674,13 +1674,13 @@
             oldStates2.push(oldState);
             states2.push(state);
         };
-        Navigation.StateController.onNavigated(navigatedHandler1);
-        Navigation.StateController.onNavigated(navigatedHandler2);
+        Navigation.StateController.onNavigate(navigatedHandler1);
+        Navigation.StateController.onNavigate(navigatedHandler2);
         var link = Navigation.StateController.getNavigationLink('t0');
         Navigation.StateController.navigateLink(link);
-        Navigation.StateController.offNavigated(navigatedHandler1);
+        Navigation.StateController.offNavigate(navigatedHandler1);
         Navigation.StateController.navigate('d1');
-        Navigation.StateController.offNavigated(navigatedHandler2);
+        Navigation.StateController.offNavigate(navigatedHandler2);
         assert.equal(oldStates1[0], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
         assert.equal(states1[0], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
         assert.equal(oldStates2[0], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);

--- a/NavigationJS/Test/Navigation.Test.ts
+++ b/NavigationJS/Test/Navigation.Test.ts
@@ -1480,6 +1480,103 @@
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s4']);
     });
 
+    QUnit.test('OnNavigatedTest', function (assert) {
+        var oldStates: Array<State> = [];
+        var states: Array<State> = [];
+        Navigation.StateController.navigate('d0');
+        var navigatedHandler = (oldState, state, data) => {
+            oldStates.push(oldState);
+            states.push(state);
+        };
+        Navigation.StateController.onNavigated(navigatedHandler);
+        var link = Navigation.StateController.getNavigationLink('t0');
+        Navigation.StateController.navigateLink(link);
+        Navigation.StateController.navigate('d1');
+        Navigation.StateController.offNavigated(navigatedHandler);
+        assert.equal(oldStates[0], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
+        assert.equal(states[0], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+        assert.equal(oldStates[1], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+        assert.equal(states[1], Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
+        assert.equal(oldStates.length, 2);
+        assert.equal(states.length, 2);
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
+    });
+
+    QUnit.test('OnNavigatedDuplicateTest', function (assert) {
+        var oldStates: Array<State> = [];
+        var states: Array<State> = [];
+        Navigation.StateController.navigate('d0');
+        var navigatedHandler = (oldState, state, data) => {
+            oldStates.push(oldState);
+            states.push(state);
+        };
+        Navigation.StateController.onNavigated(navigatedHandler);
+        Navigation.StateController.onNavigated(navigatedHandler);
+        var link = Navigation.StateController.getNavigationLink('t0');
+        Navigation.StateController.navigateLink(link);
+        Navigation.StateController.navigate('d1');
+        Navigation.StateController.offNavigated(navigatedHandler);
+        assert.equal(oldStates[0], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
+        assert.equal(states[0], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+        assert.equal(oldStates[1], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+        assert.equal(states[1], Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
+        assert.equal(oldStates.length, 2);
+        assert.equal(states.length, 2);
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
+    });
+
+    QUnit.test('OnNavigatedMultipleTest', function (assert) {
+        var oldStates: Array<State> = [];
+        var states: Array<State> = [];
+        Navigation.StateController.navigate('d0');
+        var navigatedHandler1 = (oldState, state, data) => {
+            oldStates.push(oldState);
+            states.push(state);
+        };
+        var navigatedHandler2 = (oldState, state, data) => {
+            oldStates.push(oldState);
+            states.push(state);
+        };
+        Navigation.StateController.onNavigated(navigatedHandler1);
+        Navigation.StateController.onNavigated(navigatedHandler2);
+        var link = Navigation.StateController.getNavigationLink('t0');
+        Navigation.StateController.navigateLink(link);
+        Navigation.StateController.navigate('d1');
+        Navigation.StateController.offNavigated(navigatedHandler1);
+        Navigation.StateController.offNavigated(navigatedHandler2);
+        assert.equal(oldStates[0], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
+        assert.equal(states[0], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+        assert.equal(oldStates[1], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
+        assert.equal(states[1], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+        assert.equal(oldStates[2], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+        assert.equal(states[2], Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
+        assert.equal(oldStates[3], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+        assert.equal(states[3], Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
+        assert.equal(oldStates.length, 4);
+        assert.equal(states.length, 4);
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
+    });
+
+    QUnit.test('OffNavigatedTest', function (assert) {
+        var oldStates: Array<State> = [];
+        var states: Array<State> = [];
+        Navigation.StateController.navigate('d0');
+        var navigatedHandler = (oldState, state, data) => {
+            oldStates.push(oldState);
+            states.push(state);
+        };
+        Navigation.StateController.onNavigated(navigatedHandler);
+        var link = Navigation.StateController.getNavigationLink('t0');
+        Navigation.StateController.navigateLink(link);
+        Navigation.StateController.offNavigated(navigatedHandler);
+        Navigation.StateController.navigate('d1');
+        assert.equal(oldStates[0], Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
+        assert.equal(states[0], Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+        assert.equal(oldStates.length, 1);
+        assert.equal(states.length, 1);
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
+    });
+
     var individualNavigationData = {};
     individualNavigationData['string'] = 'Hello';
     individualNavigationData['boolean'] = true;


### PR DESCRIPTION
The onNavigate event allows any number of subscribers to know when navigation occurs. Navigation plugins can use it to update their Hyperlinks.