### PR TITLE
Added onNavigate Handlers

### DIFF
--- a/NavigationJS/Navigation.Knockout.ts
+++ b/NavigationJS/Navigation.Knockout.ts
@@ -50,7 +50,11 @@
 
     function setLink(element: HTMLAnchorElement, linkAccessor: () => string) {
         if (element.getAttribute('data-state-context-url') !== Navigation.StateContext.url) {
-            element.href = Navigation.historyManager.getHref(linkAccessor());
+            try {
+                element.href = Navigation.historyManager.getHref(linkAccessor());
+            } catch (e) {
+                element.removeAttribute('href');
+            }
             element.setAttribute('data-state-context-url', Navigation.StateContext.url);
         }
     }

--- a/NavigationJS/Navigation.Knockout.ts
+++ b/NavigationJS/Navigation.Knockout.ts
@@ -2,34 +2,67 @@
     ko.bindingHandlers['navigationLink'] = {
         init: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
             addClickListener(element);
+            var navigateHandler = () => {
+                setNavigationLink(element, valueAccessor, allBindings);
+            }
+            Navigation.StateController.onNavigate(navigateHandler);
+            ko.utils.domNodeDisposal.addDisposeCallback(element, () => {
+                Navigation.StateController.offNavigate(navigateHandler);
+            });
         },
-        update: (element: Element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
-            var link = Navigation.StateController.getNavigationLink(ko.unwrap(valueAccessor()),
-                getData(allBindings.get('toData'), allBindings.get('includeCurrentData'), allBindings.get('currentDataKeys')));
-            element['href'] = Navigation.historyManager.getHref(link);
+        update: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
+            setNavigationLink(element, valueAccessor, allBindings);
         }
     };
+
+    function setNavigationLink(element: HTMLAnchorElement, valueAccessor, allBindings: KnockoutAllBindingsAccessor) {
+        var link = Navigation.StateController.getNavigationLink(ko.unwrap(valueAccessor()),
+            getData(allBindings.get('toData'), allBindings.get('includeCurrentData'), allBindings.get('currentDataKeys')));
+        element.href = Navigation.historyManager.getHref(link);
+    }
 
     ko.bindingHandlers['navigationBackLink'] = {
         init: (element, valueAccessor) => {
             addClickListener(element);
+            var navigateHandler = () => {
+                setNavigationBackLink(element, valueAccessor);
+            }
+            Navigation.StateController.onNavigate(navigateHandler);
+            ko.utils.domNodeDisposal.addDisposeCallback(element, () => {
+                Navigation.StateController.offNavigate(navigateHandler);
+            });
         },
-        update: (element: Element, valueAccessor) => {
-            var link = Navigation.StateController.getNavigationBackLink(ko.unwrap(valueAccessor()));
-            element['href'] = Navigation.historyManager.getHref(link);
+        update: (element, valueAccessor) => {
+            setNavigationBackLink(element, valueAccessor);
         }
     };
+
+    function setNavigationBackLink(element: HTMLAnchorElement, valueAccessor) {
+        var link = Navigation.StateController.getNavigationBackLink(ko.unwrap(valueAccessor()));
+        element['href'] = Navigation.historyManager.getHref(link);
+    }
 
     ko.bindingHandlers['refreshLink'] = {
         init: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
             addClickListener(element);
+            var navigateHandler = () => {
+                setRefreshLink(element, valueAccessor, allBindings);
+            }
+            Navigation.StateController.onNavigate(navigateHandler);
+            ko.utils.domNodeDisposal.addDisposeCallback(element, () => {
+                Navigation.StateController.offNavigate(navigateHandler);
+            });
         },
-        update: (element: Element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
-            var link = Navigation.StateController.getRefreshLink(
-                getData(valueAccessor(), allBindings.get('includeCurrentData'), allBindings.get('currentDataKeys')));
-            element['href'] = Navigation.historyManager.getHref(link);
+        update: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
+            setRefreshLink(element, valueAccessor, allBindings);
         }
     };
