### PR TITLE
Cross Browser History Suppport

### DIFF
--- a/NavigationJS/Navigation.ts
+++ b/NavigationJS/Navigation.ts
@@ -169,7 +169,7 @@
         navigateLink(oldState: State, state: State, url: string) {
             StateController.setStateContext(state, url);
             if (StateContext.url === url)
-                historyManager.addHistory(oldState, state, url);
+                historyManager.addHistory(state, url);
         }
 
         getNavigationData(state: State, url: string): any {
@@ -726,7 +726,7 @@
     export interface IHistoryManager {
         disabled: boolean;
         init();
-        addHistory(oldState: State, state: State, url: string);
+        addHistory(state: State, url: string);
         getCurrentUrl(): string;
         getHref(url: string): string;
         getUrl(anchor: HTMLAnchorElement): string;
@@ -753,7 +753,7 @@
             }
         }
 
-        addHistory(oldState: State, state: State, url: string) {
+        addHistory(state: State, url: string) {
             if (state.title && (typeof document !== 'undefined'))
                 document.title = state.title;
             if (!this.disabled && location.hash.substring(1) !== url)
@@ -785,7 +785,7 @@
             }
         }
 
-        addHistory(oldState: State, state: State, url: string) {
+        addHistory(state: State, url: string) {
             if (state.title && (typeof document !== 'undefined'))
                 document.title = state.title;
             url = settings.applicationPath + url;

--- a/NavigationJS/Navigation.ts
+++ b/NavigationJS/Navigation.ts
@@ -774,16 +774,21 @@
     }
 
     export class HTML5HistoryManager implements IHistoryManager {
-        constructor() {
-            window.removeEventListener('popstate', navigateHistory);
-            window.addEventListener('popstate', navigateHistory);
+        private disabled: boolean = false;
+
+        constructor(disable?: boolean) {
+            this.disabled = !!disable || (typeof window === 'undefined') || !(window.history && window.history.pushState);
+            if (!this.disabled) {
+                window.removeEventListener('popstate', navigateHistory);
+                window.addEventListener('popstate', navigateHistory);
+            }
         }
 
         addHistory(oldState: State, state: State, url: string) {
             if (state.title)
                 document.title = state.title;
             url = settings.applicationPath + url;
-            if (location.pathname + location.search !== url)
+            if (!this.disabled && location.pathname + location.search !== url)
                 window.history.pushState(null, null, url);
         }
 

--- a/NavigationJS/Navigation.ts
+++ b/NavigationJS/Navigation.ts
@@ -802,24 +802,5 @@
         }
     }
 
-    export class VoidHistoryManager implements IHistoryManager {
-        addHistory(oldState: State, state: State, url: string) {
-        }
-
-        getCurrentUrl(): string {
-            return null;
-        }
-
-        getHref(url: string): string {
-            if (!url)
-                throw new Error('The Url is invalid');
-            return '#' + url;
-        }
-
-        getUrl(anchor: HTMLAnchorElement) {
-            return anchor.hash.substring(1);
-        }
-    }
-
     export var historyManager: IHistoryManager = new HashHistoryManager();
 }

