### PR TITLE
Combined Crumb Trail

### DIFF
--- a/NavigationJS/.settings/launch.json
+++ b/NavigationJS/.settings/launch.json
@@ -1,0 +1,38 @@
+{
+	"version": "0.1.0",
+	// List of configurations. Add new configurations or edit existing ones.  
+	// ONLY "node" and "mono" are supported, change "type" to switch.
+	"configurations": [
+		{
+			// Name of configuration; appears in the launch configuration drop down menu.
+			"name": "Launch app.js",
+			// Type of configuration. Possible values: "node", "mono".
+			"type": "node",
+			// Workspace relative or absolute path to the program.
+			"program": "app.js",
+			// Automatically stop program after launch.
+			"stopOnEntry": true,
+			// Command line arguments passed to the program.
+			"args": [],
+			// Workspace relative or absolute path to the working directory of the program being debugged. Default is the current workspace.
+			"cwd": ".",
+			// Workspace relative or absolute path to the runtime executable to be used. Default is the runtime executable on the PATH.
+			"runtimeExecutable": null,
+			// Optional arguments passed to the runtime executable.
+			"runtimeArguments": [],
+			// Environment variables passed to the program.
+			"env": { },
+			// Use JavaScript source maps (if they exist).
+			"sourceMaps": false
+		}, 
+		{
+			"name": "Attach",
+			"type": "node",
+			// TCP/IP address. Default is "localhost".
+			"address": "localhost",
+			// Port to attach to.
+			"port": 5858,
+			"sourceMaps": false
+		}
+	]
+}