+
+    function setRefreshLink(element: HTMLAnchorElement, valueAccessor, allBindings: KnockoutAllBindingsAccessor) {
+        var link = Navigation.StateController.getRefreshLink(
+            getData(valueAccessor(), allBindings.get('includeCurrentData'), allBindings.get('currentDataKeys')));
+        element['href'] = Navigation.historyManager.getHref(link);
+    }
 
     function getData(toData, includeCurrentData, currentDataKeys) {
         var data = {};

--- a/NavigationJS/Navigation.Knockout.ts
+++ b/NavigationJS/Navigation.Knockout.ts
@@ -1,4 +1,4 @@
-﻿module Navigation.Knockout {
+﻿module NavigationKnockout {
     ko.bindingHandlers['navigationLink'] = {
         init: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
             addClickListener(element);

--- a/NavigationJS/Navigation.Knockout.ts
+++ b/NavigationJS/Navigation.Knockout.ts
@@ -77,8 +77,10 @@
     function addClickListener(element: HTMLAnchorElement) {
         var navigate = (e: MouseEvent) => {
             if (!e.ctrlKey && !e.shiftKey) {
-                e.preventDefault();
-                Navigation.StateController.navigateLink(Navigation.historyManager.getUrl(element));
+                if (element.href) {
+                    e.preventDefault();
+                    Navigation.StateController.navigateLink(Navigation.historyManager.getUrl(element));
+                }
             }
         }
         if (window.addEventListener)

--- a/NavigationJS/Navigation.Knockout.ts
+++ b/NavigationJS/Navigation.Knockout.ts
@@ -1,10 +1,7 @@
 ﻿module Navigation.Knockout {
     ko.bindingHandlers['navigationLink'] = {
         init: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
-            addClickListener(element, () => {
-                Navigation.StateController.navigate(ko.unwrap(valueAccessor()),
-                    getData(allBindings.get('toData'), allBindings.get('includeCurrentData'), allBindings.get('currentDataKeys')));
-            });
+            addClickListener(element);
         },
         update: (element: Element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
             var link = Navigation.StateController.getNavigationLink(ko.unwrap(valueAccessor()),
@@ -15,9 +12,7 @@
 
     ko.bindingHandlers['navigationBackLink'] = {
         init: (element, valueAccessor) => {
-            addClickListener(element, () => {
-                Navigation.StateController.navigateBack(ko.unwrap(valueAccessor()));
-            });
+            addClickListener(element);
         },
         update: (element: Element, valueAccessor) => {
             var link = Navigation.StateController.getNavigationBackLink(ko.unwrap(valueAccessor()));
@@ -27,10 +22,7 @@
 
     ko.bindingHandlers['refreshLink'] = {
         init: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
-            addClickListener(element, () => {
-                Navigation.StateController.refresh(
-                    getData(valueAccessor(), allBindings.get('includeCurrentData'), allBindings.get('currentDataKeys')));
-            });
+            addClickListener(element);
         },
         update: (element: Element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
             var link = Navigation.StateController.getRefreshLink(
@@ -54,11 +46,11 @@
         return data;
     }
 
-    function addClickListener(element, listener: () => void) {
+    function addClickListener(element: HTMLAnchorElement) {
         var navigate = (e: MouseEvent) => {
             if (!e.ctrlKey && !e.shiftKey) {
                 e.preventDefault();
-                listener();
+                Navigation.StateController.navigateLink(Navigation.historyManager.getUrl(element));
             }
         }
         if (window.addEventListener)

--- a/NavigationJS/Navigation.Knockout.ts
+++ b/NavigationJS/Navigation.Knockout.ts
@@ -11,14 +11,18 @@
             });
         },
         update: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
+            element.removeAttribute('data-state-context-url');
             setNavigationLink(element, valueAccessor, allBindings);
         }
     };
 
     function setNavigationLink(element: HTMLAnchorElement, valueAccessor, allBindings: KnockoutAllBindingsAccessor) {
-        var link = Navigation.StateController.getNavigationLink(ko.unwrap(valueAccessor()),
-            getData(allBindings.get('toData'), allBindings.get('includeCurrentData'), allBindings.get('currentDataKeys')));
-        element.href = Navigation.historyManager.getHref(link);
+        if (element.getAttribute('data-state-context-url') !== Navigation.StateContext.url) {
+            var link = Navigation.StateController.getNavigationLink(ko.unwrap(valueAccessor()),
+                getData(allBindings.get('toData'), allBindings.get('includeCurrentData'), allBindings.get('currentDataKeys')));
+            element.href = Navigation.historyManager.getHref(link);
+            element.setAttribute('data-state-context-url', Navigation.StateContext.url);
+        }
     }
 
     ko.bindingHandlers['navigationBackLink'] = {
@@ -33,13 +37,17 @@
             });
         },
         update: (element, valueAccessor) => {
+            element.removeAttribute('data-state-context-url');
             setNavigationBackLink(element, valueAccessor);
         }
     };
 
     function setNavigationBackLink(element: HTMLAnchorElement, valueAccessor) {
-        var link = Navigation.StateController.getNavigationBackLink(ko.unwrap(valueAccessor()));
-        element['href'] = Navigation.historyManager.getHref(link);
+        if (element.getAttribute('data-state-context-url') !== Navigation.StateContext.url) {
+            var link = Navigation.StateController.getNavigationBackLink(ko.unwrap(valueAccessor()));
+            element['href'] = Navigation.historyManager.getHref(link);
+            element.setAttribute('data-state-context-url', Navigation.StateContext.url);
+        }
     }
 
     ko.bindingHandlers['refreshLink'] = {
@@ -54,14 +62,18 @@
             });
         },
         update: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
+            element.removeAttribute('data-state-context-url');
             setRefreshLink(element, valueAccessor, allBindings);
         }
     };
 
     function setRefreshLink(element: HTMLAnchorElement, valueAccessor, allBindings: KnockoutAllBindingsAccessor) {
-        var link = Navigation.StateController.getRefreshLink(
-            getData(valueAccessor(), allBindings.get('includeCurrentData'), allBindings.get('currentDataKeys')));
-        element['href'] = Navigation.historyManager.getHref(link);
+        if (element.getAttribute('data-state-context-url') !== Navigation.StateContext.url) {
+            var link = Navigation.StateController.getRefreshLink(
+                getData(valueAccessor(), allBindings.get('includeCurrentData'), allBindings.get('currentDataKeys')));
+            element['href'] = Navigation.historyManager.getHref(link);
+            element.setAttribute('data-state-context-url', Navigation.StateContext.url);
+        }
     }
 
     function getData(toData, includeCurrentData, currentDataKeys) {

--- a/NavigationJS/Navigation.Knockout.ts
+++ b/NavigationJS/Navigation.Knockout.ts
@@ -2,13 +2,7 @@
     ko.bindingHandlers['navigationLink'] = {
         init: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
             addClickListener(element);
-            var navigateHandler = () => {
-                setNavigationLink(element, valueAccessor, allBindings);
-            }
-            Navigation.StateController.onNavigate(navigateHandler);
-            ko.utils.domNodeDisposal.addDisposeCallback(element, () => {
-                Navigation.StateController.offNavigate(navigateHandler);
-            });
+            addNavigateHandler(element, () => setNavigationLink(element, valueAccessor, allBindings));
         },
         update: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
             element.removeAttribute('data-state-context-url');
@@ -28,13 +22,7 @@
     ko.bindingHandlers['navigationBackLink'] = {
         init: (element, valueAccessor) => {
             addClickListener(element);
-            var navigateHandler = () => {
-                setNavigationBackLink(element, valueAccessor);
-            }
-            Navigation.StateController.onNavigate(navigateHandler);
-            ko.utils.domNodeDisposal.addDisposeCallback(element, () => {
-                Navigation.StateController.offNavigate(navigateHandler);
-            });
+            addNavigateHandler(element, () => setNavigationBackLink(element, valueAccessor));
         },
         update: (element, valueAccessor) => {
             element.removeAttribute('data-state-context-url');
@@ -53,13 +41,7 @@
     ko.bindingHandlers['refreshLink'] = {
         init: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
             addClickListener(element);
-            var navigateHandler = () => {
-                setRefreshLink(element, valueAccessor, allBindings);
-            }
-            Navigation.StateController.onNavigate(navigateHandler);
-            ko.utils.domNodeDisposal.addDisposeCallback(element, () => {
-                Navigation.StateController.offNavigate(navigateHandler);
-            });
+            addNavigateHandler(element, () => setRefreshLink(element, valueAccessor, allBindings));
         },
         update: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
             element.removeAttribute('data-state-context-url');
@@ -102,5 +84,12 @@
             element.addEventListener('click', navigate);
         else
             element.attachEvent('click', navigate);
+    }
+
+    function addNavigateHandler(element, handler) {
+        Navigation.StateController.onNavigate(handler);
+        ko.utils.domNodeDisposal.addDisposeCallback(element, () => {
+            Navigation.StateController.offNavigate(handler);
+        });
     }
 }

--- a/NavigationJS/Navigation.Knockout.ts
+++ b/NavigationJS/Navigation.Knockout.ts
@@ -13,7 +13,7 @@
     function setNavigationLink(element: HTMLAnchorElement, valueAccessor, allBindings: KnockoutAllBindingsAccessor) {
         setLink(element, () => Navigation.StateController.getNavigationLink(ko.unwrap(valueAccessor()),
             getData(allBindings.get('toData'), allBindings.get('includeCurrentData'), allBindings.get('currentDataKeys')))
-            );
+        );
     }
 
     ko.bindingHandlers['navigationBackLink'] = {
@@ -45,7 +45,7 @@
     function setRefreshLink(element: HTMLAnchorElement, valueAccessor, allBindings: KnockoutAllBindingsAccessor) {
         setLink(element, () => Navigation.StateController.getRefreshLink(
             getData(valueAccessor(), allBindings.get('includeCurrentData'), allBindings.get('currentDataKeys')))
-            );
+        );
     }
 
     function setLink(element: HTMLAnchorElement, linkAccessor: () => string) {

--- a/NavigationJS/Navigation.Knockout.ts
+++ b/NavigationJS/Navigation.Knockout.ts
@@ -11,12 +11,9 @@
     };
 
     function setNavigationLink(element: HTMLAnchorElement, valueAccessor, allBindings: KnockoutAllBindingsAccessor) {
-        if (element.getAttribute('data-state-context-url') !== Navigation.StateContext.url) {
-            var link = Navigation.StateController.getNavigationLink(ko.unwrap(valueAccessor()),
-                getData(allBindings.get('toData'), allBindings.get('includeCurrentData'), allBindings.get('currentDataKeys')));
-            element.href = Navigation.historyManager.getHref(link);
-            element.setAttribute('data-state-context-url', Navigation.StateContext.url);
-        }
+        setLink(element, () => Navigation.StateController.getNavigationLink(ko.unwrap(valueAccessor()),
+            getData(allBindings.get('toData'), allBindings.get('includeCurrentData'), allBindings.get('currentDataKeys')))
+            );
     }
 
     ko.bindingHandlers['navigationBackLink'] = {
@@ -31,11 +28,7 @@
     };
 
     function setNavigationBackLink(element: HTMLAnchorElement, valueAccessor) {
-        if (element.getAttribute('data-state-context-url') !== Navigation.StateContext.url) {
-            var link = Navigation.StateController.getNavigationBackLink(ko.unwrap(valueAccessor()));
-            element['href'] = Navigation.historyManager.getHref(link);
-            element.setAttribute('data-state-context-url', Navigation.StateContext.url);
-        }
+        setLink(element, () => Navigation.StateController.getNavigationBackLink(ko.unwrap(valueAccessor())));
     }
 
     ko.bindingHandlers['refreshLink'] = {
@@ -50,10 +43,14 @@
     };
 
     function setRefreshLink(element: HTMLAnchorElement, valueAccessor, allBindings: KnockoutAllBindingsAccessor) {
+        setLink(element, () => Navigation.StateController.getRefreshLink(
+            getData(valueAccessor(), allBindings.get('includeCurrentData'), allBindings.get('currentDataKeys')))
+            );
+    }
+
+    function setLink(element: HTMLAnchorElement, linkAccessor: () => string) {
         if (element.getAttribute('data-state-context-url') !== Navigation.StateContext.url) {
-            var link = Navigation.StateController.getRefreshLink(
-                getData(valueAccessor(), allBindings.get('includeCurrentData'), allBindings.get('currentDataKeys')));
-            element['href'] = Navigation.historyManager.getHref(link);
+            element.href = Navigation.historyManager.getHref(linkAccessor());
             element.setAttribute('data-state-context-url', Navigation.StateContext.url);
         }
     }

--- a/NavigationJS/Navigation.React.ts
+++ b/NavigationJS/Navigation.React.ts
@@ -13,11 +13,15 @@
             var props = cloneProps(this);
             var action = props.action;
             var toData = getData(props.toData, props.includeCurrentData, props.currentDataKeys);
-            var link = Navigation.StateController.getNavigationLink(action, toData);
-            props.href = Navigation.historyManager.getHref(link);
-            props.onClick = (e) => onClick(e, this.getDOMNode());
+            try {
+                var link = Navigation.StateController.getNavigationLink(action, toData);
+                props.href = Navigation.historyManager.getHref(link);
+                props.onClick = (e) => onClick(e, this.getDOMNode());
+            } catch (e) {
+                props.href = null;
+            }
             clearProps(props);
-            return React.createElement('a', props);
+            return React.createElement(props.href ? 'a' : 'span', props);
         }
     });
 
