### PR TITLE
Added Pre-Navigation State Hook

### DIFF
--- a/NavigationJS/src/Navigation.ts
+++ b/NavigationJS/src/Navigation.ts
@@ -43,6 +43,6 @@ class Navigation {
 HistoryNavigator.navigateHistory = () => {
     if (StateContext.url === settings.historyManager.getCurrentUrl())
         return;
-    StateController.navigateLink(settings.historyManager.getCurrentUrl());
+    StateController.navigateLink(settings.historyManager.getCurrentUrl(), true);
 }
 export = Navigation;

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -122,7 +122,7 @@ class StateController {
         } catch (e) {
             throw new Error('The Url is invalid\n' + e.message);
         }
-        state.navigating(data, url, () => {
+        var navigate =  () => {
             if (oldUrl === StateContext.url) {
                 state.stateHandler.navigateLink(oldState, state, url);
                 StateController.setStateContext(state, url);
@@ -137,6 +137,10 @@ class StateController {
                     settings.historyManager.addHistory(state, url);
                 }
             }
+        };
+        state.unloading(url, () => {
+            if (oldUrl === StateContext.url)
+                state.navigating(data, url, navigate);
         });
     }
 

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -145,9 +145,8 @@ class StateController {
                     if (url === StateContext.url)
                         this.navigateHandlers[id](oldState, state, StateContext.data);
                 }
-                if (url === StateContext.url) {
+                if (url === StateContext.url)
                     settings.historyManager.addHistory(state, url);
-                }
             }
         };
     }

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -104,7 +104,7 @@ class StateController {
         return CrumbTrailManager.getRefreshHref(toData);
     }
 
