### PR TITLE
Added support for ie6-8

### DIFF
--- a/NavigationJS/sample/knockout/app.js
+++ b/NavigationJS/sample/knockout/app.js
@@ -46,7 +46,7 @@ Navigation.StateInfoConfig.build([
 	{ key: 'person', initial: 'list', states: [
 		{ key: 'list', route: '{startRowIndex}/{maximumRows}/{sortExpression}', defaults: { startRowIndex: 0, maximumRows: 10, sortExpression: 'Name'}, trackCrumbTrail: false, title: 'Person Search', transitions: [
 			{ key: 'select', to: 'details' }]},
-		{ key: 'details', route: 'person', title: 'Person Details', }]}
+		{ key: 'details', route: 'person', title: 'Person Details' }]}
 ]);
 ko.applyBindings(new PersonViewModel());
 Navigation.start();

--- a/NavigationJS/sample/personSearch.js
+++ b/NavigationJS/sample/personSearch.js
@@ -11,7 +11,7 @@
 		{ id: 9, name: 'Bridget', dateOfBirth: '25/10/1960' },
 		{ id: 10, name: 'Beth', dateOfBirth: '12/12/1980' },
 		{ id: 11, name: 'Brian', dateOfBirth: '01/06/1970' },
-		{ id: 12, name: 'Bessie', dateOfBirth: '25/10/1960' },
+		{ id: 12, name: 'Bessie', dateOfBirth: '25/10/1960' }
 	];
 
 	function search(name, sortExpression) {

--- a/NavigationJS/src/history/HTML5HistoryManager.ts
+++ b/NavigationJS/src/history/HTML5HistoryManager.ts
@@ -7,10 +7,8 @@ class HTML5HistoryManager implements IHistoryManager {
     disabled: boolean = (typeof window === 'undefined') || !(window.history && window.history.pushState);
 
     init() {
-        if (!this.disabled) {
-            window.removeEventListener('popstate', HistoryNavigator.navigateHistory);
+        if (!this.disabled)
             window.addEventListener('popstate', HistoryNavigator.navigateHistory);
-        }
     }
 
     addHistory(state: State, url: string) {

--- a/NavigationJS/src/history/HashHistoryManager.ts
+++ b/NavigationJS/src/history/HashHistoryManager.ts
@@ -4,6 +4,7 @@ import State = require('../config/State');
 
 class HashHistoryManager implements IHistoryManager {
     disabled: boolean = (typeof window === 'undefined') || !('onhashchange' in window);
+    keepQueryIdentifier: boolean = false;
 
     init() {
         if (!this.disabled) {
@@ -37,10 +38,14 @@ class HashHistoryManager implements IHistoryManager {
     }
 
     private encode(url: string): string {
+        if (this.keepQueryIdentifier)
+            return url;
         return url.replace('?', '#');
     }
 
     private decode(hash: string): string {
+        if (this.keepQueryIdentifier)
+            return hash;
         return hash.replace('#', '?');
     }
 }

--- a/NavigationJS/src/history/HashHistoryManager.ts
+++ b/NavigationJS/src/history/HashHistoryManager.ts
@@ -4,7 +4,7 @@ import State = require('../config/State');
 
 class HashHistoryManager implements IHistoryManager {
     disabled: boolean = (typeof window === 'undefined') || !('onhashchange' in window);
-    keepQueryIdentifier: boolean = false;
+    replaceQueryIdentifier: boolean = false;
 
     init() {
         if (!this.disabled) {
@@ -38,13 +38,13 @@ class HashHistoryManager implements IHistoryManager {
     }
 
     private encode(url: string): string {
-        if (this.keepQueryIdentifier)
+        if (!this.replaceQueryIdentifier)
             return url;
         return url.replace('?', '#');
     }
 
     private decode(hash: string): string {
-        if (this.keepQueryIdentifier)
+        if (!this.replaceQueryIdentifier)
             return hash;
         return hash.replace('#', '?');
     }

--- a/NavigationJS/src/history/HashHistoryManager.ts
+++ b/NavigationJS/src/history/HashHistoryManager.ts
@@ -7,13 +7,10 @@ class HashHistoryManager implements IHistoryManager {
 
     init() {
         if (!this.disabled) {
-            if (window.addEventListener) {
-                window.removeEventListener('hashchange', HistoryNavigator.navigateHistory);
+            if (window.addEventListener)
                 window.addEventListener('hashchange', HistoryNavigator.navigateHistory);
-            } else {
-                window.detachEvent('onhashchange', HistoryNavigator.navigateHistory);
+            else
                 window.attachEvent('onhashchange', HistoryNavigator.navigateHistory);
-            }
         }
     }
 

--- a/NavigationJS/src/history/HashHistoryManager.ts
+++ b/NavigationJS/src/history/HashHistoryManager.ts
@@ -17,22 +17,31 @@ class HashHistoryManager implements IHistoryManager {
     addHistory(state: State, url: string) {
         if (state.title && (typeof document !== 'undefined'))
             document.title = state.title;
+        url = this.encode(url);
         if (!this.disabled && location.hash.substring(1) !== url)
             location.hash = url;
     }
 
     getCurrentUrl(): string {
-        return location.hash.substring(1);
+        return this.decode(location.hash.substring(1));
     }
 
     getHref(url: string): string {
         if (!url)
             throw new Error('The Url is invalid');
-        return '#' + url;
+        return '#' + this.encode(url);
     }
 
     getUrl(anchor: HTMLAnchorElement) {
-        return anchor.hash.substring(1);
+        return this.decode(anchor.hash.substring(1));
+    }
+
+    private encode(url: string): string {
+        return url.replace('?', '#');
+    }
+
+    private decode(hash: string): string {
+        return hash.replace('#', '?');
     }
 }
 export = HashHistoryManager;

--- a/NavigationJS/src/knockout/LinkUtility.ts
+++ b/NavigationJS/src/knockout/LinkUtility.ts
@@ -32,7 +32,10 @@ class LinkUtility {
         var navigate = (e: MouseEvent) => {
             if (!e.ctrlKey && !e.shiftKey) {
                 if (element.href) {
-                    e.preventDefault();
+                    if (e.preventDefault)
+                        e.preventDefault();
+                    else
+                        e['returnValue'] = false;
                     Navigation.StateController.navigateLink(Navigation.historyManager.getUrl(element));
                 }
             }
@@ -40,7 +43,7 @@ class LinkUtility {
         if (window.addEventListener)
             element.addEventListener('click', navigate);
         else
-            element.attachEvent('click', navigate);
+            element.attachEvent('onclick', navigate);
     }
 
     static addNavigateHandler(element, handler) {


### PR DESCRIPTION
* ie6 & 7 don't like ? in the hash (see http://stackoverflow.com/questions/1078501/keeping-history-of-hash-anchor-changes-in-javascript). Added replaceQueryIdentifier property to HashHistoryManager. If set to true the ? is replaced with #. Turned off by default because don't think SPA's realistically run in < ie8
* AttachEvent needs onclick instead of click. 
* ie6,7 & 8 don't have preventDefault. Set returnValue to false. Only changed in knockout plugin because angular and react wrap the event object and normalize preventDefault
* Surplus commas in JavaScript obj/array definitions break ie8

Tested knockout example from gh-pages in BrowserStack