### PR TITLE
Added active link indicators

### DIFF
--- a/NavigationAngular/sample/app.html
+++ b/NavigationAngular/sample/app.html
@@ -5,6 +5,7 @@
     <style>
         table{border-collapse:collapse;}table,td,th{border:1px #000 solid;}
         ul{list-style-type:none;padding:0;margin:0;}li{float:left;padding-right:3px;}
+        .active{font-weight:bold;}
     </style>
 </head>
 <body>
@@ -15,8 +16,8 @@
                 <input id="name" ng-model="$parent.name" ng-blur="nameChange()" />
             </div>
             Page size
-            <a refresh-link="{ maximumRows: 5, startRowIndex: null }" include-current-data="true">5</a>
-            <a refresh-link="{ maximumRows: 10, startRowIndex: null }" include-current-data="true">10</a>
+            <a refresh-link="{ maximumRows: 5, startRowIndex: null }" include-current-data="true" active-css-class="'active'">5</a>
+            <a refresh-link="{ maximumRows: 10, startRowIndex: null }" include-current-data="true" active-css-class="'active'">10</a>
             <table>
                 <thead>
                     <tr>
@@ -32,14 +33,10 @@
                 </tbody>
             </table>
             <ul>
-                <li ng-if="previousVisible"><a refresh-link="{ startRowIndex: 0 }" include-current-data="true">First</a></li>
-                <li ng-if="previousVisible"><a refresh-link="{ startRowIndex: previous }" include-current-data="true">Previous</a></li>
-                <li ng-if="!previousVisible">First</li>
-                <li ng-if="!previousVisible">Previous</li>
-                <li ng-if="nextVisible"><a refresh-link="{ startRowIndex: next }" include-current-data="true">Next</a></li>
-                <li ng-if="nextVisible"><a refresh-link="{ startRowIndex: last }" include-current-data="true">Last</a></li>
-                <li ng-if="!nextVisible">Next</li>
-                <li ng-if="!nextVisible">Last</li>
+                <li><a refresh-link="{ startRowIndex: 0 }" include-current-data="true" disable-active="true">First</a></li>
+                <li><a refresh-link="{ startRowIndex: previous }" include-current-data="true" disable-active="true">Previous</a></li>
+                <li><a refresh-link="{ startRowIndex: next }" include-current-data="true" disable-active="true">Next</a></li>
+                <li><a refresh-link="{ startRowIndex: last }" include-current-data="true" disable-active="true">Last</a></li>
             </ul>
             Total Count {{totalCount}}
         </div>

--- a/NavigationAngular/sample/app.js
+++ b/NavigationAngular/sample/app.js
@@ -8,9 +8,7 @@ app.controller('PersonController', function ($scope) {
 	$scope.personName;
 	$scope.dateOfBirth;
 	$scope.previous;
-	$scope.previousVisible;
 	$scope.next;
-	$scope.nextVisible;
 	$scope.last;
 	$scope.totalCount;
 	$scope.nameChange = function (e) {
@@ -26,12 +24,12 @@ app.controller('PersonController', function ($scope) {
 		$scope.people = people.slice(data.startRowIndex, data.startRowIndex + data.maximumRows);
 		$scope.name = data.name;
 		$scope.sortExpression = data.sortExpression.indexOf('DESC') === -1 ? 'Name DESC' : 'Name';
-		$scope.previous = data.startRowIndex - data.maximumRows;
-		$scope.previousVisible = $scope.previous >= 0;
+		$scope.previous = Math.max(0, data.startRowIndex - data.maximumRows);
 		$scope.next = data.startRowIndex + data.maximumRows;
-		$scope.nextVisible = $scope.next < totalRowCount;
 		var remainder = totalRowCount % data.maximumRows;
 		$scope.last = remainder != 0 ? totalRowCount - remainder : totalRowCount - data.maximumRows;
+		if ($scope.next >= totalRowCount)
+			$scope.next = $scope.last = data.startRowIndex;
 		$scope.totalCount = totalRowCount;
 	};
 	personStates.details.navigated = function (data) {

--- a/NavigationAngular/src/LinkUtility.ts
+++ b/NavigationAngular/src/LinkUtility.ts
@@ -19,6 +19,17 @@ class LinkUtility {
         return toData;
     }
 
+    static isActive(key: string, val: any): boolean {
+        if (!Navigation.StateContext.state)
+            return false;
+        if (val != null && val.toString()) {
+            var trackTypes = Navigation.StateContext.state.trackTypes;
+            var currentVal = Navigation.StateContext.data[key];
+            return currentVal != null && (trackTypes ? val === currentVal : val.toString() == currentVal.toString());
+        }
+        return true;
+    }
+
     static setActive(element: ng.IAugmentedJQuery, attrs: ng.IAttributes, active: boolean, activeCssClass: string, disableActive: boolean) {
         if (activeCssClass){
             if (active && !element.hasClass(activeCssClass))

--- a/NavigationAngular/src/LinkUtility.ts
+++ b/NavigationAngular/src/LinkUtility.ts
@@ -18,7 +18,18 @@ class LinkUtility {
             toData = Navigation.StateContext.includeCurrentData(toData);
         return toData;
     }
-    
+
+    static setActive(element: ng.IAugmentedJQuery, attrs: ng.IAttributes, active: boolean, activeCssClass: string, disableActive: boolean) {
+        if (activeCssClass){
+            if (active && !element.hasClass(activeCssClass))
+                attrs.$addClass(activeCssClass)
+            if (!active && element.hasClass(activeCssClass))
+                attrs.$removeClass(activeCssClass)
+        }
+        if (active && disableActive)
+            attrs.$set('href', null);
+    }
+
     static addListeners(element: ng.IAugmentedJQuery, setLink: () => void, lazy: boolean) {
         element.on('click', (e: JQueryEventObject) => {
             var anchor = <HTMLAnchorElement> element[0];

--- a/NavigationAngular/src/LinkUtility.ts
+++ b/NavigationAngular/src/LinkUtility.ts
@@ -31,12 +31,7 @@ class LinkUtility {
     }
 
     static setActive(element: ng.IAugmentedJQuery, attrs: ng.IAttributes, active: boolean, activeCssClass: string, disableActive: boolean) {
-        if (activeCssClass){
-            if (active && !element.hasClass(activeCssClass))
-                attrs.$addClass(activeCssClass)
-            if (!active && element.hasClass(activeCssClass))
-                attrs.$removeClass(activeCssClass)
-        }
+        element.toggleClass(activeCssClass, active);
         if (active && disableActive)
             attrs.$set('href', null);
     }

--- a/NavigationAngular/src/NavigationLink.ts
+++ b/NavigationAngular/src/NavigationLink.ts
@@ -6,24 +6,39 @@ var NavigationLink = () => {
     return {
         restrict: 'EA',
         link: (scope: ng.IScope, element: ng.IAugmentedJQuery, attrs: ng.IAttributes) => {
-            var action, toData, includeCurrentData, currentDataKeys;
-            LinkUtility.addListeners(element, () => setNavigationLink(element, attrs, action, toData, includeCurrentData, currentDataKeys), !!scope.$eval(attrs['lazy']))
-            var watchAttrs = [attrs['navigationLink'], attrs['toData'], attrs['includeCurrentData'], attrs['currentDataKeys']];
+            var action, toData, includeCurrentData, currentDataKeys, activeCssClass, disableActive;
+            LinkUtility.addListeners(element, () => setNavigationLink(element, attrs, action, toData, includeCurrentData, 
+                currentDataKeys, activeCssClass, disableActive), !!scope.$eval(attrs['lazy']))
+            var watchAttrs = [attrs['navigationLink'], attrs['toData'], attrs['includeCurrentData'], 
+                attrs['currentDataKeys'], attrs['activeCssClass'], attrs['disableActive']];
             scope.$watchGroup(watchAttrs, function (values) {
                 action = values[0];
                 toData = values[1];
                 includeCurrentData = values[2];
                 currentDataKeys = values[3];
-                setNavigationLink(element, attrs, action, toData, includeCurrentData, currentDataKeys);
+                activeCssClass = values[4];
+                disableActive = values[5];
+                setNavigationLink(element, attrs, action, toData, includeCurrentData, currentDataKeys, activeCssClass, disableActive);
             });
         }
     }
 };
 
 function setNavigationLink(element: ng.IAugmentedJQuery, attrs: ng.IAttributes,
-    action: string, toData: any, includeCurrentData: boolean, currentDataKeys: string) {
+    action: string, toData: any, includeCurrentData: boolean, currentDataKeys: string, activeCssClass: string, disableActive: boolean) {
+    var active = true;
+    for (var key in toData) {
+        active = active && LinkUtility.isActive(key, toData[key]);
+    }
     LinkUtility.setLink(element, attrs, () => Navigation.StateController.getNavigationLink(action,
         LinkUtility.getData(toData, includeCurrentData, currentDataKeys))
     );
+    active = active && !!attrs['href'] && isActive(action);
+    LinkUtility.setActive(element, attrs, active, activeCssClass, disableActive);
+}
+
+function isActive(action: string): boolean {
+    var nextState = Navigation.StateController.getNextState(action);
+    return nextState === nextState.parent.initial && nextState.parent === Navigation.StateContext.dialog;
 }
 export = NavigationLink;

--- a/NavigationAngular/src/RefreshLink.ts
+++ b/NavigationAngular/src/RefreshLink.ts
@@ -23,8 +23,14 @@ var RefreshLink = () => {
 
 function setRefreshLink(element: ng.IAugmentedJQuery, attrs: ng.IAttributes,
     toData: any, includeCurrentData: boolean, currentDataKeys: string, activeCssClass: string, disableActive: boolean) {
+    var active = true;
+    for (var key in toData) {
+        active = active && LinkUtility.isActive(key, toData[key]);
+    }
     LinkUtility.setLink(element, attrs, () => Navigation.StateController.getRefreshLink(
         LinkUtility.getData(toData, includeCurrentData, currentDataKeys))
     );
+    active = active && !!attrs['href'];
+    LinkUtility.setActive(element, attrs, active, activeCssClass, disableActive);
 }
 export = RefreshLink;

--- a/NavigationAngular/src/RefreshLink.ts
+++ b/NavigationAngular/src/RefreshLink.ts
@@ -6,21 +6,23 @@ var RefreshLink = () => {
     return {
         restrict: 'EA',
         link: (scope: ng.IScope, element: ng.IAugmentedJQuery, attrs: ng.IAttributes) => {
-            var toData, includeCurrentData, currentDataKeys;
-            LinkUtility.addListeners(element, () => setRefreshLink(element, attrs, toData, includeCurrentData, currentDataKeys), !!scope.$eval(attrs['lazy']));
-            var watchAttrs = [attrs['refreshLink'], attrs['includeCurrentData'], attrs['currentDataKeys']];
+            var toData, includeCurrentData, currentDataKeys, activeCssClass, disableActive;
+            LinkUtility.addListeners(element, () => setRefreshLink(element, attrs, toData, includeCurrentData, currentDataKeys, activeCssClass, disableActive), !!scope.$eval(attrs['lazy']));
+            var watchAttrs = [attrs['refreshLink'], attrs['includeCurrentData'], attrs['currentDataKeys'], attrs['activeCssClass'], attrs['disableActive']];
             scope.$watchGroup(watchAttrs, function (values) {
                 toData = values[0];
                 includeCurrentData = values[1];
                 currentDataKeys = values[2];
-                setRefreshLink(element, attrs, toData, includeCurrentData, currentDataKeys);
+                activeCssClass = values[3];
+                disableActive = values[4];
+                setRefreshLink(element, attrs, toData, includeCurrentData, currentDataKeys, activeCssClass, disableActive);
             });
         }
     }
 };
 
 function setRefreshLink(element: ng.IAugmentedJQuery, attrs: ng.IAttributes,
-    toData: any, includeCurrentData: boolean, currentDataKeys: string) {
+    toData: any, includeCurrentData: boolean, currentDataKeys: string, activeCssClass: string, disableActive: boolean) {
     LinkUtility.setLink(element, attrs, () => Navigation.StateController.getRefreshLink(
         LinkUtility.getData(toData, includeCurrentData, currentDataKeys))
     );

--- a/NavigationAngular/src/RefreshLink.ts
+++ b/NavigationAngular/src/RefreshLink.ts
@@ -7,8 +7,10 @@ var RefreshLink = () => {
         restrict: 'EA',
         link: (scope: ng.IScope, element: ng.IAugmentedJQuery, attrs: ng.IAttributes) => {
             var toData, includeCurrentData, currentDataKeys, activeCssClass, disableActive;
-            LinkUtility.addListeners(element, () => setRefreshLink(element, attrs, toData, includeCurrentData, currentDataKeys, activeCssClass, disableActive), !!scope.$eval(attrs['lazy']));
-            var watchAttrs = [attrs['refreshLink'], attrs['includeCurrentData'], attrs['currentDataKeys'], attrs['activeCssClass'], attrs['disableActive']];
+            LinkUtility.addListeners(element, () => setRefreshLink(element, attrs, toData, includeCurrentData, 
+                currentDataKeys, activeCssClass, disableActive), !!scope.$eval(attrs['lazy']));
+            var watchAttrs = [attrs['refreshLink'], attrs['includeCurrentData'], 
+                attrs['currentDataKeys'], attrs['activeCssClass'], attrs['disableActive']];
             scope.$watchGroup(watchAttrs, function (values) {
                 toData = values[0];
                 includeCurrentData = values[1];

--- a/NavigationKnockout/sample/app.html
+++ b/NavigationKnockout/sample/app.html
@@ -5,6 +5,7 @@
     <style>
         table{border-collapse:collapse;}table,td,th{border:1px #000 solid;}
         ul{list-style-type:none;padding:0;margin:0;}li{float:left;padding-right:3px;}
+        .active{font-weight:bold;}
     </style>
 </head>
 <body>
@@ -14,8 +15,8 @@
             <input id="name" data-bind="value: name, event: { blur: nameChange }" />
         </div>
         Page size
-        <a data-bind="refreshLink: { maximumRows: 5, startRowIndex: null }, includeCurrentData: true">5</a>
-        <a data-bind="refreshLink: { maximumRows: 10, startRowIndex: null }, includeCurrentData: true">10</a>
+        <a data-bind="refreshLink: { maximumRows: 5, startRowIndex: null }, includeCurrentData: true, activeCssClass: 'active'">5</a>
+        <a data-bind="refreshLink: { maximumRows: 10, startRowIndex: null }, includeCurrentData: true, activeCssClass: 'active'">10</a>
         <table>
             <thead>
                 <tr>
@@ -31,14 +32,10 @@
             </tbody>
         </table>
         <ul>
-            <li data-bind="if: previousVisible"><a data-bind="refreshLink: { startRowIndex: 0 }, includeCurrentData: true">First</a></li>
-            <li data-bind="if: previousVisible"><a data-bind="refreshLink: { startRowIndex: previous }, includeCurrentData: true">Previous</a></li>
-            <li data-bind="ifnot: previousVisible">First</li>
-            <li data-bind="ifnot: previousVisible">Previous</li>
-            <li data-bind="if: nextVisible"><a data-bind="refreshLink: { startRowIndex: next }, includeCurrentData: true">Next</a></li>
-            <li data-bind="if: nextVisible"><a data-bind="refreshLink: { startRowIndex: last }, includeCurrentData: true">Last</a></li>
-            <li data-bind="ifnot: nextVisible">Next</li>
-            <li data-bind="ifnot: nextVisible">Last</li>
+            <li><a data-bind="refreshLink: { startRowIndex: 0 }, includeCurrentData: true, disableActive: true">First</a></li>
+            <li><a data-bind="refreshLink: { startRowIndex: previous }, includeCurrentData: true, disableActive: true">Previous</a></li>
+            <li><a data-bind="refreshLink: { startRowIndex: next }, includeCurrentData: true, disableActive: true">Next</a></li>
+            <li><a data-bind="refreshLink: { startRowIndex: last }, includeCurrentData: true, disableActive: true">Last</a></li>
         </ul>
         Total Count <span data-bind="text: totalCount"></span>
     <!-- /ko -->

--- a/NavigationKnockout/sample/app.js
+++ b/NavigationKnockout/sample/app.js
@@ -7,9 +7,7 @@
 	self.people = ko.observableArray();
 	self.sortExpression = ko.observable();
 	self.previous = ko.observable();
-	self.previousVisible = ko.observable();
 	self.next = ko.observable();
-	self.nextVisible = ko.observable();
 	self.last = ko.observable();
 	self.totalCount = ko.observable();
 	self.nameChange = function () {
@@ -25,12 +23,14 @@
 		self.name(data.name);
 		self.people(people);
 		self.sortExpression(data.sortExpression.indexOf('DESC') === -1 ? 'Name DESC' : 'Name');
-		self.previous(data.startRowIndex - data.maximumRows);
-		self.previousVisible(self.previous() >= 0);
+		self.previous(Math.max(0, data.startRowIndex - data.maximumRows));
 		self.next(data.startRowIndex + data.maximumRows);
-		self.nextVisible(self.next() < totalRowCount);
 		var remainder = totalRowCount % data.maximumRows;
 		self.last(remainder != 0 ? totalRowCount - remainder : totalRowCount - data.maximumRows);
+		if (self.next() >= totalRowCount) {
+			self.next(data.startRowIndex);
+			self.last(data.startRowIndex);
+		}
 		self.totalCount(totalRowCount);
 	};
 	personStates.details.navigated = function (data) {

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -11,18 +11,11 @@ class LinkUtility {
     }
 
     static getData(toData, includeCurrentData, currentDataKeys) {
-        var data = {};
-        toData = ko.unwrap(toData);
-        for (var key in toData) {
-            data[key] = ko.unwrap(toData[key]);
-        }
-        includeCurrentData = ko.unwrap(includeCurrentData);
-        currentDataKeys = ko.unwrap(currentDataKeys);
         if (currentDataKeys)
-            data = Navigation.StateContext.includeCurrentData(data, currentDataKeys.trim().split(/\s*,\s*/));
+            toData = Navigation.StateContext.includeCurrentData(toData, currentDataKeys.trim().split(/\s*,\s*/));
         if (includeCurrentData)
-            data = Navigation.StateContext.includeCurrentData(data);
-        return data;
+            toData = Navigation.StateContext.includeCurrentData(toData);
+        return toData;
     }
     
     static isActive(key: string, val: any): boolean {

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -28,6 +28,13 @@ class LinkUtility {
         }
         return true;
     }
+    
+    static setActive(element: HTMLAnchorElement, active: boolean, activeCssClass: string, disableActive: boolean) {
+        active = active && !!element.href;
+        ko.utils.toggleDomNodeCssClass(element, activeCssClass, active)
+        if (active && disableActive)
+            element.removeAttribute('href');        
+    }
 
     static addListeners(element: HTMLAnchorElement, setLink: () => void, lazy: boolean) {
         ko.utils.registerEventHandler(element, 'click', (e: MouseEvent) => {

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -17,7 +17,7 @@ class LinkUtility {
             toData = Navigation.StateContext.includeCurrentData(toData);
         return toData;
     }
-    
+
     static isActive(key: string, val: any): boolean {
         if (!Navigation.StateContext.state)
             return false;
@@ -28,7 +28,7 @@ class LinkUtility {
         }
         return true;
     }
-    
+
     static setActive(element: HTMLAnchorElement, active: boolean, activeCssClass: string, disableActive: boolean) {
         ko.utils.toggleDomNodeCssClass(element, activeCssClass, active)
         if (active && disableActive)

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -30,7 +30,6 @@ class LinkUtility {
     }
     
     static setActive(element: HTMLAnchorElement, active: boolean, activeCssClass: string, disableActive: boolean) {
-        active = active && !!element.href;
         ko.utils.toggleDomNodeCssClass(element, activeCssClass, active)
         if (active && disableActive)
             element.removeAttribute('href');        

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -24,6 +24,17 @@ class LinkUtility {
             data = Navigation.StateContext.includeCurrentData(data);
         return data;
     }
+    
+    static isActive(key: string, val: any): boolean {
+        if (!Navigation.StateContext.state)
+            return false;
+        if (val != null && val.toString()) {
+            var trackTypes = Navigation.StateContext.state.trackTypes;
+            var currentVal = Navigation.StateContext.data[key];
+            return currentVal != null && (trackTypes ? val === currentVal : val.toString() == currentVal.toString());
+        }
+        return true;
+    }
 
     static addListeners(element: HTMLAnchorElement, setLink: () => void, lazy: boolean) {
         ko.utils.registerEventHandler(element, 'click', (e: MouseEvent) => {

--- a/NavigationKnockout/src/NavigationLink.ts
+++ b/NavigationKnockout/src/NavigationLink.ts
@@ -12,8 +12,14 @@ var NavigationLink = ko.bindingHandlers['navigationLink'] = {
 };
 
 function setNavigationLink(element: HTMLAnchorElement, valueAccessor: () => any, allBindings: KnockoutAllBindingsAccessor) {
+    var data = {};
+    var toData = ko.unwrap(allBindings.get('toData'));
+    toData = ko.unwrap(toData);
+    for (var key in toData) {
+        data[key] = ko.unwrap(toData[key]);
+    }
     LinkUtility.setLink(element, () => Navigation.StateController.getNavigationLink(ko.unwrap(valueAccessor()),
-        LinkUtility.getData(allBindings.get('toData'), allBindings.get('includeCurrentData'), allBindings.get('currentDataKeys')))
+        LinkUtility.getData(data, ko.unwrap(allBindings.get('includeCurrentData')), ko.unwrap(allBindings.get('currentDataKeys'))))
     );
 }
 export = NavigationLink;

--- a/NavigationKnockout/src/NavigationLink.ts
+++ b/NavigationKnockout/src/NavigationLink.ts
@@ -12,13 +12,18 @@ var NavigationLink = ko.bindingHandlers['navigationLink'] = {
 };
 
 function setNavigationLink(element: HTMLAnchorElement, valueAccessor: () => any, allBindings: KnockoutAllBindingsAccessor) {
+    var action = ko.unwrap(valueAccessor());
     var data = {};
     var toData = ko.unwrap(allBindings.get('toData'));
     toData = ko.unwrap(toData);
+    var nextState = Navigation.StateController.getNextState(action);
+    var active = nextState === nextState.parent.initial && nextState.parent === Navigation.StateContext.dialog;
     for (var key in toData) {
-        data[key] = ko.unwrap(toData[key]);
+        var val = ko.unwrap(toData[key]);
+        data[key] = val;
+        active = active && LinkUtility.isActive(key, val);
     }
-    LinkUtility.setLink(element, () => Navigation.StateController.getNavigationLink(ko.unwrap(valueAccessor()),
+    LinkUtility.setLink(element, () => Navigation.StateController.getNavigationLink(action,
         LinkUtility.getData(data, ko.unwrap(allBindings.get('includeCurrentData')), ko.unwrap(allBindings.get('currentDataKeys'))))
     );
 }

--- a/NavigationKnockout/src/NavigationLink.ts
+++ b/NavigationKnockout/src/NavigationLink.ts
@@ -15,7 +15,6 @@ function setNavigationLink(element: HTMLAnchorElement, valueAccessor: () => any,
     var action = ko.unwrap(valueAccessor());
     var data = {};
     var toData = ko.unwrap(allBindings.get('toData'));
-    toData = ko.unwrap(toData);
     var nextState = Navigation.StateController.getNextState(action);
     var active = nextState === nextState.parent.initial && nextState.parent === Navigation.StateContext.dialog;
     for (var key in toData) {

--- a/NavigationKnockout/src/NavigationLink.ts
+++ b/NavigationKnockout/src/NavigationLink.ts
@@ -15,8 +15,7 @@ function setNavigationLink(element: HTMLAnchorElement, valueAccessor: () => any,
     var action = ko.unwrap(valueAccessor());
     var data = {};
     var toData = ko.unwrap(allBindings.get('toData'));
-    var nextState = Navigation.StateController.getNextState(action);
-    var active = nextState === nextState.parent.initial && nextState.parent === Navigation.StateContext.dialog;
+    var active = true;
     for (var key in toData) {
         var val = ko.unwrap(toData[key]);
         data[key] = val;
@@ -25,6 +24,12 @@ function setNavigationLink(element: HTMLAnchorElement, valueAccessor: () => any,
     LinkUtility.setLink(element, () => Navigation.StateController.getNavigationLink(action,
         LinkUtility.getData(data, ko.unwrap(allBindings.get('includeCurrentData')), ko.unwrap(allBindings.get('currentDataKeys'))))
     );
+    active = active && !!element.href && isActive(action);
     LinkUtility.setActive(element, active, ko.unwrap(allBindings.get('activeCssClass')), ko.unwrap(allBindings.get('disableActive')));
+}
+
+function isActive(action: string): boolean {
+    var nextState = Navigation.StateController.getNextState(action);
+    return nextState === nextState.parent.initial && nextState.parent === Navigation.StateContext.dialog;
 }
 export = NavigationLink;

--- a/NavigationKnockout/src/NavigationLink.ts
+++ b/NavigationKnockout/src/NavigationLink.ts
@@ -25,5 +25,6 @@ function setNavigationLink(element: HTMLAnchorElement, valueAccessor: () => any,
     LinkUtility.setLink(element, () => Navigation.StateController.getNavigationLink(action,
         LinkUtility.getData(data, ko.unwrap(allBindings.get('includeCurrentData')), ko.unwrap(allBindings.get('currentDataKeys'))))
     );
+    LinkUtility.setActive(element, active, ko.unwrap(allBindings.get('activeCssClass')), ko.unwrap(allBindings.get('disableActive')));
 }
 export = NavigationLink;

--- a/NavigationKnockout/src/RefreshLink.ts
+++ b/NavigationKnockout/src/RefreshLink.ts
@@ -22,7 +22,7 @@ function setRefreshLink(element: HTMLAnchorElement, valueAccessor: () => any, al
         active = active && LinkUtility.isActive(key, val);
     }
     LinkUtility.setLink(element, () => Navigation.StateController.getRefreshLink(
-        LinkUtility.getData(valueAccessor(), allBindings.get('includeCurrentData'), allBindings.get('currentDataKeys')))
+        LinkUtility.getData(data, ko.unwrap(allBindings.get('includeCurrentData')), ko.unwrap(allBindings.get('currentDataKeys'))))
     );
 }
 export = RefreshLink;

--- a/NavigationKnockout/src/RefreshLink.ts
+++ b/NavigationKnockout/src/RefreshLink.ts
@@ -12,6 +12,19 @@ var RefreshLink = ko.bindingHandlers['refreshLink'] = {
 };
 
 function setRefreshLink(element: HTMLAnchorElement, valueAccessor: () => any, allBindings: KnockoutAllBindingsAccessor) {
+    var data = {};
+    var toData = valueAccessor();
+    toData = ko.unwrap(toData);
+    var trackTypes = Navigation.StateContext.state.trackTypes;
+    var active = true;
+    for (var key in toData) {
+        var val = ko.unwrap(toData[key]);
+        data[key] = val;
+        var currentVal = Navigation.StateContext.data[key];
+        if (val != null && val.toString()) {
+            active = active && currentVal != null && (trackTypes ? val !== currentVal : val.toString() != currentVal.toString());
+        }
+    }
     LinkUtility.setLink(element, () => Navigation.StateController.getRefreshLink(
         LinkUtility.getData(valueAccessor(), allBindings.get('includeCurrentData'), allBindings.get('currentDataKeys')))
     );

--- a/NavigationKnockout/src/RefreshLink.ts
+++ b/NavigationKnockout/src/RefreshLink.ts
@@ -23,6 +23,7 @@ function setRefreshLink(element: HTMLAnchorElement, valueAccessor: () => any, al
     LinkUtility.setLink(element, () => Navigation.StateController.getRefreshLink(
         LinkUtility.getData(data, ko.unwrap(allBindings.get('includeCurrentData')), ko.unwrap(allBindings.get('currentDataKeys'))))
     );
+    active = active && !!element.href;
     LinkUtility.setActive(element, active, ko.unwrap(allBindings.get('activeCssClass')), ko.unwrap(allBindings.get('disableActive')));
 }
 export = RefreshLink;

--- a/NavigationKnockout/src/RefreshLink.ts
+++ b/NavigationKnockout/src/RefreshLink.ts
@@ -23,5 +23,6 @@ function setRefreshLink(element: HTMLAnchorElement, valueAccessor: () => any, al
     LinkUtility.setLink(element, () => Navigation.StateController.getRefreshLink(
         LinkUtility.getData(data, ko.unwrap(allBindings.get('includeCurrentData')), ko.unwrap(allBindings.get('currentDataKeys'))))
     );
+    LinkUtility.setActive(element, active, ko.unwrap(allBindings.get('activeCssClass')), ko.unwrap(allBindings.get('disableActive')));
 }
 export = RefreshLink;

--- a/NavigationKnockout/src/RefreshLink.ts
+++ b/NavigationKnockout/src/RefreshLink.ts
@@ -15,14 +15,14 @@ function setRefreshLink(element: HTMLAnchorElement, valueAccessor: () => any, al
     var data = {};
     var toData = valueAccessor();
     toData = ko.unwrap(toData);
-    var trackTypes = Navigation.StateContext.state.trackTypes;
-    var active = true;
+    var active = !!Navigation.StateContext.state;
     for (var key in toData) {
         var val = ko.unwrap(toData[key]);
         data[key] = val;
-        if (val != null && val.toString()) {
+        if (active && val != null && val.toString()) {
+            var trackTypes = Navigation.StateContext.state.trackTypes;
             var currentVal = Navigation.StateContext.data[key];
-            active = active && currentVal != null && (trackTypes ? val !== currentVal : val.toString() != currentVal.toString());
+            active = active && currentVal != null && (trackTypes ? val === currentVal : val.toString() == currentVal.toString());
         }
     }
     LinkUtility.setLink(element, () => Navigation.StateController.getRefreshLink(

--- a/NavigationKnockout/src/RefreshLink.ts
+++ b/NavigationKnockout/src/RefreshLink.ts
@@ -15,15 +15,11 @@ function setRefreshLink(element: HTMLAnchorElement, valueAccessor: () => any, al
     var data = {};
     var toData = valueAccessor();
     toData = ko.unwrap(toData);
-    var active = !!Navigation.StateContext.state;
+    var active = true;
     for (var key in toData) {
         var val = ko.unwrap(toData[key]);
         data[key] = val;
-        if (active && val != null && val.toString()) {
-            var trackTypes = Navigation.StateContext.state.trackTypes;
-            var currentVal = Navigation.StateContext.data[key];
-            active = active && currentVal != null && (trackTypes ? val === currentVal : val.toString() == currentVal.toString());
-        }
+        active = active && LinkUtility.isActive(key, val);
     }
     LinkUtility.setLink(element, () => Navigation.StateController.getRefreshLink(
         LinkUtility.getData(valueAccessor(), allBindings.get('includeCurrentData'), allBindings.get('currentDataKeys')))

--- a/NavigationKnockout/src/RefreshLink.ts
+++ b/NavigationKnockout/src/RefreshLink.ts
@@ -20,8 +20,8 @@ function setRefreshLink(element: HTMLAnchorElement, valueAccessor: () => any, al
     for (var key in toData) {
         var val = ko.unwrap(toData[key]);
         data[key] = val;
-        var currentVal = Navigation.StateContext.data[key];
         if (val != null && val.toString()) {
+            var currentVal = Navigation.StateContext.data[key];
             active = active && currentVal != null && (trackTypes ? val !== currentVal : val.toString() != currentVal.toString());
         }
     }

--- a/NavigationKnockout/src/RefreshLink.ts
+++ b/NavigationKnockout/src/RefreshLink.ts
@@ -13,8 +13,7 @@ var RefreshLink = ko.bindingHandlers['refreshLink'] = {
 
 function setRefreshLink(element: HTMLAnchorElement, valueAccessor: () => any, allBindings: KnockoutAllBindingsAccessor) {
     var data = {};
-    var toData = valueAccessor();
-    toData = ko.unwrap(toData);
+    var toData = ko.unwrap(valueAccessor());
     var active = true;
     for (var key in toData) {
         var val = ko.unwrap(toData[key]);

--- a/NavigationReact/sample/app.html
+++ b/NavigationReact/sample/app.html
@@ -5,6 +5,7 @@
     <style>
         table{border-collapse:collapse;}table,td,th{border:1px #000 solid;}
         ul{list-style-type:none;padding:0;margin:0;}li{float:left;padding-right:3px;}
+        .active{font-weight:bold;}
     </style>
 </head>
 <body>
@@ -75,8 +76,8 @@
                             <input id="name" value={this.state.name} onChange={this.nameChange} onBlur={this.nameBlur} />
                         </div>
                         Page size&nbsp;
-                        <NavigationReact.RefreshLink toData={{ maximumRows: 5, startRowIndex: null }} includeCurrentData={true}>5</NavigationReact.RefreshLink>&nbsp;
-                        <NavigationReact.RefreshLink toData={{ maximumRows: 10, startRowIndex: null }} includeCurrentData={true}>10</NavigationReact.RefreshLink>
+                        <NavigationReact.RefreshLink toData={{ maximumRows: 5, startRowIndex: null }} includeCurrentData={true} activeCssClass="active">5</NavigationReact.RefreshLink>&nbsp;
+                        <NavigationReact.RefreshLink toData={{ maximumRows: 10, startRowIndex: null }} includeCurrentData={true} activeCssClass="active">10</NavigationReact.RefreshLink>
                     </div>
                 );
             }
@@ -89,28 +90,18 @@
             },
             render: function () {
                 var remainder = this.props.totalRowCount % this.props.maximumRows;
-                var previous = this.props.startRowIndex - this.props.maximumRows;
+                var previous = Math.max(0, this.props.startRowIndex - this.props.maximumRows);
                 var next = this.props.startRowIndex + this.props.maximumRows;
                 var last = remainder != 0 ? this.props.totalRowCount - remainder : this.props.totalRowCount - this.props.maximumRows;
-                var firstLink = 'First';
-                var previousLink = 'Previous';
-                var nextLink = 'Next';
-                var lastLink = 'Last';
-                if (previous >= 0){
-                    firstLink = <NavigationReact.RefreshLink toData={{ startRowIndex: 0 }} includeCurrentData={true}>First</NavigationReact.RefreshLink>;
-                    previousLink = <NavigationReact.RefreshLink toData={{ startRowIndex: previous }} includeCurrentData={true}>Previous</NavigationReact.RefreshLink>;
-                }
-                if (next < this.props.totalRowCount){
-                    nextLink = <NavigationReact.RefreshLink toData={{ startRowIndex: next }} includeCurrentData={true}>Next</NavigationReact.RefreshLink>;
-                    lastLink = <NavigationReact.RefreshLink toData={{ startRowIndex: last }} includeCurrentData={true}>Last</NavigationReact.RefreshLink>;
-                }
+                if (next >= this.props.totalRowCount)
+                    next = last = this.props.startRowIndex;
                 return (
                     <div>
                         <ul>
-                            <li>{firstLink}</li>
-                            <li>{previousLink}</li>
-                            <li>{nextLink}</li>
-                            <li>{lastLink}</li>
+                            <li><NavigationReact.RefreshLink toData={{ startRowIndex: 0 }} includeCurrentData={true} disableActive={true}>First</NavigationReact.RefreshLink></li>
+                            <li><NavigationReact.RefreshLink toData={{ startRowIndex: previous }} includeCurrentData={true} disableActive={true}>Previous</NavigationReact.RefreshLink></li>
+                            <li><NavigationReact.RefreshLink toData={{ startRowIndex: next }} includeCurrentData={true} disableActive={true}>Next</NavigationReact.RefreshLink></li>
+                            <li><NavigationReact.RefreshLink toData={{ startRowIndex: last }} includeCurrentData={true} disableActive={true}>Last</NavigationReact.RefreshLink></li>
                         </ul>
                         Total Count {this.props.totalRowCount}
                     </div>

--- a/NavigationReact/sample/app.html
+++ b/NavigationReact/sample/app.html
@@ -17,11 +17,11 @@
     <script src="../../build/dist/navigation.react.js"></script>
     <script type="text/jsx">
         var List = React.createClass({
-            shouldComponentUpdate: function(nextProps) {
+            shouldComponentUpdate(nextProps) {
                 return nextProps.startRowIndex !== this.props.startRowIndex || nextProps.maximumRows !== this.props.maximumRows
                     || nextProps.sortExpression !== this.props.sortExpression || nextProps.name !== this.props.name;
             },
-            render: function () {
+            render() {
                 var people = personSearch.search(this.props.name, this.props.sortExpression);
                 this.props.totalRowCount = people.length;
                 people = people.slice(this.props.startRowIndex, this.props.startRowIndex + this.props.maximumRows);
@@ -53,22 +53,22 @@
         });
 
         var Filter = React.createClass({
-            getInitialState: function() {
+            getInitialState() {
                 return {name: this.props.initialName};
             },
-            componentWillReceiveProps: function(nextProps) {
+            componentWillReceiveProps(nextProps) {
                 this.setState({ name: nextProps.initialName });
             },
-            shouldComponentUpdate: function(nextProps, nextState) {
+            shouldComponentUpdate(nextProps, nextState) {
                 return nextState.name !== this.state.name;
             }, 
-            nameChange: function(event) {
+            nameChange(event) {
                 this.setState({name: event.target.value});
             },
-            nameBlur: function (event) {
+            nameBlur(event) {
                 Navigation.StateController.refresh(Navigation.StateContext.includeCurrentData({ name: event.target.value, startRowIndex: null }));
             },
-            render: function () {
+            render() {
                 return (
                     <div>
                         <div>
@@ -84,11 +84,11 @@
         });
 
         var Pager = React.createClass({
-            shouldComponentUpdate: function(nextProps) {
+            shouldComponentUpdate(nextProps) {
                 return nextProps.startRowIndex !== this.props.startRowIndex || nextProps.maximumRows !== this.props.maximumRows
                     || nextProps.totalRowCount !== this.props.totalRowCount;
             },
-            render: function () {
+            render() {
                 var remainder = this.props.totalRowCount % this.props.maximumRows;
                 var previous = Math.max(0, this.props.startRowIndex - this.props.maximumRows);
                 var next = this.props.startRowIndex + this.props.maximumRows;
@@ -110,10 +110,10 @@
         });
 
         var Details = React.createClass({
-            shouldComponentUpdate: function(nextProps) {
+            shouldComponentUpdate(nextProps) {
                 return nextProps.id !== this.props.id;
             },
-            render: function () {
+            render() {
                 var person = personSearch.getDetails(this.props.id);
                 return (
                     <div>

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -39,10 +39,16 @@ class LinkUtility {
     static addListeners(component: React.Component<any, any>, props: any, getLink: () => string, lazy: boolean) {
         props.onClick = (e: MouseEvent) => {
             var element = <HTMLAnchorElement> React.findDOMNode(component);
-            if (lazy)
-                element.href = getLink();
+            var href = element.href;
+            if (lazy) {
+                href = getLink();
+                if (href)
+                    element.href = getLink();
+                else
+                    component.forceUpdate();
+            }
             if (!e.ctrlKey && !e.shiftKey && !e.metaKey && !e.altKey && !e.button) {
-                if (element.href) {
+                if (href) {
                     e.preventDefault();
                     Navigation.StateController.navigateLink(Navigation.settings.historyManager.getUrl(element));
                 }

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -17,6 +17,24 @@ class LinkUtility {
             toData = Navigation.StateContext.includeCurrentData(toData);
         return toData;
     }
+
+    static isActive(key: string, val: any): boolean {
+        if (!Navigation.StateContext.state)
+            return false;
+        if (val != null && val.toString()) {
+            var trackTypes = Navigation.StateContext.state.trackTypes;
+            var currentVal = Navigation.StateContext.data[key];
+            return currentVal != null && (trackTypes ? val === currentVal : val.toString() == currentVal.toString());
+        }
+        return true;
+    }
+
+    static setActive(props: any, active: boolean, activeCssClass: string, disableActive: boolean) {
+        if (activeCssClass)
+            props.className += (props.className ? ' ' : '') + activeCssClass;
+        if (active && disableActive)
+            props.href = null;        
+    }
     
     static addListeners(component: React.Component<any, any>, props: any, getLink: () => string, lazy: boolean) {
         props.onClick = (e: MouseEvent) => {

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -2,11 +2,11 @@
 import React = require('react');
 
 class LinkUtility {
-    static setLink(props: any, linkAccessor: () => string) {
+    static getLink(linkAccessor: () => string): string {
         try {
-            props.href = Navigation.settings.historyManager.getHref(linkAccessor());
+            return Navigation.settings.historyManager.getHref(linkAccessor());
         } catch (e) {
-            props.href = null;
+            return null;
         }
     }
 
@@ -18,18 +18,13 @@ class LinkUtility {
         return toData;
     }
     
-    static addListeners(component: React.Component<any, any>, props: any, setLink: () => void, lazy: boolean) {
+    static addListeners(component: React.Component<any, any>, props: any, getLink: () => string, lazy: boolean) {
         props.onClick = (e: MouseEvent) => {
             var element = <HTMLAnchorElement> React.findDOMNode(component);
-            if (lazy) {
-                setLink();
-                if (props.href)
-                    element.href = props.href;
-                else
-                    component.forceUpdate();
-            }
+            if (lazy)
+                element.href = getLink();
             if (!e.ctrlKey && !e.shiftKey && !e.metaKey && !e.altKey && !e.button) {
-                if (props.href) {
+                if (element.href) {
                     e.preventDefault();
                     Navigation.StateController.navigateLink(Navigation.settings.historyManager.getUrl(element));
                 }

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -30,8 +30,8 @@ class LinkUtility {
     }
 
     static setActive(props: any, active: boolean, activeCssClass: string, disableActive: boolean) {
-        if (activeCssClass)
-            props.className += (props.className ? ' ' : '') + activeCssClass;
+        if (active && activeCssClass)
+            props.className = !props.className ? activeCssClass : props.className + ' ' + activeCssClass;
         if (active && disableActive)
             props.href = null;        
     }

--- a/NavigationReact/src/NavigationBackLink.ts
+++ b/NavigationReact/src/NavigationBackLink.ts
@@ -3,24 +3,27 @@ import Navigation = require('navigation');
 import React = require('react');
 
 var NavigationBackLink = React.createClass({
-    onNavigate: function () {
+    onNavigate() {
         this.forceUpdate();
     },
-    setNavigationBackLink: function() {
-        LinkUtility.setLink(this.props, () => Navigation.StateController.getNavigationBackLink(this.props.distance));
+    getNavigationBackLink(): string {
+        return LinkUtility.getLink(() => Navigation.StateController.getNavigationBackLink(this.props.distance));
     },
-    componentDidMount: function () {
+    componentDidMount() {
         if (!this.props.lazy)
             Navigation.StateController.onNavigate(this.onNavigate);
     },
-    componentWillUnmount: function () {
+    componentWillUnmount() {
         if (!this.props.lazy)
             Navigation.StateController.offNavigate(this.onNavigate);
     },
-    render: function () {
-        this.setNavigationBackLink();
-        LinkUtility.addListeners(this, this.props, () => this.setNavigationBackLink(), !!this.props.lazy);
-        return React.createElement(this.props.href ? 'a' : 'span', this.props);
+    render() {
+        var props: any = {};
+        for(var key in this.props)
+            props[key] = this.props[key];
+        props.href = this.getNavigationBackLink();
+        LinkUtility.addListeners(this, props, () => this.setNavigationBackLink(), !!this.props.lazy);
+        return React.createElement(props.href ? 'a' : 'span', props);
     }
 });
 export = NavigationBackLink;

--- a/NavigationReact/src/NavigationBackLink.ts
+++ b/NavigationReact/src/NavigationBackLink.ts
@@ -22,7 +22,7 @@ var NavigationBackLink = React.createClass({
         for(var key in this.props)
             props[key] = this.props[key];
         props.href = this.getNavigationBackLink();
-        LinkUtility.addListeners(this, props, () => this.setNavigationBackLink(), !!this.props.lazy);
+        LinkUtility.addListeners(this, props, () => this.getNavigationBackLink(), !!this.props.lazy);
         return React.createElement(props.href ? 'a' : 'span', props);
     }
 });

--- a/NavigationReact/src/NavigationLink.ts
+++ b/NavigationReact/src/NavigationLink.ts
@@ -3,25 +3,28 @@ import Navigation = require('navigation');
 import React = require('react');
 
 var NavigationLink = React.createClass({
-    onNavigate: function () {
+    onNavigate() {
         this.forceUpdate();
     },
-    setNavigationLink: function() {
+    getNavigationLink(): string {
         var toData = LinkUtility.getData(this.props.toData, this.props.includeCurrentData, this.props.currentDataKeys);
-        LinkUtility.setLink(this.props, () => Navigation.StateController.getNavigationLink(this.props.action, toData));
+        return LinkUtility.getLink(() => Navigation.StateController.getNavigationLink(this.props.action, toData));
     },
-    componentDidMount: function () {
+    componentDidMount() {
         if (!this.props.lazy)
             Navigation.StateController.onNavigate(this.onNavigate);
     },
-    componentWillUnmount: function () {
+    componentWillUnmount() {
         if (!this.props.lazy)
             Navigation.StateController.offNavigate(this.onNavigate);
     },
-    render: function () {
-        this.setNavigationLink();
-        LinkUtility.addListeners(this, this.props, () => this.setNavigationLink(), !!this.props.lazy);
-        return React.createElement(this.props.href ? 'a' : 'span', this.props);
+    render() {
+        var props: any = {};
+        for(var key in this.props)
+            props[key] = this.props[key];
+        props.href = this.getNavigationLink();
+        LinkUtility.addListeners(this, props, () => this.setNavigationLink(), !!this.props.lazy);
+        return React.createElement(props.href ? 'a' : 'span', props);
     }
 });
 export = NavigationLink;

--- a/NavigationReact/src/NavigationLink.ts
+++ b/NavigationReact/src/NavigationLink.ts
@@ -31,7 +31,7 @@ var NavigationLink = React.createClass({
             active = active && LinkUtility.isActive(key, this.props.toData[key]);
         }
         props.href = this.getNavigationLink();
-        LinkUtility.addListeners(this, props, () => this.setNavigationLink(), !!this.props.lazy);
+        LinkUtility.addListeners(this, props, () => this.getNavigationLink(), !!this.props.lazy);
         active = active && !!props.href && this.isActive(this.props.action);
         LinkUtility.setActive(props, active, this.props.activeCssClass, this.props.disableActive);
         return React.createElement(props.href ? 'a' : 'span', props);

--- a/NavigationReact/src/NavigationLink.ts
+++ b/NavigationReact/src/NavigationLink.ts
@@ -10,6 +10,10 @@ var NavigationLink = React.createClass({
         var toData = LinkUtility.getData(this.props.toData, this.props.includeCurrentData, this.props.currentDataKeys);
         return LinkUtility.getLink(() => Navigation.StateController.getNavigationLink(this.props.action, toData));
     },
+    isActive(action: string): boolean {
+        var nextState = Navigation.StateController.getNextState(action);
+        return nextState === nextState.parent.initial && nextState.parent === Navigation.StateContext.dialog;
+    },
     componentDidMount() {
         if (!this.props.lazy)
             Navigation.StateController.onNavigate(this.onNavigate);
@@ -22,8 +26,14 @@ var NavigationLink = React.createClass({
         var props: any = {};
         for(var key in this.props)
             props[key] = this.props[key];
+        var active = true;
+        for (var key in this.props.toData) {
+            active = active && LinkUtility.isActive(key, this.props.toData[key]);
+        }
         props.href = this.getNavigationLink();
         LinkUtility.addListeners(this, props, () => this.setNavigationLink(), !!this.props.lazy);
+        active = active && !!props.href && this.isActive(this.props.action);
+        LinkUtility.setActive(props, active, this.props.activeCssClass, this.props.disableActive);
         return React.createElement(props.href ? 'a' : 'span', props);
     }
 });

--- a/NavigationReact/src/RefreshLink.ts
+++ b/NavigationReact/src/RefreshLink.ts
@@ -3,25 +3,28 @@ import Navigation = require('navigation');
 import React = require('react');
 
 var RefreshLink = React.createClass({
-    onNavigate: function () {
+    onNavigate() {
         this.forceUpdate();
     },
-    setRefreshLink: function() {
+    getRefreshLink(): string {
         var toData = LinkUtility.getData(this.props.toData, this.props.includeCurrentData, this.props.currentDataKeys);
-        LinkUtility.setLink(this.props, () => Navigation.StateController.getRefreshLink(toData));
+        return LinkUtility.getLink(() => Navigation.StateController.getRefreshLink(toData));
     },
-    componentDidMount: function () {
+    componentDidMount() {
         if (!this.props.lazy)
             Navigation.StateController.onNavigate(this.onNavigate);
     },
-    componentWillUnmount: function () {
+    componentWillUnmount() {
         if (!this.props.lazy)
             Navigation.StateController.offNavigate(this.onNavigate);
     },
-    render: function () {
-        this.setRefreshLink();
-        LinkUtility.addListeners(this, this.props, () => this.setRefreshLink(), !!this.props.lazy);
-        return React.createElement(this.props.href ? 'a' : 'span', this.props);
+    render() {
+        var props: any = {};
+        for(var key in this.props)
+            props[key] = this.props[key];
+        props.href = this.getRefreshLink();
+        LinkUtility.addListeners(this, props, () => this.getRefreshLink(), !!this.props.lazy);
+        return React.createElement(props.href ? 'a' : 'span', props);
     }
 });
 export = RefreshLink;

--- a/NavigationReact/src/RefreshLink.ts
+++ b/NavigationReact/src/RefreshLink.ts
@@ -22,8 +22,14 @@ var RefreshLink = React.createClass({
         var props: any = {};
         for(var key in this.props)
             props[key] = this.props[key];
+        var active = true;
+        for (var key in this.props.toData) {
+            active = active && LinkUtility.isActive(key, this.props.toData[key]);
+        }
         props.href = this.getRefreshLink();
         LinkUtility.addListeners(this, props, () => this.getRefreshLink(), !!this.props.lazy);
+        active = active && !!props.href;
+        LinkUtility.setActive(props, active, this.props.activeCssClass, this.props.disableActive);
         return React.createElement(props.href ? 'a' : 'span', props);
     }
 });


### PR DESCRIPTION
Added disableActive and activeCssClass properties to plugin's Refresh and Navigation links.

A Refresh link is considered active if it's toData is a subset of the current data. For example, if the toData  is { pageSize: 5 } and the current data is { pageSize: 5, pageNumber: 2 } then it's active. Empty toData is considered active. 

A Navigation link is considered active if it's toData is a subset of the current data and it's a Dialog navigation to the current Dialog. Think of an email application with inbox and sent folders and clicking a link goes to the mail details. Could model this as two Dialogs, one for inbox and one for sent, or as one Dialog with parameters for the folder. Checking the data as well as the current Dialog ensures the relevant folder link will be highlighted in both setups.

The active data check takes into account the State's trackTypes setting. If trackTypes is false, then === is used because '2' is different from 2. If trackTypes is true, then toString() the values before comparing because '2' is the same as 2.

Updated the code samples to use the active properties. The paging links use disableActive and the page size links use activeCssClass.