### PR TITLE
Only intercepted left click without keyboard modifiers

### DIFF
--- a/NavigationAngular/src/LinkUtility.ts
+++ b/NavigationAngular/src/LinkUtility.ts
@@ -20,11 +20,11 @@ class LinkUtility {
     }
     
     static addListeners(element: ng.IAugmentedJQuery, setLink: () => void, lazy: boolean) {
-        element.on('click', (e: JQueryInputEventObject) => {
+        element.on('click', (e: JQueryEventObject) => {
             var anchor = <HTMLAnchorElement> element[0];
             if (lazy)
                 setLink();
-            if (!e.ctrlKey && !e.shiftKey) {
+            if (!e.ctrlKey && !e.shiftKey && !e.metaKey && !e.altKey && !e.button) {
                 if (anchor.href) {
                     e.preventDefault();
                     Navigation.StateController.navigateLink(Navigation.settings.historyManager.getUrl(anchor));

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -29,7 +29,7 @@ class LinkUtility {
         ko.utils.registerEventHandler(element, 'click', (e: MouseEvent) => {
             if (lazy)
                 setLink();
-            if (!e.ctrlKey && !e.shiftKey) {
+            if (!e.ctrlKey && !e.shiftKey && !e.metaKey && !e.altKey && !e.button) {
                 if (element.href) {
                     if (e.preventDefault)
                         e.preventDefault();

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -28,7 +28,7 @@ class LinkUtility {
                 else
                     component.forceUpdate();
             }
-            if (!e.ctrlKey && !e.shiftKey) {
+            if (!e.ctrlKey && !e.shiftKey && !e.metaKey && !e.altKey && !e.button) {
                 if (props.href) {
                     e.preventDefault();
                     Navigation.StateController.navigateLink(Navigation.settings.historyManager.getUrl(element));


### PR DESCRIPTION
The !e.button check for left click works cross browser (even in ie 6-8 and tested in browserstack). The rumours of ie 6-8 reporting different e.button values doesn't apply to link (or button) clicks, only to clicks on other elements like div's.