-    static navigateLink(url: string) {
+    static navigateLink(url: string, history?: boolean) {
         try {
             var state = settings.router.getData(url.split('?')[0]).state;
         } catch (e) {

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -122,7 +122,19 @@ class StateController {
         } catch (e) {
             throw new Error('The Url is invalid\n' + e.message);
         }
-        var navigate =  () => {
+        var navigateContinuation =  this.getNavigateContinuation(oldState, oldUrl, state, url);
+        if (oldState){
+            oldState.unloading(state, url, () => {
+                if (oldUrl === StateContext.url)
+                    state.navigating(data, url, navigateContinuation);
+            });
+        } else {
+            state.navigating(data, url, navigateContinuation);
+        }
+    }
+    
+    private static getNavigateContinuation(oldState: State, oldUrl: string, state: State, url: string): () => void {
+        return () => {
             if (oldUrl === StateContext.url) {
                 state.stateHandler.navigateLink(oldState, state, url);
                 StateController.setStateContext(state, url);
@@ -138,14 +150,6 @@ class StateController {
                 }
             }
         };
-        if (oldState){
-            oldState.unloading(state, url, () => {
-                if (oldUrl === StateContext.url)
-                    state.navigating(data, url, navigate);
-            });
-        } else {
-            state.navigating(data, url, navigate);
-        }
     }
 
     private static parseData(data: any, state: State): any {

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -138,7 +138,7 @@ class StateController {
                 }
             }
         };
-        state.unloading(url, () => {
+        oldState.unloading(url, () => {
             if (oldUrl === StateContext.url)
                 state.navigating(data, url, navigate);
         });

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -138,10 +138,14 @@ class StateController {
                 }
             }
         };
-        oldState.unloading(state, url, () => {
-            if (oldUrl === StateContext.url)
-                state.navigating(data, url, navigate);
-        });
+        if (oldState){
+            oldState.unloading(state, url, () => {
+                if (oldUrl === StateContext.url)
+                    state.navigating(data, url, navigate);
+            });
+        } else {
+            state.navigating(data, url, navigate);
+        }
     }
 
     private static parseData(data: any, state: State): any {

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -110,10 +110,10 @@ class StateController {
         } catch (e) {
             throw new Error('The Url is invalid\n' + e.message);
         }
-        this._navigateLink(url, state);
+        this._navigateLink(url, state, history);
     }
 
-    private static _navigateLink(url: string, state: State) {
+    private static _navigateLink(url: string, state: State, history?: boolean) {
         try {
             var oldUrl = StateContext.url;
             var oldState = StateContext.state;
@@ -126,10 +126,10 @@ class StateController {
         if (oldState){
             oldState.unloading(state, data, url, () => {
                 if (oldUrl === StateContext.url)
-                    state.navigating(data, url, navigateContinuation);
-            });
+                    state.navigating(data, url, navigateContinuation, history);
+            }, history);
         } else {
-            state.navigating(data, url, navigateContinuation);
+            state.navigating(data, url, navigateContinuation, history);
         }
     }
     

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -125,12 +125,12 @@ class StateController {
         var navigateContinuation =  this.getNavigateContinuation(oldState, oldUrl, state, url);
         var unloadContinuation = () => {
             if (oldUrl === StateContext.url)
-                state.navigating(data, url, navigateContinuation, history);
+                state.navigating(data, url, navigateContinuation, !!history);
         };
         if (oldState)
-            oldState.unloading(state, data, url, unloadContinuation, history);
+            oldState.unloading(state, data, url, unloadContinuation, !!history);
         else
-            state.navigating(data, url, navigateContinuation, history);
+            state.navigating(data, url, navigateContinuation, !!history);
     }
     
     private static getNavigateContinuation(oldState: State, oldUrl: string, state: State, url: string): () => void {

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -138,7 +138,7 @@ class StateController {
                 }
             }
         };
-        oldState.unloading(url, () => {
+        oldState.unloading(state, url, () => {
             if (oldUrl === StateContext.url)
                 state.navigating(data, url, navigate);
         });

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -123,7 +123,7 @@ class StateController {
             throw new Error('The Url is invalid\n' + e.message);
         }
         var navigateContinuation =  this.getNavigateContinuation(oldState, oldUrl, state, url);
-        if (oldState){
+        if (oldState) {
             oldState.unloading(state, data, url, () => {
                 if (oldUrl === StateContext.url)
                     state.navigating(data, url, navigateContinuation, history);

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -123,12 +123,12 @@ class StateController {
             throw new Error('The Url is invalid\n' + e.message);
         }
         var navigateContinuation =  this.getNavigateContinuation(oldState, oldUrl, state, url);
-        var unloadingContinuation = () => {
+        var unloadContinuation = () => {
             if (oldUrl === StateContext.url)
                 state.navigating(data, url, navigateContinuation, history);
         };
         if (oldState)
-            oldState.unloading(state, data, url, unloadingContinuation, history);
+            oldState.unloading(state, data, url, unloadContinuation, history);
         else
             state.navigating(data, url, navigateContinuation, history);
     }

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -124,7 +124,7 @@ class StateController {
         }
         var navigateContinuation =  this.getNavigateContinuation(oldState, oldUrl, state, url);
         if (oldState){
-            oldState.unloading(state, url, () => {
+            oldState.unloading(state, data, url, () => {
                 if (oldUrl === StateContext.url)
                     state.navigating(data, url, navigateContinuation);
             });

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -123,14 +123,14 @@ class StateController {
             throw new Error('The Url is invalid\n' + e.message);
         }
         var navigateContinuation =  this.getNavigateContinuation(oldState, oldUrl, state, url);
-        if (oldState) {
-            oldState.unloading(state, data, url, () => {
-                if (oldUrl === StateContext.url)
-                    state.navigating(data, url, navigateContinuation, history);
-            }, history);
-        } else {
+        var unloadingContinuation = () => {
+            if (oldUrl === StateContext.url)
+                state.navigating(data, url, navigateContinuation, history);
+        };
+        if (oldState)
+            oldState.unloading(state, data, url, unloadingContinuation, history);
+        else
             state.navigating(data, url, navigateContinuation, history);
-        }
     }
     
     private static getNavigateContinuation(oldState: State, oldUrl: string, state: State, url: string): () => void {

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -124,7 +124,7 @@ class StateController {
         }
         var navigateContinuation =  this.getNavigateContinuation(oldState, oldUrl, state, url);
         if (oldState) {
-            oldState.unloading(state, url, () => {
+            oldState.unloading(state, data, url, () => {
                 if (oldUrl === StateContext.url)
                     state.navigating(data, url, navigateContinuation, history);
             }, history);

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -124,7 +124,7 @@ class StateController {
         }
         var navigateContinuation =  this.getNavigateContinuation(oldState, oldUrl, state, url);
         if (oldState) {
-            oldState.unloading(state, data, url, () => {
+            oldState.unloading(state, url, () => {
                 if (oldUrl === StateContext.url)
                     state.navigating(data, url, navigateContinuation, history);
             }, history);

--- a/NavigationJS/src/config/State.ts
+++ b/NavigationJS/src/config/State.ts
@@ -18,8 +18,8 @@ class State implements IState<{ [index: string]: Transition }> {
     route: string;
     trackCrumbTrail: boolean = true;
     stateHandler: IStateHandler = new StateHandler();
-    unloading: (state: State, data: any, url: string, unload: () => void) => void = function (state, data, url, unload) { unload(); };
-    navigating: (data: any, url: string, navigate: () => void) => void = function (data, url, navigate) { navigate(); };
+    unloading: (state: State, data: any, url: string, unload: () => void, history: boolean) => void = function (state, data, url, unload, history) { unload(); };
+    navigating: (data: any, url: string, navigate: () => void, history: boolean) => void = function (data, url, navigate, history) { navigate(); };
     dispose: () => void = function () { };
     navigated: (data: any) => void = function (data: any) { };
 }

--- a/NavigationJS/src/config/State.ts
+++ b/NavigationJS/src/config/State.ts
@@ -18,7 +18,7 @@ class State implements IState<{ [index: string]: Transition }> {
     route: string;
     trackCrumbTrail: boolean = true;
     stateHandler: IStateHandler = new StateHandler();
-    unloading: (state: State, data: any, url: string, unload: () => void, history?: boolean) => void = function (state, data, url, unload) { unload(); };
+    unloading: (state: State, url: string, unload: () => void, history?: boolean) => void = function (state, url, unload) { unload(); };
     navigating: (data: any, url: string, navigate: () => void, history?: boolean) => void = function (data, url, navigate) { navigate(); };
     dispose: () => void = function () { };
     navigated: (data: any) => void = function (data: any) { };

--- a/NavigationJS/src/config/State.ts
+++ b/NavigationJS/src/config/State.ts
@@ -18,10 +18,8 @@ class State implements IState<{ [index: string]: Transition }> {
     route: string;
     trackCrumbTrail: boolean = true;
     stateHandler: IStateHandler = new StateHandler();
-    unloading: (state: State, data: any, url: string, unload: () => void, history: boolean) => void 
-        = function (state, data, url, unload, history) { unload(); };
-    navigating: (data: any, url: string, navigate: () => void, history: boolean) => void 
-        = function (data, url, navigate, history) { navigate(); };
+    unloading: (state: State, data: any, url: string, unload: () => void, history?: boolean) => void = function (state, data, url, unload) { unload(); };
+    navigating: (data: any, url: string, navigate: () => void, history?: boolean) => void = function (data, url, navigate) { navigate(); };
     dispose: () => void = function () { };
     navigated: (data: any) => void = function (data: any) { };
 }

--- a/NavigationJS/src/config/State.ts
+++ b/NavigationJS/src/config/State.ts
@@ -18,7 +18,7 @@ class State implements IState<{ [index: string]: Transition }> {
     route: string;
     trackCrumbTrail: boolean = true;
     stateHandler: IStateHandler = new StateHandler();
-    unloading: (state: State, url: string, unload: () => void, history?: boolean) => void = function (state, url, unload) { unload(); };
+    unloading: (state: State, data: any, url: string, unload: () => void, history?: boolean) => void = function (state, data, url, unload) { unload(); };
     navigating: (data: any, url: string, navigate: () => void, history?: boolean) => void = function (data, url, navigate) { navigate(); };
     dispose: () => void = function () { };
     navigated: (data: any) => void = function (data: any) { };

--- a/NavigationJS/src/config/State.ts
+++ b/NavigationJS/src/config/State.ts
@@ -18,7 +18,7 @@ class State implements IState<{ [index: string]: Transition }> {
     route: string;
     trackCrumbTrail: boolean = true;
     stateHandler: IStateHandler = new StateHandler();
-    unloading: (state: State, url: string, unload: () => void) => void = function (state, url, unload) { unload(); };
+    unloading: (state: State, data: any, url: string, unload: () => void) => void = function (state, data, url, unload) { unload(); };
     navigating: (data: any, url: string, navigate: () => void) => void = function (data, url, navigate) { navigate(); };
     dispose: () => void = function () { };
     navigated: (data: any) => void = function (data: any) { };

--- a/NavigationJS/src/config/State.ts
+++ b/NavigationJS/src/config/State.ts
@@ -18,8 +18,9 @@ class State implements IState<{ [index: string]: Transition }> {
     route: string;
     trackCrumbTrail: boolean = true;
     stateHandler: IStateHandler = new StateHandler();
+    unloading: (url: string, unload: () => void) => void = function (url, unload) { unload(); };
+    navigating: (data: any, url: string, navigate: () => void) => void = function (data, url, navigate) { navigate(); };
     dispose: () => void = function () { };
     navigated: (data: any) => void = function (data: any) { };
-    navigating: (data: any, url: string, navigate: () => void) => void = function (data, url, navigate) { navigate(); };
 }
 export = State;

--- a/NavigationJS/src/config/State.ts
+++ b/NavigationJS/src/config/State.ts
@@ -18,8 +18,10 @@ class State implements IState<{ [index: string]: Transition }> {
     route: string;
     trackCrumbTrail: boolean = true;
     stateHandler: IStateHandler = new StateHandler();
-    unloading: (state: State, data: any, url: string, unload: () => void, history: boolean) => void = function (state, data, url, unload, history) { unload(); };
-    navigating: (data: any, url: string, navigate: () => void, history: boolean) => void = function (data, url, navigate, history) { navigate(); };
+    unloading: (state: State, data: any, url: string, unload: () => void, history: boolean) => void 
+        = function (state, data, url, unload, history) { unload(); };
+    navigating: (data: any, url: string, navigate: () => void, history: boolean) => void 
+        = function (data, url, navigate, history) { navigate(); };
     dispose: () => void = function () { };
     navigated: (data: any) => void = function (data: any) { };
 }

--- a/NavigationJS/src/config/State.ts
+++ b/NavigationJS/src/config/State.ts
@@ -18,7 +18,7 @@ class State implements IState<{ [index: string]: Transition }> {
     route: string;
     trackCrumbTrail: boolean = true;
     stateHandler: IStateHandler = new StateHandler();
-    unloading: (url: string, unload: () => void) => void = function (url, unload) { unload(); };
+    unloading: (state: State, url: string, unload: () => void) => void = function (state, url, unload) { unload(); };
     navigating: (data: any, url: string, navigate: () => void) => void = function (data, url, navigate) { navigate(); };
     dispose: () => void = function () { };
     navigated: (data: any) => void = function (data: any) { };

--- a/NavigationJS/src/history/HTML5HistoryManager.ts
+++ b/NavigationJS/src/history/HTML5HistoryManager.ts
@@ -2,6 +2,7 @@
 import HistoryNavigator = require('./HistoryNavigator');
 import settings = require('../settings');
 import State = require('../config/State');
+import StateContext = require('../StateContext');
 
 class HTML5HistoryManager implements IHistoryManager {
     disabled: boolean = (typeof window === 'undefined') || !(window.history && window.history.pushState);
@@ -12,7 +13,8 @@ class HTML5HistoryManager implements IHistoryManager {
     }
 
     addHistory(state: State, url: string) {
-        if (state.title && (typeof document !== 'undefined'))
+        url = url != null ? url : StateContext.url;
+        if (state && state.title && (typeof document !== 'undefined'))
             document.title = state.title;
         url = settings.applicationPath + url;
         if (!this.disabled && location.pathname + location.search !== url)

--- a/NavigationJS/src/history/HashHistoryManager.ts
+++ b/NavigationJS/src/history/HashHistoryManager.ts
@@ -1,6 +1,7 @@
 ﻿import IHistoryManager = require('./IHistoryManager');
 import HistoryNavigator = require('./HistoryNavigator');
 import State = require('../config/State');
+import StateContext = require('../StateContext');
 
 class HashHistoryManager implements IHistoryManager {
     disabled: boolean = (typeof window === 'undefined') || !('onhashchange' in window);
@@ -16,7 +17,8 @@ class HashHistoryManager implements IHistoryManager {
     }
 
     addHistory(state: State, url: string) {
-        if (state.title && (typeof document !== 'undefined'))
+        url = url != null ? url : StateContext.url;
+        if (state && state.title && (typeof document !== 'undefined'))
             document.title = state.title;
         url = this.encode(url);
         if (!this.disabled && location.hash.substring(1) !== url)

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -523,6 +523,14 @@ declare module Navigation {
         navigationLink: string;
         /**
          * Initializes a new instance of the Crumb class
+         * @param data The Context Data held at the time of navigating away
+         * from this State
+         * @param state The configuration information associated with this
+         * navigation
+         * @param link The hyperlink navigation to return to the State and pass
+         * the associated Data
+         * @param last A value indicating whether the Crumb is the last in the
+         * crumb trail
          */
         constructor(data: any, state: State, link: string, last: boolean);
     }

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -763,6 +763,12 @@ declare module Navigation {
          */
         static navigateLink(url: string): void;
         /**
+         * Navigates to the url
+         * @param url The target location
+         * @param history A value indicating whether browser history was used
+         */
+        static navigateLink(url: string, history: boolean): void;
+        /**
          * Gets the next State. Depending on the action will either return the
          * 'to' State of a Transition or the 'initial' State of a Dialog
          * @param action The key of a child Transition or the key of a Dialog

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -186,9 +186,19 @@ declare module Navigation {
         trackCrumbTrail: boolean;
         /**
          * Gets or sets the IStateHandler responsible for building and parsing
-         * avigation links to this State
+         * navigation links to this State
          */
         stateHandler: IStateHandler;
+        /**
+         * Called on the old State (this is not the same as the previous 
+         * State) before navigating to a different State
+         * @param state The new State
+         * @param data The new NavigationData
+         * @param url The new target location
+         * @param unload The function to call to continue to navigate
+         * @param history A value indicating whether browser history was used
+         */
+        unloading: (state: State, data: any, url: string, unload: () => void, history?: boolean) => void;
         /**
          * Called on the old State (this is not the same as the previous 
          * State) after navigating to a different State
@@ -203,9 +213,10 @@ declare module Navigation {
          * Called on the new State before navigating to it
          * @param data The new NavigationData
          * @param url The new target location
-         * @param navigate The function to call to continue to navigate 
+         * @param navigate The function to call to continue to navigate
+         * @param history A value indicating whether browser history was used
          */
-        navigating: (data: any, url: string, navigate: () => void) => void;
+        navigating: (data: any, url: string, navigate: () => void, history?: boolean) => void;
     }
 
     /**

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -2762,7 +2762,7 @@ describe('NavigationDataTest', function () {
         assert.throws(() => Navigation.StateController.navigateLink(link));
     });
 
-    it('NavigateInvalilBooleanTest', function () {
+    it('NavigateInvalidBooleanTest', function () {
         Navigation.StateController.navigate('d0');
         var link = Navigation.StateController.getNavigationLink('t0', { '_bool': false });
         link = link.replace('_bool=false', '_bool=invalid');

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -17,7 +17,8 @@ arrayNavigationData['array_number'] = [1, 2];
 describe('NavigationDataTest', function () {
     beforeEach(function () {
         initStateInfo();
-        Navigation.StateContext.clear();
+        if (Navigation.StateContext.state)
+            Navigation.StateContext.clear();
     });
 
     it('NavigateIndividualDataTest', function () {

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -1483,7 +1483,11 @@ describe('NavigationTest', function () {
         var link = Navigation.StateController.getNavigationLink('t1');
         Navigation.StateController.navigateLink(link);
         Navigation.StateController.navigate('t1');
-        var disposed, navigating, navigated;
+        var unloading, disposed, navigating, navigated;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s4'].unloading = (state, data, url, unload) => {
+            unloading = true;
+            unload();
+        }
         Navigation.StateInfoConfig.dialogs['d0'].states['s4'].dispose = () => disposed = true;
         Navigation.StateInfoConfig.dialogs['d0'].states['s2'].navigating = (data, url, navigate) => {
             navigating = true;
@@ -1491,13 +1495,19 @@ describe('NavigationTest', function () {
         }
         Navigation.StateInfoConfig.dialogs['d0'].states['s2'].navigated = () => navigated = true;
         Navigation.StateController.navigateBack(1);
+        assert.strictEqual(unloading, true);
         assert.strictEqual(disposed, true);
         assert.strictEqual(navigating, true);
         assert.strictEqual(navigated, true);
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s2']);
+        unloading = undefined;
         disposed = undefined;
         navigating = undefined;
         navigated = undefined;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s2'].unloading = (state, data, url, unload) => {
+            unloading = true;
+            unload();
+        }
         Navigation.StateInfoConfig.dialogs['d0'].states['s2'].dispose = () => disposed = true;
         Navigation.StateInfoConfig.dialogs['d0'].states['s0'].navigating = (data, url, navigate) => {
             navigating = true;
@@ -1506,10 +1516,40 @@ describe('NavigationTest', function () {
         Navigation.StateInfoConfig.dialogs['d0'].states['s0'].navigated = () => navigated = true;
         var link = Navigation.StateController.getNavigationBackLink(1);
         Navigation.StateController.navigateLink(link);
+        assert.strictEqual(unloading, true);
         assert.strictEqual(disposed, true);
         assert.strictEqual(navigating, true);
         assert.strictEqual(navigated, true);
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
+    });
+
+    it('UnloadingBackOneByOneTest', function () {
+        Navigation.StateController.navigate('d0');
+        var link = Navigation.StateController.getNavigationLink('t1');
+        Navigation.StateController.navigateLink(link);
+        Navigation.StateController.navigate('t1');
+        var unloading, disposed, navigating, navigated;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s4'].unloading = (state, data, url, unload) => unloading = true;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s4'].dispose = () => disposed = true;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s2'].navigating = (data, url, navigate) => navigating = true;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s2'].navigated = () => navigated = true;
+        Navigation.StateController.navigateBack(1);
+        assert.strictEqual(unloading, true);
+        assert.strictEqual(disposed, undefined);
+        assert.strictEqual(navigating, undefined);
+        assert.strictEqual(navigated, undefined);
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s4']);
+        unloading = undefined;
+        disposed = undefined;
+        navigating = undefined;
+        navigated = undefined;
+        var link = Navigation.StateController.getNavigationBackLink(1);
+        Navigation.StateController.navigateLink(link);
+        assert.strictEqual(unloading, true);
+        assert.strictEqual(disposed, undefined);
+        assert.strictEqual(navigating, undefined);
+        assert.strictEqual(navigated, undefined);
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s4']);
     });
 
     it('NavigatingBackOneByOneTest', function () {
@@ -1517,20 +1557,27 @@ describe('NavigationTest', function () {
         var link = Navigation.StateController.getNavigationLink('t1');
         Navigation.StateController.navigateLink(link);
         Navigation.StateController.navigate('t1');
-        var disposed, navigating, navigated;
+        var unloading, disposed, navigating, navigated;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s4'].unloading = (state, data, url, unload) => {
+            unloading = true;
+            unload();
+        }
         Navigation.StateInfoConfig.dialogs['d0'].states['s4'].dispose = () => disposed = true;
         Navigation.StateInfoConfig.dialogs['d0'].states['s2'].navigating = (data, url, navigate) => navigating = true;
         Navigation.StateInfoConfig.dialogs['d0'].states['s2'].navigated = () => navigated = true;
         Navigation.StateController.navigateBack(1);
+        assert.strictEqual(unloading, true);
         assert.strictEqual(disposed, undefined);
         assert.strictEqual(navigating, true);
         assert.strictEqual(navigated, undefined);
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s4']);
+        unloading = undefined;
         disposed = undefined;
         navigating = undefined;
         navigated = undefined;
         var link = Navigation.StateController.getNavigationBackLink(1);
         Navigation.StateController.navigateLink(link);
+        assert.strictEqual(unloading, true);
         assert.strictEqual(disposed, undefined);
         assert.strictEqual(navigating, true);
         assert.strictEqual(navigated, undefined);

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -1156,7 +1156,11 @@ describe('NavigationTest', function () {
     it('NavigatedTransitionTest', function () {
         var link = Navigation.StateController.getNavigationLink('d0');
         Navigation.StateController.navigateLink(link);
-        var disposed, navigating, navigated;
+        var unloading, disposed, navigating, navigated;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s0'].unloading = (state, data, url, unload) => {
+            unloading = true;
+            unload();
+        }
         Navigation.StateInfoConfig.dialogs['d0'].states['s0'].dispose = () => disposed = true;
         Navigation.StateInfoConfig.dialogs['d0'].states['s1'].navigating = (data, url, navigate) => {
             navigating = true;
@@ -1164,20 +1168,42 @@ describe('NavigationTest', function () {
         }
         Navigation.StateInfoConfig.dialogs['d0'].states['s1'].navigated = () => navigated = true;
         Navigation.StateController.navigate('t0');
+        assert.strictEqual(unloading, true);
         assert.strictEqual(disposed, true);
         assert.strictEqual(navigating, true);
         assert.strictEqual(navigated, true);
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
     });
 
-    it('NavigatingTransitionTest', function () {
+    it('UnloadingTransitionTest', function () {
         var link = Navigation.StateController.getNavigationLink('d0');
         Navigation.StateController.navigateLink(link);
-        var disposed, navigating, navigated;
+        var unloading, disposed, navigating, navigated;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s0'].unloading = (state, data, url, unload) => unloading = true;
         Navigation.StateInfoConfig.dialogs['d0'].states['s0'].dispose = () => disposed = true;
         Navigation.StateInfoConfig.dialogs['d0'].states['s1'].navigating = (data, url, navigate) => navigating = true;
         Navigation.StateInfoConfig.dialogs['d0'].states['s1'].navigated = () => navigated = true;
         Navigation.StateController.navigate('t0');
+        assert.strictEqual(unloading, true);
+        assert.strictEqual(disposed, undefined);
+        assert.strictEqual(navigating, undefined);
+        assert.strictEqual(navigated, undefined);
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
+    });
+
+    it('NavigatingTransitionTest', function () {
+        var link = Navigation.StateController.getNavigationLink('d0');
+        Navigation.StateController.navigateLink(link);
+        var unloading, disposed, navigating, navigated;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s0'].unloading = (state, data, url, unload) => {
+            unloading = true;
+            unload();
+        }
+        Navigation.StateInfoConfig.dialogs['d0'].states['s0'].dispose = () => disposed = true;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s1'].navigating = (data, url, navigate) => navigating = true;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s1'].navigated = () => navigated = true;
+        Navigation.StateController.navigate('t0');
+        assert.strictEqual(unloading, true);
         assert.strictEqual(disposed, undefined);
         assert.strictEqual(navigating, true);
         assert.strictEqual(navigated, undefined);

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -1824,6 +1824,25 @@ describe('NavigationTest', function () {
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
     });
 
+    it('UnloadingNavigateAndContinueTest', function () {
+        Navigation.StateController.navigate('d0');
+        Navigation.StateController.navigate('t0');
+        Navigation.StateInfoConfig.dialogs['d0'].states['s1'].unloading = (state, data, url, unload) => {
+            if (data.x)
+                Navigation.StateController.navigate('t0');
+            unload();
+        }
+        var navigating;
+        Navigation.StateInfoConfig.dialogs['d1'].states['s0'].navigating = (data, url, navigate) => {
+            navigating = true;
+            navigate();
+        }
+        Navigation.StateController.navigate('d1', { x: true });
+        assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s2']);
+        assert.strictEqual(navigating, undefined);
+    });
+
     it('NavigatingNavigateAndContinueTest', function () {
         Navigation.StateController.navigate('d0');
         Navigation.StateController.navigate('t0');

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -1224,7 +1224,11 @@ describe('NavigationTest', function () {
         Navigation.StateController.navigate('d2');
         var link = Navigation.StateController.getNavigationLink('t0');
         Navigation.StateController.navigateLink(link);
-        var disposed, navigating, navigated;
+        var unloading, disposed, navigating, navigated;
+        Navigation.StateInfoConfig.dialogs['d2'].states['s1'].unloading = (state, data, url, unload) => {
+            unloading = true;
+            unload();
+        }
         Navigation.StateInfoConfig.dialogs['d2'].states['s1'].dispose = () => disposed = true;
         Navigation.StateInfoConfig.dialogs['d2'].states['s2'].navigating = (data, url, navigate) => {
             navigating = true;
@@ -1232,21 +1236,44 @@ describe('NavigationTest', function () {
         }
         Navigation.StateInfoConfig.dialogs['d2'].states['s2'].navigated = () => navigated = true;
         Navigation.StateController.navigate('t0');
+        assert.strictEqual(unloading, true);
         assert.strictEqual(disposed, true);
         assert.strictEqual(navigating, true);
         assert.strictEqual(navigated, true);
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d2'].states['s2']);
     });
 
-    it('NavigatingTransitionTransitionTest', function () {
+    it('UnloadingTransitionTransitionTest', function () {
         Navigation.StateController.navigate('d2');
         var link = Navigation.StateController.getNavigationLink('t0');
         Navigation.StateController.navigateLink(link);
-        var disposed, navigating, navigated;
+        var unloading, disposed, navigating, navigated;
+        Navigation.StateInfoConfig.dialogs['d2'].states['s1'].unloading = (state, data, url, unload) => unloading = true;
         Navigation.StateInfoConfig.dialogs['d2'].states['s1'].dispose = () => disposed = true;
         Navigation.StateInfoConfig.dialogs['d2'].states['s2'].navigating = (data, url, navigate) => navigating = true;
         Navigation.StateInfoConfig.dialogs['d2'].states['s2'].navigated = () => navigated = true;
         Navigation.StateController.navigate('t0');
+        assert.strictEqual(unloading, true);
+        assert.strictEqual(disposed, undefined);
+        assert.strictEqual(navigating, undefined);
+        assert.strictEqual(navigated, undefined);
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d2'].states['s1']);
+    });
+
+    it('NavigatingTransitionTransitionTest', function () {
+        Navigation.StateController.navigate('d2');
+        var link = Navigation.StateController.getNavigationLink('t0');
+        Navigation.StateController.navigateLink(link);
+        var unloading, disposed, navigating, navigated;
+        Navigation.StateInfoConfig.dialogs['d2'].states['s1'].unloading = (state, data, url, unload) => {
+            unloading = true;
+            unload();
+        }
+        Navigation.StateInfoConfig.dialogs['d2'].states['s1'].dispose = () => disposed = true;
+        Navigation.StateInfoConfig.dialogs['d2'].states['s2'].navigating = (data, url, navigate) => navigating = true;
+        Navigation.StateInfoConfig.dialogs['d2'].states['s2'].navigated = () => navigated = true;
+        Navigation.StateController.navigate('t0');
+        assert.strictEqual(unloading, true);
         assert.strictEqual(disposed, undefined);
         assert.strictEqual(navigating, true);
         assert.strictEqual(navigated, undefined);
@@ -1259,7 +1286,11 @@ describe('NavigationTest', function () {
         link = Navigation.StateController.getNavigationLink('t0');
         Navigation.StateController.navigateLink(link);
         Navigation.StateController.navigate('t0');
-        var disposed, navigating, navigated;
+        var unloading, disposed, navigating, navigated;
+        Navigation.StateInfoConfig.dialogs['d2'].states['s2'].unloading = (state, data, url, unload) => {
+            unloading = true;
+            unload();
+        }
         Navigation.StateInfoConfig.dialogs['d2'].states['s2'].dispose = () => disposed = true;
         Navigation.StateInfoConfig.dialogs['d2'].states['s2'].navigating = (data, url, navigate) => {
             navigating = true;
@@ -1267,9 +1298,29 @@ describe('NavigationTest', function () {
         }
         Navigation.StateInfoConfig.dialogs['d2'].states['s2'].navigated = () => navigated = true;
         Navigation.StateController.refresh();
+        assert.strictEqual(unloading, true);
         assert.strictEqual(disposed, undefined);
         assert.strictEqual(navigating, true);
         assert.strictEqual(navigated, true);
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d2'].states['s2']);
+    });
+
+    it('UnloadingRefreshTest', function () {
+        var link = Navigation.StateController.getNavigationLink('d2');
+        Navigation.StateController.navigateLink(link);
+        link = Navigation.StateController.getNavigationLink('t0');
+        Navigation.StateController.navigateLink(link);
+        Navigation.StateController.navigate('t0');
+        var unloading, disposed, navigating, navigated;
+        Navigation.StateInfoConfig.dialogs['d2'].states['s2'].unloading = (state, data, url, unload) => unloading = true;
+        Navigation.StateInfoConfig.dialogs['d2'].states['s2'].dispose = () => disposed = true;
+        Navigation.StateInfoConfig.dialogs['d2'].states['s2'].navigating = (data, url, navigate) => navigating = true;
+        Navigation.StateInfoConfig.dialogs['d2'].states['s2'].navigated = () => navigated = true;
+        Navigation.StateController.refresh();
+        assert.strictEqual(unloading, true);
+        assert.strictEqual(disposed, undefined);
+        assert.strictEqual(navigating, undefined);
+        assert.strictEqual(navigated, undefined);
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d2'].states['s2']);
     });
 
@@ -1279,11 +1330,16 @@ describe('NavigationTest', function () {
         link = Navigation.StateController.getNavigationLink('t0');
         Navigation.StateController.navigateLink(link);
         Navigation.StateController.navigate('t0');
-        var disposed, navigating, navigated;
+        var unloading, disposed, navigating, navigated;
+        Navigation.StateInfoConfig.dialogs['d2'].states['s2'].unloading = (state, data, url, unload) => {
+            unloading = true;
+            unload();
+        }
         Navigation.StateInfoConfig.dialogs['d2'].states['s2'].dispose = () => disposed = true;
         Navigation.StateInfoConfig.dialogs['d2'].states['s2'].navigating = (data, url, navigate) => navigating = true;
         Navigation.StateInfoConfig.dialogs['d2'].states['s2'].navigated = () => navigated = true;
         Navigation.StateController.refresh();
+        assert.strictEqual(unloading, true);
         assert.strictEqual(disposed, undefined);
         assert.strictEqual(navigating, true);
         assert.strictEqual(navigated, undefined);

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -1414,7 +1414,11 @@ describe('NavigationTest', function () {
         link = Navigation.StateController.getNavigationLink('t0');
         Navigation.StateController.navigateLink(link);
         Navigation.StateController.navigate('t0');
-        var disposed, navigating, navigated;
+        var unloading, disposed, navigating, navigated;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s4'].unloading = (state, data, url, unload) => {
+            unloading = true;
+            unload();
+        }
         Navigation.StateInfoConfig.dialogs['d0'].states['s4'].dispose = () => disposed = true;
         Navigation.StateInfoConfig.dialogs['d0'].states['s2'].navigating = (data, url, navigate) => {
             navigating = true;
@@ -1422,10 +1426,32 @@ describe('NavigationTest', function () {
         }
         Navigation.StateInfoConfig.dialogs['d0'].states['s2'].navigated = () => navigated = true;
         Navigation.StateController.navigateBack(2);
+        assert.strictEqual(unloading, true);
         assert.strictEqual(disposed, true);
         assert.strictEqual(navigating, true);
         assert.strictEqual(navigated, true);
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s2']);
+    });
+
+    it('UnloadingBackTwoTest', function () {
+        Navigation.StateController.navigate('d0');
+        var link = Navigation.StateController.getNavigationLink('t0');
+        Navigation.StateController.navigateLink(link);
+        Navigation.StateController.navigate('t0');
+        link = Navigation.StateController.getNavigationLink('t0');
+        Navigation.StateController.navigateLink(link);
+        Navigation.StateController.navigate('t0');
+        var unloading, disposed, navigating, navigated;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s4'].unloading = (state, data, url, unload) => unloading = true;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s4'].dispose = () => disposed = true;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s2'].navigating = (data, url, navigate) => navigating = true;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s2'].navigated = () => navigated = true;
+        Navigation.StateController.navigateBack(2);
+        assert.strictEqual(unloading, true);
+        assert.strictEqual(disposed, undefined);
+        assert.strictEqual(navigating, undefined);
+        assert.strictEqual(navigated, undefined);
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s4']);
     });
 
     it('NavigatingBackTwoTest', function () {
@@ -1436,11 +1462,16 @@ describe('NavigationTest', function () {
         link = Navigation.StateController.getNavigationLink('t0');
         Navigation.StateController.navigateLink(link);
         Navigation.StateController.navigate('t0');
-        var disposed, navigating, navigated;
+        var unloading, disposed, navigating, navigated;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s4'].unloading = (state, data, url, unload) => {
+            unloading = true;
+            unload();
+        }
         Navigation.StateInfoConfig.dialogs['d0'].states['s4'].dispose = () => disposed = true;
         Navigation.StateInfoConfig.dialogs['d0'].states['s2'].navigating = (data, url, navigate) => navigating = true;
         Navigation.StateInfoConfig.dialogs['d0'].states['s2'].navigated = () => navigated = true;
         Navigation.StateController.navigateBack(2);
+        assert.strictEqual(unloading, true);
         assert.strictEqual(disposed, undefined);
         assert.strictEqual(navigating, true);
         assert.strictEqual(navigated, undefined);

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -1843,6 +1843,28 @@ describe('NavigationTest', function () {
         assert.strictEqual(navigating, undefined);
     });
 
+    it('UnloadingNavigateUrlAndContinueTest', function () {
+        Navigation.StateController.navigate('d0');
+        Navigation.StateController.navigate('t0');
+        var unloading;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s1'].unloading = (state, data, url, unload) => {
+            if (!unloading) {
+                unloading = true;
+                Navigation.StateController.navigateLink(url);
+            }
+            unload();
+        }
+        var navigating = 0;
+        Navigation.StateInfoConfig.dialogs['d1'].states['s0'].navigating = (data, url, navigate) => {
+            navigating++;
+            navigate();
+        }
+        Navigation.StateController.navigate('d1');
+        assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
+        assert.strictEqual(navigating, 1);
+    });
+
     it('NavigatingNavigateAndContinueTest', function () {
         Navigation.StateController.navigate('d0');
         Navigation.StateController.navigate('t0');

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -1349,7 +1349,11 @@ describe('NavigationTest', function () {
     it('NavigatedBackOneTest', function () {
         Navigation.StateController.navigate('d0');
         Navigation.StateController.navigate('t2');
-        var disposed, navigating, navigated;
+        var unloading, disposed, navigating, navigated;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s3'].unloading = (state, data, url, unload) => {
+            unloading = true;
+            unload();
+        }
         Navigation.StateInfoConfig.dialogs['d0'].states['s3'].dispose = () => disposed = true;
         Navigation.StateInfoConfig.dialogs['d0'].states['s0'].navigating = (data, url, navigate) => {
             navigating = true;
@@ -1358,21 +1362,44 @@ describe('NavigationTest', function () {
         Navigation.StateInfoConfig.dialogs['d0'].states['s0'].navigated = () => navigated = true;
         var link = Navigation.StateController.getNavigationBackLink(1);
         Navigation.StateController.navigateLink(link);
+        assert.strictEqual(unloading, true);
         assert.strictEqual(disposed, true);
         assert.strictEqual(navigating, true);
         assert.strictEqual(navigated, true);
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
     });
 
-    it('NavigatingBackOneTest', function () {
+    it('UnloadingBackOneTest', function () {
         Navigation.StateController.navigate('d0');
         Navigation.StateController.navigate('t2');
-        var disposed, navigating, navigated;
+        var unloading, disposed, navigating, navigated;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s3'].unloading = (state, data, url, unload) => unloading = true;
         Navigation.StateInfoConfig.dialogs['d0'].states['s3'].dispose = () => disposed = true;
         Navigation.StateInfoConfig.dialogs['d0'].states['s0'].navigating = (data, url, navigate) => navigating = true;
         Navigation.StateInfoConfig.dialogs['d0'].states['s0'].navigated = () => navigated = true;
         var link = Navigation.StateController.getNavigationBackLink(1);
         Navigation.StateController.navigateLink(link);
+        assert.strictEqual(unloading, true);
+        assert.strictEqual(disposed, undefined);
+        assert.strictEqual(navigating, undefined);
+        assert.strictEqual(navigated, undefined);
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s3']);
+    });
+
+    it('NavigatingBackOneTest', function () {
+        Navigation.StateController.navigate('d0');
+        Navigation.StateController.navigate('t2');
+        var unloading, disposed, navigating, navigated;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s3'].unloading = (state, data, url, unload) => {
+            unloading = true;
+            unload();
+        }
+        Navigation.StateInfoConfig.dialogs['d0'].states['s3'].dispose = () => disposed = true;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s0'].navigating = (data, url, navigate) => navigating = true;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s0'].navigated = () => navigated = true;
+        var link = Navigation.StateController.getNavigationBackLink(1);
+        Navigation.StateController.navigateLink(link);
+        assert.strictEqual(unloading, true);
         assert.strictEqual(disposed, undefined);
         assert.strictEqual(navigating, true);
         assert.strictEqual(navigated, undefined);

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -1584,6 +1584,32 @@ describe('NavigationTest', function () {
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s4']);
     });
 
+    it('UnloadingNavigateTest', function () {
+        Navigation.StateController.navigate('d0');
+        var link = Navigation.StateController.getNavigationLink('t0');
+        Navigation.StateController.navigate('t0');
+        Navigation.StateController.navigate('t0');
+        var disposed = 0, unloading, navigated10, navigated01;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s2'].unloading = (state, data, url, unload) => {
+            if (!unloading) {
+                unloading = true;
+                Navigation.StateController.navigateLink(link);
+            } else {
+                unload();
+            }
+        }
+        Navigation.StateInfoConfig.dialogs['d0'].states['s2'].dispose = () => disposed++;
+        Navigation.StateInfoConfig.dialogs['d1'].states['s0'].navigated = () => navigated10 = true;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s1'].navigated = () => navigated01 = true;
+        Navigation.StateController.navigate('d1');
+        assert.strictEqual(disposed, 1);
+        assert.strictEqual(unloading, true);
+        assert.strictEqual(navigated10, undefined);
+        assert.strictEqual(navigated01, true);
+        assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+    });
+
     it('NavigatingNavigateTest', function () {
         Navigation.StateController.navigate('d0');
         var link = Navigation.StateController.getNavigationLink('t0');

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -8,6 +8,7 @@ import Navigation = require('../src/Navigation');
 describe('NavigationTest', function () {
     beforeEach(function () {
         initStateInfo();
+        Navigation.StateContext.state = null;
     });
 
     it('NavigateDialogTest', function () {
@@ -1039,7 +1040,11 @@ describe('NavigationTest', function () {
         Navigation.StateController.navigate('d0');
         var link = Navigation.StateController.getNavigationLink('t0');
         Navigation.StateController.navigateLink(link);
-        var disposed, navigating, navigated;
+        var unloading, disposed, navigating, navigated;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s1'].unloading = (state, data, url, unload) => {
+            unloading = true;
+            unload();
+        }
         Navigation.StateInfoConfig.dialogs['d0'].states['s1'].dispose = () => disposed = true;
         Navigation.StateInfoConfig.dialogs['d1'].states['s0'].navigating = (data, url, navigate) => {
             navigating = true;
@@ -1047,21 +1052,44 @@ describe('NavigationTest', function () {
         }
         Navigation.StateInfoConfig.dialogs['d1'].states['s0'].navigated = () => navigated = true;
         Navigation.StateController.navigate('d1');
+        assert.strictEqual(unloading, true);
         assert.strictEqual(disposed, true);
         assert.strictEqual(navigating, true);
         assert.strictEqual(navigated, true);
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
     });
 
-    it('NavigatingCrossDialogTest', function () {
+    it('UnloadingCrossDialogTest', function () {
         Navigation.StateController.navigate('d0');
         var link = Navigation.StateController.getNavigationLink('t0');
         Navigation.StateController.navigateLink(link);
-        var disposed, navigating, navigated;
+        var unloading, disposed, navigating, navigated;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s1'].unloading = (state, data, url, unload) => unloading = true;
         Navigation.StateInfoConfig.dialogs['d0'].states['s1'].dispose = () => disposed = true;
         Navigation.StateInfoConfig.dialogs['d1'].states['s0'].navigating = (data, url, navigate) => navigating = true;
         Navigation.StateInfoConfig.dialogs['d1'].states['s0'].navigated = () => navigated = true;
         Navigation.StateController.navigate('d1');
+        assert.strictEqual(unloading, true);
+        assert.strictEqual(disposed, undefined);
+        assert.strictEqual(navigating, undefined);
+        assert.strictEqual(navigated, undefined);
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
+    });
+
+    it('NavigatingCrossDialogTest', function () {
+        Navigation.StateController.navigate('d0');
+        var link = Navigation.StateController.getNavigationLink('t0');
+        Navigation.StateController.navigateLink(link);
+        var unloading, disposed, navigating, navigated;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s1'].unloading = (state, data, url, unload) => {
+            unloading = true;
+            unload();
+        }
+        Navigation.StateInfoConfig.dialogs['d0'].states['s1'].dispose = () => disposed = true;
+        Navigation.StateInfoConfig.dialogs['d1'].states['s0'].navigating = (data, url, navigate) => navigating = true;
+        Navigation.StateInfoConfig.dialogs['d1'].states['s0'].navigated = () => navigated = true;
+        Navigation.StateController.navigate('d1');
+        assert.strictEqual(unloading, true);
         assert.strictEqual(disposed, undefined);
         assert.strictEqual(navigating, true);
         assert.strictEqual(navigated, undefined);
@@ -1071,7 +1099,11 @@ describe('NavigationTest', function () {
     it('NavigatedDialogDialogTest', function () {
         var link = Navigation.StateController.getNavigationLink('d0');
         Navigation.StateController.navigateLink(link);
-        var disposed, navigating, navigated;
+        var unloading, disposed, navigating, navigated;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s0'].unloading = (state, data, url, unload) => {
+            unloading = true;
+            unload();
+        }
         Navigation.StateInfoConfig.dialogs['d0'].states['s0'].dispose = () => disposed = true;
         Navigation.StateInfoConfig.dialogs['d0'].states['s0'].navigating = (data, url, navigate) => {
             navigating = true;
@@ -1079,20 +1111,42 @@ describe('NavigationTest', function () {
         }
         Navigation.StateInfoConfig.dialogs['d0'].states['s0'].navigated = () => navigated = true;
         Navigation.StateController.navigate('d0');
+        assert.strictEqual(unloading, true);
         assert.strictEqual(disposed, undefined);
         assert.strictEqual(navigating, true);
         assert.strictEqual(navigated, true);
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
     });
 
-    it('NavigatingDialogDialogTest', function () {
+    it('UnloadingDialogDialogTest', function () {
         var link = Navigation.StateController.getNavigationLink('d0');
         Navigation.StateController.navigateLink(link);
-        var disposed, navigating, navigated;
+        var unloading, disposed, navigating, navigated;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s0'].unloading = (state, data, url, unload) => unloading = true;
         Navigation.StateInfoConfig.dialogs['d0'].states['s0'].dispose = () => disposed = true;
         Navigation.StateInfoConfig.dialogs['d0'].states['s0'].navigating = (data, url, navigate) => navigating = true;
         Navigation.StateInfoConfig.dialogs['d0'].states['s0'].navigated = () => navigated = true;
         Navigation.StateController.navigate('d0');
+        assert.strictEqual(unloading, true);
+        assert.strictEqual(disposed, undefined);
+        assert.strictEqual(navigating, undefined);
+        assert.strictEqual(navigated, undefined);
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
+    });
+
+    it('NavigatingDialogDialogTest', function () {
+        var link = Navigation.StateController.getNavigationLink('d0');
+        Navigation.StateController.navigateLink(link);
+        var unloading, disposed, navigating, navigated;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s0'].unloading = (state, data, url, unload) => {
+            unloading = true;
+            unload();
+        }
+        Navigation.StateInfoConfig.dialogs['d0'].states['s0'].dispose = () => disposed = true;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s0'].navigating = (data, url, navigate) => navigating = true;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s0'].navigated = () => navigated = true;
+        Navigation.StateController.navigate('d0');
+        assert.strictEqual(unloading, true);
         assert.strictEqual(disposed, undefined);
         assert.strictEqual(navigating, true);
         assert.strictEqual(navigated, undefined);

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -1898,6 +1898,40 @@ describe('NavigationTest', function () {
         assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].states['s1']);
     });
 
+    it('NavigateHistoryTest', function () {
+        Navigation.StateController.navigate('d0');
+        var link = Navigation.StateController.getNavigationLink('t0');
+        var unloadingHistory, navigatingHistory;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s0'].unloading = (state, data, url, unload, history) => {
+            unloadingHistory = history; 
+            unload();
+        }
+        Navigation.StateInfoConfig.dialogs['d0'].states['s1'].navigating = (data, url, navigate, history) => {
+            navigatingHistory = history;
+            navigate();
+        }
+        Navigation.StateController.navigateLink(link, true);
+        assert.strictEqual(unloadingHistory, true);
+        assert.strictEqual(navigatingHistory, true);
+    });
+
+    it('NavigateNonHistoryTest', function () {
+        Navigation.StateController.navigate('d0');
+        var link = Navigation.StateController.getNavigationLink('t0');
+        var unloadingHistory, navigatingHistory;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s0'].unloading = (state, data, url, unload, history) => {
+            unloadingHistory = history; 
+            unload();
+        }
+        Navigation.StateInfoConfig.dialogs['d0'].states['s1'].navigating = (data, url, navigate, history) => {
+            navigatingHistory = history;
+            navigate();
+        }
+        Navigation.StateController.navigateLink(link);
+        assert.strictEqual(unloadingHistory, false);
+        assert.strictEqual(navigatingHistory, false);
+    });
+
     it('NavigateTransitionStorageTest', function () {
         Navigation.settings.crumbTrailPersister = new Navigation.StorageCrumbTrailPersister(0);
         Navigation.StateController.navigate('d0');

--- a/NavigationJS/test/navigation-tests.ts
+++ b/NavigationJS/test/navigation-tests.ts
@@ -110,6 +110,7 @@ module NavigationTests {
 	link = Navigation.StateController.getNavigationBackLink(1);
 	var crumb = Navigation.StateController.crumbs[0];
 	link = crumb.navigationLink;
+	Navigation.StateController.navigateLink(link, true);
 	
 	// StateContext
 	Navigation.StateController.navigate('home');

--- a/NavigationJS/test/navigation-tests.ts
+++ b/NavigationJS/test/navigation-tests.ts
@@ -1,117 +1,119 @@
 /// <reference path="../src/navigation.d.ts" />
 
-// History Manager
-class LogHistoryManager extends Navigation.HashHistoryManager  {
-    addHistory(state: Navigation.State, url: string) {
-		console.log('add history');
-		super.addHistory(state, url);
-    }
+module navigationTests {
+	// History Manager
+	class LogHistoryManager extends Navigation.HashHistoryManager  {
+	    addHistory(state: Navigation.State, url: string) {
+			console.log('add history');
+			super.addHistory(state, url);
+	    }
+	}
+	
+	// State Router
+	class LogStateRouter extends Navigation.StateRouter {
+	    getData(route: string): { state: Navigation.State; data: any } {
+			console.log('get data');
+			return super.getData(route);
+	    }
+	}
+	
+	// Settings
+	Navigation.settings.router = new LogStateRouter();
+	Navigation.settings.historyManager = new LogHistoryManager();
+	Navigation.settings.stateIdKey = 'state';
+	
+	// Configuration
+	Navigation.StateInfoConfig.build([
+		{ key: 'home', initial: 'page', states: [
+			{ key: 'page', route: '' }
+		]},
+		{ key: 'person', initial: 'list', states: [
+			{ key: 'list', route: 'people/{page}', transitions: [
+				{ key: 'select', to: 'details' }
+			], defaults: { page: 1 }, trackCrumbTrail: false },
+			{ key: 'details', route: 'person/{id}', defaultTypes: { id: 'number' } }
+		]}
+	]);
+	
+	// StateInfo
+	var dialogs = Navigation.StateInfoConfig.dialogs;
+	var home = dialogs['home'];
+	var homePage = home.states['page'];
+	var homeKey = home.key;
+	var homePageKey = homePage.key;
+	homePage = home.initial;
+	var person = dialogs['person'];
+	var personList = person.states['list'];
+	var personDetails = person.states['details'];
+	var personListSelect = personList.transitions['select'];
+	personList = personListSelect.parent;
+	personDetails = personListSelect.to;
+	var pageDefault = personList.defaults.page;
+	var idDefaultType = personDetails.defaultTypes.id;
+	
+	// StateNavigator
+	personList.dispose = () => {};
+	personList.navigating = (data, url, navigate) => {
+		navigate();
+	};
+	personList.navigated = (data) => {};
+	
+	// State Handler
+	class LogStateHandler extends Navigation.StateHandler {
+	    getNavigationData(state: Navigation.State, url: string): any {
+			console.log('get navigation data');
+			super.getNavigationData(state, url);
+	    }
+	}
+	homePage.stateHandler = new LogStateHandler();
+	personList.stateHandler = new LogStateHandler();
+	personDetails.stateHandler = new LogStateHandler();
+	
+	// Navigation Event
+	var navigationListener = 
+	(oldState: Navigation.State, state: Navigation.State, data: any) => {
+		Navigation.StateController.offNavigate(navigationListener);
+	};
+	Navigation.StateController.onNavigate(navigationListener);
+	
+	// Navigation
+	Navigation.start('home');
+	Navigation.StateController.navigate('person');
+	Navigation.StateController.refresh();
+	Navigation.StateController.refresh({ page: 2 });
+	Navigation.StateController.navigate('select', { id: 10 });
+	var canGoBack: boolean = Navigation.StateController.canNavigateBack(1);
+	Navigation.StateController.navigateBack(1);
+	
+	// Navigation Link
+	var link = Navigation.StateController.getNavigationLink('person');
+	link = Navigation.StateController.getRefreshLink();
+	link = Navigation.StateController.getRefreshLink({ page: 2 });
+	link = Navigation.StateController.getNavigationLink('select', { id: 10 });
+	var nextDialog = Navigation.StateController.getNextState('select').parent;
+	person = nextDialog;
+	Navigation.StateController.navigateLink(link);
+	link = Navigation.StateController.getNavigationBackLink(1);
+	var crumb = Navigation.StateController.crumbs[0];
+	link = crumb.navigationLink;
+	
+	// StateContext
+	Navigation.StateController.navigate('home');
+	Navigation.StateController.navigate('person');
+	home = Navigation.StateContext.previousDialog;
+	homePage = Navigation.StateContext.previousState;
+	person === Navigation.StateContext.dialog;
+	personList === Navigation.StateContext.state;
+	var url: string = Navigation.StateContext.url;
+	var page: number = Navigation.StateContext.data.page;
+	
+	// Navigation Data
+	Navigation.StateController.refresh({ page: 2 });
+	var data = Navigation.StateContext.includeCurrentData({ sort: 'name' }, ['page']);
+	Navigation.StateController.refresh(data);
+	Navigation.StateContext.clear('sort');
+	var data = Navigation.StateContext.includeCurrentData({ pageSize: 10 });
+	Navigation.StateController.refresh(data);
+	Navigation.StateContext.clear();
+	Navigation.StateController.refresh();
 }
-
-// State Router
-class LogStateRouter extends Navigation.StateRouter {
-    getData(route: string): { state: Navigation.State; data: any } {
-		console.log('get data');
-		return super.getData(route);
-    }
-}
-
-// Settings
-Navigation.settings.router = new LogStateRouter();
-Navigation.settings.historyManager = new LogHistoryManager();
-Navigation.settings.stateIdKey = 'state';
-
-// Configuration
-Navigation.StateInfoConfig.build([
-	{ key: 'home', initial: 'page', states: [
-		{ key: 'page', route: '' }
-	]},
-	{ key: 'person', initial: 'list', states: [
-		{ key: 'list', route: 'people/{page}', transitions: [
-			{ key: 'select', to: 'details' }
-		], defaults: { page: 1 }, trackCrumbTrail: false },
-		{ key: 'details', route: 'person/{id}', defaultTypes: { id: 'number' } }
-	]}
-]);
-
-// StateInfo
-var dialogs = Navigation.StateInfoConfig.dialogs;
-var home = dialogs['home'];
-var homePage = home.states['page'];
-var homeKey = home.key;
-var homePageKey = homePage.key;
-homePage = home.initial;
-var person = dialogs['person'];
-var personList = person.states['list'];
-var personDetails = person.states['details'];
-var personListSelect = personList.transitions['select'];
-personList = personListSelect.parent;
-personDetails = personListSelect.to;
-var pageDefault = personList.defaults.page;
-var idDefaultType = personDetails.defaultTypes.id;
-
-// StateNavigator
-personList.dispose = () => {};
-personList.navigating = (data, url, navigate) => {
-	navigate();
-};
-personList.navigated = (data) => {};
-
-// State Handler
-class LogStateHandler extends Navigation.StateHandler {
-    getNavigationData(state: Navigation.State, url: string): any {
-		console.log('get navigation data');
-		super.getNavigationData(state, url);
-    }
-}
-homePage.stateHandler = new LogStateHandler();
-personList.stateHandler = new LogStateHandler();
-personDetails.stateHandler = new LogStateHandler();
-
-// Navigation Event
-var navigationListener = 
-(oldState: Navigation.State, state: Navigation.State, data: any) => {
-	Navigation.StateController.offNavigate(navigationListener);
-};
-Navigation.StateController.onNavigate(navigationListener);
-
-// Navigation
-Navigation.start('home');
-Navigation.StateController.navigate('person');
-Navigation.StateController.refresh();
-Navigation.StateController.refresh({ page: 2 });
-Navigation.StateController.navigate('select', { id: 10 });
-var canGoBack: boolean = Navigation.StateController.canNavigateBack(1);
-Navigation.StateController.navigateBack(1);
-
-// Navigation Link
-var link = Navigation.StateController.getNavigationLink('person');
-link = Navigation.StateController.getRefreshLink();
-link = Navigation.StateController.getRefreshLink({ page: 2 });
-link = Navigation.StateController.getNavigationLink('select', { id: 10 });
-var nextDialog = Navigation.StateController.getNextState('select').parent;
-person = nextDialog;
-Navigation.StateController.navigateLink(link);
-link = Navigation.StateController.getNavigationBackLink(1);
-var crumb = Navigation.StateController.crumbs[0];
-link = crumb.navigationLink;
-
-// StateContext
-Navigation.StateController.navigate('home');
-Navigation.StateController.navigate('person');
-home = Navigation.StateContext.previousDialog;
-homePage = Navigation.StateContext.previousState;
-person === Navigation.StateContext.dialog;
-personList === Navigation.StateContext.state;
-var url: string = Navigation.StateContext.url;
-var page: number = Navigation.StateContext.data.page;
-
-// Navigation Data
-Navigation.StateController.refresh({ page: 2 });
-var data = Navigation.StateContext.includeCurrentData({ sort: 'name' }, ['page']);
-Navigation.StateController.refresh(data);
-Navigation.StateContext.clear('sort');
-var data = Navigation.StateContext.includeCurrentData({ pageSize: 10 });
-Navigation.StateController.refresh(data);
-Navigation.StateContext.clear();
-Navigation.StateController.refresh();

--- a/NavigationJS/test/navigation-tests.ts
+++ b/NavigationJS/test/navigation-tests.ts
@@ -9,6 +9,19 @@ module NavigationTests {
 	    }
 	}
 	
+	// Crumb Trail Persister
+	class LogCrumbTrailPersister extends Navigation.CrumbTrailPersister {
+		load(crumbTrail: string): string {
+			console.log('load');
+			return crumbTrail;
+		}
+		
+		save(crumbTrail: string): string {
+			console.log('save');
+			return crumbTrail;
+		}
+	}
+	
 	// State Router
 	class LogStateRouter extends Navigation.StateRouter {
 	    getData(route: string): { state: Navigation.State; data: any } {
@@ -20,6 +33,7 @@ module NavigationTests {
 	// Settings
 	Navigation.settings.router = new LogStateRouter();
 	Navigation.settings.historyManager = new LogHistoryManager();
+	Navigation.settings.crumbTrailPersister = new LogCrumbTrailPersister();
 	Navigation.settings.stateIdKey = 'state';
 	
 	// Configuration

--- a/NavigationJS/test/navigation-tests.ts
+++ b/NavigationJS/test/navigation-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="../src/navigation.d.ts" />
 
-module navigationTests {
+module NavigationTests {
 	// History Manager
 	class LogHistoryManager extends Navigation.HashHistoryManager  {
 	    addHistory(state: Navigation.State, url: string) {


### PR DESCRIPTION
Added unloading function to State. The classic scenario is to allow the current State to cancel the navigation when there are pending changes. Included a history flag because extra action's needed to cancel a browser history navigation. Pressing the browser back button changes the Url immediately, so cancelling the navigation needs to reset the Url. To help, changed the History Managers so that calling addHistory(null, null) resets the Url.