@@ -34,9 +38,13 @@
         render: function () {
             var props = cloneProps(this);
             var distance = props.distance;
-            var link = Navigation.StateController.getNavigationBackLink(distance);
-            props.href = Navigation.historyManager.getHref(link);
-            props.onClick = (e) => onClick(e, this.getDOMNode());
+            try {
+                var link = Navigation.StateController.getNavigationBackLink(distance);
+                props.href = Navigation.historyManager.getHref(link);
+                props.onClick = (e) => onClick(e, this.getDOMNode());
+            } catch (e) {
+                props.href = null;
+            }
             clearProps(props);
             return React.createElement('a', props);
         }
@@ -55,9 +63,13 @@
         render: function () {
             var props = cloneProps(this);
             var toData = getData(props.toData, props.includeCurrentData, props.currentDataKeys);
-            var link = Navigation.StateController.getRefreshLink(toData);
-            props.href = Navigation.historyManager.getHref(link);
-            props.onClick = (e) => onClick(e, this.getDOMNode());
+            try {
+                var link = Navigation.StateController.getRefreshLink(toData);
+                props.href = Navigation.historyManager.getHref(link);
+                props.onClick = (e) => onClick(e, this.getDOMNode());
+            } catch (e) {
+                props.href = null;
+            }
             clearProps(props);
             return React.createElement('a', props);
         }

