### PR TITLE
Disabled Type Tracking

### DIFF
--- a/NavigationJS/src/CrumbTrailManager.ts
+++ b/NavigationJS/src/CrumbTrailManager.ts
@@ -70,9 +70,11 @@ class CrumbTrailManager {
         navigationData = NavigationData.clone(navigationData);
         NavigationData.setDefaults(navigationData, state.defaults);
         for (var key in navigationData) {
-            if (navigationData[key] != null && navigationData[key].toString()
-                && (!settings.router.supportsDefaults || navigationData[key] !== state.defaults[key]))
-                data[key] = ReturnDataManager.formatURLObject(key, navigationData[key], state);
+            if (navigationData[key] != null && navigationData[key].toString()) { 
+                var val = ReturnDataManager.formatURLObject(key, navigationData[key], state);
+                if (!settings.router.supportsDefaults || val !== state.formattedDefaults[key])
+                    data[key] = val;
+            }
         }
         if (!settings.combineCrumbTrail && state.trackCrumbTrail && StateContext.state) {
             var returnDataString = ReturnDataManager.formatReturnData(StateContext.state, returnData);

--- a/NavigationJS/src/ReturnDataManager.ts
+++ b/NavigationJS/src/ReturnDataManager.ts
@@ -11,9 +11,11 @@ class ReturnDataManager {
     static formatReturnData(state: State, returnData: any): string {
         var returnDataArray: string[] = [];
         for (var key in returnData) {
-            if (returnData[key] != null && returnData[key].toString()
-                && (!settings.router.supportsDefaults || returnData[key] !== state.defaults[key]))
-                returnDataArray.push(this.encodeUrlValue(key) + this.RET_1_SEP + this.formatURLObject(key, returnData[key], state, true));
+            if (returnData[key] != null && returnData[key].toString()) {
+                var val = this.formatURLObject(key, returnData[key], state, true);
+                if (!settings.router.supportsDefaults || val !== state.formattedDefaults[key])
+                    returnDataArray.push(this.encodeUrlValue(key) + this.RET_1_SEP + val);
+            }
         }
         return returnDataArray.join(this.RET_3_SEP);
     }

--- a/NavigationJS/src/ReturnDataManager.ts
+++ b/NavigationJS/src/ReturnDataManager.ts
@@ -13,7 +13,7 @@ class ReturnDataManager {
         for (var key in returnData) {
             if (returnData[key] != null && returnData[key].toString()
                 && (!settings.router.supportsDefaults || returnData[key] !== state.defaults[key]))
-                returnDataArray.push(this.encodeUrlValue(key) + this.RET_1_SEP + this.formatURLObject(key, returnData[key], state));
+                returnDataArray.push(this.encodeUrlValue(key) + this.RET_1_SEP + this.formatURLObject(key, returnData[key], state, true));
         }
         return returnDataArray.join(this.RET_3_SEP);
     }
@@ -58,7 +58,7 @@ class ReturnDataManager {
         var returnDataArray = returnData.split(this.RET_3_SEP);
         for (var i = 0; i < returnDataArray.length; i++) {
             var nameValuePair = returnDataArray[i].split(this.RET_1_SEP);
-            navigationData[this.decodeUrlValue(nameValuePair[0])] = this.parseURLString(this.decodeUrlValue(nameValuePair[0]), nameValuePair[1], state);
+            navigationData[this.decodeUrlValue(nameValuePair[0])] = this.parseURLString(this.decodeUrlValue(nameValuePair[0]), nameValuePair[1], state, true);
         }
         return navigationData;
     }

--- a/NavigationJS/src/ReturnDataManager.ts
+++ b/NavigationJS/src/ReturnDataManager.ts
@@ -26,26 +26,31 @@ class ReturnDataManager {
         return urlValue.replace(new RegExp(this.SEPARATOR, 'g'), '0' + this.SEPARATOR);
     }
 
-    static formatURLObject(key: string, urlObject: any, state: State) {
+    static formatURLObject(key: string, urlObject: any, state: State, encode?: boolean) {
+        encode = encode || state.trackTypes;
         var defaultType: string = state.defaultTypes[key] ? state.defaultTypes[key] : 'string';
         var converterKey = ConverterFactory.getKeyFromObject(urlObject);
         var formattedValue = ConverterFactory.getConverter(converterKey).convertTo(urlObject);
-        formattedValue = this.encodeUrlValue(formattedValue);
-        if (typeof urlObject !== defaultType)
+        if (encode)
+            formattedValue = this.encodeUrlValue(formattedValue);
+        if (state.trackTypes && typeof urlObject !== defaultType)
             formattedValue += this.RET_2_SEP + converterKey;
         return formattedValue;
     }
 
-    static parseURLString(key: string, val: string, state: State): any {
+    static parseURLString(key: string, val: string, state: State, decode?: boolean): any {
+        decode = decode || state.trackTypes;
         var defaultType: string = state.defaultTypes[key] ? state.defaultTypes[key] : 'string';
         var urlValue = val;
         var converterKey = ConverterFactory.getKey(defaultType);
-        if (val.indexOf(this.RET_2_SEP) > -1) {
+        if (state.trackTypes && val.indexOf(this.RET_2_SEP) > -1) {
             var arr = val.split(this.RET_2_SEP);
             urlValue = arr[0];
             converterKey = arr[1];
         }
-        return ConverterFactory.getConverter(converterKey).convertFrom(this.decodeUrlValue(urlValue));
+        if (decode)
+            urlValue = this.decodeUrlValue(urlValue);
+        return ConverterFactory.getConverter(converterKey).convertFrom(urlValue);
     }
 
     static parseReturnData(returnData: string, state: State): any {

--- a/NavigationJS/src/config/IDialog.ts
+++ b/NavigationJS/src/config/IDialog.ts
@@ -1,7 +1,7 @@
 interface IDialog<TState, TStates> {
-	states: TStates;
-	initial: TState;
-	key: string;
-	title?: string;
+    states: TStates;
+    initial: TState;
+    key: string;
+    title?: string;
 }
 export = IDialog;

--- a/NavigationJS/src/config/IState.ts
+++ b/NavigationJS/src/config/IState.ts
@@ -6,5 +6,6 @@ interface IState<TTransitions> {
 	title?: string;
 	route: string | string[];
 	trackCrumbTrail?: boolean;
+    trackTypes?: boolean;
 }
 export = IState;

--- a/NavigationJS/src/config/IState.ts
+++ b/NavigationJS/src/config/IState.ts
@@ -1,11 +1,11 @@
 interface IState<TTransitions> {
-	transitions?: TTransitions;
-	key: string;
-	defaults?: any;
-	defaultTypes?: any;
-	title?: string;
-	route: string | string[];
-	trackCrumbTrail?: boolean;
+    transitions?: TTransitions;
+    key: string;
+    defaults?: any;
+    defaultTypes?: any;
+    title?: string;
+    route: string | string[];
+    trackCrumbTrail?: boolean;
     trackTypes?: boolean;
 }
 export = IState;

--- a/NavigationJS/src/config/ITransition.ts
+++ b/NavigationJS/src/config/ITransition.ts
@@ -1,5 +1,5 @@
 interface ITransition<TState> {
-	to: TState;
-	key: string;
+    to: TState;
+    key: string;
 }
 export = ITransition;

--- a/NavigationJS/src/config/State.ts
+++ b/NavigationJS/src/config/State.ts
@@ -17,6 +17,7 @@ class State implements IState<{ [index: string]: Transition }> {
     title: string;
     route: string | string[];
     trackCrumbTrail: boolean = true;
+    trackTypes: boolean = true;
     stateHandler: IStateHandler = new StateHandler();
     unloading: (state: State, data: any, url: string, unload: () => void, history?: boolean) => void = function (state, data, url, unload) { unload(); };
     navigating: (data: any, url: string, navigate: () => void, history?: boolean) => void = function (data, url, navigate) { navigate(); };

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -70,6 +70,11 @@ declare module Navigation {
          * to produce user friendly Urls 
          */
         trackCrumbTrail?: boolean;
+        /**
+         * Gets a value that indicates whether NavigationData Types are
+         * preserved when navigating
+         */
+        trackTypes?: boolean;
     }
 
     /**
@@ -184,6 +189,11 @@ declare module Navigation {
          * to produce user friendly Urls 
          */
         trackCrumbTrail: boolean;
+        /**
+         * Gets a value that indicates whether NavigationData Types are
+         * preserved when navigating
+         */
+        trackTypes: boolean;
         /**
          * Gets or sets the IStateHandler responsible for building and parsing
          * navigation links to this State

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -2785,7 +2785,27 @@ describe('NavigationDataTest', function () {
         Navigation.StateController.navigate('t0');
         var link = Navigation.StateController.getNavigationBackLink(2);
         Navigation.StateController.navigateBack(2);
-        assert('/x=0_1_2_', link);
-        assert(Navigation.StateContext.data.x, '0_1_2_');
+        assert.strictEqual ('/s0?x=0_1_2_', link);
+        assert.strictEqual(Navigation.StateContext.data.x, '0_1_2_');
+    });
+
+    it('WithoutTypesDefaultNavigateBackTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's0', states: [
+                { key: 's0', route: 's0', trackTypes: false, defaults: { x: 2 }, defaultTypes: { y: 'boolean' }, trackCrumbTrail: false, transitions: [
+                    { key: 't0', to: 's1' }
+                ]},
+                { key: 's1', route: 's1', transitions: [
+                    { key: 't0', to: 's2' }
+                ]},
+                { key: 's2', route: 's2' }]}
+            ]);
+        Navigation.StateController.navigate('d', { x: '3', y: 'true' });
+        Navigation.StateController.navigate('t0');
+        Navigation.StateController.navigate('t0');
+        var link = Navigation.StateController.getNavigationBackLink(2);
+        Navigation.StateController.navigateLink(link);
+        assert.strictEqual(Navigation.StateContext.data.x, 3);
+        assert.strictEqual(Navigation.StateContext.data.y, true);
     });
 });

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -2808,4 +2808,18 @@ describe('NavigationDataTest', function () {
         assert.strictEqual(Navigation.StateContext.data.x, 3);
         assert.strictEqual(Navigation.StateContext.data.y, true);
     });
+
+    it('WithoutTypesArrayTypeTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', trackTypes: false, defaultTypes: { x: 'numberarray', y: 'stringarray' }, trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigate('d', { x: [ 1, 2, '3' ], y: [ '_0_1', '-2-3', 4 ] });
+        assert.strictEqual(Navigation.StateContext.data.x[0], 1);
+        assert.strictEqual(Navigation.StateContext.data.x[1], 2);
+        assert.strictEqual(Navigation.StateContext.data.x[2], 3);
+        assert.strictEqual(Navigation.StateContext.data.y[0], '_0_1');
+        assert.strictEqual(Navigation.StateContext.data.y[1], '-2-3');
+        assert.strictEqual(Navigation.StateContext.data.y[2], '4');
+    });
 });

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -2768,4 +2768,24 @@ describe('NavigationDataTest', function () {
         link = link.replace('_bool=false', '_bool=invalid');
         assert.throws(() => Navigation.StateController.navigateLink(link));
     });
+
+    it('WithoutTypesNavigateBackTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's0', states: [
+                { key: 's0', route: 's0', trackTypes: false, trackCrumbTrail: false, transitions: [
+                    { key: 't0', to: 's1' }
+                ]},
+                { key: 's1', route: 's1', transitions: [
+                    { key: 't0', to: 's2' }
+                ]},
+                { key: 's2', route: 's2' }]}
+            ]);
+        Navigation.StateController.navigate('d', { x: '0_1_2_' });
+        Navigation.StateController.navigate('t0');
+        Navigation.StateController.navigate('t0');
+        var link = Navigation.StateController.getNavigationBackLink(2);
+        Navigation.StateController.navigateBack(2);
+        assert('/x=0_1_2_', link);
+        assert(Navigation.StateContext.data.x, '0_1_2_');
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1392,6 +1392,26 @@ describe('MatchTest', function () {
         assert.throws(() => Navigation.StateController.navigateLink('/a'), /not a valid boolean/, '');
         assert.throws(() => Navigation.StateController.navigateLink('/2'), /not a valid boolean/, '');
     });
+
+    it('WithoutTypesDefaultAndDefaultTypeMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', trackTypes: false, defaults: { x: '2' }, defaultTypes: { x: 'number' }, trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/');
+        assert.strictEqual(Navigation.StateContext.data.x, 2);
+        Navigation.StateController.navigateLink('/3');
+        assert.strictEqual(Navigation.StateContext.data.x, 3);
+    });
+
+    it('WithoutTypesDefaultAndDefaultTypeNonMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', trackTypes: false, defaults: { x: '2' }, defaultTypes: { x: 'number' }, trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/a'), /not a valid number/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/true'), /not a valid number/, '');
+    });
 });
 
 describe('BuildTest', function () {
@@ -2111,6 +2131,8 @@ describe('BuildTest', function () {
                 { key: 's', route: '{x}', trackTypes: false, defaults: { x: 2 }, trackCrumbTrail: false }]}
             ]);
         assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 2 }), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '2' }), '/');
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3 }), '/3');
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '3' }), '/3');
     });
@@ -2122,5 +2144,17 @@ describe('BuildTest', function () {
             ]);
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: true }), '/true');
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'false' }), '/false');
+    });
+
+    it('WithoutTypesDefaultAndDefaultTypeBuildTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', trackTypes: false, defaults: { x: '2' }, defaultTypes: { x: 'number' }, trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 2 }), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '2' }), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3 }), '/3');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '3' }), '/3');
     });
 })

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2251,15 +2251,6 @@ describe('BuildTest', function () {
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '3' }), '/3');
     });
 
-    it('WithoutTypesTwoRouteDefaultBuildTest', function () {
-        Navigation.StateInfoConfig.build([
-            { key: 'd', initial: 's', states: [
-                { key: 's', route: ['{x}', 'a/{y}'], trackTypes: false, defaults: { x: 2 }, trackCrumbTrail: false }]}
-            ]);
-        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 2, y: 1 }), '/a/1');
-        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '2', y: 1 }), '/a/1');
-    });
-
     it('WithoutTypesQueryStringBuildTest', function () {
         Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
@@ -2302,5 +2293,14 @@ describe('BuildTest', function () {
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '2' }), '/');
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3 }), '/?x=3');
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '3' }), '/?x=3');
+    });
+
+    it('WithoutTypesTwoRouteDefaultBuildTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['{x}', 'a/{y}'], trackTypes: false, defaults: { x: 2 }, trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 2, y: 1 }), '/a/1');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '2', y: 1 }), '/a/1');
     });
 })

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1337,6 +1337,21 @@ describe('MatchTest', function () {
         assert.strictEqual(Navigation.StateContext.data.y, 'gh');
         assert.strictEqual(Navigation.StateContext.data.z, 'i');
     });
+
+    it('WithoutTypesMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', trackTypes: false, trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/abc');
+        assert.strictEqual(Navigation.StateContext.data.x, 'abc');
+        Navigation.StateController.navigateLink('/3');
+        assert.strictEqual(Navigation.StateContext.data.x, '3');
+        Navigation.StateController.navigateLink('/true');
+        assert.strictEqual(Navigation.StateContext.data.x, 'true');
+        Navigation.StateController.navigateLink('/0_1_2_');
+        assert.strictEqual(Navigation.StateContext.data.x, '0_1_2_');
+    });
 });
 
 describe('BuildTest', function () {
@@ -2051,5 +2066,16 @@ describe('BuildTest', function () {
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 'gh', z: 'i' }), '/def/gh?z=i');
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3, y: 'gh' }), '/def/gh?x=3');
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3, y: 'gh', z: 'i' }), '/def/gh?x=3&z=i');
+    });
+
+    it('WithoutTypesBuildTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', trackTypes: false, trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'abc' }), '/abc');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3 }), '/3');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: true }), '/true');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '0_1_2_' }), '/0_1_2_');
     });
 })

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2166,4 +2166,13 @@ describe('BuildTest', function () {
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3 }), '/3');
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '3' }), '/3');
     });
+
+    it('WithoutTypesTwoRouteDefaultBuildTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: ['{x}', 'a/{y}'], trackTypes: false, defaults: { x: 2 }, trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 2, y: 1 }), '/a/1');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '2', y: 1 }), '/?y=1');
+    });
 })

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1421,6 +1421,90 @@ describe('MatchTest', function () {
         assert.throws(() => Navigation.StateController.navigateLink('/'), /not a valid number/, '');
         assert.throws(() => Navigation.StateController.navigateLink('/b'), /not a valid number/, '');
     });
+
+    it('WithoutTypesQueryStringMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '', trackTypes: false, trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/');
+        assert.strictEqual(Navigation.StateContext.data.x, undefined);
+        Navigation.StateController.navigateLink('/?x=3');
+        assert.strictEqual(Navigation.StateContext.data.x, '3');
+        Navigation.StateController.navigateLink('/?x=true');
+        assert.strictEqual(Navigation.StateContext.data.x, 'true');
+        Navigation.StateController.navigateLink('/?x=0_1_2_');
+        assert.strictEqual(Navigation.StateContext.data.x, '0_1_2_');
+    });
+
+    it('WithoutTypesQueryStringDefaultMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '', trackTypes: false, defaults: { x: 2 }, trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/');
+        assert.strictEqual(Navigation.StateContext.data.x, 2);
+        Navigation.StateController.navigateLink('/?x=3');
+        assert.strictEqual(Navigation.StateContext.data.x, 3);
+    });
+
+    it('WithoutTypesQueryStringDefaultNonMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '', trackTypes: false, defaults: { x: 2 }, trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/?x=a'), /not a valid number/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/?x=true'), /not a valid number/, '');
+    });
+
+    it('WithoutTypesQueryStringDefaultTypeMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '', trackTypes: false, defaultTypes: { x: 'boolean' }, trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/?x=true');
+        assert.strictEqual(Navigation.StateContext.data.x, true);
+        Navigation.StateController.navigateLink('/?x=false');
+        assert.strictEqual(Navigation.StateContext.data.x, false);
+    });
+
+    it('WithoutTypesQueryStringDefaultTypeNonMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '', trackTypes: false, defaultTypes: { x: 'boolean' }, trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/?x=a'), /not a valid boolean/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/?x=2'), /not a valid boolean/, '');
+    });
+
+    it('WithoutTypesQueryStringDefaultAndDefaultTypeMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '', trackTypes: false, defaults: { x: '2' }, defaultTypes: { x: 'number' }, trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/');
+        assert.strictEqual(Navigation.StateContext.data.x, 2);
+        Navigation.StateController.navigateLink('/?x=3');
+        assert.strictEqual(Navigation.StateContext.data.x, 3);
+    });
+
+    it('WithoutTypesQueryStringDefaultAndDefaultTypeNonMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '', trackTypes: false, defaults: { x: '2' }, defaultTypes: { x: 'number' }, trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/?x=a'), /not a valid number/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/?x=true'), /not a valid number/, '');
+    });
+
+    it('WithoutTypesQueryStringConflicingDefaultAndDefaultTypeNonMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '', trackTypes: false, defaults: { x: 'a' }, defaultTypes: { x: 'number' }, trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /not a valid number/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/?x=b'), /not a valid number/, '');
+    });
 });
 
 describe('BuildTest', function () {
@@ -2146,7 +2230,7 @@ describe('BuildTest', function () {
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '3' }), '/3');
     });
 
-    it('WithoutTypesDefaultBuildTest', function () {
+    it('WithoutTypesDefaultTypeBuildTest', function () {
         Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
                 { key: 's', route: '{x}', trackTypes: false, defaultTypes: { x: 'boolean' }, trackCrumbTrail: false }]}
@@ -2174,5 +2258,49 @@ describe('BuildTest', function () {
             ]);
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 2, y: 1 }), '/a/1');
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '2', y: 1 }), '/a/1');
+    });
+
+    it('WithoutTypesQueryStringBuildTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '', trackTypes: false, trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'abc' }), '/?x=abc');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3 }), '/?x=3');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: true }), '/?x=true');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '0_1_2_' }), '/?x=0_1_2_');
+    });
+
+    it('WithoutTypesQueryStringDefaultBuildTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '', trackTypes: false, defaults: { x: 2 }, trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 2 }), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '2' }), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3 }), '/?x=3');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '3' }), '/?x=3');
+    });
+
+    it('WithoutTypesQueryStringDefaultTypeBuildTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '', trackTypes: false, defaultTypes: { x: 'boolean' }, trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: true }), '/?x=true');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'false' }), '/?x=false');
+    });
+
+    it('WithoutTypesQueryStringDefaultAndDefaultTypeBuildTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '', trackTypes: false, defaults: { x: '2' }, defaultTypes: { x: 'number' }, trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 2 }), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '2' }), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3 }), '/?x=3');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '3' }), '/?x=3');
     });
 })

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1372,6 +1372,26 @@ describe('MatchTest', function () {
         assert.throws(() => Navigation.StateController.navigateLink('/a'), /not a valid number/, '');
         assert.throws(() => Navigation.StateController.navigateLink('/true'), /not a valid number/, '');
     });
+
+    it('WithoutTypesDefaultTypeMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', trackTypes: false, defaultTypes: { x: 'boolean' }, trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/true');
+        assert.strictEqual(Navigation.StateContext.data.x, true);
+        Navigation.StateController.navigateLink('/false');
+        assert.strictEqual(Navigation.StateContext.data.x, false);
+    });
+
+    it('WithoutTypesDefaultTypeNonMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', trackTypes: false, defaultTypes: { x: 'boolean' }, trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/a'), /not a valid boolean/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/2'), /not a valid boolean/, '');
+    });
 });
 
 describe('BuildTest', function () {
@@ -2093,5 +2113,14 @@ describe('BuildTest', function () {
         assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3 }), '/3');
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '3' }), '/3');
+    });
+
+    it('WithoutTypesDefaultBuildTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', trackTypes: false, defaultTypes: { x: 'boolean' }, trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: true }), '/true');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'false' }), '/false');
     });
 })

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1412,6 +1412,15 @@ describe('MatchTest', function () {
         assert.throws(() => Navigation.StateController.navigateLink('/a'), /not a valid number/, '');
         assert.throws(() => Navigation.StateController.navigateLink('/true'), /not a valid number/, '');
     });
+
+    it('WithoutTypesConflicingDefaultAndDefaultTypeNonMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', trackTypes: false, defaults: { x: 'a' }, defaultTypes: { x: 'number' }, trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/'), /not a valid number/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/b'), /not a valid number/, '');
+    });
 });
 
 describe('BuildTest', function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1352,6 +1352,26 @@ describe('MatchTest', function () {
         Navigation.StateController.navigateLink('/0_1_2_');
         assert.strictEqual(Navigation.StateContext.data.x, '0_1_2_');
     });
+
+    it('WithoutTypesDefaultMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', trackTypes: false, defaults: { x: 2 }, trackCrumbTrail: false }]}
+            ]);
+        Navigation.StateController.navigateLink('/');
+        assert.strictEqual(Navigation.StateContext.data.x, 2);
+        Navigation.StateController.navigateLink('/3');
+        assert.strictEqual(Navigation.StateContext.data.x, 3);
+    });
+
+    it('WithoutTypesDefaultNonMatchTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', trackTypes: false, defaults: { x: 2 }, trackCrumbTrail: false }]}
+            ]);
+        assert.throws(() => Navigation.StateController.navigateLink('/a'), /not a valid number/, '');
+        assert.throws(() => Navigation.StateController.navigateLink('/true'), /not a valid number/, '');
+    });
 });
 
 describe('BuildTest', function () {
@@ -2011,20 +2031,6 @@ describe('BuildTest', function () {
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'd', y: 'gh', z: 'i' }), '/def/gh?z=i');
     });
 
-    it('TwoRouteDefaultNonBuildTest', function () {
-        Navigation.StateInfoConfig.build([
-            { key: 'd', initial: 's', states: [
-                { key: 's', route: ['abc/{x}', 'def/{y}'], defaults: { x: 'd' }, trackCrumbTrail: false }]}
-            ]);
-        assert.throws(() => Navigation.StateController.navigateLink('/def'), /Url is invalid/, '');
-        assert.throws(() => Navigation.StateController.navigateLink('/ abc/de'), /Url is invalid/, '');
-        assert.throws(() => Navigation.StateController.navigateLink('/ def/gh'), /Url is invalid/, '');
-        assert.throws(() => Navigation.StateController.navigateLink('/abd/ef'), /Url is invalid/, '');
-        assert.throws(() => Navigation.StateController.navigateLink('/abc/de/f'), /Url is invalid/, '');
-        assert.throws(() => Navigation.StateController.navigateLink('/def/gh/i'), /Url is invalid/, '');
-        assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
-    });
-
     it('TwoRouteOptionalBuildTest', function () {
         Navigation.StateInfoConfig.build([
             { key: 'd', initial: 's', states: [
@@ -2077,5 +2083,15 @@ describe('BuildTest', function () {
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3 }), '/3');
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: true }), '/true');
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '0_1_2_' }), '/0_1_2_');
+    });
+
+    it('WithoutTypesDefaultBuildTest', function () {
+        Navigation.StateInfoConfig.build([
+            { key: 'd', initial: 's', states: [
+                { key: 's', route: '{x}', trackTypes: false, defaults: { x: 2 }, trackCrumbTrail: false }]}
+            ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3 }), '/3');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '3' }), '/3');
     });
 })

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2300,7 +2300,14 @@ describe('BuildTest', function () {
             { key: 'd', initial: 's', states: [
                 { key: 's', route: ['{x}', 'a/{y}'], trackTypes: false, defaults: { x: 2 }, trackCrumbTrail: false }]}
             ]);
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 2, y: 1 }), '/a/1');
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '2', y: 1 }), '/a/1');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 1 }), '/1');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '1' }), '/1');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 2 }), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '2' }), '/');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 1 }), '/a/1');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 1, y: 2 }), '/1?y=2');
     });
 })

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2173,6 +2173,6 @@ describe('BuildTest', function () {
                 { key: 's', route: ['{x}', 'a/{y}'], trackTypes: false, defaults: { x: 2 }, trackCrumbTrail: false }]}
             ]);
         assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 2, y: 1 }), '/a/1');
-        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '2', y: 1 }), '/?y=1');
+        assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '2', y: 1 }), '/a/1');
     });
 })

--- a/NavigationJS/test/navigation-tests.ts
+++ b/NavigationJS/test/navigation-tests.ts
@@ -45,7 +45,7 @@ module NavigationTests {
 			{ key: 'list', route: ['people/{page}', 'people/{page}/sort/{sort}'], transitions: [
 				{ key: 'select', to: 'details' }
 			], defaults: { page: 1 }, trackCrumbTrail: false },
-			{ key: 'details', route: 'person/{id}', defaultTypes: { id: 'number' } }
+			{ key: 'details', route: 'person/{id}', trackTypes: false, defaultTypes: { id: 'number' } }
 		]}
 	]);
 	


### PR DESCRIPTION
Added a trackTypes property to State. Setting to false disables the tracking of NavigationData types in the Url. Without this strings with underscores are escaped, e.g., a_value goes to a_0value, because an underscore is used as the type separator. Setting trackTypes to false will leave strings untouched. Default types are still honoured. Setting a default type of 'number', passed strings will be converted to numbers.