### PR TITLE
Allowed async data passing from navigating to navigated

### DIFF
--- a/NavigationAngular/src/navigation.d.ts
+++ b/NavigationAngular/src/navigation.d.ts
@@ -217,8 +217,9 @@ declare module Navigation {
         /**
          * Called on the current State after navigating to it
          * @param data The current NavigationData
+         * @param asyncData The data passed asynchronously while navigating
          */
-        navigated: (data: any) => void;
+        navigated: (data: any, asyncData?: any) => void;
         /**
          * Called on the new State before navigating to it
          * @param data The new NavigationData
@@ -226,7 +227,7 @@ declare module Navigation {
          * @param navigate The function to call to continue to navigate
          * @param history A value indicating whether browser history was used
          */
-        navigating: (data: any, url: string, navigate: () => void, history?: boolean) => void;
+        navigating: (data: any, url: string, navigate: (asyncData?: any) => void, history?: boolean) => void;
     }
 
     /**

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -134,13 +134,13 @@ class StateController {
     }
     
     private static getNavigateContinuation(oldState: State, oldUrl: string, state: State, url: string): () => void {
-        return () => {
+        return (asyncData?: any) => {
             if (oldUrl === StateContext.url) {
                 state.stateHandler.navigateLink(oldState, state, url);
                 StateController.setStateContext(state, url);
                 if (oldState && oldState !== state)
                     oldState.dispose();
-                state.navigated(StateContext.data);
+                state.navigated(StateContext.data, asyncData);
                 for (var id in this.navigateHandlers) {
                     if (url === StateContext.url)
                         this.navigateHandlers[id](oldState, state, StateContext.data);

--- a/NavigationJS/src/config/State.ts
+++ b/NavigationJS/src/config/State.ts
@@ -20,8 +20,8 @@ class State implements IState<{ [index: string]: Transition }> {
     trackTypes: boolean = true;
     stateHandler: IStateHandler = new StateHandler();
     unloading: (state: State, data: any, url: string, unload: () => void, history?: boolean) => void = function (state, data, url, unload) { unload(); };
-    navigating: (data: any, url: string, navigate: () => void, history?: boolean) => void = function (data, url, navigate) { navigate(); };
+    navigating: (data: any, url: string, navigate: (asyncData?: any) => void, history?: boolean) => void = function (data, url, navigate) { navigate(); };
     dispose: () => void = function () { };
-    navigated: (data: any) => void = function (data: any) { };
+    navigated: (data: any, asyncData?: any) => void = function (data: any) { };
 }
 export = State;

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -217,8 +217,9 @@ declare module Navigation {
         /**
          * Called on the current State after navigating to it
          * @param data The current NavigationData
+         * @param asyncData The data passed asynchronously while navigating
          */
-        navigated: (data: any) => void;
+        navigated: (data: any, asyncData?: any) => void;
         /**
          * Called on the new State before navigating to it
          * @param data The new NavigationData
@@ -226,7 +227,7 @@ declare module Navigation {
          * @param navigate The function to call to continue to navigate
          * @param history A value indicating whether browser history was used
          */