--- a/NavigationJS/Navigation.ts
+++ b/NavigationJS/Navigation.ts
@@ -736,20 +736,25 @@
     }
 
     export class HashHistoryManager implements IHistoryManager {
-        constructor() {
-            if (window.addEventListener) {
-                window.removeEventListener('hashchange', navigateHistory);
-                window.addEventListener('hashchange', navigateHistory);
-            } else {
-                window.detachEvent('onhashchange', navigateHistory);
-                window.attachEvent('onhashchange', navigateHistory);
+        private disabled: boolean = false;
+
+        constructor(disable?: boolean) {
+            this.disabled = !!disable || (typeof window === 'undefined') || !('onhashchange' in window);
+            if (!this.disabled) {
+                if (window.addEventListener) {
+                    window.removeEventListener('hashchange', navigateHistory);
+                    window.addEventListener('hashchange', navigateHistory);
+                } else {
+                    window.detachEvent('onhashchange', navigateHistory);
+                    window.attachEvent('onhashchange', navigateHistory);
+                }
             }
         }
 
         addHistory(oldState: State, state: State, url: string) {
             if (state.title)
                 document.title = state.title;
-            if (location.hash.substring(1) !== url)
+            if (!this.disabled && location.hash.substring(1) !== url)
                 location.hash = url;
         }
 

--- a/NavigationJS/Navigation.ts
+++ b/NavigationJS/Navigation.ts
@@ -752,7 +752,7 @@
         }
 
         addHistory(oldState: State, state: State, url: string) {
-            if (state.title)
+            if (state.title && (typeof document !== 'undefined'))
                 document.title = state.title;
             if (!this.disabled && location.hash.substring(1) !== url)
                 location.hash = url;
@@ -785,7 +785,7 @@
         }
 
         addHistory(oldState: State, state: State, url: string) {
-            if (state.title)
+            if (state.title && (typeof document !== 'undefined'))
                 document.title = state.title;
             url = settings.applicationPath + url;
             if (!this.disabled && location.pathname + location.search !== url)

--- a/NavigationJS/Navigation.ts
+++ b/NavigationJS/Navigation.ts
@@ -719,10 +719,13 @@
     ConverterFactory.init();
 
     export function start(url?: string) {
+        historyManager.init();
         StateController.navigateLink(url ? url : historyManager.getCurrentUrl());
     }
 
     export interface IHistoryManager {
+        disabled: boolean;
+        init();
         addHistory(oldState: State, state: State, url: string);
         getCurrentUrl(): string;
         getHref(url: string): string;
@@ -736,10 +739,9 @@
     }
 
     export class HashHistoryManager implements IHistoryManager {
-        private disabled: boolean = false;
+        disabled: boolean = (typeof window === 'undefined') || !('onhashchange' in window);
 
-        constructor(disable?: boolean) {
-            this.disabled = !!disable || (typeof window === 'undefined') || !('onhashchange' in window);
+        init() {
             if (!this.disabled) {
                 if (window.addEventListener) {
                     window.removeEventListener('hashchange', navigateHistory);
@@ -774,10 +776,9 @@
     }
 
     export class HTML5HistoryManager implements IHistoryManager {
-        private disabled: boolean = false;
+        disabled: boolean = (typeof window === 'undefined') || !(window.history && window.history.pushState);
 
-        constructor(disable?: boolean) {
-            this.disabled = !!disable || (typeof window === 'undefined') || !(window.history && window.history.pushState);
+        init() {
             if (!this.disabled) {
                 window.removeEventListener('popstate', navigateHistory);
                 window.addEventListener('popstate', navigateHistory);

--- a/NavigationJS/Test/Navigation.Test.ts
+++ b/NavigationJS/Test/Navigation.Test.ts
@@ -14,7 +14,7 @@
         }
     }
 
-    Navigation.historyManager = new Navigation.VoidHistoryManager();
+    Navigation.historyManager = new Navigation.HashHistoryManager(true);
 
     function initStateInfo() {
         Navigation.StateInfoConfig.build([

--- a/NavigationJS/Test/Navigation.Test.ts
+++ b/NavigationJS/Test/Navigation.Test.ts
@@ -14,7 +14,7 @@
         }
     }
 
-    Navigation.historyManager = new Navigation.HashHistoryManager(true);
+    Navigation.historyManager.disabled = true;
 
     function initStateInfo() {
         Navigation.StateInfoConfig.build([


### PR DESCRIPTION
One approach might be to have HTML5 history in modern browsers and fall back to Hash history in old browsers. But having two sources of urls causes problems. What if someone sends a bookmarked url from old browser to someone using a new browser and vice versa?!
Instead, cross broswer history support achieved using progressive enhancement. If using HTML5 history then in an old browser the history isn't added. So the site works but the urls don't change!