### PR TITLE
Improved Route Build Performance

### DIFF
--- a/NavigationJS/src/StateHandler.ts
+++ b/NavigationJS/src/StateHandler.ts
@@ -11,7 +11,7 @@ class StateHandler implements IStateHandler {
         var routeInfo = settings.router.getRoute(state, data);
         if (routeInfo.route == null)
             return null;
-        var query: Array<string> = [];
+        var query: string[] = [];
         for (var key in data) {
             if (!routeInfo.data || routeInfo.data[key] == null)
                 query.push(encodeURIComponent(key) + '=' + encodeURIComponent(data[key]));
@@ -39,8 +39,8 @@ class StateHandler implements IStateHandler {
         return data;
     }
 
-    truncateCrumbTrail(state: State, crumbs: Array<Crumb>): Array<Crumb> {
-        var newCrumbs: Array<Crumb> = [];
+    truncateCrumbTrail(state: State, crumbs: Crumb[]): Crumb[] {
+        var newCrumbs: Crumb[] = [];
         if (state.parent.initial === state)
             return newCrumbs;
         for (var i = 0; i < crumbs.length; i++) {

--- a/NavigationJS/src/StateRouter.ts
+++ b/NavigationJS/src/StateRouter.ts
@@ -22,9 +22,9 @@ class StateRouter implements IRouter {
         return { route: route.build(data), data: routeData };
     }
 
-    addRoutes(dialogs: Array<Dialog>) {
+    addRoutes(dialogs: Dialog[]) {
         this.router = new Router();
-        var states: Array<State> = [];
+        var states: State[] = [];
         for (var i = 0; i < dialogs.length; i++) {
             for (var j = 0; j < dialogs[i]._states.length; j++) {
                 states.push(dialogs[i]._states[j]);

--- a/NavigationJS/src/routing/Route.ts
+++ b/NavigationJS/src/routing/Route.ts
@@ -3,9 +3,9 @@
 class Route {
     path: string;
     defaults: any;
-    private segments: Array<Segment> = [];
+    private segments: Segment[] = [];
     private pattern: RegExp;
-    params: Array<{ name: string; optional: boolean }> = [];
+    params: { name: string; optional: boolean }[] = [];
 
     constructor(path: string, defaults?: any) {
         this.path = path;
@@ -21,7 +21,7 @@ class Route {
             segment = new Segment(subPaths[i], segment ? segment.optional : true, this.defaults);
             this.segments.unshift(segment);
             pattern = segment.pattern + pattern;
-            var params: Array<{ name: string; optional: boolean }> = [];
+            var params: { name: string; optional: boolean }[] = [];
             for (var j = 0; j < segment.params.length; j++) {
                 params.push({ name: segment.params[j], optional: segment.optional });
             }

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -20,7 +20,6 @@
         if (this.path.length === 0) {
             return;
         }
-        var optional = false;
         var matches = this.path.match(this.itemPattern);
         for (var i = 0; i < matches.length; i++) {
             var item = matches[i];
@@ -29,14 +28,13 @@
                 var name = param.slice(-1) === '?' ? param.substring(0, param.length - 1) : param;
                 this.params.push(name);
                 var optionalOrDefault = param.slice(-1) === '?' || this.defaults[name];
-                optional = this.path.length === item.length && optionalOrDefault;
-                this.optional = this.optional && optional;
+                this.optional = this.optional && this.path.length === item.length && optionalOrDefault;
                 this.pattern += !this.optional ? '([^/]+)' : '(\/[^/]+)?';
             } else {
+                this.optional = false;
                 this.pattern += item.replace(this.escapePattern, '\\$&');
             }
         }
-        this.optional = this.optional && optional;
         if (!this.optional)
             this.pattern = '\/' + this.pattern;
         

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -21,7 +21,7 @@
         var matches = this.path.match(this.itemPattern);
         for (var i = 0; i < matches.length; i++) {
             var item = matches[i];
-            if (item.charAt(0) == '{'){
+            if (item.charAt(0) == '{') {
                 var param = item.substring(1, item.length - 1);
                 var name = param.slice(-1) === '?' ? param.substring(0, param.length - 1) : param;
                 this.params.push(name);

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -5,8 +5,8 @@
     pattern: string = '';
     params: string[] = [];
     private subSegments: { name: string; param: boolean }[] = [];
+    private subSegmentPattern: RegExp = /[{]{0,1}[^{}]+[}]{0,1}/g;
     private escapePattern: RegExp = /[\.+*\^$\[\](){}']/g;
-    private itemPattern: RegExp = /[{]{0,1}[^{}]+[}]{0,1}/g;
 
     constructor(path: string, optional: boolean, defaults?: any) {
         this.path = path;
@@ -18,7 +18,7 @@
     private parse() {
         if (this.path.length === 0)
             return;
-        var matches = this.path.match(this.itemPattern);
+        var matches = this.path.match(this.subSegmentPattern);
         for (var i = 0; i < matches.length; i++) {
             var subSegment = matches[i];
             if (subSegment.charAt(0) == '{') {

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -16,23 +16,24 @@
     }
 
     private parse() {
-        var optional = this.path.length === 0;
-        var matches = this.path.match(this.itemPattern);
         this.pattern = '';
-        if (matches) {
-            for (var i = 0; i < matches.length; i++) {
-                var item = matches[i];
-                if (item.charAt(0) == '{'){
-                    var param = item.substring(1, item.length - 1);
-                    var name = param.slice(-1) === '?' ? param.substring(0, param.length - 1) : param;
-                    this.params.push(name);
-                    var optionalOrDefault = param.slice(-1) === '?' || this.defaults[name];
-                    optional = this.path.length === item.length && optionalOrDefault;
-                    this.optional = this.optional && optional;
-                    this.pattern += !this.optional ? '([^/]+)' : '(\/[^/]+)?';
-                } else {
-                    this.pattern += item.replace(this.escapePattern, '\\$&');
-                }
+        if (this.path.length === 0) {
+            return;
+        }
+        var optional = false;
+        var matches = this.path.match(this.itemPattern);
+        for (var i = 0; i < matches.length; i++) {
+            var item = matches[i];
+            if (item.charAt(0) == '{'){
+                var param = item.substring(1, item.length - 1);
+                var name = param.slice(-1) === '?' ? param.substring(0, param.length - 1) : param;
+                this.params.push(name);
+                var optionalOrDefault = param.slice(-1) === '?' || this.defaults[name];
+                optional = this.path.length === item.length && optionalOrDefault;
+                this.optional = this.optional && optional;
+                this.pattern += !this.optional ? '([^/]+)' : '(\/[^/]+)?';
+            } else {
+                this.pattern += item.replace(this.escapePattern, '\\$&');
             }
         }
         this.optional = this.optional && optional;

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -5,7 +5,6 @@
     pattern: string = '';
     params: Array<string> = [];
     private subSegments: Array<{ name: string; param: boolean }> = [];
-    private paramsPattern: RegExp = /\{([^}]+)\}/g;
     private escapePattern: RegExp = /[\.+*\^$\[\](){}']/g;
     private itemPattern: RegExp = /[{]{0,1}[^{}]+[}]{0,1}/g;
 

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -58,17 +58,6 @@
             }
         }
         return { path: !blank ? routePath : null, optional: optional };
-        /*
-        var blank = false;
-        var replaceParam = (match: string, param: string) => {
-            var name = param.slice(-1) === '?' ? param.substring(0, param.length - 1) : param;
-            optional = optional && (!data[name] || data[name] === this.defaults[name]);
-            var val = data[name] ? data[name] : this.defaults[name];
-            blank = blank || !val;
-            return encodeURIComponent(val);
-        }
-        var routePath = this.path.replace(this.paramsPattern, replaceParam);
-        return { path: !blank ? routePath : null, optional: optional };*/
     }
 }
 export = Segment;

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -37,24 +37,6 @@
         }
         if (!this.optional)
             this.pattern = '\/' + this.pattern;
-        
-        
-        /*
-        var optional = this.path.length === 0;
-        var replaceParam = (match: string, param: string) => {
-            var name = param.slice(-1) === '?' ? param.substring(0, param.length - 1) : param;
-            this.params.push(name);
-            var optionalOrDefault = param.slice(-1) === '?' || this.defaults[name];
-            optional = this.path.length === match.length && optionalOrDefault;
-            return '?';
-        }
-        this.pattern = this.path.replace(this.paramsPattern, replaceParam);
-        this.optional = this.optional && optional;
-        this.pattern = this.pattern.replace(this.escapePattern, '\\$&');
-        if (!this.optional)
-            this.pattern = '\/' + this.pattern.replace(/\?/g, '([^/]+)');
-        else
-            this.pattern = this.pattern.replace(/\?/, '(\/[^/]+)?');*/
     }
 
     build(data?: any): { path: string; optional: boolean } {

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -3,8 +3,8 @@
     optional: boolean;
     defaults: any;
     pattern: string = '';
-    params: Array<string> = [];
-    private subSegments: Array<{ name: string; param: boolean }> = [];
+    params: string[] = [];
+    private subSegments: { name: string; param: boolean }[] = [];
     private escapePattern: RegExp = /[\.+*\^$\[\](){}']/g;
     private itemPattern: RegExp = /[{]{0,1}[^{}]+[}]{0,1}/g;
 

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -4,7 +4,7 @@
     defaults: any;
     pattern: string = '';
     params: Array<string> = [];
-    private parts: Array<{ name: string; param: boolean }> = [];
+    private subSegments: Array<{ name: string; param: boolean }> = [];
     private paramsPattern: RegExp = /\{([^}]+)\}/g;
     private escapePattern: RegExp = /[\.+*\^$\[\](){}']/g;
     private itemPattern: RegExp = /[{]{0,1}[^{}]+[}]{0,1}/g;
@@ -21,19 +21,19 @@
             return;
         var matches = this.path.match(this.itemPattern);
         for (var i = 0; i < matches.length; i++) {
-            var part = matches[i];
-            if (part.charAt(0) == '{') {
-                var param = part.substring(1, part.length - 1);
+            var subSegment = matches[i];
+            if (subSegment.charAt(0) == '{') {
+                var param = subSegment.substring(1, subSegment.length - 1);
                 var name = param.slice(-1) === '?' ? param.substring(0, param.length - 1) : param;
                 this.params.push(name);
-                this.parts.push({ name: name, param: true });
+                this.subSegments.push({ name: name, param: true });
                 var optionalOrDefault = param.slice(-1) === '?' || this.defaults[name];
-                this.optional = this.optional && this.path.length === part.length && optionalOrDefault;
+                this.optional = this.optional && this.path.length === subSegment.length && optionalOrDefault;
                 this.pattern += !this.optional ? '([^/]+)' : '(\/[^/]+)?';
             } else {
                 this.optional = false;
-                this.parts.push({ name: part, param: false });
-                this.pattern += part.replace(this.escapePattern, '\\$&');
+                this.subSegments.push({ name: subSegment, param: false });
+                this.pattern += subSegment.replace(this.escapePattern, '\\$&');
             }
         }
         if (!this.optional)
@@ -44,13 +44,13 @@
         var routePath = '';
         var optional = this.optional;
         var blank = false;
-        for(var i = 0; i < this.parts.length; i++) {
-            var part = this.parts[i];
-            if (!part.param) {
-                routePath += part.name;
+        for(var i = 0; i < this.subSegments.length; i++) {
+            var subSegment = this.subSegments[i];
+            if (!subSegment.param) {
+                routePath += subSegment.name;
             } else {
-                var val = data[part.name];
-                var defaultVal = this.defaults[part.name];
+                var val = data[subSegment.name];
+                var defaultVal = this.defaults[subSegment.name];
                 optional = optional && (!val || val === defaultVal);
                 val = val ? val : defaultVal;
                 blank = blank || !val;

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -23,7 +23,7 @@
             optional = this.path.length === match.length && optionalOrDefault;
             return '?';
         }
-            this.pattern = this.path.replace(this.paramsPattern, replaceParam);
+        this.pattern = this.path.replace(this.paramsPattern, replaceParam);
         this.optional = this.optional && optional;
         this.pattern = this.pattern.replace(this.escapePattern, '\\$&');
         if (!this.optional)

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -2,7 +2,7 @@
     path: string;
     optional: boolean;
     defaults: any;
-    pattern: string;
+    pattern: string = '';
     params: Array<string> = [];
     private paramsPattern: RegExp = /\{([^}]+)\}/g;
     private escapePattern: RegExp = /[\.+*\^$\[\](){}']/g;
@@ -16,10 +16,8 @@
     }
 
     private parse() {
-        this.pattern = '';
-        if (this.path.length === 0) {
+        if (this.path.length === 0)
             return;
-        }
         var matches = this.path.match(this.itemPattern);
         for (var i = 0; i < matches.length; i++) {
             var item = matches[i];

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1197,14 +1197,8 @@ describe('BuildTest', function () {
 
     it('ReservedRegexCharacterBuildTest', function () {
         var router = new Router();
-        var route = router.addRoute('.+*\^$\[\](){}\'/{x}');
-        assert.equal(route.build({ x: 'abc' }), '/.+*\^$\[\](){}\'/abc');
-    });
-
-    it('ReservedRegexCharacterBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('.+*\^$\[\](){}\'/{x}');
-        assert.equal(route.build({ x: 'abc' }), '/.+*\^$\[\](){}\'/abc');
+        var route = router.addRoute('.+*\^$\[\]()\'/{x}');
+        assert.equal(route.build({ x: 'abc' }), '/.+*\^$\[\]()\'/abc');
     });
 
     it('OneParamOptionalMandatoryOneMixedSegmentBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -697,8 +697,8 @@ describe('MatchTest', function () {
 
     it('ReservedRegexCharacterMatchTest', function () {
         var router = new Router();
-        var route = router.addRoute('.+*\^$\[\](){}\'/{x}');
-        var routeMatch = router.match('.+*\^$\[\](){}\'/abc');
+        var route = router.addRoute('.+*\^$\[\]()\'/{x}');
+        var routeMatch = router.match('.+*\^$\[\]()\'/abc');
         assert.equal(routeMatch.route, route);
         assert.equal(Object.keys(routeMatch.data).length, 1);
         assert.equal(routeMatch.data.x, 'abc');


### PR DESCRIPTION
Route building used RegExp to replace params with values. This is slow, bearing in mind that Navigation Links update onNavigate. Moved the hard work into the parse method, building up a list of sub Segments, so that the build method just glues the pieces together. Rough timings indicate it's three times as fast.
If there are a lot of Navigation links (1000's) on the page then it would still be too slow to update all of them onNavigate. Need ability to turn off update onNavigate. They can reevaluate their href's onclick (and onmousedown, to capture right click and open in new tab).