### PR TITLE
Changed lazy to update oncontextmenu

### DIFF
--- a/NavigationAngular/src/LinkUtility.ts
+++ b/NavigationAngular/src/LinkUtility.ts
@@ -52,7 +52,7 @@ class LinkUtility {
             Navigation.StateController.onNavigate(setLink);
             element.on('$destroy', () => Navigation.StateController.offNavigate(setLink));
         } else {
-            element.on('mousedown', (e) => setLink());
+            element.on('contextmenu', (e) => setLink());
         }
     }
 }

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -53,7 +53,7 @@ class LinkUtility {
             Navigation.StateController.onNavigate(setLink);
             ko.utils.domNodeDisposal.addDisposeCallback(element, () => Navigation.StateController.offNavigate(setLink));
         } else {
-            ko.utils.registerEventHandler(element, 'mousedown', (e: MouseEvent) => setLink());
+            ko.utils.registerEventHandler(element, 'contextmenu', (e: MouseEvent) => setLink());
         }
     }
 }

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -55,7 +55,7 @@ class LinkUtility {
             }
         };
         if (lazy)
-            props.onMouseDown = (e: MouseEvent) => component.forceUpdate();
+            props.onContextMenu = (e: MouseEvent) => component.forceUpdate();
     }
 }
 export = LinkUtility;

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -41,11 +41,10 @@ class LinkUtility {
             var element = <HTMLAnchorElement> React.findDOMNode(component);
             var href = element.href;
             if (lazy) {
+                component.forceUpdate();
                 href = getLink();
                 if (href)
                     element.href = getLink();
-                else
-                    component.forceUpdate();
             }
             if (!e.ctrlKey && !e.shiftKey && !e.metaKey && !e.altKey && !e.button) {
                 if (href) {


### PR DESCRIPTION
Need lazy links to update before the link is clicked. The onclick handles the left click. The mousedown was meant to handle the right click and open, but it didn't cater for the right click being triggered by the keyboard. Switched from mousedown to contextmenu.