### PR TITLE
Allowed a State to have more than one Route

### DIFF
--- a/NavigationJS/src/StateRouter.ts
+++ b/NavigationJS/src/StateRouter.ts
@@ -14,7 +14,7 @@ class StateRouter implements IRouter {
     }
 
     getRoute(state: State, data: any): { route: string; data: any } {
-        var routeInfo: {routes: Route[]; params: {}; matches: {} } = state['_routeInfo'];
+        var routeInfo: { routes: Route[]; params: {}; matches: {} } = state['_routeInfo'];
         var paramsKey = '';
         for(var key in routeInfo.params) {
             if (data[key])
@@ -84,7 +84,7 @@ class StateRouter implements IRouter {
         var routes = state.route.split(',');
         for(var i = 0; i < routes.length; i++) {
             var route = this.router.addRoute(routes[i], state.formattedDefaults);
-            for(var j = 0; j < route.params.length; j++){
+            for(var j = 0; j < route.params.length; j++) {
                 var param = route.params[j];
                 if (!routeInfo.params[param.name]) {
                     routeInfo.params[param.name] = count;

--- a/NavigationJS/src/StateRouter.ts
+++ b/NavigationJS/src/StateRouter.ts
@@ -64,14 +64,10 @@ class StateRouter implements IRouter {
 
     addRoutes(dialogs: Dialog[]) {
         this.router = new Router();
-        var states: State[] = [];
         for (var i = 0; i < dialogs.length; i++) {
             for (var j = 0; j < dialogs[i]._states.length; j++) {
-                states.push(dialogs[i]._states[j]);
+                this.addStateRoutes(dialogs[i]._states[j]);
             }
-        }
-        for (var i = 0; i < states.length; i++) {
-            this.addStateRoutes(states[i]);
         }
         this.router.sort((routeA: Route, routeB: Route) => {
             var routeANumber = routeA.path.charAt(0) === '{' ? -1 : 0;

--- a/NavigationJS/src/StateRouter.ts
+++ b/NavigationJS/src/StateRouter.ts
@@ -83,7 +83,7 @@ class StateRouter implements IRouter {
     private addStateRoutes(state: State) {
         var routeInfo: RouteInfo = { routes: [], params: {}, matches: {} }; 
         var count = 0;
-        var routes = this.getRoutes(state);
+        var routes = StateRouter.getRoutes(state);
         for(var i = 0; i < routes.length; i++) {
             var route = this.router.addRoute(routes[i], state.formattedDefaults);
             for(var j = 0; j < route.params.length; j++) {
@@ -99,7 +99,7 @@ class StateRouter implements IRouter {
         state['_routeInfo'] = routeInfo;
     }
     
-    private getRoutes(state: State): string[] {
+    private static getRoutes(state: State): string[] {
         var routes: string[] = [];
         var route = state.route;
         if (typeof route === 'string') {

--- a/NavigationJS/src/StateRouter.ts
+++ b/NavigationJS/src/StateRouter.ts
@@ -69,8 +69,8 @@ class StateRouter implements IRouter {
             }
         }
         states.sort((stateA, stateB) => {
-            var stateANumber = stateA.route.substring(0, 1) === '{' ? -1 : 0;
-            var stateBNumber = stateB.route.substring(0, 1) === '{' ? -1 : 0;
+            var stateANumber = stateA.route.charAt(0) === '{' ? -1 : 0;
+            var stateBNumber = stateB.route.charAt(0) === '{' ? -1 : 0;
             return stateBNumber - stateANumber;
         });
         for (var i = 0; i < states.length; i++) {

--- a/NavigationJS/src/StateRouter.ts
+++ b/NavigationJS/src/StateRouter.ts
@@ -14,27 +14,26 @@ class StateRouter implements IRouter {
     }
 
     getRoute(state: State, data: any): { route: string; data: any } {
-        var routes: Route[] = state['_routeInfo'].routes;
-        var params = state['_routeInfo'].params;
+        var routeInfo: {routes: Route[]; params: {}; matches: {} } = state['_routeInfo'];
         var paramsKey = '';
-        for(var key in params) {
+        for(var key in routeInfo.params) {
             if (data[key])
-                paramsKey += params[key] + ',';
+                paramsKey += routeInfo.params[key] + ',';
         }
         paramsKey = paramsKey.slice(0, -1);
-        var routeInfo: { route: Route; data: any; } = state['_routeInfo'][paramsKey];
+        var routeMatch: { route: Route; data: any; } = routeInfo.matches[paramsKey];
         var routePath: string = null;
-        if (routeInfo) {
-            routePath = routeInfo.route.build(data);
+        if (routeMatch) {
+            routePath = routeMatch.route.build(data);
         } else {
-            var bestMatch = StateRouter.findBestMatch(routes, data);
+            var bestMatch = StateRouter.findBestMatch(routeInfo.routes, data);
             if (bestMatch) {
                 routePath = bestMatch.routePath;
-                routeInfo = { route: bestMatch.route, data: bestMatch.data };
-                state['_routeInfo'][paramsKey] = routeInfo;
+                routeMatch = { route: bestMatch.route, data: bestMatch.data };
+                routeInfo.matches[paramsKey] = routeMatch;
             }
         }
-        return { route: routePath, data: routeInfo ? routeInfo.data : {} };
+        return { route: routePath, data: routeMatch ? routeMatch.data : {} };
     }
     
     private static findBestMatch(routes: Route[], data: any): { route: Route; data: any; routePath: string } {
@@ -80,7 +79,7 @@ class StateRouter implements IRouter {
     }
     
     private addStateRoutes(state: State) {
-        var routeInfo: { routes: Route[]; params: any} = {routes: [], params: {}}; 
+        var routeInfo = { routes: new Array<Route>(), params: {}, matches: {} }; 
         var count = 0;
         var routes = state.route.split(',');
         for(var i = 0; i < routes.length; i++) {

--- a/NavigationJS/src/StateRouter.ts
+++ b/NavigationJS/src/StateRouter.ts
@@ -68,20 +68,20 @@ class StateRouter implements IRouter {
                 states.push(dialogs[i]._states[j]);
             }
         }
-        states.sort((stateA, stateB) => {
-            var stateANumber = stateA.route.charAt(0) === '{' ? -1 : 0;
-            var stateBNumber = stateB.route.charAt(0) === '{' ? -1 : 0;
-            return stateBNumber - stateANumber;
-        });
         for (var i = 0; i < states.length; i++) {
             this.addStateRoutes(states[i]);
         }
+        this.router.sort((routeA: Route, routeB: Route) => {
+            var routeANumber = routeA.path.charAt(0) === '{' ? -1 : 0;
+            var routeBNumber = routeB.path.charAt(0) === '{' ? -1 : 0;
+            return routeBNumber - routeANumber;
+        });
     }
     
     private addStateRoutes(state: State) {
         var routeInfo = { routes: new Array<Route>(), params: {}, matches: {} }; 
         var count = 0;
-        var routes = state.route.split(',');
+        var routes = this.getRoutes(state);
         for(var i = 0; i < routes.length; i++) {
             var route = this.router.addRoute(routes[i], state.formattedDefaults);
             for(var j = 0; j < route.params.length; j++) {
@@ -95,6 +95,19 @@ class StateRouter implements IRouter {
             route['_state'] = state;
         }
         state['_routeInfo'] = routeInfo;
+    }
+    
+    private getRoutes(state: State): string[] {
+        var routes: string[] = [];
+        var route = state.route;
+        if (typeof route === 'string') {
+            routes.push(route);
+        } else {
+            for(var i = 0; i < route.length; i++) {
+                routes.push(route[i]);
+            }
+        }
+        return routes;
     }
 }
 export = StateRouter;

--- a/NavigationJS/src/StateRouter.ts
+++ b/NavigationJS/src/StateRouter.ts
@@ -3,6 +3,8 @@ import IRouter = require('./IRouter');
 import Route = require('./routing/Route');
 import Router = require('./routing/Router');
 import State = require('./config/State');
+type RouteInfo = { routes: Route[]; params: any; matches: any };
+type MatchInfo = { route: Route; data: any; routePath: string };
 
 class StateRouter implements IRouter {
     router: Router;
@@ -14,7 +16,7 @@ class StateRouter implements IRouter {
     }
 
     getRoute(state: State, data: any): { route: string; data: any } {
-        var routeInfo: { routes: Route[]; params: {}; matches: {} } = state['_routeInfo'];
+        var routeInfo: RouteInfo = state['_routeInfo'];
         var paramsKey = '';
         for(var key in routeInfo.params) {
             if (data[key])
@@ -36,8 +38,8 @@ class StateRouter implements IRouter {
         return { route: routePath, data: routeMatch ? routeMatch.data : {} };
     }
     
-    private static findBestMatch(routes: Route[], data: any): { route: Route; data: any; routePath: string } {
-        var bestMatch: { route: Route; data: any; routePath: string };
+    private static findBestMatch(routes: Route[], data: any): MatchInfo {
+        var bestMatch: MatchInfo;
         var bestMatchCount = -1;
         for(var i = 0; i < routes.length; i++) {
             var route = routes[i];
@@ -79,7 +81,7 @@ class StateRouter implements IRouter {
     }
     
     private addStateRoutes(state: State) {
-        var routeInfo = { routes: new Array<Route>(), params: {}, matches: {} }; 
+        var routeInfo: RouteInfo = { routes: [], params: {}, matches: {} }; 
         var count = 0;
         var routes = this.getRoutes(state);
         for(var i = 0; i < routes.length; i++) {

--- a/NavigationJS/src/config/IState.ts
+++ b/NavigationJS/src/config/IState.ts
@@ -4,7 +4,7 @@ interface IState<TTransitions> {
 	defaults?: any;
 	defaultTypes?: any;
 	title?: string;
-	route: string;
+	route: string | string[];
 	trackCrumbTrail?: boolean;
 }
 export = IState;

--- a/NavigationJS/src/config/State.ts
+++ b/NavigationJS/src/config/State.ts
@@ -15,7 +15,7 @@ class State implements IState<{ [index: string]: Transition }> {
     defaultTypes: any = {};
     formattedDefaults: any = {};
     title: string;
-    route: string;
+    route: string | string[];
     trackCrumbTrail: boolean = true;
     stateHandler: IStateHandler = new StateHandler();
     unloading: (state: State, data: any, url: string, unload: () => void, history?: boolean) => void = function (state, data, url, unload) { unload(); };

--- a/NavigationJS/src/history/HashHistoryManager.ts
+++ b/NavigationJS/src/history/HashHistoryManager.ts
@@ -12,7 +12,7 @@ class HashHistoryManager implements IHistoryManager {
             if (window.addEventListener)
                 window.addEventListener('hashchange', HistoryNavigator.navigateHistory);
             else
-                window.attachEvent('onhashchange', HistoryNavigator.navigateHistory);
+                window['attachEvent']('onhashchange', HistoryNavigator.navigateHistory);
         }
     }
 

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -61,9 +61,9 @@ declare module Navigation {
          */
         title?: string;
         /**
-         * Gets the route Url pattern
+         * Gets the route Url patterns
          */
-        route: string;
+        route: string | string[];
         /**
          * Gets a value that indicates whether to maintain crumb trail 
          * information e.g PreviousState. This can be used together with Route
@@ -175,9 +175,9 @@ declare module Navigation {
          */
         title: string;
         /**
-         * Gets the route Url pattern
+         * Gets the route Url patterns
          */
-        route: string;
+        route: string | string[];
         /**
          * Gets a value that indicates whether to maintain crumb trail 
          * information e.g PreviousState. This can be used together with Route
@@ -949,6 +949,11 @@ declare module Navigation {
          * @returns The matched route and data
          */
         match(path: string): { route: Route; data: any; };
+        /**
+         * Sorts the routes by the comparer
+         * @param compare The route comparer function
+         */
+        sort(compare: (routeA: Route, routeB: Route) => number): void;
     }
 
     /**

--- a/NavigationJS/src/routing/Router.ts
+++ b/NavigationJS/src/routing/Router.ts
@@ -27,5 +27,9 @@ class Router {
         }
         return null;
     }
+    
+    sort(compare: (routeA: Route, routeB: Route) => number) {
+        this.routes.sort(compare);
+    }
 }
 export = Router;

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -23,7 +23,7 @@
             var subSegment = matches[i];
             if (subSegment.charAt(0) == '{') {
                 var param = subSegment.substring(1, subSegment.length - 1);
-                var name = param.slice(-1) === '?' ? param.substring(0, param.length - 1) : param;
+                var name = param.slice(-1) === '?' ? param.slice(0, -1) : param;
                 this.params.push(name);
                 this.subSegments.push({ name: name, param: true });
                 var optionalOrDefault = param.slice(-1) === '?' || this.defaults[name];

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1066,10 +1066,16 @@ describe('MatchTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: ['', 'abc'], trackCrumbTrail: false }]}
             ]);
-        Navigation.StateController.navigateLink('');
+        Navigation.StateController.navigateLink('/');
         assert.equal(Object.keys(Navigation.StateContext.data).length, 0);
-        Navigation.StateController.navigateLink('abc');
+        Navigation.StateController.navigateLink('/?x=d');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'd');
+        Navigation.StateController.navigateLink('/abc');
         assert.equal(Object.keys(Navigation.StateContext.data).length, 0);
+        Navigation.StateController.navigateLink('/abc?x=d');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'd');
     });
 
     it('TwoRouteNoMatchTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -558,25 +558,33 @@ describe('MatchTest', function () {
     });
 
     it('OneParamOneSegmentDefaultMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}', { x: 'cde' });
-        var routeMatch = router.match('ab');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data.x, 'ab');
-        routeMatch = router.match('');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data.x, 'cde');
-        assert.equal(route.params.length, 1);
-        assert.equal(route.params[0].name, 'x');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', defaults: { x: 'cde' }, trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/ab');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'ab');
+        Navigation.StateController.navigateLink('/ab?z=cd');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'ab');
+        assert.equal(Navigation.StateContext.data.z, 'cd');
+        Navigation.StateController.navigateLink('/');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'cde');
+        Navigation.StateController.navigateLink('/?z=fg');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'cde');
+        assert.equal(Navigation.StateContext.data.z, 'fg');
     });
 
     it('OneParamOneSegmentDefaultNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}', { x: 'cde' });
-        assert.equal(router.match('ab/cd'), null);
-        assert.equal(router.match('ab//'), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', defaults: { x: 'cde' }, trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/cd'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab//'), /Url is invalid/, '');
     });
 
     it('OneParamTwoSegmentDefaultMatchTest', function () {
@@ -1266,13 +1274,18 @@ describe('BuildTest', function () {
     });
 
     it('OneParamOneSegmentDefaultBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}', { x: 'cde' });
-        assert.equal(route.build({ x: 'ab' }), '/ab');
-        assert.equal(route.build({ x: 'cde' }), '/');
-        assert.equal(route.build(), '/');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', defaults: { x: 'cde' }, trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/ab');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ab', z: 'cd' }), '/ab?z=cd');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cde' }), '/');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cde', z: 'fg' }), '/?z=fg');
+        assert.equal(Navigation.StateController.getNavigationLink('d'), '/');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'fg' }), '/?z=fg');
     });
-
+    
     it('OneParamTwoSegmentDefaultBuildTest', function () {
         var router = new Router();
         var route = router.addRoute('ab/{x}', { x: 'ccdd' });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -137,25 +137,30 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamTwoSegmentMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}/{y}');
-        var routeMatch = router.match('aa/bbb');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 2);
-        assert.equal(routeMatch.data.x, 'aa');
-        assert.equal(routeMatch.data.y, 'bbb');
-        assert.equal(route.params.length, 2);
-        assert.equal(route.params[0].name, 'x');
-        assert.equal(route.params[1].name, 'y');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}/{y}', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/aa/bbb');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'aa');
+        assert.equal(Navigation.StateContext.data.y, 'bbb');
+        Navigation.StateController.navigateLink('/aa/bbb?z=cccc');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'aa');
+        assert.equal(Navigation.StateContext.data.y, 'bbb');
+        assert.equal(Navigation.StateContext.data.z, 'cccc');
     });
 
     it('TwoParamTwoSegmentNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}/{y}');
-        assert.equal(router.match('aa/bbb/e'), null);
-        assert.equal(router.match('aa//'), null);
-        assert.equal(router.match('aa'), null);
-        assert.equal(router.match(''), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}/{y}', trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/aa/bbb/e'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/aa//'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/aa'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
 
     it('TwoParamThreeSegmentMatchTest', function () {
@@ -935,24 +940,24 @@ describe('BuildTest', function () {
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'ef' }), null);
     });
 
-    it('OneParamTwoSegmentNonBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x}');
-        assert.equal(route.build(), null);
-    });
-
     it('TwoParamTwoSegmentBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}/{y}');
-        assert.equal(route.build({ x: 'aa', y: 'bbb' }), '/aa/bbb');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}/{y}', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb' }), '/aa/bbb');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb', z: 'cccc' }), '/aa/bbb?z=cccc');
     });
 
     it('TwoParamTwoSegmentNonBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}/{y}');
-        assert.equal(route.build({ x: 'aa' }), null);
-        assert.equal(route.build({ y: 'bbb' }), null);
-        assert.equal(route.build(), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}/{y}', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa' }), null);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'bbb' }), null);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'cccc' }), null);
+        assert.equal(Navigation.StateController.getNavigationLink('d'), null);
     });
 
     it('TwoParamThreeSegmentBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1004,11 +1004,11 @@ describe('MatchTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}', defaults: { x: 'a', y: 'b' }, trackCrumbTrail: false }]}
             ]);
-        Navigation.StateController.navigateLink('');
+        Navigation.StateController.navigateLink('/');
         assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
         assert.equal(Navigation.StateContext.data.x, 'a');
         assert.equal(Navigation.StateContext.data.y, 'b');
-        Navigation.StateController.navigateLink('?z=c');
+        Navigation.StateController.navigateLink('/?z=c');
         assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
         assert.equal(Navigation.StateContext.data.x, 'a');
         assert.equal(Navigation.StateContext.data.y, 'b');
@@ -1016,41 +1016,50 @@ describe('MatchTest', function () {
     });
 
     it('CaseInsensitiveMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('abc/{x}');
-        var routeMatch = router.match('AbC/aBc');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data.x, 'aBc');
-        assert.equal(route.params.length, 1);
-        assert.equal(route.params[0].name, 'x');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'abc/{x}', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/AbC/aBc');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'aBc');
+        Navigation.StateController.navigateLink('/AbC/aBc?y=dE');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'aBc');
+        assert.equal(Navigation.StateContext.data.y, 'dE');
     });
 
     it('MultipleRoutesMatchTest', function () {
-        var router = new Router();
-        var route1 = router.addRoute('ab/{x}');
-        var route2 = router.addRoute('cd/{x}');
-        var routeMatch = router.match('ab/ef');
-        assert.equal(routeMatch.route, route1);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data.x, 'ef');
-        assert.equal(route1.params.length, 1);
-        assert.equal(route1.params[0].name, 'x');
-        routeMatch = router.match('cd/ef');
-        assert.equal(routeMatch.route, route2);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data.x, 'ef');
-        assert.equal(route2.params.length, 1);
-        assert.equal(route2.params[0].name, 'x');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x}', trackCrumbTrail: false },
+                { key: 's1', route: 'cd/{x}', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/ab/ef');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'ef');
+        Navigation.StateController.navigateLink('/ab/ef?y=gh');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'ef');
+        assert.equal(Navigation.StateContext.data.y, 'gh');
+        Navigation.StateController.navigateLink('/cd/ef');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'ef');
+        Navigation.StateController.navigateLink('/cd/ef?y=gh');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'ef');
+        assert.equal(Navigation.StateContext.data.y, 'gh');
     });
 
     it('MultipleRoutesNonMatchTest', function () {
-        var router = new Router();
-        var route1 = router.addRoute('ab/{x}');
-        var route2 = router.addRoute('cd/{x}');
-        assert.equal(router.match('aa/bbb'), null);
-        assert.equal(router.match('ab'), null);
-        assert.equal(router.match('cd'), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x}', trackCrumbTrail: false },
+                { key: 's1', route: 'cd/{x}', trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/aa/bbb'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/cd'), /Url is invalid/, '');
     });
 });
 

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -850,18 +850,24 @@ describe('MatchTest', function () {
     });
 
     it('ReservedUrlCharacterMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('a/{*="()\'-_+~@:?><.;[],!£$%^#&}', { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' });
-        var routeMatch = router.match('a/*%3D%22()\'-_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data['*="()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-_+~@:?><.;[],!£$%^#&');
-        var routeMatch = router.match('a');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data['*="()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
-        assert.equal(route.params.length, 1);
-        assert.equal(route.params[0].name, '*="()\'-_+~@:?><.;[],!£$%^#&');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'a/{*="()\'-_+~@:?><.;[]!£$%^#&}', defaults: { '*="()\'-_+~@:?><.;[]!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' }, trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/a/*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data['*="()\'-_+~@:?><.;[]!£$%^#&'], '*="()\'-_+~@:?><.;[],!£$%^#&');
+        Navigation.StateController.navigateLink('/a/*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26?*%3D%22()\'-_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data['*="()\'-_+~@:?><.;[]!£$%^#&'], '*="()\'-_+~@:?><.;[],!£$%^#&');
+        assert.equal(Navigation.StateContext.data['*="()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-_+~@:?><.;[],!£$%^#&');
+        Navigation.StateController.navigateLink('/a');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data['*="()\'-_+~@:?><.;[]!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
+        Navigation.StateController.navigateLink('/a?*%3D%22()\'-_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data['*="()\'-_+~@:?><.;[]!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
+        assert.equal(Navigation.StateContext.data['*="()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-_+~@:?><.;[],!£$%^#&');
     });
 
     it('ReservedRegexCharacterMatchTest', function () {
@@ -1514,11 +1520,16 @@ describe('BuildTest', function () {
     });
 
     it('ReservedUrlCharacterBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('a/{*="()\'-_+~@:?><.;[],!£$%^#&}', { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' });
-        assert.equal(route.build({ '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&' }), '/a/*%3D%22()\'-_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
-        assert.equal(route.build({ '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' }), '/a');
-        assert.equal(route.build(), '/a');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'a/{*="()\'-_+~@:?><.;[]!£$%^#&}', defaults: { '*="()\'-_+~@:?><.;[]!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' }, trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[]!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&' }), '/a/*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[]!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&', '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&'}), '/a/*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26?*%3D%22()\'-_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[]!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' }), '/a');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[]!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&', '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&'}), '/a?*%3D%22()\'-_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+        assert.equal(Navigation.StateController.getNavigationLink('d'), '/a');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&' }), '/a?*%3D%22()\'-_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
     });
 
     it('ReservedRegexCharacterBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1864,4 +1864,18 @@ describe('BuildTest', function () {
         assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh' }), '/abc/de?y=gh');
         assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh', z: 'i' }), '/abc/de?y=gh&z=i');
     });
+
+    it('TwoRouteDefaultNonBuildTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['abc/{x}', 'def/{y}'], defaults: { x: 'd' }, trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/def'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ abc/de'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ def/gh'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abd/ef'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abc/de/f'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/def/gh/i'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
+    });
 })

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -164,29 +164,34 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamThreeSegmentMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x}/{y}');
-        var routeMatch = router.match('ab/cd/efg');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 2);
-        assert.equal(routeMatch.data.x, 'cd');
-        assert.equal(routeMatch.data.y, 'efg');
-        assert.equal(route.params.length, 2);
-        assert.equal(route.params[0].name, 'x');
-        assert.equal(route.params[1].name, 'y');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x}/{y}', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/ab/cd/efg');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'cd');
+        assert.equal(Navigation.StateContext.data.y, 'efg');
+        Navigation.StateController.navigateLink('/ab/cd/efg?z=hi');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'cd');
+        assert.equal(Navigation.StateContext.data.y, 'efg');
+        assert.equal(Navigation.StateContext.data.z, 'hi');
     });
 
     it('TwoParamThreeSegmentNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x}/{y}');
-        assert.equal(router.match(' ab/cd/efg'), null);
-        assert.equal(router.match('ab/cde'), null);
-        assert.equal(router.match('ab/cd'), null);
-        assert.equal(router.match('ab/cd/efg/h'), null);
-        assert.equal(router.match('ab//efg'), null);
-        assert.equal(router.match('/cd/efg'), null);
-        assert.equal(router.match('ab'), null);
-        assert.equal(router.match(''), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x}/{y}', trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/ ab/cd/efg'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/cde'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/cd'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/cd/efg/h'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab//efg'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('//cd/efg'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
 
     it('TwoParamFourSegmentMatchTest', function () {
@@ -961,17 +966,23 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamThreeSegmentBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x}/{y}');
-        assert.equal(route.build({ x: 'cd', y: 'efg' }), '/ab/cd/efg');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x}/{y}', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg' }), '/ab/cd/efg');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg', z: 'hi' }), '/ab/cd/efg?z=hi');
     });
 
     it('TwoParamThreeSegmentNonBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x}/{y}');
-        assert.equal(route.build({ x: 'cd' }), null);
-        assert.equal(route.build({ y: 'efg' }), null);
-        assert.equal(route.build(), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}/{y}', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd' }), null);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'efg' }), null);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'hi' }), null);
+        assert.equal(Navigation.StateController.getNavigationLink('d'), null);
     });
 
     it('TwoParamFourSegmentBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -5,7 +5,7 @@ import Navigation = require('../src/Navigation');
 
 describe('MatchTest', function () {
     it('RootMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '', trackCrumbTrail: false }]}
             ]);
@@ -17,7 +17,7 @@ describe('MatchTest', function () {
     });
 
     it('RootNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '', trackCrumbTrail: false }]}
             ]);
@@ -27,7 +27,7 @@ describe('MatchTest', function () {
     });
 
     it('NoParamOneSegmentMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'abc', trackCrumbTrail: false }]}
             ]);
@@ -39,7 +39,7 @@ describe('MatchTest', function () {
     });
 
     it('NoParamOneSegmentNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'abc', trackCrumbTrail: false }]}
             ]);
@@ -55,7 +55,7 @@ describe('MatchTest', function () {
     });
 
     it('NoParamTwoSegmentMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/c', trackCrumbTrail: false }]}
             ]);
@@ -67,7 +67,7 @@ describe('MatchTest', function () {
     });
 
     it('NoParamTwoSegmentNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/c', trackCrumbTrail: false }]}
             ]);
@@ -83,7 +83,7 @@ describe('MatchTest', function () {
     });
 
     it('OneParamOneSegmentMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}', trackCrumbTrail: false }]}
             ]);
@@ -97,7 +97,7 @@ describe('MatchTest', function () {
     });
 
     it('OneParamOneSegmentNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}', trackCrumbTrail: false }]}
             ]);
@@ -107,7 +107,7 @@ describe('MatchTest', function () {
     });
 
     it('OneParamTwoSegmentMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}', trackCrumbTrail: false }]}
             ]);
@@ -121,7 +121,7 @@ describe('MatchTest', function () {
     });
 
     it('OneParamTwoSegmentNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}', trackCrumbTrail: false }]}
             ]);
@@ -136,7 +136,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamTwoSegmentMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y}', trackCrumbTrail: false }]}
             ]);
@@ -152,7 +152,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamTwoSegmentNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y}', trackCrumbTrail: false }]}
             ]);
@@ -163,7 +163,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamThreeSegmentMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}/{y}', trackCrumbTrail: false }]}
             ]);
@@ -179,7 +179,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamThreeSegmentNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}/{y}', trackCrumbTrail: false }]}
             ]);
@@ -194,7 +194,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamFourSegmentMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}/c/{y}', trackCrumbTrail: false }]}
             ]);
@@ -210,7 +210,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamFourSegmentNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}/c/{y}', trackCrumbTrail: false }]}
             ]);
@@ -224,7 +224,7 @@ describe('MatchTest', function () {
     });
 
     it('OneOptionalParamOneSegmentMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x?}', trackCrumbTrail: false }]}
             ]);
@@ -243,7 +243,7 @@ describe('MatchTest', function () {
     });
 
     it('OneOptionalParamOneSegmentNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x?}', trackCrumbTrail: false }]}
             ]);
@@ -252,7 +252,7 @@ describe('MatchTest', function () {
     });
 
     it('OneOptionalParamTwoSegmentMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x?}', trackCrumbTrail: false }]}
             ]);
@@ -271,7 +271,7 @@ describe('MatchTest', function () {
     });
 
     it('OneOptionalParamTwoSegmentNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x?}', trackCrumbTrail: false }]}
             ]);
@@ -285,7 +285,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoOptionalParamTwoSegmentMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x?}/{y?}', trackCrumbTrail: false }]}
             ]);
@@ -313,7 +313,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoOptionalParamTwoSegmentNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x?}/{y?}', trackCrumbTrail: false }]}
             ]);
@@ -322,7 +322,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoOptionalParamThreeSegmentMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x?}/{y?}', trackCrumbTrail: false }]}
             ]);
@@ -350,7 +350,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoOptionalParamThreeSegmentNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x?}/{y?}', trackCrumbTrail: false }]}
             ]);
@@ -362,7 +362,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamOneOptionalTwoSegmentMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y?}', trackCrumbTrail: false }]}
             ]);
@@ -385,7 +385,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamOneOptionalTwoSegmentNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y?}', trackCrumbTrail: false }]}
             ]);
@@ -395,7 +395,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamOneOptionalThreeSegmentMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}/{y?}', trackCrumbTrail: false }]}
             ]);
@@ -418,7 +418,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamOneOptionalThreeSegmentNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}/{y?}', trackCrumbTrail: false }]}
             ]);
@@ -431,7 +431,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamOneOptionalFourSegmentMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}/c/{y?}', trackCrumbTrail: false }]}
             ]);
@@ -454,7 +454,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamOneOptionalFourSegmentNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}/c/{y?}', trackCrumbTrail: false }]}
             ]);
@@ -467,7 +467,7 @@ describe('MatchTest', function () {
     });
 
     it('OneParamOneMixedSegmentMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab{x}', trackCrumbTrail: false }]}
             ]);
@@ -481,7 +481,7 @@ describe('MatchTest', function () {
     });
 
     it('OneParamOneMixedSegmentNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab{x}', trackCrumbTrail: false }]}
             ]);
@@ -492,7 +492,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamOneMixedSegmentMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab{x}e{y}', trackCrumbTrail: false }]}
             ]);
@@ -508,7 +508,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamOneMixedSegmentNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab{x}e{y}', trackCrumbTrail: false }]}
             ]);
@@ -522,7 +522,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamOneOptionalTwoSegmentOneMixedMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}ab/{y?}', trackCrumbTrail: false }]}
             ]);
@@ -545,7 +545,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamOneOptionalTwoSegmentOneMixedNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}ab/{y?}', trackCrumbTrail: false }]}
             ]);
@@ -557,7 +557,7 @@ describe('MatchTest', function () {
     });
 
     it('OneParamOneSegmentDefaultMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}', defaults: { x: 'cde' }, trackCrumbTrail: false }]}
             ]);
@@ -578,7 +578,7 @@ describe('MatchTest', function () {
     });
 
     it('OneParamOneSegmentDefaultNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}', defaults: { x: 'cde' }, trackCrumbTrail: false }]}
             ]);
@@ -587,7 +587,7 @@ describe('MatchTest', function () {
     });
 
     it('OneParamTwoSegmentDefaultMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}', defaults: { x: 'ccdd' }, trackCrumbTrail: false }]}
             ]);
@@ -608,7 +608,7 @@ describe('MatchTest', function () {
     });
 
     it('OneParamTwoSegmentDefaultNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}', defaults: { x: 'ccdd' }, trackCrumbTrail: false }]}
             ]);
@@ -622,7 +622,7 @@ describe('MatchTest', function () {
     });
 
     it('OneParamTwoSegmentDefaultMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y}', defaults: { x: 'ab', y: 'c' }, trackCrumbTrail: false }]}
             ]);
@@ -656,7 +656,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamTwoSegmentTwoDefaultNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y}', defaults: { x: 'ab', y: 'c' }, trackCrumbTrail: false }]}
             ]);
@@ -665,7 +665,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamTwoSegmentDefaultMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y}', defaults: { y: 'ab' }, trackCrumbTrail: false }]}
             ]);
@@ -690,7 +690,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamTwoSegmentDefaultNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y}', defaults: { y: 'ab' }, trackCrumbTrail: false }]}
             ]);
@@ -700,7 +700,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamOneOptionalTwoSegmentDefaultMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y?}', defaults: { x: 'abc' }, trackCrumbTrail: false }]}
             ]);
@@ -730,7 +730,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamOneOptionalTwoSegmentDefaultNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y?}', defaults: { x: 'abc' }, trackCrumbTrail: false }]}
             ]);
@@ -739,7 +739,7 @@ describe('MatchTest', function () {
     });
 
     it('FourParamTwoOptionalFiveSegmentDefaultMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{w}/{x}/{y?}/{z?}', defaults: { w: 'abc', x: 'de' }, trackCrumbTrail: false }]}
             ]);
@@ -797,7 +797,7 @@ describe('MatchTest', function () {
     });
 
     it('FourParamTwoOptionalFiveSegmentDefaultNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{w}/{x}/{y?}/{z?}', defaults: { w: 'abc', x: 'de' }, trackCrumbTrail: false }]}
             ]);
@@ -811,7 +811,7 @@ describe('MatchTest', function () {
     });
 
     it('SpacesMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}', trackCrumbTrail: false }]}
             ]);
@@ -825,7 +825,7 @@ describe('MatchTest', function () {
     });
 
     it('MultiCharParamMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'a/{someVar}', trackCrumbTrail: false }]}
             ]);
@@ -839,7 +839,7 @@ describe('MatchTest', function () {
     });
 
     it('MatchSlashTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}', trackCrumbTrail: false }]}
             ]);
@@ -849,7 +849,7 @@ describe('MatchTest', function () {
     });
 
     it('ReservedUrlCharacterMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'a/{*="()\'-_+~@:?><.;[]!£$%^#&}', defaults: { '*="()\'-_+~@:?><.;[]!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' }, trackCrumbTrail: false }]}
             ]);
@@ -870,7 +870,7 @@ describe('MatchTest', function () {
     });
 
     it('ReservedRegexCharacterMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '.+*\^$\[\]()\'/{x}', trackCrumbTrail: false }]}
             ]);
@@ -884,7 +884,7 @@ describe('MatchTest', function () {
     });
 
     it('OneParamOptionalMandatoryOneMixedSegmentMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab{x?}', trackCrumbTrail: false }]}
             ]);
@@ -898,7 +898,7 @@ describe('MatchTest', function () {
     });
 
     it('OneParamOptionalMandatoryOneMixedSegmentNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab{x?}', trackCrumbTrail: false }]}
             ]);
@@ -909,7 +909,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamOneOptionalMandatoryThreeSegmentMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x?}/{y}', trackCrumbTrail: false }]}
             ]);
@@ -925,7 +925,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamOneOptionalMandatoryThreeSegmentNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x?}/{y}', trackCrumbTrail: false }]}
             ]);
@@ -939,7 +939,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamTwoSegmentDefaultMandatoryMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y}', defaults: { x: 'ab' }, trackCrumbTrail: false }]}
             ]);
@@ -955,7 +955,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamTwoSegmentDefaultMandatoryNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y}', defaults: { x: 'ab' }, trackCrumbTrail: false }]}
             ]);
@@ -966,7 +966,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamOneOptionalMandatoryFourSegmentDefaultMandatoryMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x?}/{y}/c', defaults: { y: 'ee' }, trackCrumbTrail: false }]}
             ]);
@@ -982,7 +982,7 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamOneOptionalMandatoryFourSegmentDefaultMandatoryNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x?}/{y}/c', defaults: { y: 'ee' }, trackCrumbTrail: false }]}
             ]);
@@ -999,7 +999,7 @@ describe('MatchTest', function () {
     });
 
     it('ExtraDefaultsMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}', defaults: { x: 'a', y: 'b' }, trackCrumbTrail: false }]}
             ]);
@@ -1015,7 +1015,7 @@ describe('MatchTest', function () {
     });
 
     it('CaseInsensitiveMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'abc/{x}', trackCrumbTrail: false }]}
             ]);
@@ -1029,7 +1029,7 @@ describe('MatchTest', function () {
     });
 
     it('MultipleRoutesMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}', trackCrumbTrail: false },
                 { key: 's1', route: 'cd/{x}', trackCrumbTrail: false }]}
@@ -1051,7 +1051,7 @@ describe('MatchTest', function () {
     });
 
     it('MultipleRoutesNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}', trackCrumbTrail: false },
                 { key: 's1', route: 'cd/{x}', trackCrumbTrail: false }]}
@@ -1064,7 +1064,7 @@ describe('MatchTest', function () {
 
 describe('BuildTest', function () {
     it('RootBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '', trackCrumbTrail: false }]}
             ]);
@@ -1073,7 +1073,7 @@ describe('BuildTest', function () {
     });
 
     it('NoParamOneSegmentBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'abc', trackCrumbTrail: false }]}
             ]);
@@ -1082,7 +1082,7 @@ describe('BuildTest', function () {
     });
 
     it('NoParamTwoSegmentBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/c', trackCrumbTrail: false }]}
             ]);
@@ -1091,7 +1091,7 @@ describe('BuildTest', function () {
     });
 
     it('OneParamOneSegmentBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}', trackCrumbTrail: false }]}
             ]);
@@ -1100,7 +1100,7 @@ describe('BuildTest', function () {
     });
 
     it('OneParamOneSegmentNonBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}', trackCrumbTrail: false }]}
             ]);
@@ -1108,7 +1108,7 @@ describe('BuildTest', function () {
     });
 
     it('OneParamTwoSegmentBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}', trackCrumbTrail: false }]}
             ]);
@@ -1117,7 +1117,7 @@ describe('BuildTest', function () {
     });
 
     it('OneParamTwoSegmentNonBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}', trackCrumbTrail: false }]}
             ]);
@@ -1126,7 +1126,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamTwoSegmentBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y}', trackCrumbTrail: false }]}
             ]);
@@ -1135,7 +1135,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamTwoSegmentNonBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y}', trackCrumbTrail: false }]}
             ]);
@@ -1146,7 +1146,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamThreeSegmentBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}/{y}', trackCrumbTrail: false }]}
             ]);
@@ -1155,7 +1155,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamThreeSegmentNonBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y}', trackCrumbTrail: false }]}
             ]);
@@ -1166,7 +1166,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamFourSegmentBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}/c/{y}', trackCrumbTrail: false }]}
             ]);
@@ -1175,7 +1175,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamFourSegmentNonBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}/c/{y}', trackCrumbTrail: false }]}
             ]);
@@ -1186,7 +1186,7 @@ describe('BuildTest', function () {
     });
 
     it('OneOptionalParamOneSegmentBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x?}', trackCrumbTrail: false }]}
             ]);
@@ -1197,7 +1197,7 @@ describe('BuildTest', function () {
     });
 
     it('OneOptionalParamTwoSegmentBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x?}', trackCrumbTrail: false }]}
             ]);
@@ -1208,7 +1208,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoOptionalParamTwoSegmentBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x?}/{y?}', trackCrumbTrail: false }]}
             ]);
@@ -1221,7 +1221,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoOptionalParamTwoSegmentNonBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x?}/{y?}', trackCrumbTrail: false }]}
             ]);
@@ -1229,7 +1229,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoOptionalParamThreeSegmentBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x?}/{y?}', trackCrumbTrail: false }]}
             ]);
@@ -1242,7 +1242,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoOptionalParamThreeSegmentNonBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x?}/{y?}', trackCrumbTrail: false }]}
             ]);
@@ -1250,7 +1250,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamOneOptionalTwoSegmentBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y?}', trackCrumbTrail: false }]}
             ]);
@@ -1261,7 +1261,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamOneOptionalTwoSegmentNonBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y?}', trackCrumbTrail: false }]}
             ]);
@@ -1269,7 +1269,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamOneOptionalThreeSegmentBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}/{y?}', trackCrumbTrail: false }]}
             ]);
@@ -1280,7 +1280,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamOneOptionalThreeSegmentNonBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}/{y?}', trackCrumbTrail: false }]}
             ]);
@@ -1289,7 +1289,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamOneOptionalFourSegmentNonBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}/c/{y?}', trackCrumbTrail: false }]}
             ]);
@@ -1300,7 +1300,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamOneOptionalFourSegmentNonBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}/c/{y?}', trackCrumbTrail: false }]}
             ]);
@@ -1309,7 +1309,7 @@ describe('BuildTest', function () {
     });
 
     it('OneParamOneMixedSegmentBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab{x}', trackCrumbTrail: false }]}
             ]);
@@ -1318,7 +1318,7 @@ describe('BuildTest', function () {
     });
 
     it('OneParamOneMixedSegmentNonBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab{x}', trackCrumbTrail: false }]}
             ]);
@@ -1326,7 +1326,7 @@ describe('BuildTest', function () {
     });
 
     it('OneParamOneMixedSegmentBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab{x}e{y}', trackCrumbTrail: false }]}
             ]);
@@ -1335,7 +1335,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamOneMixedSegmentNonBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab{x}e{y}', trackCrumbTrail: false }]}
             ]);
@@ -1345,7 +1345,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamOneOptionalTwoSegmentOneMixedBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}ab/{y?}', trackCrumbTrail: false }]}
             ]);
@@ -1356,7 +1356,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamOneOptionalTwoSegmentOneMixedNonBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}ab/{y?}', trackCrumbTrail: false }]}
             ]);
@@ -1365,7 +1365,7 @@ describe('BuildTest', function () {
     });
 
     it('OneParamOneSegmentDefaultBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}', defaults: { x: 'cde' }, trackCrumbTrail: false }]}
             ]);
@@ -1378,7 +1378,7 @@ describe('BuildTest', function () {
     });
 
     it('OneParamTwoSegmentDefaultBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}', defaults: { x: 'ccdd' }, trackCrumbTrail: false }]}
             ]);
@@ -1391,7 +1391,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamTwoSegmentTwoDefaultBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y}', defaults: { x: 'ab', y: 'c' }, trackCrumbTrail: false }]}
             ]);
@@ -1414,7 +1414,7 @@ describe('BuildTest', function () {
     });
 
     it('OneParamTwoSegmentDefaultBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y}', defaults: { y: 'ab' }, trackCrumbTrail: false }]}
             ]);
@@ -1427,7 +1427,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamTwoSegmentDefaultNonBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y}', defaults: { y: 'ab' }, trackCrumbTrail: false }]}
             ]);
@@ -1436,7 +1436,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamOneOptionalTwoSegmentDefaultBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y?}', defaults: { x: 'abc' }, trackCrumbTrail: false }]}
             ]);
@@ -1455,7 +1455,7 @@ describe('BuildTest', function () {
     });
 
     it('FourParamTwoOptionalFiveSegmentDefaultBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{w}/{x}/{y?}/{z?}', defaults: { w: 'abc', x: 'de' }, trackCrumbTrail: false }]}
             ]);
@@ -1510,7 +1510,7 @@ describe('BuildTest', function () {
     });
 
     it('FourParamTwoOptionalFiveSegmentDefaultNonBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{w}/{x}/{y?}/{z?}', defaults: { w: 'abc', x: 'de' }, trackCrumbTrail: false }]}
             ]);
@@ -1526,7 +1526,7 @@ describe('BuildTest', function () {
     });
 
     it('SpacesBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}', trackCrumbTrail: false }]}
             ]);
@@ -1535,7 +1535,7 @@ describe('BuildTest', function () {
     });
 
     it('MultiCharParamBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'a/{someVar}', trackCrumbTrail: false }]}
             ]);
@@ -1544,7 +1544,7 @@ describe('BuildTest', function () {
     });
 
     it('ReservedUrlCharacterBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'a/{*="()\'-_+~@:?><.;[]!£$%^#&}', defaults: { '*="()\'-_+~@:?><.;[]!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' }, trackCrumbTrail: false }]}
             ]);
@@ -1557,7 +1557,7 @@ describe('BuildTest', function () {
     });
 
     it('ReservedRegexCharacterBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '.+*\^$\[\]()\'/{x}', trackCrumbTrail: false }]}
             ]);
@@ -1566,7 +1566,7 @@ describe('BuildTest', function () {
     });
 
     it('OneParamOptionalMandatoryOneMixedSegmentBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab{x?}', trackCrumbTrail: false }]}
             ]);
@@ -1575,7 +1575,7 @@ describe('BuildTest', function () {
     });
 
     it('OneParamOptionalMandatoryOneMixedSegmentNonBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab{x?}', trackCrumbTrail: false }]}
             ]);
@@ -1583,7 +1583,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamOneOptionalMandatoryThreeSegmentBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x?}/{y}', trackCrumbTrail: false }]}
             ]);
@@ -1592,7 +1592,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamOneOptionalMandatoryThreeSegmentNonBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x?}/{y}', trackCrumbTrail: false }]}
             ]);
@@ -1602,7 +1602,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamTwoSegmentDefaultMandatoryBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y}', defaults: { x: 'ab' }, trackCrumbTrail: false }]}
             ]);
@@ -1613,7 +1613,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamTwoSegmentDefaultMandatoryNonBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y}', defaults: { x: 'ab' }, trackCrumbTrail: false }]}
             ]);
@@ -1622,7 +1622,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamOneOptionalMandatoryFourSegmentDefaultMandatoryBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x?}/{y}/c', defaults: { y: 'ee' }, trackCrumbTrail: false }]}
             ]);
@@ -1633,7 +1633,7 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamOneOptionalMandatoryFourSegmentDefaultMandatoryNonBuildTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x?}/{y}/c', defaults: { y: 'ee' }, trackCrumbTrail: false }]}
             ]);
@@ -1642,7 +1642,7 @@ describe('BuildTest', function () {
     });
 
     it('EmptyStringNonMatchTest', function () {
-        Navigation.StateInfoConfig.build(<any> [
+        Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}', trackCrumbTrail: false }]}
             ]);

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1109,7 +1109,7 @@ describe('MatchTest', function () {
         assert.equal(Navigation.StateContext.data.y, 'i');
     });
 
-    it('TwoRouteParamMatchTest', function () {
+    it('TwoRouteParamNoMatchTest', function () {
         Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: ['abc/{x}', 'def/{x}'], trackCrumbTrail: false }]}
@@ -1121,6 +1121,44 @@ describe('MatchTest', function () {
         assert.throws(() => Navigation.StateController.navigateLink('/abd/ef'), /Url is invalid/, '');
         assert.throws(() => Navigation.StateController.navigateLink('/abc/de/f'), /Url is invalid/, '');
         assert.throws(() => Navigation.StateController.navigateLink('/def/gh/i'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
+    });
+
+    it('TwoRouteParentChildMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['abc/{x}', 'abc/{x}/def/{y}'], trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/abc/de');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'de');
+        Navigation.StateController.navigateLink('/abc/de?z=f');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'de');
+        assert.equal(Navigation.StateContext.data.z, 'f');
+        Navigation.StateController.navigateLink('/abc/de/def/gh');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'de');
+        assert.equal(Navigation.StateContext.data.y, 'gh');
+        Navigation.StateController.navigateLink('/abc/de/def/gh?z=i');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'de');
+        assert.equal(Navigation.StateContext.data.y, 'gh');
+        assert.equal(Navigation.StateContext.data.z, 'i');
+    });
+
+    it('TwoRouteParentChildNoMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['abc/{x}', 'abc/{x}/def/{y}'], trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/abc'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abc/de/def'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abc/de/def/gh/i'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abd/de'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abc/de/deg/gh'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ abc/de'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ abc/de/def/gh'), /Url is invalid/, '');
         assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1060,6 +1060,27 @@ describe('MatchTest', function () {
         assert.throws(() => Navigation.StateController.navigateLink('/ab'), /Url is invalid/, '');
         assert.throws(() => Navigation.StateController.navigateLink('/cd'), /Url is invalid/, '');
     });
+
+    it('TwoRouteMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['', 'abc'], trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 0);
+        Navigation.StateController.navigateLink('abc');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 0);
+    });
+
+    it('TwoRouteNoMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['', 'abc'], trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/ab'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ abc'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('//abc'), /Url is invalid/, '');
+    });
 });
 
 describe('BuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -396,31 +396,39 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamOneOptionalThreeSegmentMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x}/{y?}');
-        var routeMatch = router.match('ab/cd/efg');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 2);
-        assert.equal(routeMatch.data.x, 'cd');
-        assert.equal(routeMatch.data.y, 'efg');
-        routeMatch = router.match('ab/cde');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data.x, 'cde');
-        assert.equal(route.params.length, 2);
-        assert.equal(route.params[0].name, 'x');
-        assert.equal(route.params[1].name, 'y');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x}/{y?}', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/ab/cd/efg');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'cd');
+        assert.equal(Navigation.StateContext.data.y, 'efg');
+        Navigation.StateController.navigateLink('/ab/cd/efg?z=hi');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'cd');
+        assert.equal(Navigation.StateContext.data.y, 'efg');
+        assert.equal(Navigation.StateContext.data.z, 'hi');
+        Navigation.StateController.navigateLink('/ab/cde');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'cde');
+        Navigation.StateController.navigateLink('/ab/cde?z=fg');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'cde');
+        assert.equal(Navigation.StateContext.data.z, 'fg');
     });
 
     it('TwoParamOneOptionalThreeSegmentNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x}/{y?}');
-        assert.equal(router.match(' ab/cd/efg'), null);
-        assert.equal(router.match('ab/cd/efg/h'), null);
-        assert.equal(router.match('ab//efg'), null);
-        assert.equal(router.match('/cd/efg'), null);
-        assert.equal(router.match('ab'), null);
-        assert.equal(router.match(''), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x}/{y?}', trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/ ab/cd/efg'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/cd/efg/h'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab//efg'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('//cd/efg'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
 
     it('TwoParamOneOptionalFourSegmentMatchTest', function () {
@@ -1136,17 +1144,23 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamOneOptionalThreeSegmentBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x}/{y?}');
-        assert.equal(route.build({ x: 'cd', y: 'efg' }), '/ab/cd/efg');
-        assert.equal(route.build({ x: 'cde' }), '/ab/cde');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x}/{y?}', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg' }), '/ab/cd/efg');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg', z: 'hi' }), '/ab/cd/efg?z=hi');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cde' }), '/ab/cde');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cde', z: 'fg' }), '/ab/cde?z=fg');
     });
 
-    it('TwoParamOneOptionalThreeSegmentBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x}/{y?}');
-        assert.equal(route.build({ y: 'efg' }), null);
-        assert.equal(route.build(), null);
+    it('TwoParamOneOptionalThreeSegmentNonBuildTest', function () {
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x}/{y?}', trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'efg' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
     });
 
     it('TwoParamOneOptionalFourSegmentNonBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -468,23 +468,28 @@ describe('MatchTest', function () {
     });
 
     it('OneParamOneMixedSegmentMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab{x}');
-        var routeMatch = router.match('abcde');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data.x, 'cde');
-        assert.equal(route.params.length, 1);
-        assert.equal(route.params[0].name, 'x');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab{x}', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/abcde');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'cde');
+        Navigation.StateController.navigateLink('/abcde?y=fg');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'cde');
+        assert.equal(Navigation.StateContext.data.y, 'fg');
     });
 
     it('OneParamOneMixedSegmentNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab{x}');
-        assert.equal(router.match('ab/cde'), null);
-        assert.equal(router.match('abcd//'), null);
-        assert.equal(router.match('ab'), null);
-        assert.equal(router.match(''), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab{x}', trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/cde'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abcd//'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
 
     it('TwoParamOneMixedSegmentMatchTest', function () {
@@ -1192,15 +1197,20 @@ describe('BuildTest', function () {
     });
 
     it('OneParamOneMixedSegmentBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab{x}');
-        assert.equal(route.build({ x: 'cde' }), '/abcde');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab{x}', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cde' }), '/abcde');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cde', y: 'fg' }), '/abcde?y=fg');
     });
 
     it('OneParamOneMixedSegmentNonBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab{x}');
-        assert.equal(route.build(), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab{x}', trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
     });
 
     it('TwoParamOneMixedSegmentBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -10,10 +10,10 @@ describe('MatchTest', function () {
                 { key: 's', route: '', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 0);
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 0);
         Navigation.StateController.navigateLink('/?x=ab');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'ab');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'ab');
     });
 
     it('RootNonMatchTest', function () {
@@ -32,10 +32,10 @@ describe('MatchTest', function () {
                 { key: 's', route: 'abc', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/abc');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 0);
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 0);
         Navigation.StateController.navigateLink('/abc?x=ab');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'ab');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'ab');
     });
 
     it('NoParamOneSegmentNonMatchTest', function () {
@@ -60,10 +60,10 @@ describe('MatchTest', function () {
                 { key: 's', route: 'ab/c', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('ab/c');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 0);
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 0);
         Navigation.StateController.navigateLink('ab/c?x=ab');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'ab');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'ab');
     });
 
     it('NoParamTwoSegmentNonMatchTest', function () {
@@ -88,12 +88,12 @@ describe('MatchTest', function () {
                 { key: 's', route: '{x}', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/abcd');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'abcd');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'abcd');
         Navigation.StateController.navigateLink('/ab?y=cd');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'ab');
-        assert.equal(Navigation.StateContext.data.y, 'cd');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'ab');
+        assert.strictEqual(Navigation.StateContext.data.y, 'cd');
     });
 
     it('OneParamOneSegmentNonMatchTest', function () {
@@ -112,12 +112,12 @@ describe('MatchTest', function () {
                 { key: 's', route: 'ab/{x}', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/ab/cd');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'cd');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cd');
         Navigation.StateController.navigateLink('/ab/cd?y=ef');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'cd');
-        assert.equal(Navigation.StateContext.data.y, 'ef');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cd');
+        assert.strictEqual(Navigation.StateContext.data.y, 'ef');
     });
 
     it('OneParamTwoSegmentNonMatchTest', function () {
@@ -141,14 +141,14 @@ describe('MatchTest', function () {
                 { key: 's', route: '{x}/{y}', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/aa/bbb');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'aa');
-        assert.equal(Navigation.StateContext.data.y, 'bbb');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aa');
+        assert.strictEqual(Navigation.StateContext.data.y, 'bbb');
         Navigation.StateController.navigateLink('/aa/bbb?z=cccc');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'aa');
-        assert.equal(Navigation.StateContext.data.y, 'bbb');
-        assert.equal(Navigation.StateContext.data.z, 'cccc');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aa');
+        assert.strictEqual(Navigation.StateContext.data.y, 'bbb');
+        assert.strictEqual(Navigation.StateContext.data.z, 'cccc');
     });
 
     it('TwoParamTwoSegmentNonMatchTest', function () {
@@ -168,14 +168,14 @@ describe('MatchTest', function () {
                 { key: 's', route: 'ab/{x}/{y}', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/ab/cd/efg');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'cd');
-        assert.equal(Navigation.StateContext.data.y, 'efg');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cd');
+        assert.strictEqual(Navigation.StateContext.data.y, 'efg');
         Navigation.StateController.navigateLink('/ab/cd/efg?z=hi');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'cd');
-        assert.equal(Navigation.StateContext.data.y, 'efg');
-        assert.equal(Navigation.StateContext.data.z, 'hi');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cd');
+        assert.strictEqual(Navigation.StateContext.data.y, 'efg');
+        assert.strictEqual(Navigation.StateContext.data.z, 'hi');
     });
 
     it('TwoParamThreeSegmentNonMatchTest', function () {
@@ -199,14 +199,14 @@ describe('MatchTest', function () {
                 { key: 's', route: 'ab/{x}/c/{y}', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/ab/yy/c/xyz');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'yy');
-        assert.equal(Navigation.StateContext.data.y, 'xyz');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'yy');
+        assert.strictEqual(Navigation.StateContext.data.y, 'xyz');
         Navigation.StateController.navigateLink('/ab/yy/c/xyz?z=xx');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'yy');
-        assert.equal(Navigation.StateContext.data.y, 'xyz');
-        assert.equal(Navigation.StateContext.data.z, 'xx');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'yy');
+        assert.strictEqual(Navigation.StateContext.data.y, 'xyz');
+        assert.strictEqual(Navigation.StateContext.data.z, 'xx');
     });
 
     it('TwoParamFourSegmentNonMatchTest', function () {
@@ -229,17 +229,17 @@ describe('MatchTest', function () {
                 { key: 's', route: '{x?}', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/abcd');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'abcd');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'abcd');
         Navigation.StateController.navigateLink('/abcd?y=ef');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'abcd');
-        assert.equal(Navigation.StateContext.data.y, 'ef');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'abcd');
+        assert.strictEqual(Navigation.StateContext.data.y, 'ef');
         Navigation.StateController.navigateLink('/');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 0);
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 0);
         Navigation.StateController.navigateLink('/?y=ef');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.y, 'ef');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.y, 'ef');
     });
 
     it('OneOptionalParamOneSegmentNonMatchTest', function () {
@@ -257,17 +257,17 @@ describe('MatchTest', function () {
                 { key: 's', route: 'ab/{x?}', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/ab/cd');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'cd');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cd');
         Navigation.StateController.navigateLink('/ab/cd?y=ef');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'cd');
-        assert.equal(Navigation.StateContext.data.y, 'ef');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cd');
+        assert.strictEqual(Navigation.StateContext.data.y, 'ef');
         Navigation.StateController.navigateLink('/ab');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 0);
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 0);
         Navigation.StateController.navigateLink('/ab?y=ef');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.y, 'ef');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.y, 'ef');
     });
 
     it('OneOptionalParamTwoSegmentNonMatchTest', function () {
@@ -290,26 +290,26 @@ describe('MatchTest', function () {
                 { key: 's', route: '{x?}/{y?}', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/aa/bbb');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'aa');
-        assert.equal(Navigation.StateContext.data.y, 'bbb');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aa');
+        assert.strictEqual(Navigation.StateContext.data.y, 'bbb');
         Navigation.StateController.navigateLink('/aa/bbb?z=cccc');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'aa');
-        assert.equal(Navigation.StateContext.data.y, 'bbb');
-        assert.equal(Navigation.StateContext.data.z, 'cccc');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aa');
+        assert.strictEqual(Navigation.StateContext.data.y, 'bbb');
+        assert.strictEqual(Navigation.StateContext.data.z, 'cccc');
         Navigation.StateController.navigateLink('/aab');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'aab');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aab');
         Navigation.StateController.navigateLink('/aab?z=cccc');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'aab');
-        assert.equal(Navigation.StateContext.data.z, 'cccc');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aab');
+        assert.strictEqual(Navigation.StateContext.data.z, 'cccc');
         Navigation.StateController.navigateLink('/');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 0);
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 0);
         Navigation.StateController.navigateLink('/?z=cccc');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.z, 'cccc');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.z, 'cccc');
     });
 
     it('TwoOptionalParamTwoSegmentNonMatchTest', function () {
@@ -327,26 +327,26 @@ describe('MatchTest', function () {
                 { key: 's', route: 'ab/{x?}/{y?}', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/ab/cd/efg');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'cd');
-        assert.equal(Navigation.StateContext.data.y, 'efg');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cd');
+        assert.strictEqual(Navigation.StateContext.data.y, 'efg');
         Navigation.StateController.navigateLink('/ab/cd/efg?z=hi');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'cd');
-        assert.equal(Navigation.StateContext.data.y, 'efg');
-        assert.equal(Navigation.StateContext.data.z, 'hi');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cd');
+        assert.strictEqual(Navigation.StateContext.data.y, 'efg');
+        assert.strictEqual(Navigation.StateContext.data.z, 'hi');
         Navigation.StateController.navigateLink('/ab/cde');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'cde');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cde');
         Navigation.StateController.navigateLink('/ab/cde?z=fg');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'cde');
-        assert.equal(Navigation.StateContext.data.z, 'fg');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cde');
+        assert.strictEqual(Navigation.StateContext.data.z, 'fg');
         Navigation.StateController.navigateLink('/ab');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 0);
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 0);
         Navigation.StateController.navigateLink('/ab?z=cd');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.z, 'cd');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.z, 'cd');
     });
 
     it('TwoOptionalParamThreeSegmentNonMatchTest', function () {
@@ -367,21 +367,21 @@ describe('MatchTest', function () {
                 { key: 's', route: '{x}/{y?}', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/aa/bbb');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'aa');
-        assert.equal(Navigation.StateContext.data.y, 'bbb');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aa');
+        assert.strictEqual(Navigation.StateContext.data.y, 'bbb');
         Navigation.StateController.navigateLink('/aa/bbb?z=cccc');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'aa');
-        assert.equal(Navigation.StateContext.data.y, 'bbb');
-        assert.equal(Navigation.StateContext.data.z, 'cccc');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aa');
+        assert.strictEqual(Navigation.StateContext.data.y, 'bbb');
+        assert.strictEqual(Navigation.StateContext.data.z, 'cccc');
         Navigation.StateController.navigateLink('/aab');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'aab');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aab');
         Navigation.StateController.navigateLink('/aab?z=ccd');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'aab');
-        assert.equal(Navigation.StateContext.data.z, 'ccd');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aab');
+        assert.strictEqual(Navigation.StateContext.data.z, 'ccd');
     });
 
     it('TwoParamOneOptionalTwoSegmentNonMatchTest', function () {
@@ -400,21 +400,21 @@ describe('MatchTest', function () {
                 { key: 's', route: 'ab/{x}/{y?}', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/ab/cd/efg');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'cd');
-        assert.equal(Navigation.StateContext.data.y, 'efg');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cd');
+        assert.strictEqual(Navigation.StateContext.data.y, 'efg');
         Navigation.StateController.navigateLink('/ab/cd/efg?z=hi');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'cd');
-        assert.equal(Navigation.StateContext.data.y, 'efg');
-        assert.equal(Navigation.StateContext.data.z, 'hi');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cd');
+        assert.strictEqual(Navigation.StateContext.data.y, 'efg');
+        assert.strictEqual(Navigation.StateContext.data.z, 'hi');
         Navigation.StateController.navigateLink('/ab/cde');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'cde');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cde');
         Navigation.StateController.navigateLink('/ab/cde?z=fg');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'cde');
-        assert.equal(Navigation.StateContext.data.z, 'fg');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cde');
+        assert.strictEqual(Navigation.StateContext.data.z, 'fg');
     });
 
     it('TwoParamOneOptionalThreeSegmentNonMatchTest', function () {
@@ -436,21 +436,21 @@ describe('MatchTest', function () {
                 { key: 's', route: 'ab/{x}/c/{y?}', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/ab/yy/c/xyz');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'yy');
-        assert.equal(Navigation.StateContext.data.y, 'xyz');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'yy');
+        assert.strictEqual(Navigation.StateContext.data.y, 'xyz');
         Navigation.StateController.navigateLink('/ab/yy/c/xyz?z=xx');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'yy');
-        assert.equal(Navigation.StateContext.data.y, 'xyz');
-        assert.equal(Navigation.StateContext.data.z, 'xx');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'yy');
+        assert.strictEqual(Navigation.StateContext.data.y, 'xyz');
+        assert.strictEqual(Navigation.StateContext.data.z, 'xx');
         Navigation.StateController.navigateLink('/ab/yy/c');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'yy');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'yy');
         Navigation.StateController.navigateLink('/ab/yy/c?z=xx');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'yy');
-        assert.equal(Navigation.StateContext.data.z, 'xx');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'yy');
+        assert.strictEqual(Navigation.StateContext.data.z, 'xx');
     });
 
     it('TwoParamOneOptionalFourSegmentNonMatchTest', function () {
@@ -472,12 +472,12 @@ describe('MatchTest', function () {
                 { key: 's', route: 'ab{x}', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/abcde');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'cde');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cde');
         Navigation.StateController.navigateLink('/abcde?y=fg');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'cde');
-        assert.equal(Navigation.StateContext.data.y, 'fg');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cde');
+        assert.strictEqual(Navigation.StateContext.data.y, 'fg');
     });
 
     it('OneParamOneMixedSegmentNonMatchTest', function () {
@@ -497,14 +497,14 @@ describe('MatchTest', function () {
                 { key: 's', route: 'ab{x}e{y}', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/abcdefgh');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'cd');
-        assert.equal(Navigation.StateContext.data.y, 'fgh');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cd');
+        assert.strictEqual(Navigation.StateContext.data.y, 'fgh');
         Navigation.StateController.navigateLink('/abcdefgh?z=i');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'cd');
-        assert.equal(Navigation.StateContext.data.y, 'fgh');
-        assert.equal(Navigation.StateContext.data.z, 'i');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cd');
+        assert.strictEqual(Navigation.StateContext.data.y, 'fgh');
+        assert.strictEqual(Navigation.StateContext.data.z, 'i');
     });
 
     it('TwoParamOneMixedSegmentNonMatchTest', function () {
@@ -527,21 +527,21 @@ describe('MatchTest', function () {
                 { key: 's', route: '{x}ab/{y?}', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/abcab/de');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'abc');
-        assert.equal(Navigation.StateContext.data.y, 'de');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'abc');
+        assert.strictEqual(Navigation.StateContext.data.y, 'de');
         Navigation.StateController.navigateLink('/abcab/de?z=f');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'abc');
-        assert.equal(Navigation.StateContext.data.y, 'de');
-        assert.equal(Navigation.StateContext.data.z, 'f');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'abc');
+        assert.strictEqual(Navigation.StateContext.data.y, 'de');
+        assert.strictEqual(Navigation.StateContext.data.z, 'f');
         Navigation.StateController.navigateLink('/abcab');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'abc');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'abc');
         Navigation.StateController.navigateLink('/abcab?z=de');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'abc');
-        assert.equal(Navigation.StateContext.data.z, 'de');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'abc');
+        assert.strictEqual(Navigation.StateContext.data.z, 'de');
     });
 
     it('TwoParamOneOptionalTwoSegmentOneMixedNonMatchTest', function () {
@@ -562,19 +562,19 @@ describe('MatchTest', function () {
                 { key: 's', route: '{x}', defaults: { x: 'cde' }, trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/ab');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'ab');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'ab');
         Navigation.StateController.navigateLink('/ab?z=cd');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'ab');
-        assert.equal(Navigation.StateContext.data.z, 'cd');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'ab');
+        assert.strictEqual(Navigation.StateContext.data.z, 'cd');
         Navigation.StateController.navigateLink('/');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'cde');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cde');
         Navigation.StateController.navigateLink('/?z=fg');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'cde');
-        assert.equal(Navigation.StateContext.data.z, 'fg');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cde');
+        assert.strictEqual(Navigation.StateContext.data.z, 'fg');
     });
 
     it('OneParamOneSegmentDefaultNonMatchTest', function () {
@@ -592,19 +592,19 @@ describe('MatchTest', function () {
                 { key: 's', route: 'ab/{x}', defaults: { x: 'ccdd' }, trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/ab/cde');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'cde');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cde');
         Navigation.StateController.navigateLink('/ab/cde?y=fg');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'cde');
-        assert.equal(Navigation.StateContext.data.y, 'fg');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cde');
+        assert.strictEqual(Navigation.StateContext.data.y, 'fg');
         Navigation.StateController.navigateLink('/ab');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'ccdd');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'ccdd');
         Navigation.StateController.navigateLink('/ab?y=ee');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'ccdd');
-        assert.equal(Navigation.StateContext.data.y, 'ee');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'ccdd');
+        assert.strictEqual(Navigation.StateContext.data.y, 'ee');
     });
 
     it('OneParamTwoSegmentDefaultNonMatchTest', function () {
@@ -627,32 +627,32 @@ describe('MatchTest', function () {
                 { key: 's', route: '{x}/{y}', defaults: { x: 'ab', y: 'c' }, trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/aa/bbb');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'aa');
-        assert.equal(Navigation.StateContext.data.y, 'bbb');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aa');
+        assert.strictEqual(Navigation.StateContext.data.y, 'bbb');
         Navigation.StateController.navigateLink('/aa/bbb?z=cccc');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'aa');
-        assert.equal(Navigation.StateContext.data.y, 'bbb');
-        assert.equal(Navigation.StateContext.data.z, 'cccc');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aa');
+        assert.strictEqual(Navigation.StateContext.data.y, 'bbb');
+        assert.strictEqual(Navigation.StateContext.data.z, 'cccc');
         Navigation.StateController.navigateLink('/aa');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'aa');
-        assert.equal(Navigation.StateContext.data.y, 'c');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aa');
+        assert.strictEqual(Navigation.StateContext.data.y, 'c');
         Navigation.StateController.navigateLink('/aa?z=d');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'aa');
-        assert.equal(Navigation.StateContext.data.y, 'c');
-        assert.equal(Navigation.StateContext.data.z, 'd');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aa');
+        assert.strictEqual(Navigation.StateContext.data.y, 'c');
+        assert.strictEqual(Navigation.StateContext.data.z, 'd');
         Navigation.StateController.navigateLink('/');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'ab');
-        assert.equal(Navigation.StateContext.data.y, 'c');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'ab');
+        assert.strictEqual(Navigation.StateContext.data.y, 'c');
         Navigation.StateController.navigateLink('/?z=d');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'ab');
-        assert.equal(Navigation.StateContext.data.y, 'c');
-        assert.equal(Navigation.StateContext.data.z, 'd');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'ab');
+        assert.strictEqual(Navigation.StateContext.data.y, 'c');
+        assert.strictEqual(Navigation.StateContext.data.z, 'd');
     });
 
     it('TwoParamTwoSegmentTwoDefaultNonMatchTest', function () {
@@ -670,23 +670,23 @@ describe('MatchTest', function () {
                 { key: 's', route: '{x}/{y}', defaults: { y: 'ab' }, trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/aa/bbb');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'aa');
-        assert.equal(Navigation.StateContext.data.y, 'bbb');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aa');
+        assert.strictEqual(Navigation.StateContext.data.y, 'bbb');
         Navigation.StateController.navigateLink('/aa/bbb?z=cccc');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'aa');
-        assert.equal(Navigation.StateContext.data.y, 'bbb');
-        assert.equal(Navigation.StateContext.data.z, 'cccc');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aa');
+        assert.strictEqual(Navigation.StateContext.data.y, 'bbb');
+        assert.strictEqual(Navigation.StateContext.data.z, 'cccc');
         Navigation.StateController.navigateLink('/aa');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'aa');
-        assert.equal(Navigation.StateContext.data.y, 'ab');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aa');
+        assert.strictEqual(Navigation.StateContext.data.y, 'ab');
         Navigation.StateController.navigateLink('/aa?z=bb');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'aa');
-        assert.equal(Navigation.StateContext.data.y, 'ab');
-        assert.equal(Navigation.StateContext.data.z, 'bb');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aa');
+        assert.strictEqual(Navigation.StateContext.data.y, 'ab');
+        assert.strictEqual(Navigation.StateContext.data.z, 'bb');
     });
 
     it('TwoParamTwoSegmentDefaultNonMatchTest', function () {
@@ -705,28 +705,28 @@ describe('MatchTest', function () {
                 { key: 's', route: '{x}/{y?}', defaults: { x: 'abc' }, trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/aa/bbb');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'aa');
-        assert.equal(Navigation.StateContext.data.y, 'bbb');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aa');
+        assert.strictEqual(Navigation.StateContext.data.y, 'bbb');
         Navigation.StateController.navigateLink('/aa/bbb?z=cccc');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'aa');
-        assert.equal(Navigation.StateContext.data.y, 'bbb');
-        assert.equal(Navigation.StateContext.data.z, 'cccc');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aa');
+        assert.strictEqual(Navigation.StateContext.data.y, 'bbb');
+        assert.strictEqual(Navigation.StateContext.data.z, 'cccc');
         Navigation.StateController.navigateLink('/aab');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'aab');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aab');
         Navigation.StateController.navigateLink('/aab?z=ccd');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'aab');
-        assert.equal(Navigation.StateContext.data.z, 'ccd');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aab');
+        assert.strictEqual(Navigation.StateContext.data.z, 'ccd');
         Navigation.StateController.navigateLink('/');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'abc');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'abc');
         Navigation.StateController.navigateLink('/?z=de');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'abc');
-        assert.equal(Navigation.StateContext.data.z, 'de');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'abc');
+        assert.strictEqual(Navigation.StateContext.data.z, 'de');
     });
 
     it('TwoParamOneOptionalTwoSegmentDefaultNonMatchTest', function () {
@@ -744,56 +744,56 @@ describe('MatchTest', function () {
                 { key: 's', route: 'ab/{w}/{x}/{y?}/{z?}', defaults: { w: 'abc', x: 'de' }, trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/ab/cd/ef/hi/jk');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 4);
-        assert.equal(Navigation.StateContext.data.w, 'cd');
-        assert.equal(Navigation.StateContext.data.x, 'ef');
-        assert.equal(Navigation.StateContext.data.y, 'hi');
-        assert.equal(Navigation.StateContext.data.z, 'jk');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 4);
+        assert.strictEqual(Navigation.StateContext.data.w, 'cd');
+        assert.strictEqual(Navigation.StateContext.data.x, 'ef');
+        assert.strictEqual(Navigation.StateContext.data.y, 'hi');
+        assert.strictEqual(Navigation.StateContext.data.z, 'jk');
         Navigation.StateController.navigateLink('/ab/cd/ef/hi/jk?a=lm');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 5);
-        assert.equal(Navigation.StateContext.data.w, 'cd');
-        assert.equal(Navigation.StateContext.data.x, 'ef');
-        assert.equal(Navigation.StateContext.data.y, 'hi');
-        assert.equal(Navigation.StateContext.data.z, 'jk');
-        assert.equal(Navigation.StateContext.data.a, 'lm');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 5);
+        assert.strictEqual(Navigation.StateContext.data.w, 'cd');
+        assert.strictEqual(Navigation.StateContext.data.x, 'ef');
+        assert.strictEqual(Navigation.StateContext.data.y, 'hi');
+        assert.strictEqual(Navigation.StateContext.data.z, 'jk');
+        assert.strictEqual(Navigation.StateContext.data.a, 'lm');
         Navigation.StateController.navigateLink('/ab/cde/fg/h');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.w, 'cde');
-        assert.equal(Navigation.StateContext.data.x, 'fg');
-        assert.equal(Navigation.StateContext.data.y, 'h');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.w, 'cde');
+        assert.strictEqual(Navigation.StateContext.data.x, 'fg');
+        assert.strictEqual(Navigation.StateContext.data.y, 'h');
         Navigation.StateController.navigateLink('/ab/cde/fg/h?a=i');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 4);
-        assert.equal(Navigation.StateContext.data.w, 'cde');
-        assert.equal(Navigation.StateContext.data.x, 'fg');
-        assert.equal(Navigation.StateContext.data.y, 'h');
-        assert.equal(Navigation.StateContext.data.a, 'i');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 4);
+        assert.strictEqual(Navigation.StateContext.data.w, 'cde');
+        assert.strictEqual(Navigation.StateContext.data.x, 'fg');
+        assert.strictEqual(Navigation.StateContext.data.y, 'h');
+        assert.strictEqual(Navigation.StateContext.data.a, 'i');
         Navigation.StateController.navigateLink('/ab/cc/def');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.w, 'cc');
-        assert.equal(Navigation.StateContext.data.x, 'def');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.w, 'cc');
+        assert.strictEqual(Navigation.StateContext.data.x, 'def');
         Navigation.StateController.navigateLink('/ab/cc/def?a=gg');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.w, 'cc');
-        assert.equal(Navigation.StateContext.data.x, 'def');
-        assert.equal(Navigation.StateContext.data.a, 'gg');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.w, 'cc');
+        assert.strictEqual(Navigation.StateContext.data.x, 'def');
+        assert.strictEqual(Navigation.StateContext.data.a, 'gg');
         Navigation.StateController.navigateLink('/ab/ccdd');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.w, 'ccdd');
-        assert.equal(Navigation.StateContext.data.x, 'de');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.w, 'ccdd');
+        assert.strictEqual(Navigation.StateContext.data.x, 'de');
         Navigation.StateController.navigateLink('/ab/ccdd?a=fg');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.w, 'ccdd');
-        assert.equal(Navigation.StateContext.data.x, 'de');
-        assert.equal(Navigation.StateContext.data.a, 'fg');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.w, 'ccdd');
+        assert.strictEqual(Navigation.StateContext.data.x, 'de');
+        assert.strictEqual(Navigation.StateContext.data.a, 'fg');
         Navigation.StateController.navigateLink('/ab');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.w, 'abc');
-        assert.equal(Navigation.StateContext.data.x, 'de');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.w, 'abc');
+        assert.strictEqual(Navigation.StateContext.data.x, 'de');
         Navigation.StateController.navigateLink('/ab?a=fg');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.w, 'abc');
-        assert.equal(Navigation.StateContext.data.x, 'de');
-        assert.equal(Navigation.StateContext.data.a, 'fg');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.w, 'abc');
+        assert.strictEqual(Navigation.StateContext.data.x, 'de');
+        assert.strictEqual(Navigation.StateContext.data.a, 'fg');
     });
 
     it('FourParamTwoOptionalFiveSegmentDefaultNonMatchTest', function () {
@@ -816,12 +816,12 @@ describe('MatchTest', function () {
                 { key: 's', route: '{x}', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/   a  ');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, '   a  ');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, '   a  ');
         Navigation.StateController.navigateLink('/   a  ?y=   b  ');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, '   a  ');
-        assert.equal(Navigation.StateContext.data.y, '   b  ');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, '   a  ');
+        assert.strictEqual(Navigation.StateContext.data.y, '   b  ');
     });
 
     it('MultiCharParamMatchTest', function () {
@@ -830,12 +830,12 @@ describe('MatchTest', function () {
                 { key: 's', route: 'a/{someVar}', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/a/someVal');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.someVar, 'someVal');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.someVar, 'someVal');
         Navigation.StateController.navigateLink('/a/someVal?anotherVar=anotherVal');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.someVar, 'someVal');
-        assert.equal(Navigation.StateContext.data.anotherVar, 'anotherVal');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.someVar, 'someVal');
+        assert.strictEqual(Navigation.StateContext.data.anotherVar, 'anotherVal');
     });
 
     it('MatchSlashTest', function () {
@@ -844,8 +844,8 @@ describe('MatchTest', function () {
                 { key: 's', route: '{x}', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('abc/');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'abc');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'abc');
     });
 
     it('ReservedUrlCharacterMatchTest', function () {
@@ -854,19 +854,19 @@ describe('MatchTest', function () {
                 { key: 's', route: 'a/{*="()\'-_+~@:?><.;[],!£$%^#&}', defaults: { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' }, trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/a/*%3D%22()\'-0__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data['*="()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data['*="()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
         Navigation.StateController.navigateLink('/a/*%3D%22()\'-0__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data['*="()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
-        assert.equal(Navigation.StateContext.data['*="()\'-__+~@:?><.;[],!£$%^#&'], '*="()\'-_+~@:?><.;[],!£$%^#&');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data['*="()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
+        assert.strictEqual(Navigation.StateContext.data['*="()\'-__+~@:?><.;[],!£$%^#&'], '*="()\'-_+~@:?><.;[],!£$%^#&');
         Navigation.StateController.navigateLink('/a');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data['*="()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data['*="()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
         Navigation.StateController.navigateLink('/a?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data['*="()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
-        assert.equal(Navigation.StateContext.data['*="()\'-__+~@:?><.;[],!£$%^#&'], '*="()\'-_+~@:?><.;[],!£$%^#&');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data['*="()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
+        assert.strictEqual(Navigation.StateContext.data['*="()\'-__+~@:?><.;[],!£$%^#&'], '*="()\'-_+~@:?><.;[],!£$%^#&');
     });
 
     it('ReservedRegexCharacterMatchTest', function () {
@@ -875,12 +875,12 @@ describe('MatchTest', function () {
                 { key: 's', route: '.+*\^$\[\]()\'/{x}', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/.+*\^$\[\]()\'/abc');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'abc');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'abc');
         Navigation.StateController.navigateLink('/.+*\^$\[\]()\'/abc?y=de');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'abc');
-        assert.equal(Navigation.StateContext.data.y, 'de');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'abc');
+        assert.strictEqual(Navigation.StateContext.data.y, 'de');
     });
 
     it('OneParamOptionalMandatoryOneMixedSegmentMatchTest', function () {
@@ -889,12 +889,12 @@ describe('MatchTest', function () {
                 { key: 's', route: 'ab{x?}', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/abcde');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'cde');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cde');
         Navigation.StateController.navigateLink('/abcde?y=fg');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'cde');
-        assert.equal(Navigation.StateContext.data.y, 'fg');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cde');
+        assert.strictEqual(Navigation.StateContext.data.y, 'fg');
     });
 
     it('OneParamOptionalMandatoryOneMixedSegmentNonMatchTest', function () {
@@ -914,14 +914,14 @@ describe('MatchTest', function () {
                 { key: 's', route: 'ab/{x?}/{y}', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/ab/cd/efg');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'cd');
-        assert.equal(Navigation.StateContext.data.y, 'efg');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cd');
+        assert.strictEqual(Navigation.StateContext.data.y, 'efg');
         Navigation.StateController.navigateLink('/ab/cd/efg?z=hi');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'cd');
-        assert.equal(Navigation.StateContext.data.y, 'efg');
-        assert.equal(Navigation.StateContext.data.z, 'hi');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cd');
+        assert.strictEqual(Navigation.StateContext.data.y, 'efg');
+        assert.strictEqual(Navigation.StateContext.data.z, 'hi');
     });
 
     it('TwoParamOneOptionalMandatoryThreeSegmentNonMatchTest', function () {
@@ -944,14 +944,14 @@ describe('MatchTest', function () {
                 { key: 's', route: '{x}/{y}', defaults: { x: 'ab' }, trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/aa/bbb');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'aa');
-        assert.equal(Navigation.StateContext.data.y, 'bbb');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aa');
+        assert.strictEqual(Navigation.StateContext.data.y, 'bbb');
         Navigation.StateController.navigateLink('/aa/bbb?z=cccc');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'aa');
-        assert.equal(Navigation.StateContext.data.y, 'bbb');
-        assert.equal(Navigation.StateContext.data.z, 'cccc');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aa');
+        assert.strictEqual(Navigation.StateContext.data.y, 'bbb');
+        assert.strictEqual(Navigation.StateContext.data.z, 'cccc');
     });
 
     it('TwoParamTwoSegmentDefaultMandatoryNonMatchTest', function () {
@@ -971,14 +971,14 @@ describe('MatchTest', function () {
                 { key: 's', route: 'ab/{x?}/{y}/c', defaults: { y: 'ee' }, trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/ab/cd/efg/c');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'cd');
-        assert.equal(Navigation.StateContext.data.y, 'efg');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cd');
+        assert.strictEqual(Navigation.StateContext.data.y, 'efg');
         Navigation.StateController.navigateLink('/ab/cd/efg/c?z=hi');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'cd');
-        assert.equal(Navigation.StateContext.data.y, 'efg');
-        assert.equal(Navigation.StateContext.data.z, 'hi');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'cd');
+        assert.strictEqual(Navigation.StateContext.data.y, 'efg');
+        assert.strictEqual(Navigation.StateContext.data.z, 'hi');
     });
 
     it('TwoParamOneOptionalMandatoryFourSegmentDefaultMandatoryNonMatchTest', function () {
@@ -1004,14 +1004,14 @@ describe('MatchTest', function () {
                 { key: 's', route: '{x}', defaults: { x: 'a', y: 'b' }, trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'a');
-        assert.equal(Navigation.StateContext.data.y, 'b');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'a');
+        assert.strictEqual(Navigation.StateContext.data.y, 'b');
         Navigation.StateController.navigateLink('/?z=c');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'a');
-        assert.equal(Navigation.StateContext.data.y, 'b');
-        assert.equal(Navigation.StateContext.data.z, 'c');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'a');
+        assert.strictEqual(Navigation.StateContext.data.y, 'b');
+        assert.strictEqual(Navigation.StateContext.data.z, 'c');
     });
 
     it('CaseInsensitiveMatchTest', function () {
@@ -1020,12 +1020,12 @@ describe('MatchTest', function () {
                 { key: 's', route: 'abc/{x}', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/AbC/aBc');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'aBc');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aBc');
         Navigation.StateController.navigateLink('/AbC/aBc?y=dE');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'aBc');
-        assert.equal(Navigation.StateContext.data.y, 'dE');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'aBc');
+        assert.strictEqual(Navigation.StateContext.data.y, 'dE');
     });
 
     it('MultipleRoutesMatchTest', function () {
@@ -1035,19 +1035,19 @@ describe('MatchTest', function () {
                 { key: 's1', route: 'cd/{x}', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/ab/ef');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'ef');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'ef');
         Navigation.StateController.navigateLink('/ab/ef?y=gh');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'ef');
-        assert.equal(Navigation.StateContext.data.y, 'gh');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'ef');
+        assert.strictEqual(Navigation.StateContext.data.y, 'gh');
         Navigation.StateController.navigateLink('/cd/ef');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'ef');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'ef');
         Navigation.StateController.navigateLink('/cd/ef?y=gh');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'ef');
-        assert.equal(Navigation.StateContext.data.y, 'gh');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'ef');
+        assert.strictEqual(Navigation.StateContext.data.y, 'gh');
     });
 
     it('MultipleRoutesNonMatchTest', function () {
@@ -1067,17 +1067,17 @@ describe('MatchTest', function () {
                 { key: 's', route: ['', 'abc/{x}'], trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 0);
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 0);
         Navigation.StateController.navigateLink('/?y=d');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.y, 'd');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.y, 'd');
         Navigation.StateController.navigateLink('/abc/de');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'de');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'de');
         Navigation.StateController.navigateLink('/abc/de?y=f');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'de');
-        assert.equal(Navigation.StateContext.data.y, 'f');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'de');
+        assert.strictEqual(Navigation.StateContext.data.y, 'f');
     });
 
     it('TwoRouteOneWithParamNonMatchTest', function () {
@@ -1097,28 +1097,28 @@ describe('MatchTest', function () {
                 { key: 's', route: ['abc/{x}', 'def/{y}'], trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/abc/de');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'de');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'de');
         Navigation.StateController.navigateLink('/abc/de?z=f');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'de');
-        assert.equal(Navigation.StateContext.data.z, 'f');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'de');
+        assert.strictEqual(Navigation.StateContext.data.z, 'f');
         Navigation.StateController.navigateLink('/def/gh');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.y, 'gh');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.y, 'gh');
         Navigation.StateController.navigateLink('/def/gh?z=i');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.y, 'gh');
-        assert.equal(Navigation.StateContext.data.z, 'i');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.y, 'gh');
+        assert.strictEqual(Navigation.StateContext.data.z, 'i');
         Navigation.StateController.navigateLink('/abc/de?y=fg');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'de');
-        assert.equal(Navigation.StateContext.data.y, 'fg');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'de');
+        assert.strictEqual(Navigation.StateContext.data.y, 'fg');
         Navigation.StateController.navigateLink('/abc/de?y=fg&z=h');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'de');
-        assert.equal(Navigation.StateContext.data.y, 'fg');
-        assert.equal(Navigation.StateContext.data.z, 'h');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'de');
+        assert.strictEqual(Navigation.StateContext.data.y, 'fg');
+        assert.strictEqual(Navigation.StateContext.data.z, 'h');
     });
 
     it('TwoRouteParamNonMatchTest', function () {
@@ -1142,21 +1142,21 @@ describe('MatchTest', function () {
                 { key: 's', route: ['abc/{x}', 'abc/{x}/def/{y}'], trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/abc/de');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'de');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'de');
         Navigation.StateController.navigateLink('/abc/de?z=f');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'de');
-        assert.equal(Navigation.StateContext.data.z, 'f');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'de');
+        assert.strictEqual(Navigation.StateContext.data.z, 'f');
         Navigation.StateController.navigateLink('/abc/de/def/gh');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'de');
-        assert.equal(Navigation.StateContext.data.y, 'gh');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'de');
+        assert.strictEqual(Navigation.StateContext.data.y, 'gh');
         Navigation.StateController.navigateLink('/abc/de/def/gh?z=i');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'de');
-        assert.equal(Navigation.StateContext.data.y, 'gh');
-        assert.equal(Navigation.StateContext.data.z, 'i');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'de');
+        assert.strictEqual(Navigation.StateContext.data.y, 'gh');
+        assert.strictEqual(Navigation.StateContext.data.z, 'i');
     });
 
     it('TwoRouteParentChildNonMatchTest', function () {
@@ -1180,37 +1180,37 @@ describe('MatchTest', function () {
                 { key: 's', route: ['abc/{x}', 'def/{y}'], defaults: { x: 'd' }, trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/abc');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'd');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'd');
         Navigation.StateController.navigateLink('/abc?z=e');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'd');
-        assert.equal(Navigation.StateContext.data.z, 'e');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'd');
+        assert.strictEqual(Navigation.StateContext.data.z, 'e');
         Navigation.StateController.navigateLink('/abc/de');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'de');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'de');
         Navigation.StateController.navigateLink('/abc/de?z=f');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'de');
-        assert.equal(Navigation.StateContext.data.z, 'f');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'de');
+        assert.strictEqual(Navigation.StateContext.data.z, 'f');
         Navigation.StateController.navigateLink('/def/gh');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'd');
-        assert.equal(Navigation.StateContext.data.y, 'gh');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'd');
+        assert.strictEqual(Navigation.StateContext.data.y, 'gh');
         Navigation.StateController.navigateLink('/def/gh?z=i');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'd');
-        assert.equal(Navigation.StateContext.data.y, 'gh');
-        assert.equal(Navigation.StateContext.data.z, 'i');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'd');
+        assert.strictEqual(Navigation.StateContext.data.y, 'gh');
+        assert.strictEqual(Navigation.StateContext.data.z, 'i');
         Navigation.StateController.navigateLink('/abc/de?y=gh');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'de');
-        assert.equal(Navigation.StateContext.data.y, 'gh');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'de');
+        assert.strictEqual(Navigation.StateContext.data.y, 'gh');
         Navigation.StateController.navigateLink('/abc/de?y=gh&z=i');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'de');
-        assert.equal(Navigation.StateContext.data.y, 'gh');
-        assert.equal(Navigation.StateContext.data.z, 'i');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'de');
+        assert.strictEqual(Navigation.StateContext.data.y, 'gh');
+        assert.strictEqual(Navigation.StateContext.data.z, 'i');
     });
 
     it('TwoRouteDefaultNonMatchTest', function () {
@@ -1233,26 +1233,26 @@ describe('MatchTest', function () {
                 { key: 's', route: ['abc/{x?}', 'abc/{x}/def/{y}'], trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/abc');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 0);
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 0);
         Navigation.StateController.navigateLink('/abc?z=d');
-        assert.equal(Navigation.StateContext.data.z, 'd');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.z, 'd');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
         Navigation.StateController.navigateLink('/abc/de');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'de');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 'de');
         Navigation.StateController.navigateLink('/abc/de?z=f');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'de');
-        assert.equal(Navigation.StateContext.data.z, 'f');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'de');
+        assert.strictEqual(Navigation.StateContext.data.z, 'f');
         Navigation.StateController.navigateLink('/abc/de/def/gh');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'de');
-        assert.equal(Navigation.StateContext.data.y, 'gh');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 'de');
+        assert.strictEqual(Navigation.StateContext.data.y, 'gh');
         Navigation.StateController.navigateLink('/abc/de/def/gh?z=i');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
-        assert.equal(Navigation.StateContext.data.x, 'de');
-        assert.equal(Navigation.StateContext.data.y, 'gh');
-        assert.equal(Navigation.StateContext.data.z, 'i');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 'de');
+        assert.strictEqual(Navigation.StateContext.data.y, 'gh');
+        assert.strictEqual(Navigation.StateContext.data.z, 'i');
     });
 
     it('TwoRouteOptionalNonMatchTest', function () {
@@ -1276,36 +1276,36 @@ describe('MatchTest', function () {
             ]);
         Navigation.StateController.navigateLink('/abc');
         assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 2);
-        Navigation.StateController.navigateLink('/abc?z=e');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
         assert.strictEqual(Navigation.StateContext.data.x, 2);
-        assert.equal(Navigation.StateContext.data.z, 'e');
+        Navigation.StateController.navigateLink('/abc?z=e');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 2);
+        assert.strictEqual(Navigation.StateContext.data.z, 'e');
         Navigation.StateController.navigateLink('/abc/3');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
         assert.strictEqual(Navigation.StateContext.data.x, 3);
         Navigation.StateController.navigateLink('/abc/3?z=f');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
         assert.strictEqual(Navigation.StateContext.data.x, 3);
-        assert.equal(Navigation.StateContext.data.z, 'f');
+        assert.strictEqual(Navigation.StateContext.data.z, 'f');
         Navigation.StateController.navigateLink('/def/gh');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
         assert.strictEqual(Navigation.StateContext.data.x, 2);
-        assert.equal(Navigation.StateContext.data.y, 'gh');
+        assert.strictEqual(Navigation.StateContext.data.y, 'gh');
         Navigation.StateController.navigateLink('/def/gh?z=i');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
         assert.strictEqual(Navigation.StateContext.data.x, 2);
-        assert.equal(Navigation.StateContext.data.y, 'gh');
-        assert.equal(Navigation.StateContext.data.z, 'i');
+        assert.strictEqual(Navigation.StateContext.data.y, 'gh');
+        assert.strictEqual(Navigation.StateContext.data.z, 'i');
         Navigation.StateController.navigateLink('/def/gh?x=3');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
         assert.strictEqual(Navigation.StateContext.data.x, 3);
-        assert.equal(Navigation.StateContext.data.y, 'gh');
+        assert.strictEqual(Navigation.StateContext.data.y, 'gh');
         Navigation.StateController.navigateLink('/def/gh?x=3&z=i');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
         assert.strictEqual(Navigation.StateContext.data.x, 3);
-        assert.equal(Navigation.StateContext.data.y, 'gh');
-        assert.equal(Navigation.StateContext.data.z, 'i');
+        assert.strictEqual(Navigation.StateContext.data.y, 'gh');
+        assert.strictEqual(Navigation.StateContext.data.z, 'i');
     });
 
     it('TwoRouteDefaultTypeNumberMatchTest', function () {
@@ -1314,28 +1314,28 @@ describe('MatchTest', function () {
                 { key: 's', route: ['def/{y}', 'abc/{x}'], defaultTypes: { x: 'number' }, trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/abc/3');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
         assert.strictEqual(Navigation.StateContext.data.x, 3);
         Navigation.StateController.navigateLink('/abc/3?z=f');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
         assert.strictEqual(Navigation.StateContext.data.x, 3);
-        assert.equal(Navigation.StateContext.data.z, 'f');
+        assert.strictEqual(Navigation.StateContext.data.z, 'f');
         Navigation.StateController.navigateLink('/def/gh');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.y, 'gh');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.y, 'gh');
         Navigation.StateController.navigateLink('/def/gh?z=i');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.y, 'gh');
-        assert.equal(Navigation.StateContext.data.z, 'i');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.y, 'gh');
+        assert.strictEqual(Navigation.StateContext.data.z, 'i');
         Navigation.StateController.navigateLink('/def/gh?x=3');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
         assert.strictEqual(Navigation.StateContext.data.x, 3);
-        assert.equal(Navigation.StateContext.data.y, 'gh');
+        assert.strictEqual(Navigation.StateContext.data.y, 'gh');
         Navigation.StateController.navigateLink('/def/gh?x=3&z=i');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
         assert.strictEqual(Navigation.StateContext.data.x, 3);
-        assert.equal(Navigation.StateContext.data.y, 'gh');
-        assert.equal(Navigation.StateContext.data.z, 'i');
+        assert.strictEqual(Navigation.StateContext.data.y, 'gh');
+        assert.strictEqual(Navigation.StateContext.data.z, 'i');
     });
 });
 
@@ -1345,8 +1345,8 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d'), '/');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/?x=ab');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/?x=ab');
     });
 
     it('NoParamOneSegmentBuildTest', function () {
@@ -1354,8 +1354,8 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'abc', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d'), '/abc');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/abc?x=ab');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/abc');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/abc?x=ab');
     });
 
     it('NoParamTwoSegmentBuildTest', function () {
@@ -1363,8 +1363,8 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/c', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d'), '/ab/c');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/ab/c?x=ab');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/ab/c');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/ab/c?x=ab');
     });
 
     it('OneParamOneSegmentBuildTest', function () {
@@ -1372,8 +1372,8 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abcd' }), '/abcd');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ab', y: 'cd' }), '/ab?y=cd');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'abcd' }), '/abcd');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab', y: 'cd' }), '/ab?y=cd');
     });
 
     it('OneParamOneSegmentNonBuildTest', function () {
@@ -1389,8 +1389,8 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd' }), '/ab/cd');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'ef' }), '/ab/cd?y=ef');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cd' }), '/ab/cd');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'ef' }), '/ab/cd?y=ef');
     });
 
     it('OneParamTwoSegmentNonBuildTest', function () {
@@ -1407,8 +1407,8 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y}', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb' }), '/aa/bbb');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb', z: 'cccc' }), '/aa/bbb?z=cccc');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb' }), '/aa/bbb');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb', z: 'cccc' }), '/aa/bbb?z=cccc');
     });
 
     it('TwoParamTwoSegmentNonBuildTest', function () {
@@ -1427,8 +1427,8 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}/{y}', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg' }), '/ab/cd/efg');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg', z: 'hi' }), '/ab/cd/efg?z=hi');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg' }), '/ab/cd/efg');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg', z: 'hi' }), '/ab/cd/efg?z=hi');
     });
 
     it('TwoParamThreeSegmentNonBuildTest', function () {
@@ -1447,8 +1447,8 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}/c/{y}', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'yy', y: 'xyz' }), '/ab/yy/c/xyz');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'yy', y: 'xyz', z: 'xx' }), '/ab/yy/c/xyz?z=xx');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'yy', y: 'xyz' }), '/ab/yy/c/xyz');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'yy', y: 'xyz', z: 'xx' }), '/ab/yy/c/xyz?z=xx');
     });
 
     it('TwoParamFourSegmentNonBuildTest', function () {
@@ -1467,10 +1467,10 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x?}', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abcd' }), '/abcd');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abcd', y: 'ef' }), '/abcd?y=ef');
-        assert.equal(Navigation.StateController.getNavigationLink('d'), '/');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'ef' }), '/?y=ef');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'abcd' }), '/abcd');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'abcd', y: 'ef' }), '/abcd?y=ef');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'ef' }), '/?y=ef');
     });
 
     it('OneOptionalParamTwoSegmentBuildTest', function () {
@@ -1478,10 +1478,10 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x?}', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd' }), '/ab/cd');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'ef' }), '/ab/cd?y=ef');
-        assert.equal(Navigation.StateController.getNavigationLink('d'), '/ab');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'ef' }), '/ab?y=ef');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cd' }), '/ab/cd');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'ef' }), '/ab/cd?y=ef');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/ab');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'ef' }), '/ab?y=ef');
     });
 
     it('TwoOptionalParamTwoSegmentBuildTest', function () {
@@ -1489,12 +1489,12 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x?}/{y?}', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb' }), '/aa/bbb');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb', z: 'cccc' }), '/aa/bbb?z=cccc');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aab' }), '/aab');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aab', z: 'cccc' }), '/aab?z=cccc');
-        assert.equal(Navigation.StateController.getNavigationLink('d'), '/');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'cccc' }), '/?z=cccc');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb' }), '/aa/bbb');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb', z: 'cccc' }), '/aa/bbb?z=cccc');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aab' }), '/aab');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aab', z: 'cccc' }), '/aab?z=cccc');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { z: 'cccc' }), '/?z=cccc');
     });
 
     it('TwoOptionalParamTwoSegmentNonBuildTest', function () {
@@ -1510,12 +1510,12 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x?}/{y?}', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg' }), '/ab/cd/efg');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg', z: 'hi' }), '/ab/cd/efg?z=hi');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cde' }), '/ab/cde');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cde', z: 'fg' }), '/ab/cde?z=fg');
-        assert.equal(Navigation.StateController.getNavigationLink('d'), '/ab');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'cd' }), '/ab?z=cd');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg' }), '/ab/cd/efg');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg', z: 'hi' }), '/ab/cd/efg?z=hi');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cde' }), '/ab/cde');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cde', z: 'fg' }), '/ab/cde?z=fg');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/ab');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { z: 'cd' }), '/ab?z=cd');
     });
 
     it('TwoOptionalParamThreeSegmentNonBuildTest', function () {
@@ -1531,10 +1531,10 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y?}', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb' }), '/aa/bbb');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb', z: 'cccc' }), '/aa/bbb?z=cccc');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aab' }), '/aab');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aab', z: 'ccd' }), '/aab?z=ccd');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb' }), '/aa/bbb');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb', z: 'cccc' }), '/aa/bbb?z=cccc');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aab' }), '/aab');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aab', z: 'ccd' }), '/aab?z=ccd');
     });
 
     it('TwoParamOneOptionalTwoSegmentNonBuildTest', function () {
@@ -1550,10 +1550,10 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}/{y?}', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg' }), '/ab/cd/efg');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg', z: 'hi' }), '/ab/cd/efg?z=hi');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cde' }), '/ab/cde');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cde', z: 'fg' }), '/ab/cde?z=fg');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg' }), '/ab/cd/efg');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg', z: 'hi' }), '/ab/cd/efg?z=hi');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cde' }), '/ab/cde');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cde', z: 'fg' }), '/ab/cde?z=fg');
     });
 
     it('TwoParamOneOptionalThreeSegmentNonBuildTest', function () {
@@ -1570,10 +1570,10 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}/c/{y?}', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'yy', y: 'xyz' }), '/ab/yy/c/xyz');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'yy', y: 'xyz', z: 'xx' }), '/ab/yy/c/xyz?z=xx');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'yy' }), '/ab/yy/c');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'yy', z: 'xx' }), '/ab/yy/c?z=xx');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'yy', y: 'xyz' }), '/ab/yy/c/xyz');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'yy', y: 'xyz', z: 'xx' }), '/ab/yy/c/xyz?z=xx');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'yy' }), '/ab/yy/c');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'yy', z: 'xx' }), '/ab/yy/c?z=xx');
     });
 
     it('TwoParamOneOptionalFourSegmentNonBuildTest', function () {
@@ -1590,8 +1590,8 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab{x}', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cde' }), '/abcde');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cde', y: 'fg' }), '/abcde?y=fg');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cde' }), '/abcde');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cde', y: 'fg' }), '/abcde?y=fg');
     });
 
     it('OneParamOneMixedSegmentNonBuildTest', function () {
@@ -1607,8 +1607,8 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab{x}e{y}', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'fgh' }), '/abcdefgh');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'fgh', z: 'i' }), '/abcdefgh?z=i');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'fgh' }), '/abcdefgh');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'fgh', z: 'i' }), '/abcdefgh?z=i');
     });
 
     it('TwoParamOneMixedSegmentNonBuildTest', function () {
@@ -1626,10 +1626,10 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}ab/{y?}', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abc', y: 'de' }), '/abcab/de');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abc', y: 'de', z: 'f' }), '/abcab/de?z=f');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abc' }), '/abcab');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abc', z: 'de' }), '/abcab?z=de');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'abc', y: 'de' }), '/abcab/de');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'abc', y: 'de', z: 'f' }), '/abcab/de?z=f');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'abc' }), '/abcab');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'abc', z: 'de' }), '/abcab?z=de');
     });
 
     it('TwoParamOneOptionalTwoSegmentOneMixedNonBuildTest', function () {
@@ -1646,12 +1646,12 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}', defaults: { x: 'cde' }, trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/ab');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ab', z: 'cd' }), '/ab?z=cd');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cde' }), '/');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cde', z: 'fg' }), '/?z=fg');
-        assert.equal(Navigation.StateController.getNavigationLink('d'), '/');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'fg' }), '/?z=fg');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/ab');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab', z: 'cd' }), '/ab?z=cd');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cde' }), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cde', z: 'fg' }), '/?z=fg');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { z: 'fg' }), '/?z=fg');
     });
 
     it('OneParamTwoSegmentDefaultBuildTest', function () {
@@ -1659,12 +1659,12 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x}', defaults: { x: 'ccdd' }, trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cde' }), '/ab/cde');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cde', y: 'fg' }), '/ab/cde?y=fg');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ccdd' }), '/ab');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ccdd', y: 'ee' }), '/ab?y=ee');
-        assert.equal(Navigation.StateController.getNavigationLink('d'), '/ab');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'ee' }), '/ab?y=ee');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cde' }), '/ab/cde');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cde', y: 'fg' }), '/ab/cde?y=fg');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ccdd' }), '/ab');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ccdd', y: 'ee' }), '/ab?y=ee');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/ab');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'ee' }), '/ab?y=ee');
     });
 
     it('TwoParamTwoSegmentTwoDefaultBuildTest', function () {
@@ -1672,22 +1672,22 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y}', defaults: { x: 'ab', y: 'c' }, trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb' }), '/aa/bbb');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb', z: 'cccc' }), '/aa/bbb?z=cccc');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'c' }), '/aa');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'c', z: 'd' }), '/aa?z=d');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'bbb' }), '/ab/bbb');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'bbb', z: 'cccc' }), '/ab/bbb?z=cccc');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'c' }), '/');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'c', z: 'd' }), '/?z=d');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa' }), '/aa');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', z: 'd' }), '/aa?z=d');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ab', y: 'c' }), '/');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ab', y: 'c', z: 'd' }), '/?z=d');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ab', z: 'd' }), '/?z=d');
-        assert.equal(Navigation.StateController.getNavigationLink('d'), '/');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'd' }), '/?z=d');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb' }), '/aa/bbb');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb', z: 'cccc' }), '/aa/bbb?z=cccc');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'c' }), '/aa');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'c', z: 'd' }), '/aa?z=d');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'bbb' }), '/ab/bbb');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'bbb', z: 'cccc' }), '/ab/bbb?z=cccc');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'c' }), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'c', z: 'd' }), '/?z=d');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aa' }), '/aa');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aa', z: 'd' }), '/aa?z=d');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab', y: 'c' }), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab', y: 'c', z: 'd' }), '/?z=d');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab', z: 'd' }), '/?z=d');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { z: 'd' }), '/?z=d');
     });
 
     it('OneParamTwoSegmentDefaultBuildTest', function () {
@@ -1695,12 +1695,12 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y}', defaults: { y: 'ab' }, trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb' }), '/aa/bbb');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb', z: 'cccc' }), '/aa/bbb?z=cccc');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'ab' }), '/aa');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'ab', z: 'bb' }), '/aa?z=bb');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa' }), '/aa');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', z: 'bb' }), '/aa?z=bb');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb' }), '/aa/bbb');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb', z: 'cccc' }), '/aa/bbb?z=cccc');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'ab' }), '/aa');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'ab', z: 'bb' }), '/aa?z=bb');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aa' }), '/aa');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aa', z: 'bb' }), '/aa?z=bb');
     });
 
     it('TwoParamTwoSegmentDefaultNonBuildTest', function () {
@@ -1717,18 +1717,18 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y?}', defaults: { x: 'abc' }, trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb' }), '/aa/bbb');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb', z: 'cccc' }), '/aa/bbb?z=cccc');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abc', y: 'bbb' }), '/abc/bbb');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abc', y: 'bbb', z: 'cccc' }), '/abc/bbb?z=cccc');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'bbb' }), '/abc/bbb');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'bbb', z: 'cccc' }), '/abc/bbb?z=cccc');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aab' }), '/aab');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aab', z: 'ccd' }), '/aab?z=ccd');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abc' }), '/');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abc', z: 'de' }), '/?z=de');
-        assert.equal(Navigation.StateController.getNavigationLink('d'), '/');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'de' }), '/?z=de');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb' }), '/aa/bbb');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb', z: 'cccc' }), '/aa/bbb?z=cccc');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'abc', y: 'bbb' }), '/abc/bbb');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'abc', y: 'bbb', z: 'cccc' }), '/abc/bbb?z=cccc');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'bbb' }), '/abc/bbb');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'bbb', z: 'cccc' }), '/abc/bbb?z=cccc');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aab' }), '/aab');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aab', z: 'ccd' }), '/aab?z=ccd');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'abc' }), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'abc', z: 'de' }), '/?z=de');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { z: 'de' }), '/?z=de');
     });
 
     it('FourParamTwoOptionalFiveSegmentDefaultBuildTest', function () {
@@ -1736,54 +1736,54 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{w}/{x}/{y?}/{z?}', defaults: { w: 'abc', x: 'de' }, trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cd', x: 'ef', y: 'hi', z: 'jk' }), '/ab/cd/ef/hi/jk');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cd', x: 'ef', y: 'hi', z: 'jk', a: 'lm' }), '/ab/cd/ef/hi/jk?a=lm');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cd', x: 'de', y: 'hi', z: 'jk' }), '/ab/cd/de/hi/jk');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cd', x: 'de', y: 'hi', z: 'jk', a: 'lm' }), '/ab/cd/de/hi/jk?a=lm');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'ef', y: 'hi', z: 'jk' }), '/ab/abc/ef/hi/jk');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'ef', y: 'hi', z: 'jk', a: 'lm' }), '/ab/abc/ef/hi/jk?a=lm');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'de', y: 'hi', z: 'jk' }), '/ab/abc/de/hi/jk');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'de', y: 'hi', z: 'jk', a: 'lm' }), '/ab/abc/de/hi/jk?a=lm');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ef', y: 'hi', z: 'jk' }), '/ab/abc/ef/hi/jk');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ef', y: 'hi', z: 'jk', a: 'lm' }), '/ab/abc/ef/hi/jk?a=lm');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'hi', z: 'jk' }), '/ab/abc/de/hi/jk');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'hi', z: 'jk', a: 'lm' }), '/ab/abc/de/hi/jk?a=lm');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'hi' }), '/ab/abc/de/hi');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'hi', a: 'lm' }), '/ab/abc/de/hi?a=lm');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ef' }), '/ab/abc/ef');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ef', a: 'lm' }), '/ab/abc/ef?a=lm');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de' }), '/ab');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', a: 'lm' }), '/ab?a=lm');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'hi', z: 'jk' }), '/ab/abc/de/hi/jk');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'hi', z: 'jk', a: 'lm' }), '/ab/abc/de/hi/jk?a=lm');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'hi' }), '/ab/abc/de/hi');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'hi', a: 'lm' }), '/ab/abc/de/hi?a=lm');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cde', x: 'fg', y: 'h' }), '/ab/cde/fg/h');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cde', x: 'fg', y: 'h', a: 'i' }), '/ab/cde/fg/h?a=i');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'de', y: 'h' }), '/ab/abc/de/h');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'de', y: 'h', a: 'i' }), '/ab/abc/de/h?a=i');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cde', y: 'h', z: 'jk' }), '/ab/cde/de/h/jk');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cde', y: 'h', z: 'jk', a: 'lm' }), '/ab/cde/de/h/jk?a=lm');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', y: 'h', z: 'jk' }), '/ab/abc/de/h/jk');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', y: 'h', z: 'jk', a: 'lm' }), '/ab/abc/de/h/jk?a=lm');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cde', y: 'h' }), '/ab/cde/de/h');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cde', y: 'h', a: 'i' }), '/ab/cde/de/h?a=i');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', y: 'h' }), '/ab/abc/de/h');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', y: 'h', a: 'i' }), '/ab/abc/de/h?a=i');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cc', x: 'def' }), '/ab/cc/def');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cc', x: 'def', a: 'gg' }), '/ab/cc/def?a=gg');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cc', x: 'de' }), '/ab/cc');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cc', x: 'de', a: 'gg' }), '/ab/cc?a=gg');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'de' }), '/ab');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'de', a: 'fg' }), '/ab?a=fg');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'def' }), '/ab/abc/def');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'def', a: 'gg' }), '/ab/abc/def?a=gg');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'ccdd' }), '/ab/ccdd');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'ccdd', a: 'gg' }), '/ab/ccdd?a=gg');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc' }), '/ab');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', a: 'fg' }), '/ab?a=fg');
-        assert.equal(Navigation.StateController.getNavigationLink('d'), '/ab');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { a: 'fg' }), '/ab?a=fg');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'cd', x: 'ef', y: 'hi', z: 'jk' }), '/ab/cd/ef/hi/jk');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'cd', x: 'ef', y: 'hi', z: 'jk', a: 'lm' }), '/ab/cd/ef/hi/jk?a=lm');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'cd', x: 'de', y: 'hi', z: 'jk' }), '/ab/cd/de/hi/jk');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'cd', x: 'de', y: 'hi', z: 'jk', a: 'lm' }), '/ab/cd/de/hi/jk?a=lm');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'ef', y: 'hi', z: 'jk' }), '/ab/abc/ef/hi/jk');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'ef', y: 'hi', z: 'jk', a: 'lm' }), '/ab/abc/ef/hi/jk?a=lm');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'de', y: 'hi', z: 'jk' }), '/ab/abc/de/hi/jk');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'de', y: 'hi', z: 'jk', a: 'lm' }), '/ab/abc/de/hi/jk?a=lm');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ef', y: 'hi', z: 'jk' }), '/ab/abc/ef/hi/jk');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ef', y: 'hi', z: 'jk', a: 'lm' }), '/ab/abc/ef/hi/jk?a=lm');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'hi', z: 'jk' }), '/ab/abc/de/hi/jk');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'hi', z: 'jk', a: 'lm' }), '/ab/abc/de/hi/jk?a=lm');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'hi' }), '/ab/abc/de/hi');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'hi', a: 'lm' }), '/ab/abc/de/hi?a=lm');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ef' }), '/ab/abc/ef');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ef', a: 'lm' }), '/ab/abc/ef?a=lm');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de' }), '/ab');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de', a: 'lm' }), '/ab?a=lm');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'hi', z: 'jk' }), '/ab/abc/de/hi/jk');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'hi', z: 'jk', a: 'lm' }), '/ab/abc/de/hi/jk?a=lm');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'hi' }), '/ab/abc/de/hi');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'hi', a: 'lm' }), '/ab/abc/de/hi?a=lm');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'cde', x: 'fg', y: 'h' }), '/ab/cde/fg/h');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'cde', x: 'fg', y: 'h', a: 'i' }), '/ab/cde/fg/h?a=i');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'de', y: 'h' }), '/ab/abc/de/h');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'de', y: 'h', a: 'i' }), '/ab/abc/de/h?a=i');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'cde', y: 'h', z: 'jk' }), '/ab/cde/de/h/jk');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'cde', y: 'h', z: 'jk', a: 'lm' }), '/ab/cde/de/h/jk?a=lm');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'abc', y: 'h', z: 'jk' }), '/ab/abc/de/h/jk');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'abc', y: 'h', z: 'jk', a: 'lm' }), '/ab/abc/de/h/jk?a=lm');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'cde', y: 'h' }), '/ab/cde/de/h');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'cde', y: 'h', a: 'i' }), '/ab/cde/de/h?a=i');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'abc', y: 'h' }), '/ab/abc/de/h');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'abc', y: 'h', a: 'i' }), '/ab/abc/de/h?a=i');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'cc', x: 'def' }), '/ab/cc/def');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'cc', x: 'def', a: 'gg' }), '/ab/cc/def?a=gg');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'cc', x: 'de' }), '/ab/cc');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'cc', x: 'de', a: 'gg' }), '/ab/cc?a=gg');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'de' }), '/ab');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'de', a: 'fg' }), '/ab?a=fg');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'def' }), '/ab/abc/def');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'def', a: 'gg' }), '/ab/abc/def?a=gg');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'ccdd' }), '/ab/ccdd');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'ccdd', a: 'gg' }), '/ab/ccdd?a=gg');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'abc' }), '/ab');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'abc', a: 'fg' }), '/ab?a=fg');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/ab');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { a: 'fg' }), '/ab?a=fg');
     });
 
     it('FourParamTwoOptionalFiveSegmentDefaultNonBuildTest', function () {
@@ -1807,8 +1807,8 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: '   a  ' }), '/%20%20%20a%20%20');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: '   a  ', y: '   b  ' }), '/%20%20%20a%20%20?y=%20%20%20b%20%20');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '   a  ' }), '/%20%20%20a%20%20');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '   a  ', y: '   b  ' }), '/%20%20%20a%20%20?y=%20%20%20b%20%20');
     });
 
     it('MultiCharParamBuildTest', function () {
@@ -1816,8 +1816,8 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'a/{someVar}', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { someVar: 'someVal' }), '/a/someVal');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { someVar: 'someVal', anotherVar: 'anotherVal' }), '/a/someVal?anotherVar=anotherVal');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { someVar: 'someVal' }), '/a/someVal');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { someVar: 'someVal', anotherVar: 'anotherVal' }), '/a/someVal?anotherVar=anotherVal');
     });
 
     it('ReservedUrlCharacterBuildTest', function () {
@@ -1825,12 +1825,12 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'a/{*="()\'-_+~@:?><.;[],!£$%^#&}', defaults: { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' }, trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&' }), '/a/*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&', '*="()\'-__+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&'}), '/a/*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' }), '/a');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&', '*="()\'-__+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&'}), '/a?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
-        assert.equal(Navigation.StateController.getNavigationLink('d'), '/a');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { '*="()\'-__+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&' }), '/a?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&' }), '/a/*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&', '*="()\'-__+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&'}), '/a/*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' }), '/a');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&', '*="()\'-__+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&'}), '/a?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/a');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { '*="()\'-__+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&' }), '/a?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
     });
 
     it('ReservedRegexCharacterBuildTest', function () {
@@ -1838,8 +1838,8 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '.+*\^$\[\]()\'/{x}', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abc' }), '/.+*\^$\[\]()\'/abc');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abc', y: 'de' }), '/.+*\^$\[\]()\'/abc?y=de');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'abc' }), '/.+*\^$\[\]()\'/abc');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'abc', y: 'de' }), '/.+*\^$\[\]()\'/abc?y=de');
     });
 
     it('OneParamOptionalMandatoryOneMixedSegmentBuildTest', function () {
@@ -1847,8 +1847,8 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab{x?}', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cde' }), '/abcde');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cde', y: 'fg' }), '/abcde?y=fg');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cde' }), '/abcde');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cde', y: 'fg' }), '/abcde?y=fg');
     });
 
     it('OneParamOptionalMandatoryOneMixedSegmentNonBuildTest', function () {
@@ -1864,8 +1864,8 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x?}/{y}', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg' }), '/ab/cd/efg');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg', z: 'hi' }), '/ab/cd/efg?z=hi');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg' }), '/ab/cd/efg');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg', z: 'hi' }), '/ab/cd/efg?z=hi');
     });
 
     it('TwoParamOneOptionalMandatoryThreeSegmentNonBuildTest', function () {
@@ -1883,10 +1883,10 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y}', defaults: { x: 'ab' }, trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb' }), '/aa/bbb');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb', z: 'cccc' }), '/aa/bbb?z=cccc');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'bbb' }), '/ab/bbb');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'bbb', z: 'cccc' }), '/ab/bbb?z=cccc');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb' }), '/aa/bbb');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb', z: 'cccc' }), '/aa/bbb?z=cccc');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'bbb' }), '/ab/bbb');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'bbb', z: 'cccc' }), '/ab/bbb?z=cccc');
     });
 
     it('TwoParamTwoSegmentDefaultMandatoryNonBuildTest', function () {
@@ -1903,10 +1903,10 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab/{x?}/{y}/c', defaults: { y: 'ee' }, trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg' }), '/ab/cd/efg/c');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg', z: 'hi' }), '/ab/cd/efg/c?z=hi');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd' }), '/ab/cd/ee/c');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', z: 'ef' }), '/ab/cd/ee/c?z=ef');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg' }), '/ab/cd/efg/c');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg', z: 'hi' }), '/ab/cd/efg/c?z=hi');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cd' }), '/ab/cd/ee/c');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cd', z: 'ef' }), '/ab/cd/ee/c?z=ef');
     });
 
     it('TwoParamOneOptionalMandatoryFourSegmentDefaultMandatoryNonBuildTest', function () {
@@ -1931,10 +1931,10 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: ['', 'abc/{x}'], trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d'), '/');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'd' }), '/?y=d');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de' }), '/abc/de');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'f' }), '/abc/de?y=f');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'd' }), '/?y=d');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de' }), '/abc/de');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'f' }), '/abc/de?y=f');
     });
 
     it('TwoRouteParamBuildTest', function () {
@@ -1942,12 +1942,12 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: ['abc/{x}', 'def/{y}'], trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de' }), '/abc/de');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', z: 'f' }), '/abc/de?z=f');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'gh' }), '/def/gh');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'gh', z: 'i' }), '/def/gh?z=i');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh' }), '/abc/de?y=gh');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh', z: 'i' }), '/abc/de?y=gh&z=i');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de' }), '/abc/de');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de', z: 'f' }), '/abc/de?z=f');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'gh' }), '/def/gh');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'gh', z: 'i' }), '/def/gh?z=i');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh' }), '/abc/de?y=gh');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh', z: 'i' }), '/abc/de?y=gh&z=i');
     });
 
     it('TwoRouteParamNonBuildTest', function () {
@@ -1964,10 +1964,10 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: ['abc/{x}', 'abc/{x}/def/{y}'], trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de' }), '/abc/de');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', z: 'f' }), '/abc/de?z=f');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh' }), '/abc/de/def/gh');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh', z: 'f' }), '/abc/de/def/gh?z=f');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de' }), '/abc/de');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de', z: 'f' }), '/abc/de?z=f');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh' }), '/abc/de/def/gh');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh', z: 'f' }), '/abc/de/def/gh?z=f');
     });
 
     it('TwoRouteParentChildNonBuildTest', function () {
@@ -1984,16 +1984,16 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: ['abc/{x}', 'def/{y}'], defaults: { x: 'd' }, trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d'), '/abc');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'e' }), '/abc?z=e');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de' }), '/abc/de');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', z: 'f' }), '/abc/de?z=f');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'gh' }), '/def/gh');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'gh', z: 'i' }), '/def/gh?z=i');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh' }), '/abc/de?y=gh');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh', z: 'i' }), '/abc/de?y=gh&z=i');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'd', y: 'gh' }), '/def/gh');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'd', y: 'gh', z: 'i' }), '/def/gh?z=i');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/abc');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { z: 'e' }), '/abc?z=e');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de' }), '/abc/de');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de', z: 'f' }), '/abc/de?z=f');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'gh' }), '/def/gh');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'gh', z: 'i' }), '/def/gh?z=i');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh' }), '/abc/de?y=gh');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh', z: 'i' }), '/abc/de?y=gh&z=i');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'd', y: 'gh' }), '/def/gh');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'd', y: 'gh', z: 'i' }), '/def/gh?z=i');
     });
 
     it('TwoRouteDefaultNonBuildTest', function () {
@@ -2015,12 +2015,12 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: ['abc/{x?}', 'abc/{x}/def/{y}'], trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d'), '/abc');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'd' }), '/abc?z=d');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de' }), '/abc/de');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', z: 'f' }), '/abc/de?z=f');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh' }), '/abc/de/def/gh');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh', z: 'f' }), '/abc/de/def/gh?z=f');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/abc');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { z: 'd' }), '/abc?z=d');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de' }), '/abc/de');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de', z: 'f' }), '/abc/de?z=f');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh' }), '/abc/de/def/gh');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh', z: 'f' }), '/abc/de/def/gh?z=f');
     });
 
     it('TwoRouteDefaultNumberBuildTest', function () {
@@ -2028,16 +2028,16 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: ['def/{y}', 'abc/{x}'], defaults: { x: 2 }, trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d'), '/abc');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'e' }), '/abc?z=e');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 3 }), '/abc/3');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 3, z: 'f' }), '/abc/3?z=f');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'gh' }), '/def/gh');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'gh', z: 'i' }), '/def/gh?z=i');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 3, y: 'gh' }), '/def/gh?x=3');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 3, y: 'gh', z: 'i' }), '/def/gh?x=3&z=i');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 2, y: 'gh' }), '/def/gh');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 2, y: 'gh', z: 'i' }), '/def/gh?z=i');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/abc');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { z: 'e' }), '/abc?z=e');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3 }), '/abc/3');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3, z: 'f' }), '/abc/3?z=f');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'gh' }), '/def/gh');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'gh', z: 'i' }), '/def/gh?z=i');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3, y: 'gh' }), '/def/gh?x=3');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3, y: 'gh', z: 'i' }), '/def/gh?x=3&z=i');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 2, y: 'gh' }), '/def/gh');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 2, y: 'gh', z: 'i' }), '/def/gh?z=i');
     });
 
     it('TwoRouteDefaultTypeNumberBuildTest', function () {
@@ -2045,11 +2045,11 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: ['def/{y}', 'abc/{x}'], defaultTypes: { x: 'number' }, trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 3 }), '/abc/3');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 3, z: 'f' }), '/abc/3?z=f');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'gh' }), '/def/gh');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'gh', z: 'i' }), '/def/gh?z=i');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 3, y: 'gh' }), '/def/gh?x=3');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 3, y: 'gh', z: 'i' }), '/def/gh?x=3&z=i');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3 }), '/abc/3');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3, z: 'f' }), '/abc/3?z=f');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'gh' }), '/def/gh');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'gh', z: 'i' }), '/def/gh?z=i');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3, y: 'gh' }), '/def/gh?x=3');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3, y: 'gh', z: 'i' }), '/def/gh?x=3&z=i');
     });
 })

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1272,7 +1272,7 @@ describe('MatchTest', function () {
     it('TwoRouteDefaultNumberMatchTest', function () {
         Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
-                { key: 's', route: ['abc/{x}', 'def/{y}'], defaults: { x: 2 }, trackCrumbTrail: false }]}
+                { key: 's', route: ['def/{y}', 'abc/{x}'], defaults: { x: 2 }, trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/abc');
         assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
@@ -1297,11 +1297,11 @@ describe('MatchTest', function () {
         assert.strictEqual(Navigation.StateContext.data.x, 2);
         assert.equal(Navigation.StateContext.data.y, 'gh');
         assert.equal(Navigation.StateContext.data.z, 'i');
-        Navigation.StateController.navigateLink('/abc/3?y=gh');
+        Navigation.StateController.navigateLink('/def/gh?x=3');
         assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
         assert.strictEqual(Navigation.StateContext.data.x, 3);
         assert.equal(Navigation.StateContext.data.y, 'gh');
-        Navigation.StateController.navigateLink('/abc/3?y=gh&z=i');
+        Navigation.StateController.navigateLink('/def/gh?x=3&z=i');
         assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
         assert.strictEqual(Navigation.StateContext.data.x, 3);
         assert.equal(Navigation.StateContext.data.y, 'gh');
@@ -1996,7 +1996,7 @@ describe('BuildTest', function () {
     it('TwoRouteDefaultNumberBuildTest', function () {
         Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
-                { key: 's', route: ['abc/{x}', 'def/{y}'], defaults: { x: 2 }, trackCrumbTrail: false }]}
+                { key: 's', route: ['def/{y}', 'abc/{x}'], defaults: { x: 2 }, trackCrumbTrail: false }]}
             ]);
         assert.equal(Navigation.StateController.getNavigationLink('d'), '/abc');
         assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'e' }), '/abc?z=e');
@@ -2004,8 +2004,8 @@ describe('BuildTest', function () {
         assert.equal(Navigation.StateController.getNavigationLink('d', { x: 3, z: 'f' }), '/abc/3?z=f');
         assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'gh' }), '/def/gh');
         assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'gh', z: 'i' }), '/def/gh?z=i');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 3, y: 'gh' }), '/abc/3?y=gh');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 3, y: 'gh', z: 'i' }), '/abc/3?y=gh&z=i');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 3, y: 'gh' }), '/def/gh?x=3');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 3, y: 'gh', z: 'i' }), '/def/gh?x=3&z=i');
         assert.equal(Navigation.StateController.getNavigationLink('d', { x: 2, y: 'gh' }), '/def/gh');
         assert.equal(Navigation.StateController.getNavigationLink('d', { x: 2, y: 'gh', z: 'i' }), '/def/gh?z=i');
     });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1268,6 +1268,45 @@ describe('MatchTest', function () {
         assert.throws(() => Navigation.StateController.navigateLink('/ abc/de/def/gh'), /Url is invalid/, '');
         assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
+
+    it('TwoRouteDefaultNumberMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['abc/{x}', 'def/{y}'], defaults: { x: 2 }, trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/abc');
+        assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 2);
+        Navigation.StateController.navigateLink('/abc?z=e');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 2);
+        assert.equal(Navigation.StateContext.data.z, 'e');
+        Navigation.StateController.navigateLink('/abc/3');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 3);
+        Navigation.StateController.navigateLink('/abc/3?z=f');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 3);
+        assert.equal(Navigation.StateContext.data.z, 'f');
+        Navigation.StateController.navigateLink('/def/gh');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 2);
+        assert.equal(Navigation.StateContext.data.y, 'gh');
+        Navigation.StateController.navigateLink('/def/gh?z=i');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 2);
+        assert.equal(Navigation.StateContext.data.y, 'gh');
+        assert.equal(Navigation.StateContext.data.z, 'i');
+        Navigation.StateController.navigateLink('/abc/3?y=gh');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 3);
+        assert.equal(Navigation.StateContext.data.y, 'gh');
+        Navigation.StateController.navigateLink('/abc/3?y=gh&z=i');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 3);
+        assert.equal(Navigation.StateContext.data.y, 'gh');
+        assert.equal(Navigation.StateContext.data.z, 'i');
+    });
 });
 
 describe('BuildTest', function () {
@@ -1952,5 +1991,22 @@ describe('BuildTest', function () {
         assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', z: 'f' }), '/abc/de?z=f');
         assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh' }), '/abc/de/def/gh');
         assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh', z: 'f' }), '/abc/de/def/gh?z=f');
+    });
+
+    it('TwoRouteDefaultNumberBuildTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['abc/{x}', 'def/{y}'], defaults: { x: 2 }, trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d'), '/abc');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'e' }), '/abc?z=e');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 3 }), '/abc/3');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 3, z: 'f' }), '/abc/3?z=f');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'gh' }), '/def/gh');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'gh', z: 'i' }), '/def/gh?z=i');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 3, y: 'gh' }), '/abc/3?y=gh');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 3, y: 'gh', z: 'i' }), '/abc/3?y=gh&z=i');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 2, y: 'gh' }), '/def/gh');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 2, y: 'gh', z: 'i' }), '/def/gh?z=i');
     });
 })

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -940,28 +940,30 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamTwoSegmentDefaultMandatoryMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}/{y}', { x: 'ab' });
-        var routeMatch = router.match('aa/bbb');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 2);
-        assert.equal(routeMatch.data.x, 'aa');
-        assert.equal(routeMatch.data.y, 'bbb');
-        assert.equal(route.params.length, 2);
-        assert.equal(route.params[0].name, 'x');
-        assert.equal(route.params[1].name, 'y');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}/{y}', defaults: { x: 'ab' }, trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/aa/bbb');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'aa');
+        assert.equal(Navigation.StateContext.data.y, 'bbb');
+        Navigation.StateController.navigateLink('/aa/bbb?z=cccc');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'aa');
+        assert.equal(Navigation.StateContext.data.y, 'bbb');
+        assert.equal(Navigation.StateContext.data.z, 'cccc');
     });
 
     it('TwoParamTwoSegmentDefaultMandatoryNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}/{y}', { x: 'ab' });
-        assert.equal(router.match('aa/bbb/e'), null);
-        assert.equal(router.match('aa//'), null);
-        assert.equal(router.match('aa'), null);
-        assert.equal(router.match(''), null);
-        assert.equal(route.params.length, 2);
-        assert.equal(route.params[0].name, 'x');
-        assert.equal(route.params[1].name, 'y');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}/{y}', defaults: { x: 'ab' }, trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/aa/bbb/e'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/aa//'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/aa'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
 
     it('TwoParamOneOptionalMandatoryFourSegmentDefaultMandatoryMatchTest', function () {
@@ -1586,17 +1588,23 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamTwoSegmentDefaultMandatoryBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}/{y}', { x: 'ab' });
-        assert.equal(route.build({ x: 'aa', y: 'bbb' }), '/aa/bbb');
-        assert.equal(route.build({ y: 'bbb' }), '/ab/bbb');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}/{y}', defaults: { x: 'ab' }, trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb' }), '/aa/bbb');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb', z: 'cccc' }), '/aa/bbb?z=cccc');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'bbb' }), '/ab/bbb');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'bbb', z: 'cccc' }), '/ab/bbb?z=cccc');
     });
 
     it('TwoParamTwoSegmentDefaultMandatoryNonBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}/{y}', { x: 'ab' });
-        assert.equal(route.build({ x: 'aa' }), null);
-        assert.equal(route.build(), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}/{y}', defaults: { x: 'ab' }, trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aa' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
     });
 
     it('TwoParamOneOptionalMandatoryFourSegmentDefaultMandatoryBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -740,53 +740,75 @@ describe('MatchTest', function () {
     });
 
     it('FourParamTwoOptionalFiveSegmentDefaultMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{w}/{x}/{y?}/{z?}', { w: 'abc', x: 'de' });
-        var routeMatch = router.match('ab/cd/ef/hi/jk');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 4);
-        assert.equal(routeMatch.data.w, 'cd');
-        assert.equal(routeMatch.data.x, 'ef');
-        assert.equal(routeMatch.data.y, 'hi');
-        assert.equal(routeMatch.data.z, 'jk');
-        routeMatch = router.match('ab/cde/fg/h');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 3);
-        assert.equal(routeMatch.data.w, 'cde');
-        assert.equal(routeMatch.data.x, 'fg');
-        assert.equal(routeMatch.data.y, 'h');
-        routeMatch = router.match('ab/cc/def');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 2);
-        assert.equal(routeMatch.data.w, 'cc');
-        assert.equal(routeMatch.data.x, 'def');
-        routeMatch = router.match('ab/ccdd');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 2);
-        assert.equal(routeMatch.data.w, 'ccdd');
-        assert.equal(routeMatch.data.x, 'de');
-        routeMatch = router.match('ab');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 2);
-        assert.equal(routeMatch.data.w, 'abc');
-        assert.equal(routeMatch.data.x, 'de');
-        assert.equal(route.params.length, 4);
-        assert.equal(route.params[0].name, 'w');
-        assert.equal(route.params[1].name, 'x');
-        assert.equal(route.params[2].name, 'y');
-        assert.equal(route.params[3].name, 'z');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{w}/{x}/{y?}/{z?}', defaults: { w: 'abc', x: 'de' }, trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/ab/cd/ef/hi/jk');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 4);
+        assert.equal(Navigation.StateContext.data.w, 'cd');
+        assert.equal(Navigation.StateContext.data.x, 'ef');
+        assert.equal(Navigation.StateContext.data.y, 'hi');
+        assert.equal(Navigation.StateContext.data.z, 'jk');
+        Navigation.StateController.navigateLink('/ab/cd/ef/hi/jk?a=lm');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 5);
+        assert.equal(Navigation.StateContext.data.w, 'cd');
+        assert.equal(Navigation.StateContext.data.x, 'ef');
+        assert.equal(Navigation.StateContext.data.y, 'hi');
+        assert.equal(Navigation.StateContext.data.z, 'jk');
+        assert.equal(Navigation.StateContext.data.a, 'lm');
+        Navigation.StateController.navigateLink('/ab/cde/fg/h');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.w, 'cde');
+        assert.equal(Navigation.StateContext.data.x, 'fg');
+        assert.equal(Navigation.StateContext.data.y, 'h');
+        Navigation.StateController.navigateLink('/ab/cde/fg/h?a=i');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 4);
+        assert.equal(Navigation.StateContext.data.w, 'cde');
+        assert.equal(Navigation.StateContext.data.x, 'fg');
+        assert.equal(Navigation.StateContext.data.y, 'h');
+        assert.equal(Navigation.StateContext.data.a, 'i');
+        Navigation.StateController.navigateLink('/ab/cc/def');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.w, 'cc');
+        assert.equal(Navigation.StateContext.data.x, 'def');
+        Navigation.StateController.navigateLink('/ab/cc/def?a=gg');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.w, 'cc');
+        assert.equal(Navigation.StateContext.data.x, 'def');
+        assert.equal(Navigation.StateContext.data.a, 'gg');
+        Navigation.StateController.navigateLink('/ab/ccdd');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.w, 'ccdd');
+        assert.equal(Navigation.StateContext.data.x, 'de');
+        Navigation.StateController.navigateLink('/ab/ccdd?a=fg');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.w, 'ccdd');
+        assert.equal(Navigation.StateContext.data.x, 'de');
+        assert.equal(Navigation.StateContext.data.a, 'fg');
+        Navigation.StateController.navigateLink('/ab');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.w, 'abc');
+        assert.equal(Navigation.StateContext.data.x, 'de');
+        Navigation.StateController.navigateLink('/ab?a=fg');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.w, 'abc');
+        assert.equal(Navigation.StateContext.data.x, 'de');
+        assert.equal(Navigation.StateContext.data.a, 'fg');
     });
 
     it('FourParamTwoOptionalFiveSegmentDefaultNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{w}/{x}/{y?}/{z?}', { w: 'abc', x: 'de' });
-        assert.equal(router.match(' ab/cde/fg/h'), null);
-        assert.equal(router.match('ab/cde/fg/h/ij/k'), null);
-        assert.equal(router.match('ab/cde/fg/h//'), null);
-        assert.equal(router.match('ab/cde/fg//'), null);
-        assert.equal(router.match('ab/cd//'), null);
-        assert.equal(router.match('ab//'), null);
-        assert.equal(router.match(''), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{w}/{x}/{y?}/{z?}', defaults: { w: 'abc', x: 'de' }, trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/ ab/cde/fg/h'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/cde/fg/h/ij/k'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/cde/fg/h//'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/cde/fg//'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/cd//'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab//'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
 
     it('SpacesMatchTest', function () {
@@ -1405,46 +1427,74 @@ describe('BuildTest', function () {
     });
 
     it('FourParamTwoOptionalFiveSegmentDefaultBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{w}/{x}/{y?}/{z?}', { w: 'abc', x: 'de' });
-        assert.equal(route.build({ w: 'cd', x: 'ef', y: 'hi', z: 'jk' }), '/ab/cd/ef/hi/jk');
-        assert.equal(route.build({ w: 'cd', x: 'de', y: 'hi', z: 'jk' }), '/ab/cd/de/hi/jk');
-        assert.equal(route.build({ w: 'abc', x: 'ef', y: 'hi', z: 'jk' }), '/ab/abc/ef/hi/jk');
-        assert.equal(route.build({ w: 'abc', x: 'de', y: 'hi', z: 'jk' }), '/ab/abc/de/hi/jk');
-        assert.equal(route.build({ x: 'ef', y: 'hi', z: 'jk' }), '/ab/abc/ef/hi/jk');
-        assert.equal(route.build({ x: 'de', y: 'hi', z: 'jk' }), '/ab/abc/de/hi/jk');
-        assert.equal(route.build({ x: 'de', y: 'hi' }), '/ab/abc/de/hi');
-        assert.equal(route.build({ x: 'ef' }), '/ab/abc/ef');
-        assert.equal(route.build({ x: 'de' }), '/ab');
-        assert.equal(route.build({ y: 'hi', z: 'jk' }), '/ab/abc/de/hi/jk');
-        assert.equal(route.build({ y: 'hi' }), '/ab/abc/de/hi');
-        assert.equal(route.build({ w: 'cde', x: 'fg', y: 'h' }), '/ab/cde/fg/h');
-        assert.equal(route.build({ w: 'abc', x: 'de', y: 'h' }), '/ab/abc/de/h');
-        assert.equal(route.build({ w: 'cde', y: 'h', z: 'jk' }), '/ab/cde/de/h/jk');
-        assert.equal(route.build({ w: 'abc', y: 'h', z: 'jk' }), '/ab/abc/de/h/jk');
-        assert.equal(route.build({ w: 'cde', y: 'h' }), '/ab/cde/de/h');
-        assert.equal(route.build({ w: 'abc', y: 'h' }), '/ab/abc/de/h');
-        assert.equal(route.build({ w: 'cc', x: 'def' }), '/ab/cc/def');
-        assert.equal(route.build({ w: 'cc', x: 'de' }), '/ab/cc');
-        assert.equal(route.build({ w: 'abc', x: 'de' }), '/ab');
-        assert.equal(route.build({ w: 'abc', x: 'def' }), '/ab/abc/def');
-        assert.equal(route.build({ w: 'ccdd' }), '/ab/ccdd');
-        assert.equal(route.build({ w: 'abc' }), '/ab');
-        assert.equal(route.build(), '/ab');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{w}/{x}/{y?}/{z?}', defaults: { w: 'abc', x: 'de' }, trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cd', x: 'ef', y: 'hi', z: 'jk' }), '/ab/cd/ef/hi/jk');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cd', x: 'ef', y: 'hi', z: 'jk', a: 'lm' }), '/ab/cd/ef/hi/jk?a=lm');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cd', x: 'de', y: 'hi', z: 'jk' }), '/ab/cd/de/hi/jk');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cd', x: 'de', y: 'hi', z: 'jk', a: 'lm' }), '/ab/cd/de/hi/jk?a=lm');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'ef', y: 'hi', z: 'jk' }), '/ab/abc/ef/hi/jk');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'ef', y: 'hi', z: 'jk', a: 'lm' }), '/ab/abc/ef/hi/jk?a=lm');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'de', y: 'hi', z: 'jk' }), '/ab/abc/de/hi/jk');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'de', y: 'hi', z: 'jk', a: 'lm' }), '/ab/abc/de/hi/jk?a=lm');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ef', y: 'hi', z: 'jk' }), '/ab/abc/ef/hi/jk');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ef', y: 'hi', z: 'jk', a: 'lm' }), '/ab/abc/ef/hi/jk?a=lm');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'hi', z: 'jk' }), '/ab/abc/de/hi/jk');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'hi', z: 'jk', a: 'lm' }), '/ab/abc/de/hi/jk?a=lm');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'hi' }), '/ab/abc/de/hi');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'hi', a: 'lm' }), '/ab/abc/de/hi?a=lm');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ef' }), '/ab/abc/ef');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ef', a: 'lm' }), '/ab/abc/ef?a=lm');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de' }), '/ab');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', a: 'lm' }), '/ab?a=lm');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'hi', z: 'jk' }), '/ab/abc/de/hi/jk');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'hi', z: 'jk', a: 'lm' }), '/ab/abc/de/hi/jk?a=lm');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'hi' }), '/ab/abc/de/hi');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'hi', a: 'lm' }), '/ab/abc/de/hi?a=lm');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cde', x: 'fg', y: 'h' }), '/ab/cde/fg/h');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cde', x: 'fg', y: 'h', a: 'i' }), '/ab/cde/fg/h?a=i');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'de', y: 'h' }), '/ab/abc/de/h');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'de', y: 'h', a: 'i' }), '/ab/abc/de/h?a=i');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cde', y: 'h', z: 'jk' }), '/ab/cde/de/h/jk');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cde', y: 'h', z: 'jk', a: 'lm' }), '/ab/cde/de/h/jk?a=lm');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', y: 'h', z: 'jk' }), '/ab/abc/de/h/jk');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', y: 'h', z: 'jk', a: 'lm' }), '/ab/abc/de/h/jk?a=lm');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cde', y: 'h' }), '/ab/cde/de/h');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cde', y: 'h', a: 'i' }), '/ab/cde/de/h?a=i');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', y: 'h' }), '/ab/abc/de/h');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', y: 'h', a: 'i' }), '/ab/abc/de/h?a=i');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cc', x: 'def' }), '/ab/cc/def');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cc', x: 'def', a: 'gg' }), '/ab/cc/def?a=gg');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cc', x: 'de' }), '/ab/cc');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'cc', x: 'de', a: 'gg' }), '/ab/cc?a=gg');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'de' }), '/ab');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'de', a: 'fg' }), '/ab?a=fg');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'def' }), '/ab/abc/def');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'def', a: 'gg' }), '/ab/abc/def?a=gg');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'ccdd' }), '/ab/ccdd');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'ccdd', a: 'gg' }), '/ab/ccdd?a=gg');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc' }), '/ab');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { w: 'abc', a: 'fg' }), '/ab?a=fg');
+        assert.equal(Navigation.StateController.getNavigationLink('d'), '/ab');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { a: 'fg' }), '/ab?a=fg');
     });
 
-    it('FourParamTwoOptionalFiveSegmentDefaultBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{w}/{x}/{y?}/{z?}', { w: 'abc', x: 'de' });
-        assert.equal(route.build({ z: 'jk' }), null);
-        assert.equal(route.build({ w: 'cde', z: 'jk' }), null);
-        assert.equal(route.build({ w: 'abc', z: 'jk' }), null);
-        assert.equal(route.build({ x: 'fg', z: 'jk' }), null);
-        assert.equal(route.build({ x: 'de', z: 'jk' }), null);
-        assert.equal(route.build({ w: 'abc', x: 'fg', z: 'jk' }), null);
-        assert.equal(route.build({ w: 'cde', x: 'de', z: 'jk' }), null);
-        assert.equal(route.build({ w: 'cde', x: 'fg', z: 'jk' }), null);
-        assert.equal(route.build({ w: 'abc', x: 'de', z: 'jk' }), null);
+    it('FourParamTwoOptionalFiveSegmentDefaultNonBuildTest', function () {
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{w}/{x}/{y?}/{z?}', defaults: { w: 'abc', x: 'de' }, trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { z: 'jk' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'cde', z: 'jk' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'abc', z: 'jk' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'fg', z: 'jk' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'de', z: 'jk' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'fg', z: 'jk' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'cde', x: 'de', z: 'jk' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'cde', x: 'fg', z: 'jk' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { w: 'abc', x: 'de', z: 'jk' }), null);
     });
 
     it('SpacesBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1110,6 +1110,15 @@ describe('MatchTest', function () {
         assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
         assert.equal(Navigation.StateContext.data.y, 'gh');
         assert.equal(Navigation.StateContext.data.z, 'i');
+        Navigation.StateController.navigateLink('/abc/de?y=fg');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'de');
+        assert.equal(Navigation.StateContext.data.y, 'fg');
+        Navigation.StateController.navigateLink('/abc/de?y=fg&z=h');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'de');
+        assert.equal(Navigation.StateContext.data.y, 'fg');
+        assert.equal(Navigation.StateContext.data.z, 'h');
     });
 
     it('TwoRouteParamNonMatchTest', function () {
@@ -1191,6 +1200,15 @@ describe('MatchTest', function () {
         Navigation.StateController.navigateLink('/def/gh?z=i');
         assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
         assert.equal(Navigation.StateContext.data.x, 'd');
+        assert.equal(Navigation.StateContext.data.y, 'gh');
+        assert.equal(Navigation.StateContext.data.z, 'i');
+        Navigation.StateController.navigateLink('/abc/de?y=gh');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'de');
+        assert.equal(Navigation.StateContext.data.y, 'gh');
+        Navigation.StateController.navigateLink('/abc/de?y=gh&z=i');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'de');
         assert.equal(Navigation.StateContext.data.y, 'gh');
         assert.equal(Navigation.StateContext.data.z, 'i');
     });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -195,28 +195,33 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamFourSegmentMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x}/c/{y}');
-        var routeMatch = router.match('ab/yy/c/xyz');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 2);
-        assert.equal(routeMatch.data.x, 'yy');
-        assert.equal(routeMatch.data.y, 'xyz');
-        assert.equal(route.params.length, 2);
-        assert.equal(route.params[0].name, 'x');
-        assert.equal(route.params[1].name, 'y');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x}/c/{y}', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/ab/yy/c/xyz');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'yy');
+        assert.equal(Navigation.StateContext.data.y, 'xyz');
+        Navigation.StateController.navigateLink('/ab/yy/c/xyz?z=xx');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'yy');
+        assert.equal(Navigation.StateContext.data.y, 'xyz');
+        assert.equal(Navigation.StateContext.data.z, 'xx');
     });
 
     it('TwoParamFourSegmentNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x}/c/{y}');
-        assert.equal(router.match(' ab/yy/c/xyz'), null);
-        assert.equal(router.match('ab/b/c'), null);
-        assert.equal(router.match('ab/b/c/d/e'), null);
-        assert.equal(router.match('ab/c'), null);
-        assert.equal(router.match('ab/b/c//d'), null);
-        assert.equal(router.match('ab//b/c/d'), null);
-        assert.equal(router.match(''), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x}/c/{y}', trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/ ab/yy/c/xyz'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/b/c'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/b/c/d/e'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/c'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/b/c//d'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab//b/c/d'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
 
     it('OneOptionalParamOneSegmentMatchTest', function () {
@@ -959,10 +964,10 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y}', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa' }), null);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'bbb' }), null);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'cccc' }), null);
-        assert.equal(Navigation.StateController.getNavigationLink('d'), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'aa' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'bbb' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { z: 'cccc' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
     });
 
     it('TwoParamThreeSegmentBuildTest', function () {
@@ -979,24 +984,30 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}/{y}', trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd' }), null);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'efg' }), null);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'hi' }), null);
-        assert.equal(Navigation.StateController.getNavigationLink('d'), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cd' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'efg' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { z: 'hi' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
     });
 
     it('TwoParamFourSegmentBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x}/c/{y}');
-        assert.equal(route.build({ x: 'yy', y: 'xyz' }), '/ab/yy/c/xyz');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x}/c/{y}', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'yy', y: 'xyz' }), '/ab/yy/c/xyz');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'yy', y: 'xyz', z: 'xx' }), '/ab/yy/c/xyz?z=xx');
     });
 
     it('TwoParamFourSegmentNonBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x}/c/{y}');
-        assert.equal(route.build({ x: 'yy' }), null);
-        assert.equal(route.build({ y: 'xyz' }), null);
-        assert.equal(route.build(), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x}/c/{y}', trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'yy' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'xyz' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { z: 'zz' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
     });
 
     it('OneOptionalParamOneSegmentBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -871,14 +871,17 @@ describe('MatchTest', function () {
     });
 
     it('ReservedRegexCharacterMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('.+*\^$\[\]()\'/{x}');
-        var routeMatch = router.match('.+*\^$\[\]()\'/abc');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data.x, 'abc');
-        assert.equal(route.params.length, 1);
-        assert.equal(route.params[0].name, 'x');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '.+*\^$\[\]()\'/{x}', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('.+*\^$\[\]()\'/abc');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'abc');
+        Navigation.StateController.navigateLink('.+*\^$\[\]()\'/abc?y=de');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'abc');
+        assert.equal(Navigation.StateContext.data.y, 'de');
     });
 
     it('OneParamOptionalMandatoryOneMixedSegmentMatchTest', function () {
@@ -1533,9 +1536,12 @@ describe('BuildTest', function () {
     });
 
     it('ReservedRegexCharacterBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('.+*\^$\[\]()\'/{x}');
-        assert.equal(route.build({ x: 'abc' }), '/.+*\^$\[\]()\'/abc');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '.+*\^$\[\]()\'/{x}', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abc' }), '/.+*\^$\[\]()\'/abc');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abc', y: 'de' }), '/.+*\^$\[\]()\'/abc?y=de');
     });
 
     it('OneParamOptionalMandatoryOneMixedSegmentBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -225,19 +225,33 @@ describe('MatchTest', function () {
     });
 
     it('OneOptionalParamOneSegmentMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x?}');
-        var routeMatch = router.match('abcd');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data.x, 'abcd');
-        routeMatch = router.match('');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 0);
-        assert.equal(route.params.length, 1);
-        assert.equal(route.params[0].name, 'x');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x?}', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/abcd');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'abcd');
+        Navigation.StateController.navigateLink('/abcd?y=ef');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'abcd');
+        assert.equal(Navigation.StateContext.data.y, 'ef');
+        Navigation.StateController.navigateLink('/');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 0);
+        Navigation.StateController.navigateLink('/?y=ef');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.y, 'ef');
     });
 
+    it('OneOptionalParamOneSegmentNonMatchTest', function () {
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x?}', trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/cd'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab//'), /Url is invalid/, '');
+    });
+    
     it('OneOptionalParamOneSegmentNonMatchTest', function () {
         var router = new Router();
         var route = router.addRoute('{x?}');
@@ -1011,10 +1025,14 @@ describe('BuildTest', function () {
     });
 
     it('OneOptionalParamOneSegmentBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x?}');
-        assert.equal(route.build({ x: 'abcd' }), '/abcd');
-        assert.equal(route.build(), '/');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x?}', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abcd' }), '/abcd');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abcd', y: 'ef' }), '/abcd?y=ef');
+        assert.equal(Navigation.StateController.getNavigationLink('d'), '/');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'ef' }), '/?y=ef');
     });
 
     it('OneOptionalParamTwoSegmentBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -523,30 +523,38 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamOneOptionalTwoSegmentOneMixedMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}ab/{y?}');
-        var routeMatch = router.match('abcab/de');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 2);
-        assert.equal(routeMatch.data.x, 'abc');
-        assert.equal(routeMatch.data.y, 'de');
-        routeMatch = router.match('abcab');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data.x, 'abc');
-        assert.equal(route.params.length, 2);
-        assert.equal(route.params[0].name, 'x');
-        assert.equal(route.params[1].name, 'y');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}ab/{y?}', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/abcab/de');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'abc');
+        assert.equal(Navigation.StateContext.data.y, 'de');
+        Navigation.StateController.navigateLink('/abcab/de?z=f');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'abc');
+        assert.equal(Navigation.StateContext.data.y, 'de');
+        assert.equal(Navigation.StateContext.data.z, 'f');
+        Navigation.StateController.navigateLink('/abcab');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'abc');
+        Navigation.StateController.navigateLink('/abcab?z=de');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'abc');
+        assert.equal(Navigation.StateContext.data.z, 'de');
     });
 
     it('TwoParamOneOptionalTwoSegmentOneMixedNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}ab/{y?}');
-        assert.equal(router.match('abcab /de'), null);
-        assert.equal(router.match('abcab/de/fg'), null);
-        assert.equal(router.match('abcab//'), null);
-        assert.equal(router.match('ab/de'), null);
-        assert.equal(router.match(''), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}ab/{y?}', trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/abcab /de'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abcab/de/fg'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abcab//'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/de'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
 
     it('OneParamOneSegmentDefaultMatchTest', function () {
@@ -1238,17 +1246,23 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamOneOptionalTwoSegmentOneMixedBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}ab/{y?}');
-        assert.equal(route.build({ x: 'abc', y: 'de' }), '/abcab/de');
-        assert.equal(route.build({ x: 'abc' }), '/abcab');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}ab/{y?}', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abc', y: 'de' }), '/abcab/de');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abc', y: 'de', z: 'f' }), '/abcab/de?z=f');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abc' }), '/abcab');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abc', z: 'de' }), '/abcab?z=de');
     });
 
     it('TwoParamOneOptionalTwoSegmentOneMixedNonBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}ab/{y?}');
-        assert.equal(route.build({ y: 'de' }), null);
-        assert.equal(route.build(), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}ab/{y?}', trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'de' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
     });
 
     it('OneParamOneSegmentDefaultBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -21,23 +21,6 @@ describe('MatchTest', function () {
         assert.equal(router.match('//'), null);
     });
 
-    it('RootMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('');
-        var routeMatch = router.match('');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 0);
-        assert.equal(route.params.length, 0);
-    });
-
-    it('RootNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('');
-        assert.equal(router.match(' '), null);
-        assert.equal(router.match('a'), null);
-        assert.equal(router.match('//'), null);
-    });
-
     it('NoParamOneSegmentMatchTest', function () {
         var router = new Router();
         var route = router.addRoute('abc');

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1863,6 +1863,8 @@ describe('BuildTest', function () {
         assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'gh', z: 'i' }), '/def/gh?z=i');
         assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh' }), '/abc/de?y=gh');
         assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh', z: 'i' }), '/abc/de?y=gh&z=i');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'd', y: 'gh' }), '/def/gh');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'd', y: 'gh', z: 'i' }), '/def/gh?z=i');
     });
 
     it('TwoRouteDefaultNonBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -622,34 +622,47 @@ describe('MatchTest', function () {
         assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
 
-    it('TwoParamTwoSegmentTwoDefaultMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}/{y}', { x: 'ab', y: 'c' });
-        var routeMatch = router.match('aa/bbb');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 2);
-        assert.equal(routeMatch.data.x, 'aa');
-        assert.equal(routeMatch.data.y, 'bbb');
-        routeMatch = router.match('aa');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 2);
-        assert.equal(routeMatch.data.x, 'aa');
-        assert.equal(routeMatch.data.y, 'c');
-        routeMatch = router.match('');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 2);
-        assert.equal(routeMatch.data.x, 'ab');
-        assert.equal(routeMatch.data.y, 'c');
-        assert.equal(route.params.length, 2);
-        assert.equal(route.params[0].name, 'x');
-        assert.equal(route.params[1].name, 'y');
+    it('OneParamTwoSegmentDefaultMatchTest', function () {
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}/{y}', defaults: { x: 'ab', y: 'c' }, trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/aa/bbb');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'aa');
+        assert.equal(Navigation.StateContext.data.y, 'bbb');
+        Navigation.StateController.navigateLink('/aa/bbb?z=cccc');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'aa');
+        assert.equal(Navigation.StateContext.data.y, 'bbb');
+        assert.equal(Navigation.StateContext.data.z, 'cccc');
+        Navigation.StateController.navigateLink('/aa');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'aa');
+        assert.equal(Navigation.StateContext.data.y, 'c');
+        Navigation.StateController.navigateLink('/aa?z=d');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'aa');
+        assert.equal(Navigation.StateContext.data.y, 'c');
+        assert.equal(Navigation.StateContext.data.z, 'd');
+        Navigation.StateController.navigateLink('/');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'ab');
+        assert.equal(Navigation.StateContext.data.y, 'c');
+        Navigation.StateController.navigateLink('/?z=d');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'ab');
+        assert.equal(Navigation.StateContext.data.y, 'c');
+        assert.equal(Navigation.StateContext.data.z, 'd');
     });
 
     it('TwoParamTwoSegmentTwoDefaultNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}/{y}', { x: 'ab', y: 'c' });
-        assert.equal(router.match('aa/bbb/e'), null);
-        assert.equal(router.match('aa//'), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}/{y}', defaults: { x: 'ab', y: 'c' }, trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/aa/bbb/e'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/aa//'), /Url is invalid/, '');
     });
 
     it('TwoParamTwoSegmentDefaultMatchTest', function () {
@@ -1308,16 +1321,26 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamTwoSegmentTwoDefaultBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}/{y}', { x: 'ab', y: 'c' });
-        assert.equal(route.build({ x: 'aa', y: 'bbb' }), '/aa/bbb');
-        assert.equal(route.build({ x: 'aa', y: 'c' }), '/aa');
-        assert.equal(route.build({ y: 'bbb' }), '/ab/bbb');
-        assert.equal(route.build({ y: 'c' }), '/');
-        assert.equal(route.build({ x: 'aa' }), '/aa');
-        assert.equal(route.build({ x: 'ab', y: 'c' }), '/');
-        assert.equal(route.build({ x: 'ab' }), '/');
-        assert.equal(route.build(), '/');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}/{y}', defaults: { x: 'ab', y: 'c' }, trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb' }), '/aa/bbb');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb', z: 'cccc' }), '/aa/bbb?z=cccc');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'c' }), '/aa');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'c', z: 'd' }), '/aa?z=d');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'bbb' }), '/ab/bbb');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'bbb', z: 'cccc' }), '/ab/bbb?z=cccc');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'c' }), '/');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'c', z: 'd' }), '/?z=d');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa' }), '/aa');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', z: 'd' }), '/aa?z=d');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ab', y: 'c' }), '/');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ab', y: 'c', z: 'd' }), '/?z=d');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ab', z: 'd' }), '/?z=d');
+        assert.equal(Navigation.StateController.getNavigationLink('d'), '/');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'd' }), '/?z=d');
     });
 
     it('TwoParamTwoSegmentDefaultBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -851,22 +851,22 @@ describe('MatchTest', function () {
     it('ReservedUrlCharacterMatchTest', function () {
         Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
-                { key: 's', route: 'a/{*="()\'-_+~@:?><.;[]!£$%^#&}', defaults: { '*="()\'-_+~@:?><.;[]!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' }, trackCrumbTrail: false }]}
+                { key: 's', route: 'a/{*="()\'-_+~@:?><.;[],!£$%^#&}', defaults: { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' }, trackCrumbTrail: false }]}
             ]);
-        Navigation.StateController.navigateLink('/a/*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+        Navigation.StateController.navigateLink('/a/*%3D%22()\'-0__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
         assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data['*="()\'-_+~@:?><.;[]!£$%^#&'], '*="()\'-_+~@:?><.;[],!£$%^#&');
-        Navigation.StateController.navigateLink('/a/*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26?*%3D%22()\'-_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+        assert.equal(Navigation.StateContext.data['*="()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
+        Navigation.StateController.navigateLink('/a/*%3D%22()\'-0__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
         assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data['*="()\'-_+~@:?><.;[]!£$%^#&'], '*="()\'-_+~@:?><.;[],!£$%^#&');
-        assert.equal(Navigation.StateContext.data['*="()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-_+~@:?><.;[],!£$%^#&');
+        assert.equal(Navigation.StateContext.data['*="()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
+        assert.equal(Navigation.StateContext.data['*="()\'-__+~@:?><.;[],!£$%^#&'], '*="()\'-_+~@:?><.;[],!£$%^#&');
         Navigation.StateController.navigateLink('/a');
         assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data['*="()\'-_+~@:?><.;[]!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
-        Navigation.StateController.navigateLink('/a?*%3D%22()\'-_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+        assert.equal(Navigation.StateContext.data['*="()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
+        Navigation.StateController.navigateLink('/a?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
         assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data['*="()\'-_+~@:?><.;[]!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
-        assert.equal(Navigation.StateContext.data['*="()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-_+~@:?><.;[],!£$%^#&');
+        assert.equal(Navigation.StateContext.data['*="()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
+        assert.equal(Navigation.StateContext.data['*="()\'-__+~@:?><.;[],!£$%^#&'], '*="()\'-_+~@:?><.;[],!£$%^#&');
     });
 
     it('ReservedRegexCharacterMatchTest', function () {
@@ -1736,14 +1736,14 @@ describe('BuildTest', function () {
     it('ReservedUrlCharacterBuildTest', function () {
         Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
-                { key: 's', route: 'a/{*="()\'-_+~@:?><.;[]!£$%^#&}', defaults: { '*="()\'-_+~@:?><.;[]!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' }, trackCrumbTrail: false }]}
+                { key: 's', route: 'a/{*="()\'-_+~@:?><.;[],!£$%^#&}', defaults: { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' }, trackCrumbTrail: false }]}
             ]);
-        assert.equal(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[]!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&' }), '/a/*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[]!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&', '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&'}), '/a/*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26?*%3D%22()\'-_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[]!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' }), '/a');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[]!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&', '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&'}), '/a?*%3D%22()\'-_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&' }), '/a/*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&', '*="()\'-__+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&'}), '/a/*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' }), '/a');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&', '*="()\'-__+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&'}), '/a?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
         assert.equal(Navigation.StateController.getNavigationLink('d'), '/a');
-        assert.equal(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&' }), '/a?*%3D%22()\'-_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { '*="()\'-__+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&' }), '/a?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
     });
 
     it('ReservedRegexCharacterBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -286,30 +286,40 @@ describe('MatchTest', function () {
     });
 
     it('TwoOptionalParamTwoSegmentMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x?}/{y?}');
-        var routeMatch = router.match('aa/bbb');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 2);
-        assert.equal(routeMatch.data.x, 'aa');
-        assert.equal(routeMatch.data.y, 'bbb');
-        routeMatch = router.match('aab');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data.x, 'aab');
-        routeMatch = router.match('');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 0);
-        assert.equal(route.params.length, 2);
-        assert.equal(route.params[0].name, 'x');
-        assert.equal(route.params[1].name, 'y');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x?}/{y?}', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/aa/bbb');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'aa');
+        assert.equal(Navigation.StateContext.data.y, 'bbb');
+        Navigation.StateController.navigateLink('/aa/bbb?z=cccc');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'aa');
+        assert.equal(Navigation.StateContext.data.y, 'bbb');
+        assert.equal(Navigation.StateContext.data.z, 'cccc');
+        Navigation.StateController.navigateLink('/aab');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'aab');
+        Navigation.StateController.navigateLink('/aab?z=cccc');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'aab');
+        assert.equal(Navigation.StateContext.data.z, 'cccc');
+        Navigation.StateController.navigateLink('/');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 0);
+        Navigation.StateController.navigateLink('/?z=cccc');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.z, 'cccc');
     });
 
     it('TwoOptionalParamTwoSegmentNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x?}/{y?}');
-        assert.equal(router.match('aa/bbb/e'), null);
-        assert.equal(router.match('aa//'), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x?}/{y?}', trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/aa/bbb/e'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/aa//'), /Url is invalid/, '');
     });
 
     it('TwoOptionalParamThreeSegmentMatchTest', function () {
@@ -1046,11 +1056,17 @@ describe('BuildTest', function () {
         assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'ef' }), '/ab?y=ef');
     });
 
-    it('OneOptionalParamTwoSegmentBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x?}');
-        assert.equal(route.build({ x: 'cd' }), '/ab/cd');
-        assert.equal(route.build(), '/ab');
+    it('TwoOptionalParamTwoSegmentBuildTest', function () {
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x?}/{y?}', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb' }), '/aa/bbb');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb', z: 'cccc' }), '/aa/bbb?z=cccc');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aab' }), '/aab');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aab', z: 'cccc' }), '/aab?z=cccc');
+        assert.equal(Navigation.StateController.getNavigationLink('d'), '/');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'cccc' }), '/?z=cccc');
     });
 
     it('TwoOptionalParamTwoSegmentBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -666,29 +666,38 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamTwoSegmentDefaultMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}/{y}', { y: 'ab' });
-        var routeMatch = router.match('aa/bbb');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 2);
-        assert.equal(routeMatch.data.x, 'aa');
-        assert.equal(routeMatch.data.y, 'bbb');
-        routeMatch = router.match('aa');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 2);
-        assert.equal(routeMatch.data.x, 'aa');
-        assert.equal(routeMatch.data.y, 'ab');
-        assert.equal(route.params.length, 2);
-        assert.equal(route.params[0].name, 'x');
-        assert.equal(route.params[1].name, 'y');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}/{y}', defaults: { y: 'ab' }, trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/aa/bbb');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'aa');
+        assert.equal(Navigation.StateContext.data.y, 'bbb');
+        Navigation.StateController.navigateLink('/aa/bbb?z=cccc');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'aa');
+        assert.equal(Navigation.StateContext.data.y, 'bbb');
+        assert.equal(Navigation.StateContext.data.z, 'cccc');
+        Navigation.StateController.navigateLink('/aa');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'aa');
+        assert.equal(Navigation.StateContext.data.y, 'ab');
+        Navigation.StateController.navigateLink('/aa?z=bb');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'aa');
+        assert.equal(Navigation.StateContext.data.y, 'ab');
+        assert.equal(Navigation.StateContext.data.z, 'bb');
     });
 
     it('TwoParamTwoSegmentDefaultNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}/{y}', { y: 'ab' });
-        assert.equal(router.match('aa/bbb/e'), null);
-        assert.equal(router.match('aa//'), null);
-        assert.equal(router.match(''), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}/{y}', defaults: { y: 'ab' }, trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/aa/bbb/e'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/aa//'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
 
     it('TwoParamOneOptionalTwoSegmentDefaultMatchTest', function () {
@@ -1343,18 +1352,26 @@ describe('BuildTest', function () {
         assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'd' }), '/?z=d');
     });
 
-    it('TwoParamTwoSegmentDefaultBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}/{y}', { y: 'ab' });
-        assert.equal(route.build({ x: 'aa', y: 'bbb' }), '/aa/bbb');
-        assert.equal(route.build({ x: 'aa', y: 'ab' }), '/aa');
-        assert.equal(route.build({ x: 'aa' }), '/aa');
+    it('OneParamTwoSegmentDefaultBuildTest', function () {
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}/{y}', defaults: { y: 'ab' }, trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb' }), '/aa/bbb');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb', z: 'cccc' }), '/aa/bbb?z=cccc');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'ab' }), '/aa');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'ab', z: 'bb' }), '/aa?z=bb');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa' }), '/aa');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', z: 'bb' }), '/aa?z=bb');
     });
 
     it('TwoParamTwoSegmentDefaultNonBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}/{y}', { y: 'ab' });
-        assert.equal(route.build({ y: 'bbb' }), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}/{y}', defaults: { y: 'ab' }, trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'bbb' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
     });
 
     it('TwoParamOneOptionalTwoSegmentDefaultBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -967,34 +967,36 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamOneOptionalMandatoryFourSegmentDefaultMandatoryMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x?}/{y}/c', { y: 'ee' });
-        var routeMatch = router.match('ab/cd/efg/c');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 2);
-        assert.equal(routeMatch.data.x, 'cd');
-        assert.equal(routeMatch.data.y, 'efg');
-        assert.equal(route.params.length, 2);
-        assert.equal(route.params[0].name, 'x');
-        assert.equal(route.params[1].name, 'y');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x?}/{y}/c', defaults: { y: 'ee' }, trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/ab/cd/efg/c');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'cd');
+        assert.equal(Navigation.StateContext.data.y, 'efg');
+        Navigation.StateController.navigateLink('/ab/cd/efg/c?z=hi');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'cd');
+        assert.equal(Navigation.StateContext.data.y, 'efg');
+        assert.equal(Navigation.StateContext.data.z, 'hi');
     });
 
-    it('TwoParamOneOptionalMandatoryFourSegmentDefaultMandatoryMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x?}/{y}/c', { y: 'ee' });
-        assert.equal(router.match(' ab/cd/efg/c'), null);
-        assert.equal(router.match('ab/cd/efg'), null);
-        assert.equal(router.match('ab/cd'), null);
-        assert.equal(router.match('ab'), null);
-        assert.equal(router.match('ab/cd/efg/c//'), null);
-        assert.equal(router.match('ab//efg/c'), null);
-        assert.equal(router.match('ab/cd//c'), null);
-        assert.equal(router.match('ab///c'), null);
-        assert.equal(router.match('ab/c'), null);
-        assert.equal(router.match(''), null);
-        assert.equal(route.params.length, 2);
-        assert.equal(route.params[0].name, 'x');
-        assert.equal(route.params[1].name, 'y');
+    it('TwoParamOneOptionalMandatoryFourSegmentDefaultMandatoryNonMatchTest', function () {
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x?}/{y}/c', defaults: { y: 'ee' }, trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/ ab/cd/efg/c'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/cd/efg'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/cd'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/cd/efg/c//'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab//efg/c'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/cd//c'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab///c'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/c'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
 
     it('ExtraDefaultsMatchTest', function () {
@@ -1608,17 +1610,23 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamOneOptionalMandatoryFourSegmentDefaultMandatoryBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x?}/{y}/c', { y: 'ee' });
-        assert.equal(route.build({ x: 'cd', y: 'efg' }), '/ab/cd/efg/c');
-        assert.equal(route.build({ x: 'cd' }), '/ab/cd/ee/c');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x?}/{y}/c', defaults: { y: 'ee' }, trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg' }), '/ab/cd/efg/c');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg', z: 'hi' }), '/ab/cd/efg/c?z=hi');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd' }), '/ab/cd/ee/c');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', z: 'ef' }), '/ab/cd/ee/c?z=ef');
     });
 
     it('TwoParamOneOptionalMandatoryFourSegmentDefaultMandatoryNonBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x?}/{y}/c', { y: 'ee' });
-        assert.equal(route.build({ y: 'efg' }), null);
-        assert.equal(route.build(), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x?}/{y}/c', defaults: { y: 'ee' }, trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'efg' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
     });
 
     it('ExtraDataMatchTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -885,25 +885,28 @@ describe('MatchTest', function () {
     });
 
     it('OneParamOptionalMandatoryOneMixedSegmentMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab{x?}');
-        var routeMatch = router.match('abcde');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data.x, 'cde');
-        assert.equal(route.params.length, 1);
-        assert.equal(route.params[0].name, 'x');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab{x?}', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('abcde');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'cde');
+        Navigation.StateController.navigateLink('abcde?y=fg');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'cde');
+        assert.equal(Navigation.StateContext.data.y, 'fg');
     });
 
     it('OneParamOptionalMandatoryOneMixedSegmentNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab{x?}');
-        assert.equal(router.match('ab/cde'), null);
-        assert.equal(router.match('abcd//'), null);
-        assert.equal(router.match('ab'), null);
-        assert.equal(router.match(''), null);
-        assert.equal(route.params.length, 1);
-        assert.equal(route.params[0].name, 'x');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab{x?}', trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/cde'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abcd//'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
 
     it('TwoParamOneOptionalMandatoryThreeSegmentMatchTest', function () {
@@ -1545,15 +1548,20 @@ describe('BuildTest', function () {
     });
 
     it('OneParamOptionalMandatoryOneMixedSegmentBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab{x?}');
-        assert.equal(route.build({ x: 'cde' }), '/abcde');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab{x?}', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cde' }), '/abcde');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cde', y: 'fg' }), '/abcde?y=fg');
     });
 
     it('OneParamOptionalMandatoryOneMixedSegmentNonBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab{x?}');
-        assert.equal(route.build(), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab{x?}', trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
     });
 
     it('TwoParamOneOptionalMandatoryThreeSegmentBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1087,6 +1087,42 @@ describe('MatchTest', function () {
         assert.throws(() => Navigation.StateController.navigateLink('/ abc'), /Url is invalid/, '');
         assert.throws(() => Navigation.StateController.navigateLink('//abc'), /Url is invalid/, '');
     });
+
+    it('TwoRouteParamMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['abc/{x}', 'def/{x}'], trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/abc/de');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'de');
+        Navigation.StateController.navigateLink('/abc/de?y=f');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'de');
+        assert.equal(Navigation.StateContext.data.y, 'f');
+        Navigation.StateController.navigateLink('/def/gh');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'gh');
+        Navigation.StateController.navigateLink('/def/gh?y=i');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'gh');
+        assert.equal(Navigation.StateContext.data.y, 'i');
+    });
+
+    it('TwoRouteParamMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['abc/{x}', 'def/{x}'], trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/abc'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/def'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ abc/de'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ def/gh'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abd/ef'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abc/de/f'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/def/gh/i'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
+    });
 });
 
 describe('BuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1208,6 +1208,48 @@ describe('MatchTest', function () {
         assert.throws(() => Navigation.StateController.navigateLink('/def/gh/i'), /Url is invalid/, '');
         assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
+
+    it('TwoRouteOptionalMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['abc/{x?}', 'abc/{x}/def/{y}'], trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/abc');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 0);
+        Navigation.StateController.navigateLink('/abc?z=d');
+        assert.equal(Navigation.StateContext.data.z, 'd');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        Navigation.StateController.navigateLink('/abc/de');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'de');
+        Navigation.StateController.navigateLink('/abc/de?z=f');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'de');
+        assert.equal(Navigation.StateContext.data.z, 'f');
+        Navigation.StateController.navigateLink('/abc/de/def/gh');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'de');
+        assert.equal(Navigation.StateContext.data.y, 'gh');
+        Navigation.StateController.navigateLink('/abc/de/def/gh?z=i');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'de');
+        assert.equal(Navigation.StateContext.data.y, 'gh');
+        assert.equal(Navigation.StateContext.data.z, 'i');
+    });
+
+    it('TwoRouteOptionalNonMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['abc/{x?}', 'abc/{x}/def/{y}'], trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/abc/de/def'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abc/de/def/gh/i'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abd/de'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abc/de/deg/gh'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ abc/de'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ abc/de/def/gh'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
+    });
 });
 
 describe('BuildTest', function () {
@@ -1879,5 +1921,18 @@ describe('BuildTest', function () {
         assert.throws(() => Navigation.StateController.navigateLink('/abc/de/f'), /Url is invalid/, '');
         assert.throws(() => Navigation.StateController.navigateLink('/def/gh/i'), /Url is invalid/, '');
         assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
+    });
+
+    it('TwoRouteOptionalBuildTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['abc/{x?}', 'abc/{x}/def/{y}'], trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d'), '/abc');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'd' }), '/abc?z=d');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de' }), '/abc/de');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', z: 'f' }), '/abc/de?z=f');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh' }), '/abc/de/def/gh');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh', z: 'f' }), '/abc/de/def/gh?z=f');
     });
 })

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1817,6 +1817,8 @@ describe('BuildTest', function () {
         assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', z: 'f' }), '/abc/de?z=f');
         assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'gh' }), '/def/gh');
         assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'gh', z: 'i' }), '/def/gh?z=i');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh' }), '/abc/de?y=gh');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh', z: 'i' }), '/abc/de?y=gh&z=i');
     });
 
     it('TwoRouteParamNonBuildTest', function () {
@@ -1859,5 +1861,7 @@ describe('BuildTest', function () {
         assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', z: 'f' }), '/abc/de?z=f');
         assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'gh' }), '/def/gh');
         assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'gh', z: 'i' }), '/def/gh?z=i');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh' }), '/abc/de?y=gh');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh', z: 'i' }), '/abc/de?y=gh&z=i');
     });
 })

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -812,14 +812,17 @@ describe('MatchTest', function () {
     });
 
     it('SpacesMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}');
-        var routeMatch = router.match('   a  ');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data.x, '   a  ');
-        assert.equal(route.params.length, 1);
-        assert.equal(route.params[0].name, 'x');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('   a  ');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, '   a  ');
+        Navigation.StateController.navigateLink('   a  ?y=   b  ');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, '   a  ');
+        assert.equal(Navigation.StateContext.data.y, '   b  ');
     });
 
     it('MultiCharParamMatchTest', function () {
@@ -1498,9 +1501,12 @@ describe('BuildTest', function () {
     });
 
     it('SpacesBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}');
-        assert.equal(route.build({ x: '   a  ' }), '/%20%20%20a%20%20');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: '   a  ' }), '/%20%20%20a%20%20');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: '   a  ', y: '   b  ' }), '/%20%20%20a%20%20?y=%20%20%20b%20%20');
     });
 
     it('MultiCharParamBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -432,31 +432,39 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamOneOptionalFourSegmentMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x}/c/{y?}');
-        var routeMatch = router.match('ab/yy/c/xyz');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 2);
-        assert.equal(routeMatch.data.x, 'yy');
-        assert.equal(routeMatch.data.y, 'xyz');
-        var routeMatch = router.match('ab/yy/c');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data.x, 'yy');
-        assert.equal(route.params.length, 2);
-        assert.equal(route.params[0].name, 'x');
-        assert.equal(route.params[1].name, 'y');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x}/c/{y?}', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/ab/yy/c/xyz');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'yy');
+        assert.equal(Navigation.StateContext.data.y, 'xyz');
+        Navigation.StateController.navigateLink('/ab/yy/c/xyz?z=xx');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'yy');
+        assert.equal(Navigation.StateContext.data.y, 'xyz');
+        assert.equal(Navigation.StateContext.data.z, 'xx');
+        Navigation.StateController.navigateLink('/ab/yy/c');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'yy');
+        Navigation.StateController.navigateLink('/ab/yy/c?z=xx');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'yy');
+        assert.equal(Navigation.StateContext.data.z, 'xx');
     });
 
     it('TwoParamOneOptionalFourSegmentNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x}/c/{y?}');
-        assert.equal(router.match(' ab/yy/c/xyz'), null);
-        assert.equal(router.match('ab/b/c/d/e'), null);
-        assert.equal(router.match('ab/c'), null);
-        assert.equal(router.match('ab/b/c//d'), null);
-        assert.equal(router.match('ab//b/c/d'), null);
-        assert.equal(router.match(''), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x}/c/{y?}', trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/ ab/yy/c/xyz'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/b/c/d/e'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/c'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/b/c//d'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab//b/c/d'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
 
     it('OneParamOneMixedSegmentMatchTest', function () {
@@ -1164,17 +1172,23 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamOneOptionalFourSegmentNonBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x}/c/{y?}');
-        assert.equal(route.build({ x: 'yy', y: 'xyz' }), '/ab/yy/c/xyz');
-        assert.equal(route.build({ x: 'yy' }), '/ab/yy/c');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x}/c/{y?}', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'yy', y: 'xyz' }), '/ab/yy/c/xyz');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'yy', y: 'xyz', z: 'xx' }), '/ab/yy/c/xyz?z=xx');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'yy' }), '/ab/yy/c');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'yy', z: 'xx' }), '/ab/yy/c?z=xx');
     });
 
     it('TwoParamOneOptionalFourSegmentNonBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x}/c/{y?}');
-        assert.equal(route.build({ y: 'xyz' }), null);
-        assert.equal(route.build(), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x}/c/{y?}', trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'xyz' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
     });
 
     it('OneParamOneMixedSegmentBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -8,60 +8,51 @@ describe('MatchTest', function () {
     it('RootMatchTest', function () {
         Navigation.StateInfoConfig.build(<any> [
             { key: 'd', initial: 's', states: [
-                { key: 's', route: '' }]}
+                { key: 's', route: '', trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/');
         assert.equal(Object.keys(Navigation.StateContext.data).length, 0);
+        Navigation.StateController.navigateLink('/?x=ab');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'ab');
     });
 
     it('RootNonMatchTest', function () {
         Navigation.StateInfoConfig.build(<any> [
             { key: 'd', initial: 's', states: [
-                { key: 's', route: '' }]}
+                { key: 's', route: '', trackCrumbTrail: false }]}
             ]);
         assert.throws(() => Navigation.StateController.navigateLink('/ '), /Url is invalid/, '');
         assert.throws(() => Navigation.StateController.navigateLink('/a'), /Url is invalid/, '');
         assert.throws(() => Navigation.StateController.navigateLink('//'), /Url is invalid/, '');
     });
 
-    it('RootMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('');
-        var routeMatch = router.match('');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 0);
-        assert.equal(route.params.length, 0);
-    });
-
-    it('RootNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('');
-        assert.equal(router.match(' '), null);
-        assert.equal(router.match('a'), null);
-        assert.equal(router.match('//'), null);
-    });
-
     it('NoParamOneSegmentMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('abc');
-        var routeMatch = router.match('abc');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 0);
-        assert.equal(route.params.length, 0);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'abc', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/abc');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 0);
+        Navigation.StateController.navigateLink('/abc?x=ab');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'ab');
     });
 
     it('NoParamOneSegmentNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('abc');
-        assert.equal(router.match(' abc'), null);
-        assert.equal(router.match('abc '), null);
-        assert.equal(router.match('abd'), null);
-        assert.equal(router.match('abcd'), null);
-        assert.equal(router.match('dbc'), null);
-        assert.equal(router.match('ab/c'), null);
-        assert.equal(router.match('adc'), null);
-        assert.equal(router.match('aabc'), null);
-        assert.equal(router.match(''), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'abc', trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/ abc'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abc '), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abd'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abd'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/dbc'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/c'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/adc'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/aabc'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
 
     it('NoParamTwoSegmentMatchTest', function () {
@@ -875,11 +866,14 @@ describe('BuildTest', function () {
         assert.equal(Navigation.StateController.getNavigationLink('d'), '/');
         assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/?x=ab');
     });
-    
+
     it('NoParamOneSegmentBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('abc');
-        assert.equal(route.build(), '/abc');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'abc', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d'), '/abc');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/abc?x=ab');
     });
 
     it('NoParamTwoSegmentBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2,8 +2,28 @@
 /// <reference path="mocha.d.ts" />
 import assert = require('assert');
 import Router = require('../src/routing/Router');
+import Navigation = require('../src/Navigation');
 
 describe('MatchTest', function () {
+    it('RootMatchTest', function () {
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '' }]}
+            ]);
+        Navigation.StateController.navigateLink('/');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 0);
+    });
+
+    it('RootNonMatchTest', function () {
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '' }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/ '), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/a'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('//'), /Url is invalid/, '');
+    });
+
     it('RootMatchTest', function () {
         var router = new Router();
         var route = router.addRoute('');
@@ -848,11 +868,14 @@ describe('MatchTest', function () {
 
 describe('BuildTest', function () {
     it('RootBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('');
-        assert.equal(route.build(), '/');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d'), '/');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/?x=ab');
     });
-
+    
     it('NoParamOneSegmentBuildTest', function () {
         var router = new Router();
         var route = router.addRoute('abc');

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1,7 +1,6 @@
 ﻿/// <reference path="assert.d.ts" />
 /// <reference path="mocha.d.ts" />
 import assert = require('assert');
-import Router = require('../src/routing/Router');
 import Navigation = require('../src/Navigation');
 
 describe('MatchTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -493,28 +493,33 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamOneMixedSegmentMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab{x}e{y}');
-        var routeMatch = router.match('abcdefgh');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 2);
-        assert.equal(routeMatch.data.x, 'cd');
-        assert.equal(routeMatch.data.y, 'fgh');
-        assert.equal(route.params.length, 2);
-        assert.equal(route.params[0].name, 'x');
-        assert.equal(route.params[1].name, 'y');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab{x}e{y}', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/abcdefgh');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'cd');
+        assert.equal(Navigation.StateContext.data.y, 'fgh');
+        Navigation.StateController.navigateLink('/abcdefgh?z=i');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'cd');
+        assert.equal(Navigation.StateContext.data.y, 'fgh');
+        assert.equal(Navigation.StateContext.data.z, 'i');
     });
 
     it('TwoParamOneMixedSegmentNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab{x}e{y}');
-        assert.equal(router.match(' abcdefgh'), null);
-        assert.equal(router.match('ab/cdefgh'), null);
-        assert.equal(router.match('abcdefgh//'), null);
-        assert.equal(router.match('abcde'), null);
-        assert.equal(router.match('abc'), null);
-        assert.equal(router.match('ab'), null);
-        assert.equal(router.match(''), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab{x}e{y}', trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/ abcdefgh'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/cdefgh'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abcdefgh//'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abcde'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abc'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
 
     it('TwoParamOneOptionalTwoSegmentOneMixedMatchTest', function () {
@@ -1213,18 +1218,23 @@ describe('BuildTest', function () {
         assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
     });
 
-    it('TwoParamOneMixedSegmentBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab{x}e{y}');
-        assert.equal(route.build({ x: 'cd', y: 'fgh' }), '/abcdefgh');
+    it('OneParamOneMixedSegmentBuildTest', function () {
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab{x}e{y}', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'fgh' }), '/abcdefgh');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'fgh', z: 'i' }), '/abcdefgh?z=i');
     });
 
     it('TwoParamOneMixedSegmentNonBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab{x}e{y}');
-        assert.equal(route.build({ x: 'cd' }), null);
-        assert.equal(route.build({ y: 'fgh' }), null);
-        assert.equal(route.build(), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab{x}e{y}', trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cd' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'fghh' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
     });
 
     it('TwoParamOneOptionalTwoSegmentOneMixedBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1307,6 +1307,36 @@ describe('MatchTest', function () {
         assert.equal(Navigation.StateContext.data.y, 'gh');
         assert.equal(Navigation.StateContext.data.z, 'i');
     });
+
+    it('TwoRouteDefaultTypeNumberMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['def/{y}', 'abc/{x}'], defaultTypes: { x: 'number' }, trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/abc/3');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.strictEqual(Navigation.StateContext.data.x, 3);
+        Navigation.StateController.navigateLink('/abc/3?z=f');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 3);
+        assert.equal(Navigation.StateContext.data.z, 'f');
+        Navigation.StateController.navigateLink('/def/gh');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.y, 'gh');
+        Navigation.StateController.navigateLink('/def/gh?z=i');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.y, 'gh');
+        assert.equal(Navigation.StateContext.data.z, 'i');
+        Navigation.StateController.navigateLink('/def/gh?x=3');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.strictEqual(Navigation.StateContext.data.x, 3);
+        assert.equal(Navigation.StateContext.data.y, 'gh');
+        Navigation.StateController.navigateLink('/def/gh?x=3&z=i');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.strictEqual(Navigation.StateContext.data.x, 3);
+        assert.equal(Navigation.StateContext.data.y, 'gh');
+        assert.equal(Navigation.StateContext.data.z, 'i');
+    });
 });
 
 describe('BuildTest', function () {
@@ -2008,5 +2038,18 @@ describe('BuildTest', function () {
         assert.equal(Navigation.StateController.getNavigationLink('d', { x: 3, y: 'gh', z: 'i' }), '/def/gh?x=3&z=i');
         assert.equal(Navigation.StateController.getNavigationLink('d', { x: 2, y: 'gh' }), '/def/gh');
         assert.equal(Navigation.StateController.getNavigationLink('d', { x: 2, y: 'gh', z: 'i' }), '/def/gh?z=i');
+    });
+
+    it('TwoRouteDefaultTypeNumberBuildTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['def/{y}', 'abc/{x}'], defaultTypes: { x: 'number' }, trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 3 }), '/abc/3');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 3, z: 'f' }), '/abc/3?z=f');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'gh' }), '/def/gh');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'gh', z: 'i' }), '/def/gh?z=i');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 3, y: 'gh' }), '/def/gh?x=3');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 3, y: 'gh', z: 'i' }), '/def/gh?x=3&z=i');
     });
 })

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1061,38 +1061,16 @@ describe('MatchTest', function () {
         assert.throws(() => Navigation.StateController.navigateLink('/cd'), /Url is invalid/, '');
     });
 
-    it('TwoRouteMatchTest', function () {
+    it('TwoRouteOneWithParamMatchTest', function () {
         Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
-                { key: 's', route: ['', 'abc'], trackCrumbTrail: false }]}
+                { key: 's', route: ['', 'abc/{x}'], trackCrumbTrail: false }]}
             ]);
         Navigation.StateController.navigateLink('/');
         assert.equal(Object.keys(Navigation.StateContext.data).length, 0);
-        Navigation.StateController.navigateLink('/?x=d');
+        Navigation.StateController.navigateLink('/?y=d');
         assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'd');
-        Navigation.StateController.navigateLink('/abc');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 0);
-        Navigation.StateController.navigateLink('/abc?x=d');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'd');
-    });
-
-    it('TwoRouteNoMatchTest', function () {
-        Navigation.StateInfoConfig.build([
-            { key: 'd', initial: 's', states: [
-                { key: 's', route: ['', 'abc'], trackCrumbTrail: false }]}
-            ]);
-        assert.throws(() => Navigation.StateController.navigateLink('/ab'), /Url is invalid/, '');
-        assert.throws(() => Navigation.StateController.navigateLink('/ abc'), /Url is invalid/, '');
-        assert.throws(() => Navigation.StateController.navigateLink('//abc'), /Url is invalid/, '');
-    });
-
-    it('TwoRouteParamMatchTest', function () {
-        Navigation.StateInfoConfig.build([
-            { key: 'd', initial: 's', states: [
-                { key: 's', route: ['abc/{x}', 'def/{x}'], trackCrumbTrail: false }]}
-            ]);
+        assert.equal(Navigation.StateContext.data.y, 'd');
         Navigation.StateController.navigateLink('/abc/de');
         assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
         assert.equal(Navigation.StateContext.data.x, 'de');
@@ -1100,19 +1078,44 @@ describe('MatchTest', function () {
         assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
         assert.equal(Navigation.StateContext.data.x, 'de');
         assert.equal(Navigation.StateContext.data.y, 'f');
-        Navigation.StateController.navigateLink('/def/gh');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
-        assert.equal(Navigation.StateContext.data.x, 'gh');
-        Navigation.StateController.navigateLink('/def/gh?y=i');
-        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
-        assert.equal(Navigation.StateContext.data.x, 'gh');
-        assert.equal(Navigation.StateContext.data.y, 'i');
     });
 
-    it('TwoRouteParamNoMatchTest', function () {
+    it('TwoRouteOneWithParamNonMatchTest', function () {
         Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
-                { key: 's', route: ['abc/{x}', 'def/{x}'], trackCrumbTrail: false }]}
+                { key: 's', route: ['', 'abc/{x}'], trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/abc'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/de'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ abc/de'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('//abc/de'), /Url is invalid/, '');
+    });
+
+    it('TwoRouteParamMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['abc/{x}', 'def/{y}'], trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/abc/de');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'de');
+        Navigation.StateController.navigateLink('/abc/de?z=f');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'de');
+        assert.equal(Navigation.StateContext.data.z, 'f');
+        Navigation.StateController.navigateLink('/def/gh');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.y, 'gh');
+        Navigation.StateController.navigateLink('/def/gh?z=i');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.y, 'gh');
+        assert.equal(Navigation.StateContext.data.z, 'i');
+    });
+
+    it('TwoRouteParamNonMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['abc/{x}', 'def/{y}'], trackCrumbTrail: false }]}
             ]);
         assert.throws(() => Navigation.StateController.navigateLink('/abc'), /Url is invalid/, '');
         assert.throws(() => Navigation.StateController.navigateLink('/def'), /Url is invalid/, '');
@@ -1147,7 +1150,7 @@ describe('MatchTest', function () {
         assert.equal(Navigation.StateContext.data.z, 'i');
     });
 
-    it('TwoRouteParentChildNoMatchTest', function () {
+    it('TwoRouteParentChildNonMatchTest', function () {
         Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: ['abc/{x}', 'abc/{x}/def/{y}'], trackCrumbTrail: false }]}
@@ -1748,5 +1751,56 @@ describe('BuildTest', function () {
                 { key: 's', route: '{x}', trackCrumbTrail: false }]}
             ]);
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '' }), null);
+    });
+
+    it('TwoRouteOneWithParamBuildTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['', 'abc/{x}'], trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d'), '/');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'd' }), '/?y=d');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de' }), '/abc/de');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'f' }), '/abc/de?y=f');
+    });
+
+    it('TwoRouteParamBuildTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['abc/{x}', 'def/{y}'], trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de' }), '/abc/de');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', z: 'f' }), '/abc/de?z=f');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'gh' }), '/def/gh');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'gh', z: 'i' }), '/def/gh?z=i');
+    });
+
+    it('TwoRouteParamNonBuildTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['abc/{x}', 'def/{y}'], trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { z: 'g' }), null);
+    });
+
+    it('TwoRouteParentChildBuildTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['abc/{x}', 'abc/{x}/def/{y}'], trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de' }), '/abc/de');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', z: 'f' }), '/abc/de?z=f');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh' }), '/abc/de/def/gh');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', y: 'gh', z: 'f' }), '/abc/de/def/gh?z=f');
+    });
+
+    it('TwoRouteParentChildNonBuildTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['abc/{x}', 'abc/{x}/def/{y}'], trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { z: 'g' }), null);
     });
 })

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1000,15 +1000,19 @@ describe('MatchTest', function () {
     });
 
     it('ExtraDefaultsMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}', { x: 'a', y: 'b' });
-        var routeMatch = router.match('');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 2);
-        assert.equal(routeMatch.data.x, 'a');
-        assert.equal(routeMatch.data.y, 'b');
-        assert.equal(route.params.length, 1);
-        assert.equal(route.params[0].name, 'x');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', defaults: { x: 'a', y: 'b' }, trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'a');
+        assert.equal(Navigation.StateContext.data.y, 'b');
+        Navigation.StateController.navigateLink('?z=c');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'a');
+        assert.equal(Navigation.StateContext.data.y, 'b');
+        assert.equal(Navigation.StateContext.data.z, 'c');
     });
 
     it('CaseInsensitiveMatchTest', function () {
@@ -1629,15 +1633,11 @@ describe('BuildTest', function () {
         assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
     });
 
-    it('ExtraDataMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}');
-        assert.equal(route.build({ x: 'a', y: 'b' }), '/a');
-    });
-
     it('EmptyStringNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}');
-        assert.equal(route.build({ x: '' }), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '' }), null);
     });
 })

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -323,33 +323,43 @@ describe('MatchTest', function () {
     });
 
     it('TwoOptionalParamThreeSegmentMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x?}/{y?}');
-        var routeMatch = router.match('ab/cd/efg');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 2);
-        assert.equal(routeMatch.data.x, 'cd');
-        assert.equal(routeMatch.data.y, 'efg');
-        routeMatch = router.match('ab/cde');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data.x, 'cde');
-        routeMatch = router.match('ab');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 0);
-        assert.equal(route.params.length, 2);
-        assert.equal(route.params[0].name, 'x');
-        assert.equal(route.params[1].name, 'y');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x?}/{y?}', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/ab/cd/efg');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'cd');
+        assert.equal(Navigation.StateContext.data.y, 'efg');
+        Navigation.StateController.navigateLink('/ab/cd/efg?z=hi');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'cd');
+        assert.equal(Navigation.StateContext.data.y, 'efg');
+        assert.equal(Navigation.StateContext.data.z, 'hi');
+        Navigation.StateController.navigateLink('/ab/cde');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'cde');
+        Navigation.StateController.navigateLink('/ab/cde?z=fg');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'cde');
+        assert.equal(Navigation.StateContext.data.z, 'fg');
+        Navigation.StateController.navigateLink('/ab');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 0);
+        Navigation.StateController.navigateLink('/ab?z=cd');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.z, 'cd');
     });
 
     it('TwoOptionalParamThreeSegmentNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x?}/{y?}');
-        assert.equal(router.match(' ab/cd/efg'), null);
-        assert.equal(router.match('ab/cd/efg/h'), null);
-        assert.equal(router.match('ab//efg'), null);
-        assert.equal(router.match('/cd/efg'), null);
-        assert.equal(router.match(''), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x?}/{y?}', trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/ ab/cd/efg'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/cd/efg/h'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab//efg'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('//cd/efg'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
 
     it('TwoParamOneOptionalTwoSegmentMatchTest', function () {
@@ -1069,26 +1079,25 @@ describe('BuildTest', function () {
         assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'cccc' }), '/?z=cccc');
     });
 
-    it('TwoOptionalParamTwoSegmentBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x?}/{y?}');
-        assert.equal(route.build({ x: 'aa', y: 'bbb' }), '/aa/bbb');
-        assert.equal(route.build({ x: 'aab' }), '/aab');
-        assert.equal(route.build(), '/');
-    });
-
     it('TwoOptionalParamTwoSegmentNonBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x?}/{y?}');
-        assert.equal(route.build({ y: 'bbb' }), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x?}/{y?}', trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'bbb' }), null);
     });
 
     it('TwoOptionalParamThreeSegmentBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x?}/{y?}');
-        assert.equal(route.build({ x: 'cd', y: 'efg' }), '/ab/cd/efg');
-        assert.equal(route.build({ x: 'cde' }), '/ab/cde');
-        assert.equal(route.build(), '/ab');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x?}/{y?}', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg' }), '/ab/cd/efg');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg', z: 'hi' }), '/ab/cd/efg?z=hi');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cde' }), '/ab/cde');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cde', z: 'fg' }), '/ab/cde?z=fg');
+        assert.equal(Navigation.StateController.getNavigationLink('d'), '/ab');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'cd' }), '/ab?z=cd');
     });
 
     it('TwoOptionalParamThreeSegmentBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1164,6 +1164,50 @@ describe('MatchTest', function () {
         assert.throws(() => Navigation.StateController.navigateLink('/ abc/de/def/gh'), /Url is invalid/, '');
         assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
+
+    it('TwoRouteDefaultMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['abc/{x}', 'def/{y}'], defaults: { x: 'd' }, trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/abc');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'd');
+        Navigation.StateController.navigateLink('/abc?z=e');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'd');
+        assert.equal(Navigation.StateContext.data.z, 'e');
+        Navigation.StateController.navigateLink('/abc/de');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'de');
+        Navigation.StateController.navigateLink('/abc/de?z=f');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'de');
+        assert.equal(Navigation.StateContext.data.z, 'f');
+        Navigation.StateController.navigateLink('/def/gh');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'd');
+        assert.equal(Navigation.StateContext.data.y, 'gh');
+        Navigation.StateController.navigateLink('/def/gh?z=i');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'd');
+        assert.equal(Navigation.StateContext.data.y, 'gh');
+        assert.equal(Navigation.StateContext.data.z, 'i');
+    });
+
+    it('TwoRouteDefaultNonMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['abc/{x}', 'def/{y}'], defaults: { x: 'd' }, trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/def'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ abc/de'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ def/gh'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abd/ef'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abc/de/f'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/def/gh/i'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
+    });
 });
 
 describe('BuildTest', function () {
@@ -1802,5 +1846,18 @@ describe('BuildTest', function () {
             ]);
         assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { z: 'g' }), null);
+    });
+
+    it('TwoRouteDefaultBuildTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['abc/{x}', 'def/{y}'], defaults: { x: 'd' }, trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d'), '/abc');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'e' }), '/abc?z=e');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de' }), '/abc/de');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'de', z: 'f' }), '/abc/de?z=f');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'gh' }), '/def/gh');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'gh', z: 'i' }), '/def/gh?z=i');
     });
 })

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -363,28 +363,36 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamOneOptionalTwoSegmentMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}/{y?}');
-        var routeMatch = router.match('aa/bbb');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 2);
-        assert.equal(routeMatch.data.x, 'aa');
-        assert.equal(routeMatch.data.y, 'bbb');
-        routeMatch = router.match('aab');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data.x, 'aab');
-        assert.equal(route.params.length, 2);
-        assert.equal(route.params[0].name, 'x');
-        assert.equal(route.params[1].name, 'y');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}/{y?}', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/aa/bbb');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'aa');
+        assert.equal(Navigation.StateContext.data.y, 'bbb');
+        Navigation.StateController.navigateLink('/aa/bbb?z=cccc');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'aa');
+        assert.equal(Navigation.StateContext.data.y, 'bbb');
+        assert.equal(Navigation.StateContext.data.z, 'cccc');
+        Navigation.StateController.navigateLink('/aab');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'aab');
+        Navigation.StateController.navigateLink('/aab?z=ccd');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'aab');
+        assert.equal(Navigation.StateContext.data.z, 'ccd');
     });
 
     it('TwoParamOneOptionalTwoSegmentNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}/{y?}');
-        assert.equal(router.match('aa/bbb/e'), null);
-        assert.equal(router.match('aa//'), null);
-        assert.equal(router.match(''), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}/{y?}', trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/aa/bbb/e'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/aa//'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
 
     it('TwoParamOneOptionalThreeSegmentMatchTest', function () {
@@ -1100,24 +1108,31 @@ describe('BuildTest', function () {
         assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'cd' }), '/ab?z=cd');
     });
 
-    it('TwoOptionalParamThreeSegmentBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x?}/{y?}');
-        assert.equal(route.build({ y: 'efg' }), null);
+    it('TwoOptionalParamThreeSegmentNonBuildTest', function () {
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x?}/{y?}', trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'efg' }), null);
     });
 
     it('TwoParamOneOptionalTwoSegmentBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}/{y?}');
-        assert.equal(route.build({ x: 'aa', y: 'bbb' }), '/aa/bbb');
-        assert.equal(route.build({ x: 'aab' }), '/aab');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}/{y?}', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb' }), '/aa/bbb');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb', z: 'cccc' }), '/aa/bbb?z=cccc');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aab' }), '/aab');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aab', z: 'ccd' }), '/aab?z=ccd');
     });
 
     it('TwoParamOneOptionalTwoSegmentNonBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}/{y?}');
-        assert.equal(route.build({ y: 'bbb' }), null);
-        assert.equal(route.build(), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}/{y?}', trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'bbb' }), null);
     });
 
     it('TwoParamOneOptionalThreeSegmentBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -826,6 +826,20 @@ describe('MatchTest', function () {
     });
 
     it('MultiCharParamMatchTest', function () {
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'a/{someVar}', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('a/someVal');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.someVar, 'someVal');
+        Navigation.StateController.navigateLink('a/someVal?anotherVar=anotherVal');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.someVar, 'someVal');
+        assert.equal(Navigation.StateContext.data.anotherVar, 'anotherVal');
+    });
+
+    it('MultiCharParamMatchTest', function () {
         var router = new Router();
         var route = router.addRoute('a/{someVar}');
         var routeMatch = router.match('a/someVal');
@@ -1510,9 +1524,12 @@ describe('BuildTest', function () {
     });
 
     it('MultiCharParamBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('a/{someVar}');
-        assert.equal(route.build({ someVar: 'someVal' }), '/a/someVal');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'a/{someVar}', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { someVar: 'someVal' }), '/a/someVal');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { someVar: 'someVal', anotherVar: 'anotherVal' }), '/a/someVal?anotherVar=anotherVal');
     });
 
     it('SlashBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -875,10 +875,10 @@ describe('MatchTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '.+*\^$\[\]()\'/{x}', trackCrumbTrail: false }]}
             ]);
-        Navigation.StateController.navigateLink('.+*\^$\[\]()\'/abc');
+        Navigation.StateController.navigateLink('/.+*\^$\[\]()\'/abc');
         assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
         assert.equal(Navigation.StateContext.data.x, 'abc');
-        Navigation.StateController.navigateLink('.+*\^$\[\]()\'/abc?y=de');
+        Navigation.StateController.navigateLink('/.+*\^$\[\]()\'/abc?y=de');
         assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
         assert.equal(Navigation.StateContext.data.x, 'abc');
         assert.equal(Navigation.StateContext.data.y, 'de');
@@ -889,10 +889,10 @@ describe('MatchTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'ab{x?}', trackCrumbTrail: false }]}
             ]);
-        Navigation.StateController.navigateLink('abcde');
+        Navigation.StateController.navigateLink('/abcde');
         assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
         assert.equal(Navigation.StateContext.data.x, 'cde');
-        Navigation.StateController.navigateLink('abcde?y=fg');
+        Navigation.StateController.navigateLink('/abcde?y=fg');
         assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
         assert.equal(Navigation.StateContext.data.x, 'cde');
         assert.equal(Navigation.StateContext.data.y, 'fg');
@@ -910,31 +910,33 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamOneOptionalMandatoryThreeSegmentMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x?}/{y}');
-        var routeMatch = router.match('ab/cd/efg');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 2);
-        assert.equal(routeMatch.data.x, 'cd');
-        assert.equal(routeMatch.data.y, 'efg');
-        assert.equal(route.params.length, 2);
-        assert.equal(route.params[0].name, 'x');
-        assert.equal(route.params[1].name, 'y');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x?}/{y}', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/ab/cd/efg');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'cd');
+        assert.equal(Navigation.StateContext.data.y, 'efg');
+        Navigation.StateController.navigateLink('/ab/cd/efg?z=hi');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'cd');
+        assert.equal(Navigation.StateContext.data.y, 'efg');
+        assert.equal(Navigation.StateContext.data.z, 'hi');
     });
 
     it('TwoParamOneOptionalMandatoryThreeSegmentNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x?}/{y}');
-        assert.equal(router.match(' ab/cd/efg'), null);
-        assert.equal(router.match('ab/cd/efg/h'), null);
-        assert.equal(router.match('ab//efg'), null);
-        assert.equal(router.match('/cd/efg'), null);
-        assert.equal(router.match('ab/cde'), null);
-        assert.equal(router.match('ab'), null);
-        assert.equal(router.match(''), null);
-        assert.equal(route.params.length, 2);
-        assert.equal(route.params[0].name, 'x');
-        assert.equal(route.params[1].name, 'y');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x?}/{y}', trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/ ab/cd/efg'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/cd/efg/h'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab//efg'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('//cd/efg'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/cde'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
 
     it('TwoParamTwoSegmentDefaultMandatoryMatchTest', function () {
@@ -1565,17 +1567,22 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamOneOptionalMandatoryThreeSegmentBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x?}/{y}');
-        assert.equal(route.build({ x: 'cd', y: 'efg' }), '/ab/cd/efg');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x?}/{y}', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg' }), '/ab/cd/efg');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg', z: 'hi' }), '/ab/cd/efg?z=hi');
     });
 
     it('TwoParamOneOptionalMandatoryThreeSegmentNonBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x?}/{y}');
-        assert.equal(route.build({ x: 'cd' }), null);
-        assert.equal(route.build({ y: 'efg' }), null);
-        assert.equal(route.build(), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x?}/{y}', trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cd' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'efg' }), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
     });
 
     it('TwoParamTwoSegmentDefaultMandatoryBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -701,31 +701,42 @@ describe('MatchTest', function () {
     });
 
     it('TwoParamOneOptionalTwoSegmentDefaultMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}/{y?}', { x: 'abc' });
-        var routeMatch = router.match('aa/bbb');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 2);
-        assert.equal(routeMatch.data.x, 'aa');
-        assert.equal(routeMatch.data.y, 'bbb');
-        routeMatch = router.match('aab');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data.x, 'aab');
-        routeMatch = router.match('');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data.x, 'abc');
-        assert.equal(route.params.length, 2);
-        assert.equal(route.params[0].name, 'x');
-        assert.equal(route.params[1].name, 'y');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}/{y?}', defaults: { x: 'abc' }, trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/aa/bbb');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'aa');
+        assert.equal(Navigation.StateContext.data.y, 'bbb');
+        Navigation.StateController.navigateLink('/aa/bbb?z=cccc');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 3);
+        assert.equal(Navigation.StateContext.data.x, 'aa');
+        assert.equal(Navigation.StateContext.data.y, 'bbb');
+        assert.equal(Navigation.StateContext.data.z, 'cccc');
+        Navigation.StateController.navigateLink('/aab');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'aab');
+        Navigation.StateController.navigateLink('/aab?z=ccd');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'aab');
+        assert.equal(Navigation.StateContext.data.z, 'ccd');
+        Navigation.StateController.navigateLink('/');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'abc');
+        Navigation.StateController.navigateLink('/?z=de');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'abc');
+        assert.equal(Navigation.StateContext.data.z, 'de');
     });
 
     it('TwoParamOneOptionalTwoSegmentDefaultNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}/{y?}', { x: 'abc' });
-        assert.equal(router.match('aa/bbb/e'), null);
-        assert.equal(router.match('aa//'), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}/{y?}', defaults: { x: 'abc' }, trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/aa/bbb/e'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/aa//'), /Url is invalid/, '');
     });
 
     it('FourParamTwoOptionalFiveSegmentDefaultMatchTest', function () {
@@ -1375,14 +1386,22 @@ describe('BuildTest', function () {
     });
 
     it('TwoParamOneOptionalTwoSegmentDefaultBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}/{y?}', { x: 'abc' });
-        assert.equal(route.build({ x: 'aa', y: 'bbb' }), '/aa/bbb');
-        assert.equal(route.build({ x: 'abc', y: 'bbb' }), '/abc/bbb');
-        assert.equal(route.build({ y: 'bbb' }), '/abc/bbb');
-        assert.equal(route.build({ x: 'aab' }), '/aab');
-        assert.equal(route.build({ x: 'abc' }), '/');
-        assert.equal(route.build(), '/');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}/{y?}', defaults: { x: 'abc' }, trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb' }), '/aa/bbb');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aa', y: 'bbb', z: 'cccc' }), '/aa/bbb?z=cccc');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abc', y: 'bbb' }), '/abc/bbb');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abc', y: 'bbb', z: 'cccc' }), '/abc/bbb?z=cccc');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'bbb' }), '/abc/bbb');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'bbb', z: 'cccc' }), '/abc/bbb?z=cccc');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aab' }), '/aab');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'aab', z: 'ccd' }), '/aab?z=ccd');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abc' }), '/');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abc', z: 'de' }), '/?z=de');
+        assert.equal(Navigation.StateController.getNavigationLink('d'), '/');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'de' }), '/?z=de');
     });
 
     it('FourParamTwoOptionalFiveSegmentDefaultBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -816,10 +816,10 @@ describe('MatchTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}', trackCrumbTrail: false }]}
             ]);
-        Navigation.StateController.navigateLink('   a  ');
+        Navigation.StateController.navigateLink('/   a  ');
         assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
         assert.equal(Navigation.StateContext.data.x, '   a  ');
-        Navigation.StateController.navigateLink('   a  ?y=   b  ');
+        Navigation.StateController.navigateLink('/   a  ?y=   b  ');
         assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
         assert.equal(Navigation.StateContext.data.x, '   a  ');
         assert.equal(Navigation.StateContext.data.y, '   b  ');
@@ -830,42 +830,23 @@ describe('MatchTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: 'a/{someVar}', trackCrumbTrail: false }]}
             ]);
-        Navigation.StateController.navigateLink('a/someVal');
+        Navigation.StateController.navigateLink('/a/someVal');
         assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
         assert.equal(Navigation.StateContext.data.someVar, 'someVal');
-        Navigation.StateController.navigateLink('a/someVal?anotherVar=anotherVal');
+        Navigation.StateController.navigateLink('/a/someVal?anotherVar=anotherVal');
         assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
         assert.equal(Navigation.StateContext.data.someVar, 'someVal');
         assert.equal(Navigation.StateContext.data.anotherVar, 'anotherVal');
     });
 
-    it('MultiCharParamMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('a/{someVar}');
-        var routeMatch = router.match('a/someVal');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data.someVar, 'someVal');
-        assert.equal(route.params.length, 1);
-        assert.equal(route.params[0].name, 'someVar');
-    });
-
-    it('SlashMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('/abc/');
-        var routeMatch = router.match('abc');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 0);
-        assert.equal(route.params.length, 0);
-    });
-
     it('MatchSlashTest', function () {
-        var router = new Router();
-        var route = router.addRoute('abc');
-        var routeMatch = router.match('/abc/');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 0);
-        assert.equal(route.params.length, 0);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('abc/');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'abc');
     });
 
     it('ReservedUrlCharacterMatchTest', function () {
@@ -1530,12 +1511,6 @@ describe('BuildTest', function () {
             ]);
         assert.equal(Navigation.StateController.getNavigationLink('d', { someVar: 'someVal' }), '/a/someVal');
         assert.equal(Navigation.StateController.getNavigationLink('d', { someVar: 'someVal', anotherVar: 'anotherVal' }), '/a/someVal?anotherVar=anotherVal');
-    });
-
-    it('SlashBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('/abc/');
-        assert.equal(route.build(), '/abc');
     });
 
     it('ReservedUrlCharacterBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -82,24 +82,29 @@ describe('MatchTest', function () {
         assert.throws(() => Navigation.StateController.navigateLink('/aab/c'), /Url is invalid/, '');
         assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
-
+    
     it('OneParamOneSegmentMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}');
-        var routeMatch = router.match('abcd');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data.x, 'abcd');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/abcd');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'abcd');
+        Navigation.StateController.navigateLink('/ab?y=cd');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'ab');
+        assert.equal(Navigation.StateContext.data.y, 'cd');
     });
 
     it('OneParamOneSegmentNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}');
-        assert.equal(router.match('ab/cd'), null);
-        assert.equal(router.match('ab//'), null);
-        assert.equal(router.match(''), null);
-        assert.equal(route.params.length, 1);
-        assert.equal(route.params[0].name, 'x');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/cd'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab//'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
 
     it('OneParamTwoSegmentMatchTest', function () {
@@ -888,6 +893,15 @@ describe('BuildTest', function () {
             ]);
         assert.equal(Navigation.StateController.getNavigationLink('d'), '/ab/c');
         assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/ab/c?x=ab');
+    });
+
+    it('OneParamOneSegmentBuildTest', function () {
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abcd' }), '/abcd');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ab', y: 'cd' }), '/ab?y=cd');
     });
 
     it('OneParamOneSegmentBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -82,7 +82,7 @@ describe('MatchTest', function () {
         assert.throws(() => Navigation.StateController.navigateLink('/aab/c'), /Url is invalid/, '');
         assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
-    
+
     it('OneParamOneSegmentMatchTest', function () {
         Navigation.StateInfoConfig.build(<any> [
             { key: 'd', initial: 's', states: [
@@ -108,27 +108,32 @@ describe('MatchTest', function () {
     });
 
     it('OneParamTwoSegmentMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x}');
-        var routeMatch = router.match('ab/cd');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data.x, 'cd');
-        assert.equal(route.params.length, 1);
-        assert.equal(route.params[0].name, 'x');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x}', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/ab/cd');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'cd');
+        Navigation.StateController.navigateLink('/ab/cd?y=ef');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'cd');
+        assert.equal(Navigation.StateContext.data.y, 'ef');
     });
 
     it('OneParamTwoSegmentNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x}');
-        assert.equal(router.match(' ab/cd'), null);
-        assert.equal(router.match('abc/d'), null);
-        assert.equal(router.match('ab/d/e'), null);
-        assert.equal(router.match('a/b/d'), null);
-        assert.equal(router.match('abd'), null);
-        assert.equal(router.match('cab/d'), null);
-        assert.equal(router.match('ab'), null);
-        assert.equal(router.match(''), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x}', trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/ ab/cd'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abc/d'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/d/e'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/a/b/d'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abd'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/cab/d'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
 
     it('TwoParamTwoSegmentMatchTest', function () {
@@ -904,22 +909,30 @@ describe('BuildTest', function () {
         assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ab', y: 'cd' }), '/ab?y=cd');
     });
 
-    it('OneParamOneSegmentBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}');
-        assert.equal(route.build({ x: 'abcd' }), '/abcd');
-    });
-
     it('OneParamOneSegmentNonBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x}');
-        assert.equal(route.build(), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
     });
 
     it('OneParamTwoSegmentBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x}');
-        assert.equal(route.build({ x: 'cd' }), '/ab/cd');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x}', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd' }), '/ab/cd');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'ef' }), '/ab/cd?y=ef');
+    });
+
+    it('OneParamTwoSegmentNonBuildTest', function () {
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x}', trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'ef' }), null);
     });
 
     it('OneParamTwoSegmentNonBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -588,30 +588,38 @@ describe('MatchTest', function () {
     });
 
     it('OneParamTwoSegmentDefaultMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x}', { x: 'ccdd' });
-        var routeMatch = router.match('ab/cde');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data.x, 'cde');
-        routeMatch = router.match('ab');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data.x, 'ccdd');
-        assert.equal(route.params.length, 1);
-        assert.equal(route.params[0].name, 'x');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x}', defaults: { x: 'ccdd' }, trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/ab/cde');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'cde');
+        Navigation.StateController.navigateLink('/ab/cde?y=fg');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'cde');
+        assert.equal(Navigation.StateContext.data.y, 'fg');
+        Navigation.StateController.navigateLink('/ab');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'ccdd');
+        Navigation.StateController.navigateLink('/ab?y=ee');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'ccdd');
+        assert.equal(Navigation.StateContext.data.y, 'ee');
     });
 
     it('OneParamTwoSegmentDefaultNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x}', { x: 'ccdd' });
-        assert.equal(router.match(' ab/cd'), null);
-        assert.equal(router.match('abc/d'), null);
-        assert.equal(router.match('ab/d/e'), null);
-        assert.equal(router.match('a/b/d'), null);
-        assert.equal(router.match('abd'), null);
-        assert.equal(router.match('cab/d'), null);
-        assert.equal(router.match(''), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x}', defaults: { x: 'ccdd' }, trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/ ab/cd'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abc/d'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/d/e'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/a/b/d'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abd'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/cab/d'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
 
     it('TwoParamTwoSegmentTwoDefaultMatchTest', function () {
@@ -1285,13 +1293,18 @@ describe('BuildTest', function () {
         assert.equal(Navigation.StateController.getNavigationLink('d'), '/');
         assert.equal(Navigation.StateController.getNavigationLink('d', { z: 'fg' }), '/?z=fg');
     });
-    
+
     it('OneParamTwoSegmentDefaultBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x}', { x: 'ccdd' });
-        assert.equal(route.build({ x: 'cde' }), '/ab/cde');
-        assert.equal(route.build({ x: 'ccdd' }), '/ab');
-        assert.equal(route.build(), '/ab');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x}', defaults: { x: 'ccdd' }, trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cde' }), '/ab/cde');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cde', y: 'fg' }), '/ab/cde?y=fg');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ccdd' }), '/ab');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ccdd', y: 'ee' }), '/ab?y=ee');
+        assert.equal(Navigation.StateController.getNavigationLink('d'), '/ab');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'ee' }), '/ab?y=ee');
     });
 
     it('TwoParamTwoSegmentTwoDefaultBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -251,38 +251,38 @@ describe('MatchTest', function () {
         assert.throws(() => Navigation.StateController.navigateLink('/ab/cd'), /Url is invalid/, '');
         assert.throws(() => Navigation.StateController.navigateLink('/ab//'), /Url is invalid/, '');
     });
-    
-    it('OneOptionalParamOneSegmentNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('{x?}');
-        assert.equal(router.match('ab/cd'), null);
-        assert.equal(router.match('ab//'), null);
-    });
 
     it('OneOptionalParamTwoSegmentMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x?}');
-        var routeMatch = router.match('ab/cd');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 1);
-        assert.equal(routeMatch.data.x, 'cd');
-        routeMatch = router.match('ab');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 0);
-        assert.equal(route.params.length, 1);
-        assert.equal(route.params[0].name, 'x');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x?}', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/ab/cd');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'cd');
+        Navigation.StateController.navigateLink('/ab/cd?y=ef');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 2);
+        assert.equal(Navigation.StateContext.data.x, 'cd');
+        assert.equal(Navigation.StateContext.data.y, 'ef');
+        Navigation.StateController.navigateLink('/ab');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 0);
+        Navigation.StateController.navigateLink('/ab?y=ef');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.y, 'ef');
     });
 
     it('OneOptionalParamTwoSegmentNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/{x?}');
-        assert.equal(router.match(' ab/cd'), null);
-        assert.equal(router.match('abc/d'), null);
-        assert.equal(router.match('ab/d/e'), null);
-        assert.equal(router.match('a/b/d'), null);
-        assert.equal(router.match('abd'), null);
-        assert.equal(router.match('cab/d'), null);
-        assert.equal(router.match(''), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x?}', trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/ ab/cd'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abc/d'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/d/e'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/a/b/d'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abd'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/cab/d'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
 
     it('TwoOptionalParamTwoSegmentMatchTest', function () {
@@ -1033,6 +1033,17 @@ describe('BuildTest', function () {
         assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'abcd', y: 'ef' }), '/abcd?y=ef');
         assert.equal(Navigation.StateController.getNavigationLink('d'), '/');
         assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'ef' }), '/?y=ef');
+    });
+
+    it('OneOptionalParamTwoSegmentBuildTest', function () {
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/{x?}', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd' }), '/ab/cd');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'ef' }), '/ab/cd?y=ef');
+        assert.equal(Navigation.StateController.getNavigationLink('d'), '/ab');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { y: 'ef' }), '/ab?y=ef');
     });
 
     it('OneOptionalParamTwoSegmentBuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -56,26 +56,31 @@ describe('MatchTest', function () {
     });
 
     it('NoParamTwoSegmentMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/c');
-        var routeMatch = router.match('ab/c');
-        assert.equal(routeMatch.route, route);
-        assert.equal(Object.keys(routeMatch.data).length, 0);
-        assert.equal(route.params.length, 0);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/c', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('ab/c');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 0);
+        Navigation.StateController.navigateLink('ab/c?x=ab');
+        assert.equal(Object.keys(Navigation.StateContext.data).length, 1);
+        assert.equal(Navigation.StateContext.data.x, 'ab');
     });
 
     it('NoParamTwoSegmentNonMatchTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/c');
-        assert.equal(router.match(' ab/c'), null);
-        assert.equal(router.match('ab/c '), null);
-        assert.equal(router.match('ab/d'), null);
-        assert.equal(router.match('ab/cd'), null);
-        assert.equal(router.match('a/b/c'), null);
-        assert.equal(router.match('abc'), null);
-        assert.equal(router.match('ad/c'), null);
-        assert.equal(router.match('aab/c'), null);
-        assert.equal(router.match(''), null);
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/c', trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/ ab/c'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/c '), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/d'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ab/cd'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/a/b/c'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/abc'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/ad/c'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/aab/c'), /Url is invalid/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
     });
 
     it('OneParamOneSegmentMatchTest', function () {
@@ -877,9 +882,12 @@ describe('BuildTest', function () {
     });
 
     it('NoParamTwoSegmentBuildTest', function () {
-        var router = new Router();
-        var route = router.addRoute('ab/c');
-        assert.equal(route.build(), '/ab/c');
+        Navigation.StateInfoConfig.build(<any> [
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: 'ab/c', trackCrumbTrail: false }]}
+            ]);
+        assert.equal(Navigation.StateController.getNavigationLink('d'), '/ab/c');
+        assert.equal(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/ab/c?x=ab');
     });
 
     it('OneParamOneSegmentBuildTest', function () {

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -2103,7 +2103,7 @@ describe('NavigationTest', function () {
         assert.equal(Navigation.StateController.crumbs.length, 0);
     });
 
-    it('NavigateUncombinedToCombinedCrumbTrail', function () {
+    it('NavigateUncombinedToCombinedCrumbTrailTest', function () {
         Navigation.settings.combineCrumbTrail = false;
         Navigation.StateController.navigate('d0');
         Navigation.StateController.navigate('t0');
@@ -2114,7 +2114,7 @@ describe('NavigationTest', function () {
         assert.equal(Navigation.StateController.crumbs.length, 2);
     });
 
-    it('NavigateCombinedToUnombinedCrumbTrail', function () {
+    it('NavigateCombinedToUnombinedCrumbTrailTest', function () {
         Navigation.settings.combineCrumbTrail = true;
         Navigation.StateController.navigate('d0');
         Navigation.StateController.navigate('t0');
@@ -2123,5 +2123,33 @@ describe('NavigationTest', function () {
         Navigation.StateController.navigateLink(link);
         assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig._dialogs[0]._states[1]);
         assert.equal(Navigation.StateController.crumbs.length, 2);
+    });
+
+    it('NavigateTwoRouteTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's0', states: [
+                { key: 's0', route: 's', trackCrumbTrail: false },
+                { key: 's1', route: ['abc/{x}', 'def/{y}'], trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/abc/de');
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig._dialogs[0]._states[1]);
+        Navigation.StateController.navigateLink('/def/gh');
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig._dialogs[0]._states[1]);
+        Navigation.StateController.navigateLink('/s');
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig._dialogs[0]._states[0]);
+    });
+
+    it('NavigateTwoRouteRootTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's0', states: [
+                { key: 's0', route: ['abc/{x}', '{y}'], trackCrumbTrail: false },
+                { key: 's1', route: 's', trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/abc/de');
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig._dialogs[0]._states[0]);
+        Navigation.StateController.navigateLink('/sa');
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig._dialogs[0]._states[0]);
+        Navigation.StateController.navigateLink('/s');
+        assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig._dialogs[0]._states[1]);
     });
 });

--- a/NavigationJS/test/navigation-tests.ts
+++ b/NavigationJS/test/navigation-tests.ts
@@ -42,7 +42,7 @@ module NavigationTests {
 			{ key: 'page', route: '' }
 		]},
 		{ key: 'person', initial: 'list', states: [
-			{ key: 'list', route: 'people/{page}', transitions: [
+			{ key: 'list', route: ['people/{page}', 'people/{page}/sort/{sort}'], transitions: [
 				{ key: 'select', to: 'details' }
 			], defaults: { page: 1 }, trackCrumbTrail: false },
 			{ key: 'details', route: 'person/{id}', defaultTypes: { id: 'number' } }

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -43,7 +43,7 @@ class LinkUtility {
         if (window.addEventListener)
             element.addEventListener('click', navigate);
         else
-            element.attachEvent('onclick', navigate);
+            element['attachEvent']('onclick', navigate);
     }
 
     static addNavigateHandler(element, handler) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -64,7 +64,7 @@ function buildTask(name, from, to) {
 }
 function packageTask(name, from) {
 	return gulp.src(from)
-		.pipe(typescript())
+		.pipe(typescript({ tscSearch: ['bundle'] }))
 		.pipe(gulp.dest('./build/lib/' + name));
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -64,7 +64,7 @@ function buildTask(name, from, to) {
 }
 function packageTask(name, from) {
 	return gulp.src(from)
-		.pipe(typescript({ tscSearch: ['bundle'] }))
+		.pipe(typescript())
 		.pipe(gulp.dest('./build/lib/' + name));
 }
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "gulp-mocha": "^2.0.0",
     "gulp-rename": "^1.2.0",
     "gulp-streamify": "0.0.5",
-    "gulp-tsc": "^0.9.4",
+    "gulp-tsc": "^0.10.1",
     "gulp-uglify": "^1.1.0",
     "tsify": "^0.8.1",
     "vinyl-source-stream": "^1.1.0"
@@ -22,7 +22,7 @@
     "navigation": "global:Navigation",
     "angular": "global:angular",
     "knockout": "global:ko",
-    "react":  "global:React"
+    "react": "global:React"
   },
   "scripts": {
     "test": "gulp test",


### PR DESCRIPTION
Changed the route property on a State to be a string or array of strings (string | string[], requires TypeScript 1.4). When building a link, the best matched route is used. The algorithm is based on the most matching route parameters (not counting default values).

To avoid finding the best match each time a link is built, the result is cached. The cache key is based on the intersection of data keys with parameter keys. For example, a State with routes a/{x} and b/{y} has params x and y. If the incoming data is {x: 1, z: 2} then the cache key is x. If the incoming data is {x: 1, z: 2, y: 3} the cache key is x,y. The data values aren't part of the key so {x: 1, z: 2} and {x: 2, z: 10 } have the same cache keys.

Before this fix you couldn't have {category}/page/{page} with optional page parameter. Could've given page a default value but it would never have matched 'category'. Now can specify two routes: ['{category}', '{category}/page/{page}' ].