-        navigating: (data: any, url: string, navigate: () => void, history?: boolean) => void;
+        navigating: (data: any, url: string, navigate: (asyncData?: any) => void, history?: boolean) => void;
     }
 
     /**

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -1935,7 +1935,7 @@ describe('NavigationTest', function () {
     it('NavigatingAsyncDataTest', function (done: MochaDone) {
         Navigation.StateController.navigate('d0');
         Navigation.StateInfoConfig.dialogs['d0'].states['s1'].navigated = (data, asyncData) => {
-            assert.equal('hello', asyncData);
+            assert.equal(asyncData, 'hello');
             done();
         }
         Navigation.StateInfoConfig.dialogs['d0'].states['s1'].navigating = (data, url, navigate) => {
@@ -1947,12 +1947,27 @@ describe('NavigationTest', function () {
     it('NavigatingNavigatingAsyncDataTest', function (done: MochaDone) {
         Navigation.StateController.navigate('d0');
         Navigation.StateInfoConfig.dialogs['d0'].states['s1'].navigated = (data, asyncData) => {
-            assert.equal(0, asyncData);
+            assert.equal(asyncData, 0);
             done();
         }
         var i = 0;
         Navigation.StateInfoConfig.dialogs['d0'].states['s1'].navigating = (data, url, navigate) => {
             ((count) => setTimeout(() => navigate(count), 0))(i);
+            i++;
+        }
+        Navigation.StateController.navigate('t0');
+        Navigation.StateController.navigate('t0');
+    });
+
+    it('NavigatingNavigatingReversedAsyncDataTest', function (done: MochaDone) {
+        Navigation.StateController.navigate('d0');
+        Navigation.StateInfoConfig.dialogs['d0'].states['s1'].navigated = (data, asyncData) => {
+            assert.equal(asyncData, 1);
+            done();
+        }
+        var i = 0;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s1'].navigating = (data, url, navigate) => {
+            ((count) => setTimeout(() => navigate(count), 5 - 5 * count))(i);
             i++;
         }
         Navigation.StateController.navigate('t0');

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -1944,6 +1944,21 @@ describe('NavigationTest', function () {
         Navigation.StateController.navigate('t0');
     });
 
+    it('NavigatingNavigatingAsyncDataTest', function (done: MochaDone) {
+        Navigation.StateController.navigate('d0');
+        Navigation.StateInfoConfig.dialogs['d0'].states['s1'].navigated = (data, asyncData) => {
+            assert.equal(0, asyncData);
+            done();
+        }
+        var i = 0;
+        Navigation.StateInfoConfig.dialogs['d0'].states['s1'].navigating = (data, url, navigate) => {
+            ((count) => setTimeout(() => navigate(count), 0))(i);
+            i++;
+        }
+        Navigation.StateController.navigate('t0');
+        Navigation.StateController.navigate('t0');
+    });
+
     it('NavigateTransitionStorageTest', function () {
         Navigation.settings.crumbTrailPersister = new Navigation.StorageCrumbTrailPersister(0);
         Navigation.StateController.navigate('d0');

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -1974,6 +1974,21 @@ describe('NavigationTest', function () {
         Navigation.StateController.navigate('t0');
     });
 
+    it('NavigatingNoAsyncDataTest', function (done: MochaDone) {
+        Navigation.StateController.navigate('d0');
+        Navigation.StateInfoConfig.dialogs['d0'].states['s1'].navigated = (data, asyncData) => {
+            Navigation.StateController.navigate('t0');
+        }
+        Navigation.StateInfoConfig.dialogs['d0'].states['s2'].navigated = (data, asyncData) => {
+            assert.equal(asyncData, undefined);
+            done();
+        }
+        Navigation.StateInfoConfig.dialogs['d0'].states['s1'].navigating = (data, url, navigate) => {
+            setTimeout(() => navigate('hello'), 0);
+        }
+        Navigation.StateController.navigate('t0');
+    });
+
     it('NavigateTransitionStorageTest', function () {
         Navigation.settings.crumbTrailPersister = new Navigation.StorageCrumbTrailPersister(0);
         Navigation.StateController.navigate('d0');

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -1932,6 +1932,18 @@ describe('NavigationTest', function () {
         assert.strictEqual(navigatingHistory, false);
     });
 
+    it('NavigatingAsyncDataTest', function (done: MochaDone) {
+        Navigation.StateController.navigate('d0');
+        Navigation.StateInfoConfig.dialogs['d0'].states['s1'].navigated = (data, asyncData) => {
+            assert.equal('hello', asyncData);
+            done();
+        }
+        Navigation.StateInfoConfig.dialogs['d0'].states['s1'].navigating = (data, url, navigate) => {
+            setTimeout(() => navigate('hello'), 0);
+        }
+        Navigation.StateController.navigate('t0');
+    });
+
     it('NavigateTransitionStorageTest', function () {
         Navigation.settings.crumbTrailPersister = new Navigation.StorageCrumbTrailPersister(0);
         Navigation.StateController.navigate('d0');

--- a/NavigationJS/test/navigation-tests.ts
+++ b/NavigationJS/test/navigation-tests.ts
@@ -68,9 +68,13 @@ module NavigationTests {
 	// StateNavigator
 	personList.dispose = () => {};
 	personList.navigating = (data, url, navigate) => {
+		navigate([]);
+	};
+	personList.navigated = (data, asyncData) => {};
+	personDetails.navigating = (data, url, navigate) => {
 		navigate();
 	};
-	personList.navigated = (data) => {};
+	personDetails.navigated = (data) => {};
 	
 	// State Handler
 	class LogStateHandler extends Navigation.StateHandler {

--- a/NavigationKnockout/src/navigation.d.ts
+++ b/NavigationKnockout/src/navigation.d.ts
@@ -217,8 +217,9 @@ declare module Navigation {
         /**
          * Called on the current State after navigating to it
          * @param data The current NavigationData
+         * @param asyncData The data passed asynchronously while navigating
          */
-        navigated: (data: any) => void;
+        navigated: (data: any, asyncData?: any) => void;
         /**
          * Called on the new State before navigating to it
          * @param data The new NavigationData
@@ -226,7 +227,7 @@ declare module Navigation {
          * @param navigate The function to call to continue to navigate
          * @param history A value indicating whether browser history was used
          */
-        navigating: (data: any, url: string, navigate: () => void, history?: boolean) => void;
+        navigating: (data: any, url: string, navigate: (asyncData?: any) => void, history?: boolean) => void;
     }
 
     /**

--- a/NavigationReact/src/navigation.d.ts
+++ b/NavigationReact/src/navigation.d.ts
@@ -217,8 +217,9 @@ declare module Navigation {
         /**
          * Called on the current State after navigating to it
          * @param data The current NavigationData
+         * @param asyncData The data passed asynchronously while navigating
          */
-        navigated: (data: any) => void;
+        navigated: (data: any, asyncData?: any) => void;
         /**
          * Called on the new State before navigating to it
          * @param data The new NavigationData
@@ -226,7 +227,7 @@ declare module Navigation {
          * @param navigate The function to call to continue to navigate
          * @param history A value indicating whether browser history was used
          */
-        navigating: (data: any, url: string, navigate: () => void, history?: boolean) => void;
+        navigating: (data: any, url: string, navigate: (asyncData?: any) => void, history?: boolean) => void;
     }
 
     /**


### PR DESCRIPTION
State navigating method can be used to retrieve data asynchronously before continuing. Prevents 'blank' screens where the navigation happens but the data's not ready. Allowed the async data retrieved during navigating method to be passed along to the State navigated method, by adding an async data parameter to the navigate continuation and navigated methods.