--- a/NavigationJS/src/CrumbTrailManager.ts
+++ b/NavigationJS/src/CrumbTrailManager.ts
@@ -14,9 +14,8 @@ class CrumbTrailManager {
 
     static buildCrumbTrail() {
         var crumbs = this.getCrumbs(false);
-        if (StateContext.previousState)
-            crumbs.push(new Crumb(this.returnData, StateContext.previousState, this.getHref(StateContext.previousState, this.returnData, null), false));
         crumbs = StateContext.state.stateHandler.truncateCrumbTrail(StateContext.state, crumbs);
+        crumbs.push(new Crumb(StateContext.data, StateContext.state, this.getHref(StateContext.state, StateContext.data, null), false));
         crumbs.reverse();
         var trailString: string = '';
         for (var i = 0; i < crumbs.length; i++) {
@@ -26,7 +25,7 @@ class CrumbTrailManager {
         this.crumbTrail = trailString ? trailString : null;
     }
 
-    static getCrumbs(setLast: boolean): Array<Crumb> {
+    static getCrumbs(setLast: boolean, skipLatest?: boolean): Array<Crumb> {
         var crumbTrailArray: Array<Crumb> = [];
         var arrayCount = 0;
         var trail = this.crumbTrail;
@@ -41,8 +40,11 @@ class CrumbTrailManager {
                 navigationData = ReturnDataManager.parseReturnData(data, state);
             var nextTrailStart = trail.indexOf(this.CRUMB_1_SEP, 1);
             trail = nextTrailStart != -1 ? trail.substring(nextTrailStart) : '';
-            crumbTrailArray.push(new Crumb(navigationData, state, this.getHref(state, navigationData, null), setLast && last));
-            last = false;
+            if (!skipLatest) {
+                crumbTrailArray.push(new Crumb(navigationData, state, this.getHref(state, navigationData, null), setLast && last));
+                last = false;
+            }
+            skipLatest = false;
             arrayCount++;
         }
         crumbTrailArray.reverse();
@@ -58,19 +60,12 @@ class CrumbTrailManager {
     static getHref(state: State, navigationData: any, returnData: any): string {
         var data = {};
         data[settings.stateIdKey] = state.id;
-        if (state.trackCrumbTrail && StateContext.state)
-            data[settings.previousStateIdKey] = StateContext.state.id;
         navigationData = NavigationData.clone(navigationData);
         NavigationData.setDefaults(navigationData, state.defaults);
         for (var key in navigationData) {
             if (navigationData[key] != null && navigationData[key].toString()
                 && (!settings.router.supportsDefaults || navigationData[key] !== state.defaults[key]))
                 data[key] = ReturnDataManager.formatURLObject(key, navigationData[key], state);
-        }
-        if (state.trackCrumbTrail && StateContext.state) {
-            var returnDataString = ReturnDataManager.formatReturnData(StateContext.state, returnData);
-            if (returnDataString)
-                data[settings.returnDataKey] = returnDataString;
         }
         if (this.crumbTrail && state.trackCrumbTrail)
             data[settings.crumbTrailKey] = this.crumbTrail;

--- a/NavigationJS/src/CrumbTrailManager.ts
+++ b/NavigationJS/src/CrumbTrailManager.ts
@@ -76,7 +76,7 @@ class CrumbTrailManager {
             var returnDataString = ReturnDataManager.formatReturnData(StateContext.state, returnData);
             if (returnDataString)
                 data[settings.returnDataKey] = returnDataString;
-        }        
+        }
         if (this.crumbTrail && state.trackCrumbTrail)
             data[settings.crumbTrailKey] = this.crumbTrail;
         return state.stateHandler.getNavigationLink(state, data);

--- a/NavigationJS/src/CrumbTrailManager.ts
+++ b/NavigationJS/src/CrumbTrailManager.ts
@@ -14,8 +14,11 @@ class CrumbTrailManager {
 
     static buildCrumbTrail() {
         var crumbs = this.getCrumbs(false);
+        if (!settings.combineCrumbTrail && StateContext.previousState)
+            crumbs.push(new Crumb(this.returnData, StateContext.previousState, this.getHref(StateContext.previousState, this.returnData, null), false));        
         crumbs = StateContext.state.stateHandler.truncateCrumbTrail(StateContext.state, crumbs);
-        crumbs.push(new Crumb(StateContext.data, StateContext.state, this.getHref(StateContext.state, StateContext.data, null), false));
+        if (settings.combineCrumbTrail)
+            crumbs.push(new Crumb(StateContext.data, StateContext.state, this.getHref(StateContext.state, StateContext.data, null), false));
         crumbs.reverse();
         var trailString: string = '';
         for (var i = 0; i < crumbs.length; i++) {
@@ -60,6 +63,8 @@ class CrumbTrailManager {
     static getHref(state: State, navigationData: any, returnData: any): string {
         var data = {};
         data[settings.stateIdKey] = state.id;
+        if (!settings.combineCrumbTrail && state.trackCrumbTrail && StateContext.state)
+            data[settings.previousStateIdKey] = StateContext.state.id;
         navigationData = NavigationData.clone(navigationData);
         NavigationData.setDefaults(navigationData, state.defaults);
         for (var key in navigationData) {
@@ -67,6 +72,11 @@ class CrumbTrailManager {
                 && (!settings.router.supportsDefaults || navigationData[key] !== state.defaults[key]))
                 data[key] = ReturnDataManager.formatURLObject(key, navigationData[key], state);
         }
+        if (!settings.combineCrumbTrail && state.trackCrumbTrail && StateContext.state) {
+            var returnDataString = ReturnDataManager.formatReturnData(StateContext.state, returnData);
+            if (returnDataString)
+                data[settings.returnDataKey] = returnDataString;
+        }        
         if (this.crumbTrail && state.trackCrumbTrail)
             data[settings.crumbTrailKey] = this.crumbTrail;
         return state.stateHandler.getNavigationLink(state, data);

--- a/NavigationJS/src/NavigationSettings.ts
+++ b/NavigationJS/src/NavigationSettings.ts
@@ -11,5 +11,6 @@ class NavigationSettings {
     returnDataKey: string = 'c2';
     crumbTrailKey: string = 'c3';
     applicationPath: string = '';
+    combineCrumbTrail: boolean = false;
 }
 export = NavigationSettings;

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -29,8 +29,14 @@ class StateController {
                 CrumbTrailManager.returnData = ReturnDataManager.parseReturnData(data[settings.returnDataKey], StateContext.previousState);
             CrumbTrailManager.crumbTrail = data[settings.crumbTrailKey];
             StateContext.data = this.parseData(data, state);
+            var previousCrumb = CrumbTrailManager.getCrumbs(false).pop();
+            if (previousCrumb){
+                StateContext.previousState = previousCrumb.state;
+                StateContext.previousDialog = StateContext.previousState.parent;
+                CrumbTrailManager.returnData = previousCrumb.data;
+            }
             CrumbTrailManager.buildCrumbTrail();
-            this.crumbs = CrumbTrailManager.getCrumbs(true);
+            this.crumbs = CrumbTrailManager.getCrumbs(true, true);
         } catch (e) {
             throw new Error('The Url is invalid\n' + e.message);
         }

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -21,6 +21,10 @@ class StateController {
             StateContext.dialog = state.parent;
             var data = state.stateHandler.getNavigationData(state, url);
             StateContext.data = this.parseData(data, state);
+            StateContext.previousState = null;
+            StateContext.previousDialog = null;
+            CrumbTrailManager.returnData = {};
+            CrumbTrailManager.crumbTrail = data[settings.crumbTrailKey];
             this.setPreviousStateContext(data);
             CrumbTrailManager.buildCrumbTrail();
             this.crumbs = CrumbTrailManager.getCrumbs(true, settings.combineCrumbTrail);
@@ -30,10 +34,6 @@ class StateController {
     }
     
     private static setPreviousStateContext(data: any){
-        CrumbTrailManager.returnData = {};
-        StateContext.previousState = null;
-        StateContext.previousDialog = null;
-        CrumbTrailManager.crumbTrail = data[settings.crumbTrailKey];
         if (!settings.combineCrumbTrail){
             StateContext.previousState = CrumbTrailManager.getState(data[settings.previousStateIdKey]);
             if (StateContext.previousState)

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -41,11 +41,11 @@ class StateController {
             if (data[settings.returnDataKey])
                 CrumbTrailManager.returnData = ReturnDataManager.parseReturnData(data[settings.returnDataKey], StateContext.previousState);
         } else {
-            var previousCrumb = CrumbTrailManager.getCrumbs(false).pop();
-            if (previousCrumb){
-                StateContext.previousState = previousCrumb.state;
+            var previousStateCrumb = CrumbTrailManager.getCrumbs(false).pop();
+            if (previousStateCrumb){
+                StateContext.previousState = previousStateCrumb.state;
                 StateContext.previousDialog = StateContext.previousState.parent;
-                CrumbTrailManager.returnData = previousCrumb.data;
+                CrumbTrailManager.returnData = previousStateCrumb.data;
             }
         }
     }

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -23,7 +23,7 @@ class StateController {
             StateContext.data = this.parseData(data, state);
             this.setPreviousStateContext(data);
             CrumbTrailManager.buildCrumbTrail();
-            this.crumbs = CrumbTrailManager.getCrumbs(true, true);
+            this.crumbs = CrumbTrailManager.getCrumbs(true, settings.combineCrumbTrail);
         } catch (e) {
             throw new Error('The Url is invalid\n' + e.message);
         }
@@ -33,17 +33,20 @@ class StateController {
         CrumbTrailManager.returnData = {};
         StateContext.previousState = null;
         StateContext.previousDialog = null;
-        StateContext.previousState = CrumbTrailManager.getState(data[settings.previousStateIdKey]);
-        if (StateContext.previousState)
-            StateContext.previousDialog = StateContext.previousState.parent;
-        if (data[settings.returnDataKey])
-            CrumbTrailManager.returnData = ReturnDataManager.parseReturnData(data[settings.returnDataKey], StateContext.previousState);
         CrumbTrailManager.crumbTrail = data[settings.crumbTrailKey];
-        var previousCrumb = CrumbTrailManager.getCrumbs(false).pop();
-        if (previousCrumb){
-            StateContext.previousState = previousCrumb.state;
-            StateContext.previousDialog = StateContext.previousState.parent;
-            CrumbTrailManager.returnData = previousCrumb.data;
+        if (!settings.combineCrumbTrail){
+            StateContext.previousState = CrumbTrailManager.getState(data[settings.previousStateIdKey]);
+            if (StateContext.previousState)
+                StateContext.previousDialog = StateContext.previousState.parent;
+            if (data[settings.returnDataKey])
+                CrumbTrailManager.returnData = ReturnDataManager.parseReturnData(data[settings.returnDataKey], StateContext.previousState);
+        } else {
+            var previousCrumb = CrumbTrailManager.getCrumbs(false).pop();
+            if (previousCrumb){
+                StateContext.previousState = previousCrumb.state;
+                StateContext.previousDialog = StateContext.previousState.parent;
+                CrumbTrailManager.returnData = previousCrumb.data;
+            }
         }
     }
 

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -20,25 +20,30 @@ class StateController {
             StateContext.url = url;
             StateContext.dialog = state.parent;
             var data = state.stateHandler.getNavigationData(state, url);
-            StateContext.previousState = CrumbTrailManager.getState(data[settings.previousStateIdKey]);
-            StateContext.previousDialog = null;
-            if (StateContext.previousState)
-                StateContext.previousDialog = StateContext.previousState.parent;
-            CrumbTrailManager.returnData = {};
-            if (data[settings.returnDataKey])
-                CrumbTrailManager.returnData = ReturnDataManager.parseReturnData(data[settings.returnDataKey], StateContext.previousState);
-            CrumbTrailManager.crumbTrail = data[settings.crumbTrailKey];
             StateContext.data = this.parseData(data, state);
-            var previousCrumb = CrumbTrailManager.getCrumbs(false).pop();
-            if (previousCrumb){
-                StateContext.previousState = previousCrumb.state;
-                StateContext.previousDialog = StateContext.previousState.parent;
-                CrumbTrailManager.returnData = previousCrumb.data;
-            }
+            this.setPreviousStateContext(data);
             CrumbTrailManager.buildCrumbTrail();
             this.crumbs = CrumbTrailManager.getCrumbs(true, true);
         } catch (e) {
             throw new Error('The Url is invalid\n' + e.message);
+        }
+    }
+    
+    private static setPreviousStateContext(data: any){
+        CrumbTrailManager.returnData = {};
+        StateContext.previousState = null;
+        StateContext.previousDialog = null;
+        StateContext.previousState = CrumbTrailManager.getState(data[settings.previousStateIdKey]);
+        if (StateContext.previousState)
+            StateContext.previousDialog = StateContext.previousState.parent;
+        if (data[settings.returnDataKey])
+            CrumbTrailManager.returnData = ReturnDataManager.parseReturnData(data[settings.returnDataKey], StateContext.previousState);
+        CrumbTrailManager.crumbTrail = data[settings.crumbTrailKey];
+        var previousCrumb = CrumbTrailManager.getCrumbs(false).pop();
+        if (previousCrumb){
+            StateContext.previousState = previousCrumb.state;
+            StateContext.previousDialog = StateContext.previousState.parent;
+            CrumbTrailManager.returnData = previousCrumb.data;
         }
     }
 

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -469,7 +469,6 @@ declare module Navigation {
          * ReturnData should be part of the CrumbTrail
          */
         combineCrumbTrail: boolean;
-        
     }
 
     /**

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -464,6 +464,12 @@ declare module Navigation {
          * Gets or sets the application path
          */
         applicationPath: string;
+        /**
+         * Gets or sets a value indicating whether the PreviousStateId and
+         * ReturnData should be part of the CrumbTrail
+         */
+        combineCrumbTrail: boolean;
+        
     }
 
     /**

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -148,8 +148,9 @@ describe('NavigationDataTest', function () {
 
     it('InvalidArrayDataTest', function () {
         Navigation.StateController.navigate('d0');
-        Navigation.StateContext.data['item'] = [new Date()];
-        assert.throws(() => Navigation.StateController.navigate('t0'));
+        var data = {}
+        data['item'] = [new Date()];
+        assert.throws(() => Navigation.StateController.navigate('t0', data));
     });
 
     it('InvalidDataGetNavigationLinkTest', function () {
@@ -372,6 +373,7 @@ describe('NavigationDataTest', function () {
         Navigation.StateController.navigate('d0');
         Navigation.StateContext.data['s'] = '';
         Navigation.StateContext.data['t'] = '1';
+        Navigation.StateController.refresh(Navigation.StateContext.includeCurrentData({}))
         Navigation.StateController.navigate('t0');
         Navigation.StateController.navigateBack(1);
         assert.strictEqual(Navigation.StateContext.data['s'], undefined);
@@ -383,6 +385,8 @@ describe('NavigationDataTest', function () {
         Navigation.StateController.navigateLink(link);
         Navigation.StateContext.data['s'] = '';
         Navigation.StateContext.data['t'] = '1';
+        link = Navigation.StateController.getRefreshLink(Navigation.StateContext.includeCurrentData({}));
+        Navigation.StateController.navigateLink(link);
         link = Navigation.StateController.getNavigationLink('t0');
         Navigation.StateController.navigateLink(link);
         link = Navigation.StateController.getNavigationBackLink(1);
@@ -426,6 +430,7 @@ describe('NavigationDataTest', function () {
         Navigation.StateController.navigate('d0', data);
         Navigation.StateContext.data['s'] = 'World';
         Navigation.StateContext.data['i'] = 2;
+        Navigation.StateController.refresh(Navigation.StateContext.includeCurrentData({}))
         Navigation.StateController.navigate('t0');
         assert.strictEqual(Navigation.StateController.crumbs[0].data['s'], 'World');
         assert.strictEqual(Navigation.StateController.crumbs[0].data['i'], 2);
@@ -441,6 +446,8 @@ describe('NavigationDataTest', function () {
         Navigation.StateController.navigateLink(link);
         Navigation.StateContext.data['s'] = 'World';
         Navigation.StateContext.data['i'] = 2;
+        link = Navigation.StateController.getRefreshLink(Navigation.StateContext.includeCurrentData({}));
+        Navigation.StateController.navigateLink(link);
         link = Navigation.StateController.getNavigationLink('t0');
         Navigation.StateController.navigateLink(link);
         assert.strictEqual(Navigation.StateController.crumbs[0].data['s'], 'World');
@@ -457,6 +464,7 @@ describe('NavigationDataTest', function () {
         Navigation.StateController.navigate('d0', data);
         Navigation.StateContext.data['s'] = null;
         Navigation.StateContext.data['i'] = 2;
+        Navigation.StateController.refresh(Navigation.StateContext.includeCurrentData({}))
         Navigation.StateController.navigate('t0');
         assert.strictEqual(Navigation.StateController.crumbs[0].data['s'], undefined);
         assert.strictEqual(Navigation.StateController.crumbs[0].data['i'], 2);
@@ -472,6 +480,8 @@ describe('NavigationDataTest', function () {
         Navigation.StateController.navigateLink(link);
         Navigation.StateContext.data['s'] = null;
         Navigation.StateContext.data['i'] = 2;
+        link = Navigation.StateController.getRefreshLink(Navigation.StateContext.includeCurrentData({}));
+        Navigation.StateController.navigateLink(link);
         link = Navigation.StateController.getNavigationLink('t0');
         Navigation.StateController.navigateLink(link);
         assert.strictEqual(Navigation.StateController.crumbs[0].data['s'], undefined);
@@ -487,6 +497,7 @@ describe('NavigationDataTest', function () {
         data['s'] = 'Hello';
         Navigation.StateController.navigate('d0', data);
         Navigation.StateContext.clear();
+        Navigation.StateController.refresh(Navigation.StateContext.includeCurrentData({}))
         Navigation.StateController.navigate('t0');
         assert.strictEqual(Navigation.StateController.crumbs[0].data['s'], undefined);
         assert.strictEqual(Navigation.StateController.crumbs[0].data['i'], undefined);
@@ -501,6 +512,8 @@ describe('NavigationDataTest', function () {
         var link = Navigation.StateController.getNavigationLink('d0', data);
         Navigation.StateController.navigateLink(link);
         Navigation.StateContext.clear();
+        link = Navigation.StateController.getRefreshLink(Navigation.StateContext.includeCurrentData({}));
+        Navigation.StateController.navigateLink(link);
         link = Navigation.StateController.getNavigationLink('t0');
         Navigation.StateController.navigateLink(link);
         assert.strictEqual(Navigation.StateController.crumbs[0].data['s'], undefined);
@@ -517,6 +530,7 @@ describe('NavigationDataTest', function () {
         Navigation.StateController.navigate('d0', data);
         Navigation.StateContext.clear('s');
         Navigation.StateContext.data['i'] = 2;
+        Navigation.StateController.refresh(Navigation.StateContext.includeCurrentData({}))
         Navigation.StateController.navigate('t0');
         assert.strictEqual(Navigation.StateController.crumbs[0].data['s'], undefined);
         assert.strictEqual(Navigation.StateController.crumbs[0].data['i'], 2);
@@ -532,6 +546,8 @@ describe('NavigationDataTest', function () {
         Navigation.StateController.navigateLink(link);
         Navigation.StateContext.clear('s');
         Navigation.StateContext.data['i'] = 2;
+        link = Navigation.StateController.getRefreshLink(Navigation.StateContext.includeCurrentData({}));
+        Navigation.StateController.navigateLink(link);
         link = Navigation.StateController.getNavigationLink('t0');
         Navigation.StateController.navigateLink(link);
         assert.strictEqual(Navigation.StateController.crumbs[0].data['s'], undefined);
@@ -883,6 +899,7 @@ describe('NavigationDataTest', function () {
         Navigation.StateController.navigate('d0', data);
         assert.strictEqual(Navigation.StateContext.data['s'], 1);
         Navigation.StateContext.data['s'] = 11;
+        Navigation.StateController.refresh(Navigation.StateContext.includeCurrentData({}))
         assert.strictEqual(Navigation.StateContext.data['t'], undefined);
         data['s'] = 2;
         data['t'] = '2';
@@ -892,6 +909,7 @@ describe('NavigationDataTest', function () {
         assert.strictEqual(Navigation.StateContext.data['s'], 2);
         assert.strictEqual(Navigation.StateContext.data['t'], '2');
         Navigation.StateContext.data['s'] = '22';
+        Navigation.StateController.refresh(Navigation.StateContext.includeCurrentData({}))
         data['s'] = 3;
         data['t'] = '3';
         Navigation.StateController.navigate('t1', data);
@@ -910,6 +928,8 @@ describe('NavigationDataTest', function () {
         Navigation.StateController.navigateLink(link);
         assert.strictEqual(Navigation.StateContext.data['s'], 1);
         Navigation.StateContext.data['s'] = 11;
+        link = Navigation.StateController.getRefreshLink(Navigation.StateContext.includeCurrentData({}));
+        Navigation.StateController.navigateLink(link);
         assert.strictEqual(Navigation.StateContext.data['t'], undefined);
         data['s'] = 2;
         data['t'] = '2';
@@ -920,6 +940,8 @@ describe('NavigationDataTest', function () {
         assert.strictEqual(Navigation.StateContext.data['s'], 2);
         assert.strictEqual(Navigation.StateContext.data['t'], '2');
         Navigation.StateContext.data['s'] = '22';
+        link = Navigation.StateController.getRefreshLink(Navigation.StateContext.includeCurrentData({}));
+        Navigation.StateController.navigateLink(link);
         data['s'] = 3;
         data['t'] = '3';
         link = Navigation.StateController.getNavigationLink('t1', data);
@@ -2330,6 +2352,7 @@ describe('NavigationDataTest', function () {
         Navigation.StateContext.data['emptyString'] = 1;
         Navigation.StateContext.data['number'] = 4;
         Navigation.StateContext.data['char'] = null;
+        Navigation.StateController.refresh(Navigation.StateContext.includeCurrentData({}))
         var link = Navigation.StateController.getNavigationLink('t0');
         assert.equal(link.indexOf('number'), -1);
         assert.equal(link.indexOf('char'), -1);
@@ -2343,6 +2366,8 @@ describe('NavigationDataTest', function () {
         Navigation.StateContext.data['emptyString'] = 1;
         Navigation.StateContext.data['number'] = 4;
         Navigation.StateContext.data['char'] = null;
+        link = Navigation.StateController.getRefreshLink(Navigation.StateContext.includeCurrentData({}));
+        Navigation.StateController.navigateLink(link);
         var link = Navigation.StateController.getNavigationLink('t0');
         assert.equal(link.indexOf('number'), -1);
         assert.equal(link.indexOf('char'), -1);
@@ -2367,6 +2392,7 @@ describe('NavigationDataTest', function () {
         Navigation.StateContext.data['_bool'] = null;
         Navigation.StateContext.data['string'] = 'Hello';
         Navigation.StateContext.data['number'] = 0;
+        Navigation.StateController.refresh(Navigation.StateContext.includeCurrentData({}))
         Navigation.StateController.navigate('t0');
         var link = Navigation.StateController.getNavigationBackLink(1);
         assert.equal(link.indexOf('string'), -1);
@@ -2380,6 +2406,7 @@ describe('NavigationDataTest', function () {
         Navigation.StateContext.data['number'] = 1;
         Navigation.StateContext.data['_bool'] = '';
         Navigation.StateContext.data['string'] = 4;
+        Navigation.StateController.refresh(Navigation.StateContext.includeCurrentData({}))
         Navigation.StateController.navigate('t0');
         var link = Navigation.StateController.crumbs[1].navigationLink;
         assert.equal(link.indexOf('_bool'), -1);
@@ -2391,8 +2418,8 @@ describe('NavigationDataTest', function () {
         Navigation.StateController.navigate('d2');
         Navigation.StateContext.data['_number'] = 1;
         Navigation.StateContext.data['string'] = 'Hello';
+        Navigation.StateController.refresh(Navigation.StateContext.includeCurrentData({}))
         var link = Navigation.StateController.getNavigationLink('t0');
-        assert.notEqual(link.indexOf('c1'), -1);
         assert.notEqual(link.indexOf('_number'), -1);
         assert.notEqual(link.indexOf('string'), -1);
     });


### PR DESCRIPTION
Stored the Previous State and Return Data in the Crumb Trail, making a single QueryString parameter for all crumb trail tracking. Couldn't do this with .NET version because it's not until the render stage to that all the current data's been set. So the Return Data can't be determined when the crumb trail's built on the server. On the client, refresh navigation is used to change data rather than setting StateContext data directly. That the Navigation Links only update onNavigate means already tacitly assumed this behaviour.
Couldn't make this the default because it would be a breaking change. Instead, added a combineCrumbTrail Navigation setting. All set for bringing back the CrumbTrailPersister, which should set combineCrumbTrail to true.