### PR TITLE
Lazy evaluated plugin Navigation links

### DIFF
--- a/NavigationAngular/src/LinkUtility.ts
+++ b/NavigationAngular/src/LinkUtility.ts
@@ -18,10 +18,12 @@ class LinkUtility {
             toData = Navigation.StateContext.includeCurrentData(toData);
         return toData;
     }
-
-    static addClickListener(element: ng.IAugmentedJQuery) {
-        element.on('click', (e) => {
+    
+    static addListeners(element: ng.IAugmentedJQuery, setLink: () => void, lazy: boolean) {
+        element.on('click', (e: JQueryInputEventObject) => {
             var anchor = <HTMLAnchorElement> element[0];
+            if (lazy)
+                setLink();
             if (!e.ctrlKey && !e.shiftKey) {
                 if (anchor.href) {
                     e.preventDefault();
@@ -29,11 +31,12 @@ class LinkUtility {
                 }
             }
         });
-    }
-
-    static addNavigateHandler(element: ng.IAugmentedJQuery, handler) {
-        Navigation.StateController.onNavigate(handler);
-        element.on('$destroy', () => Navigation.StateController.offNavigate(handler));
+        if (!lazy) {
+            Navigation.StateController.onNavigate(setLink);
+            element.on('$destroy', () => Navigation.StateController.offNavigate(setLink));
+        } else {
+            element.on('mouseDown', (e) => setLink());
+        }
     }
 }
 export = LinkUtility; 

--- a/NavigationAngular/src/LinkUtility.ts
+++ b/NavigationAngular/src/LinkUtility.ts
@@ -35,7 +35,7 @@ class LinkUtility {
             Navigation.StateController.onNavigate(setLink);
             element.on('$destroy', () => Navigation.StateController.offNavigate(setLink));
         } else {
-            element.on('mouseDown', (e) => setLink());
+            element.on('mousedown', (e) => setLink());
         }
     }
 }

--- a/NavigationAngular/src/NavigationBackLink.ts
+++ b/NavigationAngular/src/NavigationBackLink.ts
@@ -7,8 +7,7 @@ var NavigationBackLink = () => {
         restrict: 'EA',
         link: (scope: ng.IScope, element: ng.IAugmentedJQuery, attrs: ng.IAttributes) => {
             var distance;
-            LinkUtility.addClickListener(element);
-            LinkUtility.addNavigateHandler(element, () => setNavigationBackLink(element, attrs, distance));
+            LinkUtility.addListeners(element, () => setNavigationBackLink(element, attrs, distance), !!scope.$eval(attrs['lazy']));
             scope.$watch(attrs['navigationBackLink'], function (value) {
                 distance = value;
                 setNavigationBackLink(element, attrs, distance);

--- a/NavigationAngular/src/NavigationLink.ts
+++ b/NavigationAngular/src/NavigationLink.ts
@@ -7,8 +7,7 @@ var NavigationLink = () => {
         restrict: 'EA',
         link: (scope: ng.IScope, element: ng.IAugmentedJQuery, attrs: ng.IAttributes) => {
             var action, toData, includeCurrentData, currentDataKeys;
-            LinkUtility.addClickListener(element);
-            LinkUtility.addNavigateHandler(element, () => setNavigationLink(element, attrs, action, toData, includeCurrentData, currentDataKeys));
+            LinkUtility.addListeners(element, () => setNavigationLink(element, attrs, action, toData, includeCurrentData, currentDataKeys), !!scope.$eval(attrs['lazy']))
             var watchAttrs = [attrs['navigationLink'], attrs['toData'], attrs['includeCurrentData'], attrs['currentDataKeys']];
             scope.$watchGroup(watchAttrs, function (values) {
                 action = values[0];

--- a/NavigationAngular/src/RefreshLink.ts
+++ b/NavigationAngular/src/RefreshLink.ts
@@ -7,8 +7,7 @@ var RefreshLink = () => {
         restrict: 'EA',
         link: (scope: ng.IScope, element: ng.IAugmentedJQuery, attrs: ng.IAttributes) => {
             var toData, includeCurrentData, currentDataKeys;
-            LinkUtility.addClickListener(element);
-            LinkUtility.addNavigateHandler(element, () => setRefreshLink(element, attrs, toData, includeCurrentData, currentDataKeys));
+            LinkUtility.addListeners(element, () => setRefreshLink(element, attrs, toData, includeCurrentData, currentDataKeys), !!scope.$eval(attrs['lazy']));
             var watchAttrs = [attrs['refreshLink'], attrs['includeCurrentData'], attrs['currentDataKeys']];
             scope.$watchGroup(watchAttrs, function (values) {
                 toData = values[0];

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -38,10 +38,7 @@ class LinkUtility {
                 }
             }
         };
-        var update = (e: MouseEvent) => {
-            if (e.button === 2)
-                setLink();
-        };
+        var update = (e: MouseEvent) => setLink();
         if (window.addEventListener) {
             element.addEventListener('click', navigate);
             element.addEventListener('mousedown', update);

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -25,8 +25,9 @@ class LinkUtility {
         return data;
     }
 
-    static addClickListener(element: HTMLAnchorElement) {
+    static addClickListener(element: HTMLAnchorElement, handler?: () => void) {
         var navigate = (e: MouseEvent) => {
+            handler();
             if (!e.ctrlKey && !e.shiftKey) {
                 if (element.href) {
                     if (e.preventDefault)
@@ -43,7 +44,7 @@ class LinkUtility {
             element['attachEvent']('onclick', navigate);
     }
 
-    static addNavigateHandler(element, handler) {
+    static addNavigateHandler(element: HTMLAnchorElement, handler: () => void) {
         Navigation.StateController.onNavigate(handler);
         ko.utils.domNodeDisposal.addDisposeCallback(element, () => Navigation.StateController.offNavigate(handler));
     }

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -26,17 +26,7 @@ class LinkUtility {
     }
 
     static addListeners(element: HTMLAnchorElement, setLink: () => void, lazy: boolean) {
-        this.addClickListener(element, setLink, lazy);
-        if (!lazy) {
-            Navigation.StateController.onNavigate(setLink);
-            ko.utils.domNodeDisposal.addDisposeCallback(element, () => Navigation.StateController.offNavigate(setLink));
-        } else {
-            this.addListener(element, 'mousedown', (e: MouseEvent) => setLink());
-        }
-    }
-
-    private static addClickListener(element: HTMLAnchorElement, setLink: () => void, lazy: boolean) {
-        this.addListener(element, 'click', (e: MouseEvent) => {
+        ko.utils.registerEventHandler(element, 'click', (e: MouseEvent) => {
             if (lazy)
                 setLink();
             if (!e.ctrlKey && !e.shiftKey) {
@@ -49,13 +39,12 @@ class LinkUtility {
                 }
             }
         });
-    }
-    
-    private static addListener(element: HTMLAnchorElement, type: string, listener: (e: MouseEvent) => void) {
-        if (window.addEventListener)
-            element.addEventListener(type, listener);
-        else
-            element['attachEvent']('on' + type, listener);        
+        if (!lazy) {
+            Navigation.StateController.onNavigate(setLink);
+            ko.utils.domNodeDisposal.addDisposeCallback(element, () => Navigation.StateController.offNavigate(setLink));
+        } else {
+            ko.utils.registerEventHandler(element, 'mousedown', (e: MouseEvent) => setLink());
+        }
     }
 }
 export = LinkUtility;

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -3,13 +3,10 @@ import ko = require('knockout');
 
 class LinkUtility {
     static setLink(element: HTMLAnchorElement, linkAccessor: () => string) {
-        if (element.getAttribute('data-state-context-url') !== Navigation.StateContext.url) {
-            try {
-                element.href = Navigation.settings.historyManager.getHref(linkAccessor());
-            } catch (e) {
-                element.removeAttribute('href');
-            }
-            element.setAttribute('data-state-context-url', Navigation.StateContext.url);
+        try {
+            element.href = Navigation.settings.historyManager.getHref(linkAccessor());
+        } catch (e) {
+            element.removeAttribute('href');
         }
     }
 

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -25,9 +25,9 @@ class LinkUtility {
         return data;
     }
 
-    static addClickListener(element: HTMLAnchorElement, handler?: () => void) {
+    static addClickListener(element: HTMLAnchorElement, setLink?: () => void) {
         var navigate = (e: MouseEvent) => {
-            handler();
+            setLink();
             if (!e.ctrlKey && !e.shiftKey) {
                 if (element.href) {
                     if (e.preventDefault)

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -37,11 +37,18 @@ class LinkUtility {
                     Navigation.StateController.navigateLink(Navigation.settings.historyManager.getUrl(element));
                 }
             }
-        }
-        if (window.addEventListener)
+        };
+        var update = (e: MouseEvent) => {
+            if (e.button === 2)
+                setLink();
+        };
+        if (window.addEventListener) {
             element.addEventListener('click', navigate);
-        else
+            element.addEventListener('mousedown', update);
+        } else {
             element['attachEvent']('onclick', navigate);
+            element['attachEvent']('onmousedown', update);
+        }
     }
 
     static addNavigateHandler(element: HTMLAnchorElement, handler: () => void) {

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -25,9 +25,28 @@ class LinkUtility {
         return data;
     }
 
-    static addClickListener(element: HTMLAnchorElement, setLink: () => void) {
-        var navigate = (e: MouseEvent) => {
-            setLink();
+    static addListeners(element: HTMLAnchorElement, setLink: () => void, lazy: boolean) {
+        var navigate = this.getClickListener(element, setLink, lazy);
+        var update = (e: MouseEvent) => setLink();
+        if (window.addEventListener) {
+            element.addEventListener('click', navigate);
+            if (lazy)
+                element.addEventListener('mousedown', update);
+        } else {
+            element['attachEvent']('onclick', navigate);
+            if (lazy)
+                element['attachEvent']('onmousedown', update);
+        }
+        if (!lazy) {
+            Navigation.StateController.onNavigate(setLink);
+            ko.utils.domNodeDisposal.addDisposeCallback(element, () => Navigation.StateController.offNavigate(setLink));
+        }
+    }
+
+    private static getClickListener(element: HTMLAnchorElement, setLink: () => void, lazy: boolean) {
+        return (e: MouseEvent) => {
+            if (lazy)
+                setLink();
             if (!e.ctrlKey && !e.shiftKey) {
                 if (element.href) {
                     if (e.preventDefault)
@@ -38,19 +57,6 @@ class LinkUtility {
                 }
             }
         };
-        var update = (e: MouseEvent) => setLink();
-        if (window.addEventListener) {
-            element.addEventListener('click', navigate);
-            element.addEventListener('mousedown', update);
-        } else {
-            element['attachEvent']('onclick', navigate);
-            element['attachEvent']('onmousedown', update);
-        }
-    }
-
-    static addNavigateHandler(element: HTMLAnchorElement, handler: () => void) {
-        Navigation.StateController.onNavigate(handler);
-        ko.utils.domNodeDisposal.addDisposeCallback(element, () => Navigation.StateController.offNavigate(handler));
     }
 }
 export = LinkUtility;

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -25,7 +25,7 @@ class LinkUtility {
         return data;
     }
 
-    static addClickListener(element: HTMLAnchorElement, setLink?: () => void) {
+    static addClickListener(element: HTMLAnchorElement, setLink: () => void) {
         var navigate = (e: MouseEvent) => {
             setLink();
             if (!e.ctrlKey && !e.shiftKey) {

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -26,25 +26,17 @@ class LinkUtility {
     }
 
     static addListeners(element: HTMLAnchorElement, setLink: () => void, lazy: boolean) {
-        var navigate = this.getClickListener(element, setLink, lazy);
-        var update = (e: MouseEvent) => setLink();
-        if (window.addEventListener) {
-            element.addEventListener('click', navigate);
-            if (lazy)
-                element.addEventListener('mousedown', update);
-        } else {
-            element['attachEvent']('onclick', navigate);
-            if (lazy)
-                element['attachEvent']('onmousedown', update);
-        }
+        this.addClickListener(element, setLink, lazy);
+        if (lazy)
+            this.addListener(element, 'mousedown', (e: MouseEvent) => setLink());
         if (!lazy) {
             Navigation.StateController.onNavigate(setLink);
             ko.utils.domNodeDisposal.addDisposeCallback(element, () => Navigation.StateController.offNavigate(setLink));
         }
     }
 
-    private static getClickListener(element: HTMLAnchorElement, setLink: () => void, lazy: boolean) {
-        return (e: MouseEvent) => {
+    private static addClickListener(element: HTMLAnchorElement, setLink: () => void, lazy: boolean) {
+        this.addListener(element, 'click', (e: MouseEvent) => {
             if (lazy)
                 setLink();
             if (!e.ctrlKey && !e.shiftKey) {
@@ -56,7 +48,14 @@ class LinkUtility {
                     Navigation.StateController.navigateLink(Navigation.settings.historyManager.getUrl(element));
                 }
             }
-        };
+        });
+    }
+    
+    private static addListener(element: HTMLAnchorElement, type: string, listener: (e: MouseEvent) => void) {
+        if (window.addEventListener)
+            element.addEventListener(type, listener);
+        else
+            element['attachEvent']('on' + type, listener);        
     }
 }
 export = LinkUtility;

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -27,11 +27,11 @@ class LinkUtility {
 
     static addListeners(element: HTMLAnchorElement, setLink: () => void, lazy: boolean) {
         this.addClickListener(element, setLink, lazy);
-        if (lazy)
-            this.addListener(element, 'mousedown', (e: MouseEvent) => setLink());
         if (!lazy) {
             Navigation.StateController.onNavigate(setLink);
             ko.utils.domNodeDisposal.addDisposeCallback(element, () => Navigation.StateController.offNavigate(setLink));
+        } else {
+            this.addListener(element, 'mousedown', (e: MouseEvent) => setLink());
         }
     }
 

--- a/NavigationKnockout/src/NavigationBackLink.ts
+++ b/NavigationKnockout/src/NavigationBackLink.ts
@@ -8,7 +8,6 @@ var NavigationBackLink = ko.bindingHandlers['navigationBackLink'] = {
         LinkUtility.addNavigateHandler(element, () => setNavigationBackLink(element, valueAccessor));
     },
     update: (element, valueAccessor) => {
-        element.removeAttribute('data-state-context-url');
         setNavigationBackLink(element, valueAccessor);
     }
 };

--- a/NavigationKnockout/src/NavigationBackLink.ts
+++ b/NavigationKnockout/src/NavigationBackLink.ts
@@ -3,7 +3,7 @@ import Navigation = require('navigation');
 import ko = require('knockout');
 
 var NavigationBackLink = ko.bindingHandlers['navigationBackLink'] = {
-    init: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
+    init: (element, valueAccessor: () => any, allBindings: KnockoutAllBindingsAccessor) => {
         LinkUtility.addClickListener(element, () => setNavigationBackLink(element, valueAccessor));
         LinkUtility.addNavigateHandler(element, () => {
             if (!allBindings.get('lazy'))
@@ -15,7 +15,7 @@ var NavigationBackLink = ko.bindingHandlers['navigationBackLink'] = {
     }
 };
 
-function setNavigationBackLink(element: HTMLAnchorElement, valueAccessor) {
+function setNavigationBackLink(element: HTMLAnchorElement, valueAccessor: () => any) {
     LinkUtility.setLink(element, () => Navigation.StateController.getNavigationBackLink(ko.unwrap(valueAccessor())));
 }
 export = NavigationBackLink;

--- a/NavigationKnockout/src/NavigationBackLink.ts
+++ b/NavigationKnockout/src/NavigationBackLink.ts
@@ -3,9 +3,12 @@ import Navigation = require('navigation');
 import ko = require('knockout');
 
 var NavigationBackLink = ko.bindingHandlers['navigationBackLink'] = {
-    init: (element, valueAccessor) => {
-        LinkUtility.addClickListener(element);
-        LinkUtility.addNavigateHandler(element, () => setNavigationBackLink(element, valueAccessor));
+    init: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
+        LinkUtility.addClickListener(element, () => setNavigationBackLink(element, valueAccessor));
+        LinkUtility.addNavigateHandler(element, () => {
+            if (!allBindings.get('lazy'))
+                setNavigationBackLink(element, valueAccessor);
+        });
     },
     update: (element, valueAccessor) => {
         setNavigationBackLink(element, valueAccessor);

--- a/NavigationKnockout/src/NavigationBackLink.ts
+++ b/NavigationKnockout/src/NavigationBackLink.ts
@@ -4,11 +4,7 @@ import ko = require('knockout');
 
 var NavigationBackLink = ko.bindingHandlers['navigationBackLink'] = {
     init: (element, valueAccessor: () => any, allBindings: KnockoutAllBindingsAccessor) => {
-        LinkUtility.addClickListener(element, () => setNavigationBackLink(element, valueAccessor));
-        LinkUtility.addNavigateHandler(element, () => {
-            if (!allBindings.get('lazy'))
-                setNavigationBackLink(element, valueAccessor);
-        });
+        LinkUtility.addListeners(element, () => setNavigationBackLink(element, valueAccessor), !!allBindings.get('lazy'));
     },
     update: (element, valueAccessor) => {
         setNavigationBackLink(element, valueAccessor);

--- a/NavigationKnockout/src/NavigationLink.ts
+++ b/NavigationKnockout/src/NavigationLink.ts
@@ -8,7 +8,6 @@ var NavigationLink = ko.bindingHandlers['navigationLink'] = {
         LinkUtility.addNavigateHandler(element, () => setNavigationLink(element, valueAccessor, allBindings));
     },
     update: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
-        element.removeAttribute('data-state-context-url');
         setNavigationLink(element, valueAccessor, allBindings);
     }
 };

--- a/NavigationKnockout/src/NavigationLink.ts
+++ b/NavigationKnockout/src/NavigationLink.ts
@@ -3,7 +3,7 @@ import Navigation = require('navigation');
 import ko = require('knockout');
 
 var NavigationLink = ko.bindingHandlers['navigationLink'] = {
-    init: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
+    init: (element, valueAccessor: () => any, allBindings: KnockoutAllBindingsAccessor) => {
         LinkUtility.addClickListener(element, () => setNavigationLink(element, valueAccessor, allBindings));
         LinkUtility.addNavigateHandler(element, () => {
             if (!allBindings.get('lazy'))
@@ -15,7 +15,7 @@ var NavigationLink = ko.bindingHandlers['navigationLink'] = {
     }
 };
 
-function setNavigationLink(element: HTMLAnchorElement, valueAccessor, allBindings: KnockoutAllBindingsAccessor) {
+function setNavigationLink(element: HTMLAnchorElement, valueAccessor: () => any, allBindings: KnockoutAllBindingsAccessor) {
     LinkUtility.setLink(element, () => Navigation.StateController.getNavigationLink(ko.unwrap(valueAccessor()),
         LinkUtility.getData(allBindings.get('toData'), allBindings.get('includeCurrentData'), allBindings.get('currentDataKeys')))
     );

--- a/NavigationKnockout/src/NavigationLink.ts
+++ b/NavigationKnockout/src/NavigationLink.ts
@@ -4,11 +4,7 @@ import ko = require('knockout');
 
 var NavigationLink = ko.bindingHandlers['navigationLink'] = {
     init: (element, valueAccessor: () => any, allBindings: KnockoutAllBindingsAccessor) => {
-        LinkUtility.addClickListener(element, () => setNavigationLink(element, valueAccessor, allBindings));
-        LinkUtility.addNavigateHandler(element, () => {
-            if (!allBindings.get('lazy'))
-                setNavigationLink(element, valueAccessor, allBindings);
-        });
+        LinkUtility.addListeners(element, () => setNavigationLink(element, valueAccessor, allBindings), !!allBindings.get('lazy'));
     },
     update: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
         setNavigationLink(element, valueAccessor, allBindings);

--- a/NavigationKnockout/src/NavigationLink.ts
+++ b/NavigationKnockout/src/NavigationLink.ts
@@ -4,8 +4,11 @@ import ko = require('knockout');
 
 var NavigationLink = ko.bindingHandlers['navigationLink'] = {
     init: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
-        LinkUtility.addClickListener(element);
-        LinkUtility.addNavigateHandler(element, () => setNavigationLink(element, valueAccessor, allBindings));
+        LinkUtility.addClickListener(element, () => setNavigationLink(element, valueAccessor, allBindings));
+        LinkUtility.addNavigateHandler(element, () => {
+            if (!allBindings.get('lazy'))
+                setNavigationLink(element, valueAccessor, allBindings);
+        });
     },
     update: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
         setNavigationLink(element, valueAccessor, allBindings);

--- a/NavigationKnockout/src/RefreshLink.ts
+++ b/NavigationKnockout/src/RefreshLink.ts
@@ -3,7 +3,7 @@ import Navigation = require('navigation');
 import ko = require('knockout');
 
 var RefreshLink = ko.bindingHandlers['refreshLink'] = {
-    init: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
+    init: (element, valueAccessor: () => any, allBindings: KnockoutAllBindingsAccessor) => {
         LinkUtility.addClickListener(element, () => setRefreshLink(element, valueAccessor, allBindings));
         LinkUtility.addNavigateHandler(element, () => {
             if (!allBindings.get('lazy'))
@@ -15,7 +15,7 @@ var RefreshLink = ko.bindingHandlers['refreshLink'] = {
     }
 };
 
-function setRefreshLink(element: HTMLAnchorElement, valueAccessor, allBindings: KnockoutAllBindingsAccessor) {
+function setRefreshLink(element: HTMLAnchorElement, valueAccessor: () => any, allBindings: KnockoutAllBindingsAccessor) {
     LinkUtility.setLink(element, () => Navigation.StateController.getRefreshLink(
         LinkUtility.getData(valueAccessor(), allBindings.get('includeCurrentData'), allBindings.get('currentDataKeys')))
     );

--- a/NavigationKnockout/src/RefreshLink.ts
+++ b/NavigationKnockout/src/RefreshLink.ts
@@ -8,7 +8,6 @@ var RefreshLink = ko.bindingHandlers['refreshLink'] = {
         LinkUtility.addNavigateHandler(element, () => setRefreshLink(element, valueAccessor, allBindings));
     },
     update: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
-        element.removeAttribute('data-state-context-url');
         setRefreshLink(element, valueAccessor, allBindings);
     }
 };

--- a/NavigationKnockout/src/RefreshLink.ts
+++ b/NavigationKnockout/src/RefreshLink.ts
@@ -4,8 +4,11 @@ import ko = require('knockout');
 
 var RefreshLink = ko.bindingHandlers['refreshLink'] = {
     init: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
-        LinkUtility.addClickListener(element);
-        LinkUtility.addNavigateHandler(element, () => setRefreshLink(element, valueAccessor, allBindings));
+        LinkUtility.addClickListener(element, () => setRefreshLink(element, valueAccessor, allBindings));
+        LinkUtility.addNavigateHandler(element, () => {
+            if (!allBindings.get('lazy'))
+                setRefreshLink(element, valueAccessor, allBindings);
+        });
     },
     update: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
         setRefreshLink(element, valueAccessor, allBindings);

--- a/NavigationKnockout/src/RefreshLink.ts
+++ b/NavigationKnockout/src/RefreshLink.ts
@@ -4,11 +4,7 @@ import ko = require('knockout');
 
 var RefreshLink = ko.bindingHandlers['refreshLink'] = {
     init: (element, valueAccessor: () => any, allBindings: KnockoutAllBindingsAccessor) => {
-        LinkUtility.addClickListener(element, () => setRefreshLink(element, valueAccessor, allBindings));
-        LinkUtility.addNavigateHandler(element, () => {
-            if (!allBindings.get('lazy'))
-                setRefreshLink(element, valueAccessor, allBindings);
-        });
+        LinkUtility.addListeners(element, () => setRefreshLink(element, valueAccessor, allBindings), !!allBindings.get('lazy'));
     },
     update: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
         setRefreshLink(element, valueAccessor, allBindings);

--- a/NavigationReact/sample/app.html
+++ b/NavigationReact/sample/app.html
@@ -8,8 +8,7 @@
     </style>
 </head>
 <body>
-    <div id="list"></div>
-    <div id="details"></div>
+    <div id="content"></div>
     <script src="../../NavigationJS/sample/personSearch.js"></script>
     <script src="react-0.12.2.js"></script>
     <script src="JSXTransformer-0.12.2.js"></script>
@@ -17,30 +16,12 @@
     <script src="../../build/dist/navigation.react.js"></script>
     <script type="text/jsx">
         var List = React.createClass({
-	        getInitialState: function () {
-		        return {};
-	        },
-  	        componentDidMount: function (){
-		        var self = this;
-		        var personStates = Navigation.StateInfoConfig.dialogs.person.states;
-		        personStates.list.navigated = function (data) {
-			        var people = personSearch.search(data.name, data.sortExpression);
-			        self.props.name = data.name;
-			        self.props.totalRowCount = people.length;
-			        self.props.startRowIndex = data.startRowIndex;
-			        self.props.maximumRows = data.maximumRows;
-			        people = people.slice(data.startRowIndex, data.startRowIndex + data.maximumRows);
-			        self.props.sortExpression = data.sortExpression.indexOf('DESC') === -1 ? 'Name DESC' : 'Name';
-			        self.setState({ people: people });
-		        };
-		        personStates.list.dispose = function () { 
-			        self.setState({ people: null });
-		        }
-	        },
 	        render: function () {
-		        if (this.state.people == null)
-			        return null;
-                var people = this.state.people.map(function (person) {
+		        var people = personSearch.search(this.props.name, this.props.sortExpression);
+		        this.props.totalRowCount = people.length;
+		        people = people.slice(this.props.startRowIndex, this.props.startRowIndex + this.props.maximumRows);
+		        this.props.sortExpression = this.props.sortExpression.indexOf('DESC') === -1 ? 'Name DESC' : 'Name';
+                people = people.map(function (person) {
                     return (
                         <tr>
                             <td><NavigationReact.NavigationLink action="select" toData={{ id: person.id }}>{person.name}</NavigationReact.NavigationLink></td>
@@ -118,29 +99,14 @@
         });
 
         var Details = React.createClass({
-	        getInitialState: function () {
-		        return {};
-	        },
-  	        componentDidMount: function (){
-		        var self = this;
-		        var personStates = Navigation.StateInfoConfig.dialogs.person.states;
-		        personStates.details.navigated = function (data) {
-		            var person = personSearch.getDetails(data.id);
-			        self.setState({ person: person });
-		        };
-		        personStates.details.dispose = function () { 
-			        self.setState({ person: null });
-		        }
-	        },
 	        render: function () {
-		        if (this.state.person == null)
-			        return null;
+	            var person = personSearch.getDetails(this.props.id);
 		        return (
 			        <div>
 				        <NavigationReact.NavigationBackLink distance={1}>Person Search</NavigationReact.NavigationBackLink>
 				        <div>
-					        Name: {this.state.person.name}<br />
-					        Date of Birth: {this.state.person.dateOfBirth}
+					        Name: {person.name}<br />
+					        Date of Birth: {person.dateOfBirth}
 				        </div>
 			        </div>
 		        );
@@ -154,14 +120,19 @@
 		        { key: 'details', route: 'person', title: 'Person Details', }]}
         ]);
 
-        React.render(
-	        <List show={false} />,
-	        document.getElementById('list')
-        );
-        React.render(
-	        <Details show={false} />,
-	        document.getElementById('details')
-        );
+        var personStates = Navigation.StateInfoConfig.dialogs.person.states;
+        personStates.list.navigated = function (data) {
+            React.render(
+    	        <List name={data.name} startRowIndex={data.startRowIndex} maximumRows={data.maximumRows} sortExpression={data.sortExpression} />,
+    	        document.getElementById('content')
+            );
+        };
+        personStates.details.navigated = function (data) {
+            React.render(
+    	        <Details id={data.id} />,
+    	        document.getElementById('content')
+            );
+        }
         Navigation.start();
     </script>
 </body>

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -23,9 +23,10 @@ class LinkUtility {
             var element = component.getDOMNode();
             if (lazy) {
                 setLink();
-                component.forceUpdate();
                 if (props.href)
                     element.href = props.href;
+                else
+                    component.forceUpdate();
             }
             if (!e.ctrlKey && !e.shiftKey) {
                 if (props.href) {

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -23,10 +23,12 @@ class LinkUtility {
             var element = component.getDOMNode();
             if (lazy) {
                 setLink();
-                element.href = props.href;
+                component.forceUpdate();
+                if (props.href)
+                    element.href = props.href;
             }
             if (!e.ctrlKey && !e.shiftKey) {
-                if (element.href) {
+                if (props.href) {
                     e.preventDefault();
                     Navigation.StateController.navigateLink(Navigation.settings.historyManager.getUrl(element));
                 }

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -2,18 +2,9 @@
 import React = require('react');
 
 class LinkUtility {
-    static cloneProps(elem: React.ReactElement<any, any>): any {
-        var props = {};
-        for (var key in elem.props) {
-            props[key] = elem.props[key];
-        }
-        return props;
-    }
-
     static setLink(component: any, props: any, linkAccessor: () => string) {
         try {
             props.href = Navigation.settings.historyManager.getHref(linkAccessor());
-            props.onClick = (e) => this.onClick(e, component.getDOMNode());
         } catch (e) {
             props.href = null;
         }
@@ -26,23 +17,33 @@ class LinkUtility {
             toData = Navigation.StateContext.includeCurrentData(toData);
         return toData;
     }
-
-    static onClick(e: MouseEvent, element: HTMLAnchorElement) {
-        if (!e.ctrlKey && !e.shiftKey) {
-            if (element.href) {
-                e.preventDefault();
-                Navigation.StateController.navigateLink(Navigation.settings.historyManager.getUrl(element));
+    
+    static addListeners(component: any, props: any, setLink: () => void, lazy: boolean) {
+        props.onClick = (e: MouseEvent) => {
+            var element = component.getDOMNode();
+            if (lazy) {
+                setLink();
+                element.href = props.href;
             }
-        }
+            if (!e.ctrlKey && !e.shiftKey) {
+                if (element.href) {
+                    e.preventDefault();
+                    Navigation.StateController.navigateLink(Navigation.settings.historyManager.getUrl(element));
+                }
+            }
+        };
+        if (lazy)
+            props.onMouseDown = (e: MouseEvent) => component.forceUpdate();
     }
 
     static createElement(props: any) {
-        delete props.action;
-        delete props.toData;
-        delete props.includeCurrentData;
-        delete props.currentDataKeys;
-        delete props.distance;
-        return React.createElement(props.href ? 'a' : 'span', props);
+        var clonedProps: any = {};
+        for (var key in props) {
+            if (key !== 'action' && key !== 'toData' && key !== 'includeCurrentData'
+                    && key !== 'currentDataKeys' && key !== 'distance')
+            clonedProps[key] = props[key];
+        }
+        return React.createElement(clonedProps.href ? 'a' : 'span', clonedProps);
     }
 }
 export = LinkUtility;

--- a/NavigationReact/src/NavigationBackLink.ts
+++ b/NavigationReact/src/NavigationBackLink.ts
@@ -18,8 +18,8 @@ var NavigationBackLink = React.createClass({
             Navigation.StateController.offNavigate(this.onNavigate);
     },
     render: function () {
-        LinkUtility.addListeners(this, this.props, () => this.setNavigationBackLink(), !!this.props.lazy);
         this.setNavigationBackLink();
+        LinkUtility.addListeners(this, this.props, () => this.setNavigationBackLink(), !!this.props.lazy);
         return LinkUtility.createElement(this.props);
     }
 });

--- a/NavigationReact/src/NavigationBackLink.ts
+++ b/NavigationReact/src/NavigationBackLink.ts
@@ -6,17 +6,21 @@ var NavigationBackLink = React.createClass({
     onNavigate: function () {
         this.forceUpdate();
     },
+    setNavigationBackLink: function() {
+        LinkUtility.setLink(this, this.props, () => Navigation.StateController.getNavigationBackLink(this.props.distance));
+    },
     componentDidMount: function () {
-        Navigation.StateController.onNavigate(this.onNavigate);
+        if (!this.props.lazy)
+            Navigation.StateController.onNavigate(this.onNavigate);
     },
     componentWillUnmount: function () {
-        Navigation.StateController.offNavigate(this.onNavigate);
+        if (!this.props.lazy)
+            Navigation.StateController.offNavigate(this.onNavigate);
     },
     render: function () {
-        var props = LinkUtility.cloneProps(this);
-        var distance = props.distance;
-        LinkUtility.setLink(this, props, () => Navigation.StateController.getNavigationBackLink(distance));
-        return LinkUtility.createElement(props);
+        LinkUtility.addListeners(this, this.props, () => this.setNavigationBackLink(), !!this.props.lazy);
+        this.setNavigationBackLink();
+        return LinkUtility.createElement(this.props);
     }
 });
 export = NavigationBackLink;

--- a/NavigationReact/src/NavigationLink.ts
+++ b/NavigationReact/src/NavigationLink.ts
@@ -6,18 +6,22 @@ var NavigationLink = React.createClass({
     onNavigate: function () {
         this.forceUpdate();
     },
+    setNavigationLink: function() {
+        var toData = LinkUtility.getData(this.props.toData, this.props.includeCurrentData, this.props.currentDataKeys);
+        LinkUtility.setLink(this, this.props, () => Navigation.StateController.getNavigationLink(this.props.action, toData));
+    },
     componentDidMount: function () {
-        Navigation.StateController.onNavigate(this.onNavigate);
+        if (!this.props.lazy)
+            Navigation.StateController.onNavigate(this.onNavigate);
     },
     componentWillUnmount: function () {
-        Navigation.StateController.offNavigate(this.onNavigate);
+        if (!this.props.lazy)
+            Navigation.StateController.offNavigate(this.onNavigate);
     },
     render: function () {
-        var props = LinkUtility.cloneProps(this);
-        var action = props.action;
-        var toData = LinkUtility.getData(props.toData, props.includeCurrentData, props.currentDataKeys);
-        LinkUtility.setLink(this, props, () => Navigation.StateController.getNavigationLink(action, toData));
-        return LinkUtility.createElement(props);
+        LinkUtility.addListeners(this, this.props, () => this.setNavigationLink(), !!this.props.lazy);
+        this.setNavigationLink();
+        return LinkUtility.createElement(this.props);
     }
 });
 export = NavigationLink;

--- a/NavigationReact/src/NavigationLink.ts
+++ b/NavigationReact/src/NavigationLink.ts
@@ -19,8 +19,8 @@ var NavigationLink = React.createClass({
             Navigation.StateController.offNavigate(this.onNavigate);
     },
     render: function () {
-        LinkUtility.addListeners(this, this.props, () => this.setNavigationLink(), !!this.props.lazy);
         this.setNavigationLink();
+        LinkUtility.addListeners(this, this.props, () => this.setNavigationLink(), !!this.props.lazy);
         return LinkUtility.createElement(this.props);
     }
 });

--- a/NavigationReact/src/RefreshLink.ts
+++ b/NavigationReact/src/RefreshLink.ts
@@ -19,8 +19,8 @@ var RefreshLink = React.createClass({
             Navigation.StateController.offNavigate(this.onNavigate);
     },
     render: function () {
-        LinkUtility.addListeners(this, this.props, () => this.setRefreshLink(), !!this.props.lazy);
         this.setRefreshLink();
+        LinkUtility.addListeners(this, this.props, () => this.setRefreshLink(), !!this.props.lazy);
         return LinkUtility.createElement(this.props);
     }
 });

--- a/NavigationReact/src/RefreshLink.ts
+++ b/NavigationReact/src/RefreshLink.ts
@@ -6,17 +6,22 @@ var RefreshLink = React.createClass({
     onNavigate: function () {
         this.forceUpdate();
     },
+    setRefreshLink: function() {
+        var toData = LinkUtility.getData(this.props.toData, this.props.includeCurrentData, this.props.currentDataKeys);
+        LinkUtility.setLink(this, this.props, () => Navigation.StateController.getRefreshLink(toData));
+    },
     componentDidMount: function () {
-        Navigation.StateController.onNavigate(this.onNavigate);
+        if (!this.props.lazy)
+            Navigation.StateController.onNavigate(this.onNavigate);
     },
     componentWillUnmount: function () {
-        Navigation.StateController.offNavigate(this.onNavigate);
+        if (!this.props.lazy)
+            Navigation.StateController.offNavigate(this.onNavigate);
     },
     render: function () {
-        var props = LinkUtility.cloneProps(this);
-        var toData = LinkUtility.getData(props.toData, props.includeCurrentData, props.currentDataKeys);
-        LinkUtility.setLink(this, props, () => Navigation.StateController.getRefreshLink(toData));
-        return LinkUtility.createElement(props);
+        LinkUtility.addListeners(this, this.props, () => this.setRefreshLink(), !!this.props.lazy);
+        this.setRefreshLink();
+        return LinkUtility.createElement(this.props);
     }
 });
 export = RefreshLink;


### PR DESCRIPTION
Updating Navigation links onNavigate can be costly if there's 100's of links on a page. Think Twitter with infinite scroll - each Twitter 'page' brings in about 100 links, so there can 1000's of links. Added a lazy flag to all plugins Navigation links. Setting the flag to true means there won't be an onNavigate listener. Instead, the link updates itself only when it's clicked. Updated in mousedown event to handle right click open in new tab (right click doesn't fire click event); and updated in the click event for keyboard enter.