--- a/NavigationJS/Navigation.React.ts
+++ b/NavigationJS/Navigation.React.ts
@@ -46,7 +46,7 @@
                 props.href = null;
             }
             clearProps(props);
-            return React.createElement('a', props);
+            return React.createElement(props.href ? 'a' : 'span', props);
         }
     });
 
@@ -71,7 +71,7 @@
                 props.href = null;
             }
             clearProps(props);
-            return React.createElement('a', props);
+            return React.createElement(props.href ? 'a' : 'span', props);
         }
     });
 

--- a/NavigationJS/Navigation.React.ts
+++ b/NavigationJS/Navigation.React.ts
@@ -8,9 +8,7 @@
             props.href = Navigation.historyManager.getHref(link);
             props.onClick = (e) => onClick(e, this.getDOMNode());
             clearProps(props);
-            return (
-                React.createElement('a', props)
-            );
+            return React.createElement('a', props);
         }
     });
 
@@ -22,9 +20,7 @@
             props.href = Navigation.historyManager.getHref(link);
             props.onClick = (e) => onClick(e, this.getDOMNode());
             clearProps(props);
-            return (
-                React.createElement('a', props)
-            );
+            return React.createElement('a', props);
         }
     });
 
@@ -36,9 +32,7 @@
             props.href = Navigation.historyManager.getHref(link);
             props.onClick = (e) => onClick(e, this.getDOMNode());
             clearProps(props);
-            return (
-                React.createElement('a', props)
-            );
+            return React.createElement('a', props);
         }
     });
 

--- a/NavigationJS/Navigation.React.ts
+++ b/NavigationJS/Navigation.React.ts
@@ -14,8 +14,7 @@
             var action = props.action;
             var toData = getData(props.toData, props.includeCurrentData, props.currentDataKeys);
             setLink(this, props, () => Navigation.StateController.getNavigationLink(action, toData));
-            clearProps(props);
-            return React.createElement(props.href ? 'a' : 'span', props);
+            return createElement(props);
         }
     });
 
@@ -33,8 +32,7 @@
             var props = cloneProps(this);
             var distance = props.distance;
             setLink(this, props, () => Navigation.StateController.getNavigationBackLink(distance));
