### PR TITLE
Add header info to built js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,11 +17,6 @@ var tests = [
 	{ name: 'Navigation', to: 'navigation.test.js' },
 	{ name: 'NavigationData', to: 'navigationData.test.js' }
 ];
-var plugins = [
-	require('./build/npm/navigation-react/package.json'),
-	require('./build/npm/navigation-knockout/package.json'),
-	require('./build/npm/navigation-angular/package.json')
-];
 var testTasks = [];
 function testTask(file, to) {
 	return browserify(file)
@@ -42,16 +37,14 @@ for (var i = 0; i < tests.length; i++) {
 }
 gulp.task('test', testTasks);
 
-var buildTasks = ['BuildNavigation'];
-var packageTasks = ['PackageNavigation'];
-gulp.task('BuildNavigation', function () {
-	return buildTask('Navigation', './NavigationJS/src/Navigation.ts', 
-		'navigation.js', require('./build/npm/navigation/package.json'));
-});
-gulp.task('PackageNavigation', function () {
-	return packageTask('Navigation', './NavigationJS/src/Navigation.ts');
-})
-
+var items = [
+	require('./build/npm/navigation/package.json'),
+	require('./build/npm/navigation-react/package.json'),
+	require('./build/npm/navigation-knockout/package.json'),
+	require('./build/npm/navigation-angular/package.json')
+];
+var buildTasks = [];
+var packageTasks = [];
 var info = ['/**',
   ' * Navigation v<%= details.version %>',
   ' * (c) Graham Mendick - <%= details.homepage %>',
@@ -78,21 +71,20 @@ function packageTask(name, file) {
 		.pipe(typescript())
 		.pipe(gulp.dest('./build/lib/' + name));
 }
-
-for (var i = 0; i < plugins.length; i++) {
-	var name = plugins[i].name
+for (var i = 0; i < items.length; i++) {
+	var name = items[i].name
 				.replace(/\b./g, function(val){ return val.toUpperCase(); })
 				.replace('-', '');
-	var tsFrom = './' + name + '/src/' + name + '.ts';
-	var jsTo = plugins[i].name.replace('-', '.') + '.js';
-	(function (name, tsFrom, jsTo, plugin) {
+	var tsFrom = './' + name + (name.length == 10 ? 'JS' : '') + '/src/' + name + '.ts';
+	var jsTo = items[i].name.replace('-', '.') + '.js';
+	(function (name, tsFrom, jsTo, item) {
 		gulp.task('Build' + name, function () {
-			return buildTask(name, tsFrom, jsTo, plugin);
+			return buildTask(name, tsFrom, jsTo, item);
 		});
 		gulp.task('Package' + name, function () {
 			return packageTask(name, tsFrom);
 		});
-	})(name, tsFrom, jsTo, plugins[i]);
+	})(name, tsFrom, jsTo, items[i]);
 	buildTasks.push('Build' + name);
 	packageTasks.push('Package' + name);
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,8 +22,8 @@ var plugins = [
 	require('./build/npm/navigation-angular/package.json')
 ];
 var testTasks = [];
-function testTask(from, to) {
-	return browserify(from)
+function testTask(file, to) {
+	return browserify(file)
 		.plugin('tsify')
 		.bundle()
 		.pipe(source(to))
@@ -49,8 +49,8 @@ gulp.task('BuildNavigation', function () {
 gulp.task('PackageNavigation', function () {
 	return packageTask('Navigation', './NavigationJS/src/Navigation.ts');
 })
-function buildTask(name, from, to) {
-	return browserify(from, { standalone: name })
+function buildTask(name, file, to) {
+	return browserify(file, { standalone: name })
 		.plugin('tsify')
 		.transform(shim)
 		.bundle()
@@ -62,8 +62,8 @@ function buildTask(name, from, to) {
 		.pipe(streamify(uglify()))
 		.pipe(gulp.dest('./build/dist'));
 }
-function packageTask(name, from) {
-	return gulp.src(from)
+function packageTask(name, file) {
+	return gulp.src(file)
 		.pipe(typescript())
 		.pipe(gulp.dest('./build/lib/' + name));
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,9 +17,9 @@ var tests = [
 	{ name: 'NavigationData', to: 'navigationData.test.js' }
 ];
 var plugins = [
-	{ name: 'NavigationReact', to: 'navigation.react.js' },
-	{ name: 'NavigationKnockout', to: 'navigation.knockout.js' },
-	{ name: 'NavigationAngular', to: 'navigation.angular.js' }
+	require('./build/npm/navigation-react/package.json'),
+	require('./build/npm/navigation-knockout/package.json'),
+	require('./build/npm/navigation-angular/package.json')
 ];
 var testTasks = [];
 function testTask(from, to) {
@@ -69,17 +69,19 @@ function packageTask(name, from) {
 }
 
 for (var i = 0; i < plugins.length; i++) {
-	(function (plugin) {
-		var from = './' + plugin.name + '/src/' + plugin.name + '.ts';
-		gulp.task('Build' + plugin.name, function () {
-			return buildTask(plugin.name, from, plugin.to);
+	var name = plugins[i].name.replace('/b./g', function(val){ return val.toUpperCase(); }).replace('-', '');
+	var tsFrom = './' + name + '/src/' + name + '.ts';
+	var jsTo = plugins[i].name.replace('-', '.') + '.js';
+	(function (name, tsFrom, jsTo) {
+		gulp.task('Build' + name, function () {
+			return buildTask(name, tsFrom, jsTo);
 		});
-		gulp.task('Package' + plugin.name, function () {
-			return packageTask(plugin.name, from);
+		gulp.task('Package' + name, function () {
+			return packageTask(name, tsFrom);
 		});
-	})(plugins[i]);
-	buildTasks.push('Build' + plugins[i].name);
-	packageTasks.push('Package' + plugins[i].name);
+	})(name, tsFrom, jsTo);
+	buildTasks.push('Build' + name);
+	packageTasks.push('Package' + name);
 }
 gulp.task('build', buildTasks);
 gulp.task('package', packageTasks);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,7 +75,8 @@ for (var i = 0; i < items.length; i++) {
 	var name = items[i].name
 				.replace(/\b./g, function(val){ return val.toUpperCase(); })
 				.replace('-', '');
-	var tsFrom = './' + name + (name.length == 10 ? 'JS' : '') + '/src/' + name + '.ts';
+	var tsFromFolder = name + (name.length == 10 ? 'JS' : '');
+	var tsFrom = './' + tsFromFolder + '/src/' + name + '.ts';
 	var jsTo = items[i].name.replace('-', '.') + '.js';
 	(function (name, tsFrom, jsTo, item) {
 		gulp.task('Build' + name, function () {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -81,7 +81,7 @@ function packageTask(name, file) {
 
 for (var i = 0; i < plugins.length; i++) {
 	var name = plugins[i].name
-				.replace('/b./g', function(val){ return val.toUpperCase(); })
+				.replace(/\b./g, function(val){ return val.toUpperCase(); })
 				.replace('-', '');
 	var tsFrom = './' + name + '/src/' + name + '.ts';
 	var jsTo = plugins[i].name.replace('-', '.') + '.js';

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "gulp": "^3.8.11",
     "gulp-concat": "^2.5.2",
     "gulp-derequire": "^2.1.0",
+    "gulp-header": "^1.2.2",
     "gulp-mocha": "^2.0.0",
     "gulp-rename": "^1.2.0",
     "gulp-streamify": "0.0.5",


### PR DESCRIPTION
Read the name, version  and license information from the npm package.json files.
Tidied up the gulpfile by moving the navigation task item into the same array as the plugin task items.