-            clearProps(props);
-            return React.createElement(props.href ? 'a' : 'span', props);
+            return createElement(props);
         }
     });
 
@@ -52,8 +50,7 @@
             var props = cloneProps(this);
             var toData = getData(props.toData, props.includeCurrentData, props.currentDataKeys);
             setLink(this, props, () => Navigation.StateController.getRefreshLink(toData));
-            clearProps(props);
-            return React.createElement(props.href ? 'a' : 'span', props);
+            return createElement(props);
         }
     });
 
@@ -91,12 +88,13 @@
         }
     }
 
-    function clearProps(props: any) {
+    function createElement(props: any) {
         delete props.action;
         delete props.toData;
         delete props.includeCurrentData;
         delete props.currentDataKeys;
         delete props.distance;
+        return React.createElement(props.href ? 'a' : 'span', props);
     }
 }
 var NavigationLink = NavigationReact.NavigationLink;

--- a/NavigationJS/Navigation.React.ts
+++ b/NavigationJS/Navigation.React.ts
@@ -1,5 +1,14 @@
 ﻿module NavigationReact {
     export var NavigationLink = React.createClass({
+        onNavigate: function () {
+            this.forceUpdate();
+        },
+        componentDidMount: function () {
+            Navigation.StateController.onNavigate(this.onNavigate);
+        },
+        componentWillUnmount: function () {
+            Navigation.StateController.offNavigate(this.onNavigate);
+        },
         render: function () {
             var props = cloneProps(this);
             var action = props.action;
@@ -13,6 +22,15 @@
     });
 
     export var NavigationBackLink = React.createClass({
+        onNavigate: function () {
+            this.forceUpdate();
+        },
+        componentDidMount: function () {
+            Navigation.StateController.onNavigate(this.onNavigate);
+        },
+        componentWillUnmount: function () {
+            Navigation.StateController.offNavigate(this.onNavigate);
+        },
         render: function () {
             var props = cloneProps(this);
             var distance = props.distance;
@@ -25,6 +43,15 @@
     });
 
     export var RefreshLink = React.createClass({
+        onNavigate: function () {
+            this.forceUpdate();
+        },
+        componentDidMount: function () {
+            Navigation.StateController.onNavigate(this.onNavigate);
+        },
+        componentWillUnmount: function () {
+            Navigation.StateController.offNavigate(this.onNavigate);
+        },
         render: function () {
             var props = cloneProps(this);
             var toData = getData(props.toData, props.includeCurrentData, props.currentDataKeys);

--- a/NavigationJS/Navigation.React.ts
+++ b/NavigationJS/Navigation.React.ts
@@ -75,10 +75,10 @@
     }
 
     function getData(toData, includeCurrentData: boolean, currentDataKeys: string): any {
-        if (includeCurrentData)
-            toData = Navigation.StateContext.includeCurrentData(toData);
         if (currentDataKeys)
             toData = Navigation.StateContext.includeCurrentData(toData, currentDataKeys.trim().split(/\s*,\s*/));
+        if (includeCurrentData)
+            toData = Navigation.StateContext.includeCurrentData(toData);
         return toData;
     }
 

--- a/NavigationJS/Navigation.React.ts
+++ b/NavigationJS/Navigation.React.ts
@@ -13,13 +13,7 @@
             var props = cloneProps(this);
             var action = props.action;
             var toData = getData(props.toData, props.includeCurrentData, props.currentDataKeys);
-            try {
-                var link = Navigation.StateController.getNavigationLink(action, toData);
-                props.href = Navigation.historyManager.getHref(link);
-                props.onClick = (e) => onClick(e, this.getDOMNode());
-            } catch (e) {
-                props.href = null;
-            }
+            setLink(this, props, () => Navigation.StateController.getNavigationLink(action, toData));
             clearProps(props);
             return React.createElement(props.href ? 'a' : 'span', props);
         }
@@ -38,13 +32,7 @@
         render: function () {
             var props = cloneProps(this);
             var distance = props.distance;
-            try {
-                var link = Navigation.StateController.getNavigationBackLink(distance);
-                props.href = Navigation.historyManager.getHref(link);
-                props.onClick = (e) => onClick(e, this.getDOMNode());
-            } catch (e) {
-                props.href = null;
-            }
+            setLink(this, props, () => Navigation.StateController.getNavigationBackLink(distance));
             clearProps(props);
             return React.createElement(props.href ? 'a' : 'span', props);
         }
@@ -63,13 +51,7 @@
         render: function () {
             var props = cloneProps(this);
             var toData = getData(props.toData, props.includeCurrentData, props.currentDataKeys);
-            try {
-                var link = Navigation.StateController.getRefreshLink(toData);
-                props.href = Navigation.historyManager.getHref(link);
-                props.onClick = (e) => onClick(e, this.getDOMNode());
-            } catch (e) {
-                props.href = null;
-            }
+            setLink(this, props, () => Navigation.StateController.getRefreshLink(toData));
             clearProps(props);
             return React.createElement(props.href ? 'a' : 'span', props);
         }
@@ -81,6 +63,15 @@
             props[key] = elem.props[key];
         }
         return props;
+    }
+
+    function setLink(component: any, props: any, linkAccessor: () => string) {
+        try {
+            props.href = Navigation.historyManager.getHref(linkAccessor());
+            props.onClick = (e) => onClick(e, component.getDOMNode());
+        } catch (e) {
+            props.href = null;
+        }
     }
 
     function getData(toData, includeCurrentData: boolean, currentDataKeys: string): any {

--- a/NavigationJS/Navigation.React.ts
+++ b/NavigationJS/Navigation.React.ts
@@ -6,7 +6,7 @@
             var toData = getData(props.toData, props.includeCurrentData, props.currentDataKeys);
             var link = Navigation.StateController.getNavigationLink(action, toData);
             props.href = Navigation.historyManager.getHref(link);
-            props.onClick = getClickListener(() => Navigation.StateController.navigate(action, toData))
+            props.onClick = (e) => onClick(e, this.getDOMNode());
             clearProps(props);
             return (
                 React.createElement('a', props)
@@ -20,7 +20,7 @@
             var distance = props.distance;
             var link = Navigation.StateController.getNavigationBackLink(distance);
             props.href = Navigation.historyManager.getHref(link);
-            props.onClick = getClickListener(() => Navigation.StateController.navigateBack(distance))
+            props.onClick = (e) => onClick(e, this.getDOMNode());
             clearProps(props);
             return (
                 React.createElement('a', props)
@@ -34,7 +34,7 @@
             var toData = getData(props.toData, props.includeCurrentData, props.currentDataKeys);
             var link = Navigation.StateController.getRefreshLink(toData);
             props.href = Navigation.historyManager.getHref(link);
-            props.onClick = getClickListener(() => Navigation.StateController.refresh(toData))
+            props.onClick = (e) => onClick(e, this.getDOMNode());
             clearProps(props);
             return (
                 React.createElement('a', props)
@@ -58,13 +58,13 @@
         return toData;
     }
 
-    function getClickListener(listener: () => void): (e: MouseEvent) => void {
-        return (e: MouseEvent) => {
-            if (!e.ctrlKey && !e.shiftKey) {
+    function onClick(e: MouseEvent, element: HTMLAnchorElement) {
+        if (!e.ctrlKey && !e.shiftKey) {
+            if (element.href) {
                 e.preventDefault();
-                listener();
+                Navigation.StateController.navigateLink(Navigation.historyManager.getUrl(element));
             }
-        };
+        }
     }
 
     function clearProps(props: any) {

--- a/NavigationJS/Navigation.ts
+++ b/NavigationJS/Navigation.ts
@@ -734,10 +734,7 @@
     }
 
     export class HashHistoryManager implements IHistoryManager {
-        private andHTML5: boolean;
-
-        constructor(andHTML5?: boolean) {
-            this.andHTML5 = !!andHTML5;
+        constructor() {
             if (window.addEventListener) {
                 window.removeEventListener('hashchange', navigateHistory);
                 window.addEventListener('hashchange', navigateHistory);
@@ -750,19 +747,12 @@
         addHistory(oldState: State, state: State, url: string) {
             if (state.title)
                 document.title = state.title;
-            if (location.hash.substring(1) !== url) {
-                if (oldState)
-                    location.hash = url;
-                else
-                    location.replace(settings.applicationPath + url + '#' + url);
-            }
+            if (location.hash.substring(1) !== url)
+                location.hash = url;
         }
 
         getCurrentUrl(): string {
-            var url = location.hash.substring(1);
-            if (!url && this.andHTML5)
-                url = location.pathname.substring(settings.applicationPath.length) + location.search;
-            return url;
+            return location.hash.substring(1);
         }
 
         getHref(url: string): string {
@@ -775,10 +765,7 @@
     }
 
     export class HTML5HistoryManager implements IHistoryManager {
-        private andHash: boolean;
-
-        constructor(andHash?: boolean) {
-            this.andHash = !!andHash;
+        constructor() {
             window.removeEventListener('popstate', navigateHistory);
             window.addEventListener('popstate', navigateHistory);
         }
@@ -787,19 +774,12 @@
             if (state.title)
                 document.title = state.title;
             url = settings.applicationPath + url;
-            if (location.pathname + location.search !== url) {
-                if (oldState)
-                    window.history.pushState(null, null, url);
-                else
-                    window.history.replaceState(null, null, url);
-            }
+            if (location.pathname + location.search !== url)
+                window.history.pushState(null, null, url);
         }
 
         getCurrentUrl(): string {
-            var url = location.pathname.substring(settings.applicationPath.length) + location.search;
-            if ((!url || url === '/') && this.andHash)
-                url = location.hash.substring(1);
-            return url;
+            return location.pathname.substring(settings.applicationPath.length) + location.search;
         }
 
         getHref(url: string): string {

--- a/NavigationJS/Navigation.ts
+++ b/NavigationJS/Navigation.ts
@@ -458,7 +458,8 @@
                 oldState.dispose();
             state.navigated(StateContext.data);
             for (var id in this.navigateHandlers) {
-                this.navigateHandlers[id](oldState, state, StateContext.data);
+                if (url === StateContext.url)
+                    this.navigateHandlers[id](oldState, state, StateContext.data);
             }
         }
 
@@ -526,6 +527,7 @@
 
         private static _navigateLink(url: string, state: State) {
             try {
+                var oldUrl = StateContext.url;
                 var oldState = StateContext.state;
                 var data = state.stateHandler.getNavigationData(state, url);
                 data = this.parseData(data, state);
@@ -533,7 +535,7 @@
                 throw new Error('The Url is invalid\n' + e.message);
             }
             state.navigating(data, url, () => {
-                if (oldState === StateContext.state)
+                if (oldUrl === StateContext.url)
                     state.stateHandler.navigateLink(oldState, state, url);
             });
         }

--- a/NavigationJS/Navigation.ts
+++ b/NavigationJS/Navigation.ts
@@ -758,6 +758,8 @@
         }
 
         getHref(url: string): string {
+            if (!url)
+                throw new Error('The Url is invalid');
             return '#' + url;
         }
 
@@ -785,6 +787,8 @@
         }
 
         getHref(url: string): string {
+            if (!url)
+                throw new Error('The Url is invalid');
             return settings.applicationPath + url;
         }
 
@@ -802,6 +806,8 @@
         }
 
         getHref(url: string): string {
+            if (!url)
+                throw new Error('The Url is invalid');
             return '#' + url;
         }
 

--- a/NavigationJS/Navigation.ts
+++ b/NavigationJS/Navigation.ts
@@ -723,6 +723,7 @@
         addHistory(oldState: State, state: State, url: string);
         getCurrentUrl(): string;
         getHref(url: string): string;
+        getUrl(anchor: HTMLAnchorElement): string;
     }
 
     var navigateHistory = () => {
@@ -766,6 +767,10 @@
         getHref(url: string): string {
             return '#' + url;
         }
+
+        getUrl(anchor: HTMLAnchorElement) {
+            return anchor.hash.substring(1);
+        }
     }
 
     export class HTML5HistoryManager implements IHistoryManager {
@@ -799,6 +804,10 @@
         getHref(url: string): string {
             return settings.applicationPath + url;
         }
+
+        getUrl(anchor: HTMLAnchorElement) {
+            return anchor.pathname.substring(settings.applicationPath.length) + anchor.search;
+        }
     }
 
     export class VoidHistoryManager implements IHistoryManager {
@@ -810,7 +819,11 @@
         }
 
         getHref(url: string): string {
-            return url;
+            return '#' + url;
+        }
+
+        getUrl(anchor: HTMLAnchorElement) {
+            return anchor.hash.substring(1);
         }
     }
 

--- a/NavigationJS/Navigation.ts
+++ b/NavigationJS/Navigation.ts
@@ -168,7 +168,8 @@
 
         navigateLink(oldState: State, state: State, url: string) {
             StateController.setStateContext(state, url);
-            historyManager.addHistory(oldState, state, url);
+            if (StateContext.url === url)
+                historyManager.addHistory(oldState, state, url);
         }
 
         getNavigationData(state: State, url: string): any {

--- a/NavigationJS/Sample/Knockout/app.js
+++ b/NavigationJS/Sample/Knockout/app.js
@@ -23,7 +23,8 @@
 	        subscription.dispose();
 	    self.name(data.name);
 	    subscription = self.name.subscribe(function (val) {
-	        Navigation.StateController.refresh(Navigation.StateContext.includeCurrentData({ name: val, startRowIndex: null }));
+	    	var data = Navigation.StateContext.includeCurrentData({ name: val, startRowIndex: null });
+	        Navigation.StateController.refresh(data);
 	    });
 	    self.people(people);
 	    self.sortExpression(data.sortExpression.indexOf('DESC') === -1 ? 'Name DESC' : 'Name');

--- a/NavigationJS/Sample/Knockout/app.js
+++ b/NavigationJS/Sample/Knockout/app.js
@@ -1,46 +1,46 @@
 ﻿function PersonViewModel() {
-    var self = this;
-    self.id = ko.observable();
-    self.name = ko.observable();
-    self.personName = ko.observable();
-    self.dateOfBirth = ko.observable();
-    self.people = ko.observableArray();
-    self.sortExpression = ko.observable();
-    self.previous = ko.observable();
-    self.previousVisible = ko.observable();
-    self.next = ko.observable();
-    self.nextVisible = ko.observable();
-    self.last = ko.observable();
-    self.totalCount = ko.observable();
+	var self = this;
+	self.id = ko.observable();
+	self.name = ko.observable();
+	self.personName = ko.observable();
+	self.dateOfBirth = ko.observable();
+	self.people = ko.observableArray();
+	self.sortExpression = ko.observable();
+	self.previous = ko.observable();
+	self.previousVisible = ko.observable();
+	self.next = ko.observable();
+	self.nextVisible = ko.observable();
+	self.last = ko.observable();
+	self.totalCount = ko.observable();
 
-    var personStates = Navigation.StateInfoConfig.dialogs.person.states;
-    var subscription;
+	var personStates = Navigation.StateInfoConfig.dialogs.person.states;
+	var subscription;
 	personStates.list.navigated = function (data) {
-	    var people = personSearch.search(data.name, data.sortExpression);
-	    var totalRowCount = people.length;
-	    people = people.slice(data.startRowIndex, data.startRowIndex + data.maximumRows);
-	    if (subscription)
-	        subscription.dispose();
-	    self.name(data.name);
-	    subscription = self.name.subscribe(function (val) {
-	    	var data = Navigation.StateContext.includeCurrentData({ name: val, startRowIndex: null });
-	        Navigation.StateController.refresh(data);
-	    });
-	    self.people(people);
-	    self.sortExpression(data.sortExpression.indexOf('DESC') === -1 ? 'Name DESC' : 'Name');
-	    self.previous(data.startRowIndex - data.maximumRows);
-	    self.previousVisible(self.previous() >= 0);
-	    self.next(data.startRowIndex + data.maximumRows);
-	    self.nextVisible(self.next() < totalRowCount);
-	    var remainder = totalRowCount % data.maximumRows;
-	    self.last(remainder != 0 ? totalRowCount - remainder : totalRowCount - data.maximumRows);
-	    self.totalCount(totalRowCount);
+		var people = personSearch.search(data.name, data.sortExpression);
+		var totalRowCount = people.length;
+		people = people.slice(data.startRowIndex, data.startRowIndex + data.maximumRows);
+		if (subscription)
+			subscription.dispose();
+		self.name(data.name);
+		subscription = self.name.subscribe(function (val) {
+			var data = Navigation.StateContext.includeCurrentData({ name: val, startRowIndex: null });
+			Navigation.StateController.refresh(data);
+		});
+		self.people(people);
+		self.sortExpression(data.sortExpression.indexOf('DESC') === -1 ? 'Name DESC' : 'Name');
+		self.previous(data.startRowIndex - data.maximumRows);
+		self.previousVisible(self.previous() >= 0);
+		self.next(data.startRowIndex + data.maximumRows);
+		self.nextVisible(self.next() < totalRowCount);
+		var remainder = totalRowCount % data.maximumRows;
+		self.last(remainder != 0 ? totalRowCount - remainder : totalRowCount - data.maximumRows);
+		self.totalCount(totalRowCount);
 	};
 	personStates.details.navigated = function (data) {
-	    self.id(data.id);
-	    var person = personSearch.getDetails(data.id);
-	    self.personName(person.name);
-	    self.dateOfBirth(person.dateOfBirth);
+		self.id(data.id);
+		var person = personSearch.getDetails(data.id);
+		self.personName(person.name);
+		self.dateOfBirth(person.dateOfBirth);
 	};
 	personStates.details.dispose = function () { self.id(null); };
 };

--- a/NavigationJS/Sample/Knockout/app.js
+++ b/NavigationJS/Sample/Knockout/app.js
@@ -13,12 +13,18 @@
     self.last = ko.observable();
     self.totalCount = ko.observable();
 
-	var personStates = Navigation.StateInfoConfig.dialogs.person.states;
+    var personStates = Navigation.StateInfoConfig.dialogs.person.states;
+    var subscription;
 	personStates.list.navigated = function (data) {
 	    var people = personSearch.search(data.name, data.sortExpression);
 	    var totalRowCount = people.length;
 	    people = people.slice(data.startRowIndex, data.startRowIndex + data.maximumRows);
+	    if (subscription)
+	        subscription.dispose();
 	    self.name(data.name);
+	    subscription = self.name.subscribe(function (val) {
+	        Navigation.StateController.refresh(Navigation.StateContext.includeCurrentData({ name: val, startRowIndex: null }));
+	    });
 	    self.people(people);
 	    self.sortExpression(data.sortExpression.indexOf('DESC') === -1 ? 'Name DESC' : 'Name');
 	    self.previous(data.startRowIndex - data.maximumRows);
@@ -37,9 +43,6 @@
 	};
 	personStates.details.dispose = function () { self.id(null); };
 	Navigation.start();
-	self.name.subscribe(function (val) {
-		Navigation.StateController.refresh(Navigation.StateContext.includeCurrentData({ name: val, startRowIndex: null }));
-	});
 };
 
 Navigation.StateInfoConfig.build([

--- a/NavigationJS/Sample/Knockout/app.js
+++ b/NavigationJS/Sample/Knockout/app.js
@@ -12,9 +12,6 @@
     self.nextVisible = ko.observable();
     self.last = ko.observable();
     self.totalCount = ko.observable();
-    self.name.subscribe(function (val) {
-        Navigation.StateController.refresh(Navigation.StateContext.includeCurrentData({ name: val, startRowIndex: null }));
-    });
 
 	var personStates = Navigation.StateInfoConfig.dialogs.person.states;
 	personStates.list.navigated = function (data) {
@@ -40,6 +37,9 @@
 	};
 	personStates.details.dispose = function () { self.id(null); };
 	Navigation.start();
+	self.name.subscribe(function (val) {
+		Navigation.StateController.refresh(Navigation.StateContext.includeCurrentData({ name: val, startRowIndex: null }));
+	});
 };
 
 Navigation.StateInfoConfig.build([

--- a/NavigationJS/Sample/Knockout/app.js
+++ b/NavigationJS/Sample/Knockout/app.js
@@ -43,7 +43,6 @@
 	    self.dateOfBirth(person.dateOfBirth);
 	};
 	personStates.details.dispose = function () { self.id(null); };
-	Navigation.start();
 };
 
 Navigation.StateInfoConfig.build([
@@ -53,3 +52,4 @@ Navigation.StateInfoConfig.build([
 		{ key: 'details', route: 'person', title: 'Person Details', }]}
 ]);
 ko.applyBindings(new PersonViewModel());
+Navigation.start();


### PR DESCRIPTION
Navigation links updated in onNavigate handlers, so their hrefs are never stale. Used the href to navigate instead of parsing the properties again. Swallowed navigation link exceptions, allows screens to be hidden and shown instead of forcing nodes to be removed.