### PR TITLE
Added click listeners to Navigation Links

### DIFF
--- a/NavigationAngular/src/LinkUtility.ts
+++ b/NavigationAngular/src/LinkUtility.ts
@@ -45,8 +45,8 @@ class LinkUtility {
             if (!e.ctrlKey && !e.shiftKey && !e.metaKey && !e.altKey && !e.button) {
                 if (anchor.href) {
                     var link = Navigation.settings.historyManager.getUrl(anchor);
-                    var navigating = this.getNavigating($parse, attrs, scope, link);
-                    if (navigating(e)) {
+                    var navigating = this.getNavigating($parse, attrs, scope);
+                    if (navigating(e, link)) {
                         e.preventDefault();
                         Navigation.StateController.navigateLink(link);
                     }
@@ -62,8 +62,8 @@ class LinkUtility {
         }
     }
 
-    static getNavigating($parse: ng.IParseService, attrs: ng.IAttributes, scope: ng.IScope, link: string): (e: JQueryEventObject) => boolean {
-        return (e: JQueryEventObject) => {
+    static getNavigating($parse: ng.IParseService, attrs: ng.IAttributes, scope: ng.IScope): (e: JQueryEventObject, link: string) => boolean {
+        return (e: JQueryEventObject, link: string) => {
             var listener = attrs['navigating'] ? $parse(attrs['navigating']) : null;
             if (listener)
                 return listener(scope, { $event: e, url: link });

--- a/NavigationAngular/src/LinkUtility.ts
+++ b/NavigationAngular/src/LinkUtility.ts
@@ -36,7 +36,8 @@ class LinkUtility {
             attrs.$set('href', null);
     }
 
-    static addListeners(element: ng.IAugmentedJQuery, setLink: () => void, lazy: boolean, scope: ng.IScope) {
+    static addListeners(element: ng.IAugmentedJQuery, setLink: () => void, attrs: ng.IAttributes, scope: ng.IScope) {
+        var lazy = !!scope.$eval(attrs['lazy']);
         element.on('click', (e: JQueryEventObject) => {
             var anchor = <HTMLAnchorElement> element[0];
             if (lazy)

--- a/NavigationAngular/src/LinkUtility.ts
+++ b/NavigationAngular/src/LinkUtility.ts
@@ -36,7 +36,7 @@ class LinkUtility {
             attrs.$set('href', null);
     }
 
-    static addListeners(element: ng.IAugmentedJQuery, setLink: () => void, lazy: boolean) {
+    static addListeners(element: ng.IAugmentedJQuery, setLink: () => void, lazy: boolean, scope: ng.IScope) {
         element.on('click', (e: JQueryEventObject) => {
             var anchor = <HTMLAnchorElement> element[0];
             if (lazy)
@@ -44,7 +44,7 @@ class LinkUtility {
             if (!e.ctrlKey && !e.shiftKey && !e.metaKey && !e.altKey && !e.button) {
                 if (anchor.href) {
                     e.preventDefault();
-                    Navigation.StateController.navigateLink(Navigation.settings.historyManager.getUrl(anchor));
+                    scope.$apply(() => Navigation.StateController.navigateLink(Navigation.settings.historyManager.getUrl(anchor)));
                 }
             }
         });

--- a/NavigationAngular/src/NavigationBackLink.ts
+++ b/NavigationAngular/src/NavigationBackLink.ts
@@ -2,12 +2,12 @@
 import Navigation = require('navigation');
 import angular = require('angular');
 
-var NavigationBackLink = () => {
+var NavigationBackLink = ($parse: ng.IParseService) => {
     return {
         restrict: 'EA',
         link: (scope: ng.IScope, element: ng.IAugmentedJQuery, attrs: ng.IAttributes) => {
             var distance;
-            LinkUtility.addListeners(element, () => setNavigationBackLink(element, attrs, distance), attrs, scope);
+            LinkUtility.addListeners(element, () => setNavigationBackLink(element, attrs, distance), $parse, attrs, scope);
             scope.$watch(attrs['navigationBackLink'], function (value) {
                 distance = value;
                 setNavigationBackLink(element, attrs, distance);

--- a/NavigationAngular/src/NavigationBackLink.ts
+++ b/NavigationAngular/src/NavigationBackLink.ts
@@ -7,7 +7,7 @@ var NavigationBackLink = () => {
         restrict: 'EA',
         link: (scope: ng.IScope, element: ng.IAugmentedJQuery, attrs: ng.IAttributes) => {
             var distance;
-            LinkUtility.addListeners(element, () => setNavigationBackLink(element, attrs, distance), !!scope.$eval(attrs['lazy']));
+            LinkUtility.addListeners(element, () => setNavigationBackLink(element, attrs, distance), !!scope.$eval(attrs['lazy']), scope);
             scope.$watch(attrs['navigationBackLink'], function (value) {
                 distance = value;
                 setNavigationBackLink(element, attrs, distance);

--- a/NavigationAngular/src/NavigationBackLink.ts
+++ b/NavigationAngular/src/NavigationBackLink.ts
@@ -7,7 +7,7 @@ var NavigationBackLink = () => {
         restrict: 'EA',
         link: (scope: ng.IScope, element: ng.IAugmentedJQuery, attrs: ng.IAttributes) => {
             var distance;
-            LinkUtility.addListeners(element, () => setNavigationBackLink(element, attrs, distance), !!scope.$eval(attrs['lazy']), scope);
+            LinkUtility.addListeners(element, () => setNavigationBackLink(element, attrs, distance), attrs, scope);
             scope.$watch(attrs['navigationBackLink'], function (value) {
                 distance = value;
                 setNavigationBackLink(element, attrs, distance);

--- a/NavigationAngular/src/NavigationLink.ts
+++ b/NavigationAngular/src/NavigationLink.ts
@@ -2,13 +2,13 @@
 import Navigation = require('navigation');
 import angular = require('angular');
 
-var NavigationLink = () => {
+var NavigationLink = ($parse: ng.IParseService) => {
     return {
         restrict: 'EA',
         link: (scope: ng.IScope, element: ng.IAugmentedJQuery, attrs: ng.IAttributes) => {
             var action, toData, includeCurrentData, currentDataKeys, activeCssClass, disableActive;
             LinkUtility.addListeners(element, () => setNavigationLink(element, attrs, action, toData, includeCurrentData, 
-                currentDataKeys, activeCssClass, disableActive), attrs, scope)
+                currentDataKeys, activeCssClass, disableActive), $parse, attrs, scope)
             var watchAttrs = [attrs['navigationLink'], attrs['toData'], attrs['includeCurrentData'], 
                 attrs['currentDataKeys'], attrs['activeCssClass'], attrs['disableActive']];
             scope.$watchGroup(watchAttrs, function (values) {

--- a/NavigationAngular/src/NavigationLink.ts
+++ b/NavigationAngular/src/NavigationLink.ts
@@ -8,7 +8,7 @@ var NavigationLink = () => {
         link: (scope: ng.IScope, element: ng.IAugmentedJQuery, attrs: ng.IAttributes) => {
             var action, toData, includeCurrentData, currentDataKeys, activeCssClass, disableActive;
             LinkUtility.addListeners(element, () => setNavigationLink(element, attrs, action, toData, includeCurrentData, 
-                currentDataKeys, activeCssClass, disableActive), !!scope.$eval(attrs['lazy']))
+                currentDataKeys, activeCssClass, disableActive), !!scope.$eval(attrs['lazy']), scope)
             var watchAttrs = [attrs['navigationLink'], attrs['toData'], attrs['includeCurrentData'], 
                 attrs['currentDataKeys'], attrs['activeCssClass'], attrs['disableActive']];
             scope.$watchGroup(watchAttrs, function (values) {

--- a/NavigationAngular/src/NavigationLink.ts
+++ b/NavigationAngular/src/NavigationLink.ts
@@ -8,7 +8,7 @@ var NavigationLink = () => {
         link: (scope: ng.IScope, element: ng.IAugmentedJQuery, attrs: ng.IAttributes) => {
             var action, toData, includeCurrentData, currentDataKeys, activeCssClass, disableActive;
             LinkUtility.addListeners(element, () => setNavigationLink(element, attrs, action, toData, includeCurrentData, 
-                currentDataKeys, activeCssClass, disableActive), !!scope.$eval(attrs['lazy']), scope)
+                currentDataKeys, activeCssClass, disableActive), attrs, scope)
             var watchAttrs = [attrs['navigationLink'], attrs['toData'], attrs['includeCurrentData'], 
                 attrs['currentDataKeys'], attrs['activeCssClass'], attrs['disableActive']];
             scope.$watchGroup(watchAttrs, function (values) {

--- a/NavigationAngular/src/RefreshLink.ts
+++ b/NavigationAngular/src/RefreshLink.ts
@@ -8,7 +8,7 @@ var RefreshLink = () => {
         link: (scope: ng.IScope, element: ng.IAugmentedJQuery, attrs: ng.IAttributes) => {
             var toData, includeCurrentData, currentDataKeys, activeCssClass, disableActive;
             LinkUtility.addListeners(element, () => setRefreshLink(element, attrs, toData, includeCurrentData, 
-                currentDataKeys, activeCssClass, disableActive), !!scope.$eval(attrs['lazy']));
+                currentDataKeys, activeCssClass, disableActive), !!scope.$eval(attrs['lazy']), scope);
             var watchAttrs = [attrs['refreshLink'], attrs['includeCurrentData'], 
                 attrs['currentDataKeys'], attrs['activeCssClass'], attrs['disableActive']];
             scope.$watchGroup(watchAttrs, function (values) {

--- a/NavigationAngular/src/RefreshLink.ts
+++ b/NavigationAngular/src/RefreshLink.ts
@@ -8,7 +8,7 @@ var RefreshLink = () => {
         link: (scope: ng.IScope, element: ng.IAugmentedJQuery, attrs: ng.IAttributes) => {
             var toData, includeCurrentData, currentDataKeys, activeCssClass, disableActive;
             LinkUtility.addListeners(element, () => setRefreshLink(element, attrs, toData, includeCurrentData, 
-                currentDataKeys, activeCssClass, disableActive), !!scope.$eval(attrs['lazy']), scope);
+                currentDataKeys, activeCssClass, disableActive), attrs, scope);
             var watchAttrs = [attrs['refreshLink'], attrs['includeCurrentData'], 
                 attrs['currentDataKeys'], attrs['activeCssClass'], attrs['disableActive']];
             scope.$watchGroup(watchAttrs, function (values) {

--- a/NavigationAngular/src/RefreshLink.ts
+++ b/NavigationAngular/src/RefreshLink.ts
@@ -2,13 +2,13 @@
 import Navigation = require('navigation');
 import angular = require('angular');
 
-var RefreshLink = () => {
+var RefreshLink = ($parse: ng.IParseService) => {
     return {
         restrict: 'EA',
         link: (scope: ng.IScope, element: ng.IAugmentedJQuery, attrs: ng.IAttributes) => {
             var toData, includeCurrentData, currentDataKeys, activeCssClass, disableActive;
             LinkUtility.addListeners(element, () => setRefreshLink(element, attrs, toData, includeCurrentData, 
-                currentDataKeys, activeCssClass, disableActive), attrs, scope);
+                currentDataKeys, activeCssClass, disableActive), $parse, attrs, scope);
             var watchAttrs = [attrs['refreshLink'], attrs['includeCurrentData'], 
                 attrs['currentDataKeys'], attrs['activeCssClass'], attrs['disableActive']];
             scope.$watchGroup(watchAttrs, function (values) {

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -43,8 +43,8 @@ class LinkUtility {
             if (!e.ctrlKey && !e.shiftKey && !e.metaKey && !e.altKey && !e.button) {
                 if (element.href) {
                     var link = Navigation.settings.historyManager.getUrl(element);
-                    var handled = this.getNavigating(allBindings, viewModel, link)(e);
-                    if (!handled) {
+                    var navigate = this.getNavigating(allBindings, viewModel, link)(e);
+                    if (navigate) {
                         if (e.preventDefault)
                             e.preventDefault();
                         else
@@ -68,7 +68,7 @@ class LinkUtility {
             var listener = ko.unwrap(allBindings.get('navigating'));
             if (listener)
                 return listener.call(viewModel, viewModel, e, link);
-            return false;
+            return true;
         }
     }
 }

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -67,7 +67,7 @@ class LinkUtility {
         return (e: MouseEvent) => {
             var listener = ko.unwrap(allBindings.get('navigating'));
             if (listener)
-                return listener.call(viewModel, e, link);
+                return listener.call(viewModel, viewModel, e, link);
             return true;
         }
     }

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -62,7 +62,7 @@ class LinkUtility {
             ko.utils.registerEventHandler(element, 'contextmenu', (e: MouseEvent) => setLink());
         }
     }
-    
+
     static getNavigating(allBindings: KnockoutAllBindingsAccessor, viewModel: any, link: string): (e: MouseEvent) => boolean {
         return (e: MouseEvent) => {
             var listener = ko.unwrap(allBindings.get('navigating'));

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -35,17 +35,20 @@ class LinkUtility {
             element.removeAttribute('href');        
     }
 
-    static addListeners(element: HTMLAnchorElement, setLink: () => void, lazy: boolean) {
+    static addListeners(element: HTMLAnchorElement, setLink: () => void, lazy: boolean, navigating?: (e: MouseEvent) => boolean) {
         ko.utils.registerEventHandler(element, 'click', (e: MouseEvent) => {
             if (lazy)
                 setLink();
             if (!e.ctrlKey && !e.shiftKey && !e.metaKey && !e.altKey && !e.button) {
                 if (element.href) {
-                    if (e.preventDefault)
-                        e.preventDefault();
-                    else
-                        e['returnValue'] = false;
-                    Navigation.StateController.navigateLink(Navigation.settings.historyManager.getUrl(element));
+                    var handled = navigating(e);
+                    if (!handled) {
+                        if (e.preventDefault)
+                            e.preventDefault();
+                        else
+                            e['returnValue'] = false;
+                        Navigation.StateController.navigateLink(Navigation.settings.historyManager.getUrl(element));
+                    }
                 }
             }
         });

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -35,13 +35,14 @@ class LinkUtility {
             element.removeAttribute('href');        
     }
 
-    static addListeners(element: HTMLAnchorElement, setLink: () => void, lazy: boolean, navigating?: (e: MouseEvent) => boolean) {
+    static addListeners(element: HTMLAnchorElement, setLink: () => void, allBindings: KnockoutAllBindingsAccessor, viewModel: any) {
+        var lazy = !!allBindings.get('lazy');
         ko.utils.registerEventHandler(element, 'click', (e: MouseEvent) => {
             if (lazy)
                 setLink();
             if (!e.ctrlKey && !e.shiftKey && !e.metaKey && !e.altKey && !e.button) {
                 if (element.href) {
-                    var handled = navigating(e);
+                    var handled = this.getNavigating(allBindings, viewModel)(e);
                     if (!handled) {
                         if (e.preventDefault)
                             e.preventDefault();
@@ -58,6 +59,15 @@ class LinkUtility {
         } else {
             ko.utils.registerEventHandler(element, 'mousedown', (e: MouseEvent) => setLink());
             ko.utils.registerEventHandler(element, 'contextmenu', (e: MouseEvent) => setLink());
+        }
+    }
+    
+    static getNavigating(allBindings: KnockoutAllBindingsAccessor, viewModel: any): (e: MouseEvent) => boolean {
+        return (e: MouseEvent) => {
+            var listener = ko.unwrap(allBindings.get('navigating'));
+            if (listener)
+                return listener.call(viewModel, viewModel, e);
+            return false;
         }
     }
 }

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -43,8 +43,8 @@ class LinkUtility {
             if (!e.ctrlKey && !e.shiftKey && !e.metaKey && !e.altKey && !e.button) {
                 if (element.href) {
                     var link = Navigation.settings.historyManager.getUrl(element);
-                    var navigate = this.getNavigating(allBindings, viewModel, link)(e);
-                    if (navigate) {
+                    var navigating = this.getNavigating(allBindings, viewModel, link);
+                    if (navigating(e)) {
                         if (e.preventDefault)
                             e.preventDefault();
                         else

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -43,8 +43,8 @@ class LinkUtility {
             if (!e.ctrlKey && !e.shiftKey && !e.metaKey && !e.altKey && !e.button) {
                 if (element.href) {
                     var link = Navigation.settings.historyManager.getUrl(element);
-                    var navigating = this.getNavigating(allBindings, viewModel, link);
-                    if (navigating(e)) {
+                    var navigating = this.getNavigating(allBindings, viewModel);
+                    if (navigating(e, link)) {
                         if (e.preventDefault)
                             e.preventDefault();
                         else
@@ -63,8 +63,8 @@ class LinkUtility {
         }
     }
 
-    static getNavigating(allBindings: KnockoutAllBindingsAccessor, viewModel: any, link: string): (e: MouseEvent) => boolean {
-        return (e: MouseEvent) => {
+    static getNavigating(allBindings: KnockoutAllBindingsAccessor, viewModel: any): (e: MouseEvent, link: string) => boolean {
+        return (e: MouseEvent, link: string) => {
             var listener = ko.unwrap(allBindings.get('navigating'));
             if (listener)
                 return listener.call(viewModel, viewModel, e, link);

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -67,7 +67,7 @@ class LinkUtility {
         return (e: MouseEvent) => {
             var listener = ko.unwrap(allBindings.get('navigating'));
             if (listener)
-                return listener.call(viewModel, viewModel, e, link);
+                return listener.call(viewModel, e, link);
             return true;
         }
     }

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -42,13 +42,14 @@ class LinkUtility {
                 setLink();
             if (!e.ctrlKey && !e.shiftKey && !e.metaKey && !e.altKey && !e.button) {
                 if (element.href) {
-                    var handled = this.getNavigating(allBindings, viewModel)(e);
+                    var link = Navigation.settings.historyManager.getUrl(element);
+                    var handled = this.getNavigating(allBindings, viewModel, link)(e);
                     if (!handled) {
                         if (e.preventDefault)
                             e.preventDefault();
                         else
                             e['returnValue'] = false;
-                        Navigation.StateController.navigateLink(Navigation.settings.historyManager.getUrl(element));
+                        Navigation.StateController.navigateLink(link);
                     }
                 }
             }
@@ -62,11 +63,11 @@ class LinkUtility {
         }
     }
     
-    static getNavigating(allBindings: KnockoutAllBindingsAccessor, viewModel: any): (e: MouseEvent) => boolean {
+    static getNavigating(allBindings: KnockoutAllBindingsAccessor, viewModel: any, link: string): (e: MouseEvent) => boolean {
         return (e: MouseEvent) => {
             var listener = ko.unwrap(allBindings.get('navigating'));
             if (listener)
-                return listener.call(viewModel, viewModel, e);
+                return listener.call(viewModel, viewModel, e, link);
             return false;
         }
     }

--- a/NavigationKnockout/src/NavigationBackLink.ts
+++ b/NavigationKnockout/src/NavigationBackLink.ts
@@ -3,8 +3,8 @@ import Navigation = require('navigation');
 import ko = require('knockout');
 
 var NavigationBackLink = ko.bindingHandlers['navigationBackLink'] = {
-    init: (element, valueAccessor: () => any, allBindings: KnockoutAllBindingsAccessor) => {
-        LinkUtility.addListeners(element, () => setNavigationBackLink(element, valueAccessor), !!allBindings.get('lazy'));
+    init: (element, valueAccessor: () => any, allBindings: KnockoutAllBindingsAccessor, viewModel: any) => {
+        LinkUtility.addListeners(element, () => setNavigationBackLink(element, valueAccessor), allBindings, viewModel);
     },
     update: (element, valueAccessor) => {
         setNavigationBackLink(element, valueAccessor);

--- a/NavigationKnockout/src/NavigationLink.ts
+++ b/NavigationKnockout/src/NavigationLink.ts
@@ -3,8 +3,14 @@ import Navigation = require('navigation');
 import ko = require('knockout');
 
 var NavigationLink = ko.bindingHandlers['navigationLink'] = {
-    init: (element, valueAccessor: () => any, allBindings: KnockoutAllBindingsAccessor) => {
-        LinkUtility.addListeners(element, () => setNavigationLink(element, valueAccessor, allBindings), !!allBindings.get('lazy'));
+    init: (element, valueAccessor: () => any, allBindings: KnockoutAllBindingsAccessor, viewModel: any) => {
+        var navigating = (e: MouseEvent) => {
+            var listener = ko.unwrap(allBindings.get('navigating'));
+            if (listener)
+                return listener.call(viewModel, viewModel, e);
+            return false;
+        }
+        LinkUtility.addListeners(element, () => setNavigationLink(element, valueAccessor, allBindings), !!allBindings.get('lazy'), navigating);
     },
     update: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
         setNavigationLink(element, valueAccessor, allBindings);

--- a/NavigationKnockout/src/NavigationLink.ts
+++ b/NavigationKnockout/src/NavigationLink.ts
@@ -4,13 +4,7 @@ import ko = require('knockout');
 
 var NavigationLink = ko.bindingHandlers['navigationLink'] = {
     init: (element, valueAccessor: () => any, allBindings: KnockoutAllBindingsAccessor, viewModel: any) => {
-        var navigating = (e: MouseEvent) => {
-            var listener = ko.unwrap(allBindings.get('navigating'));
-            if (listener)
-                return listener.call(viewModel, viewModel, e);
-            return false;
-        }
-        LinkUtility.addListeners(element, () => setNavigationLink(element, valueAccessor, allBindings), !!allBindings.get('lazy'), navigating);
+        LinkUtility.addListeners(element, () => setNavigationLink(element, valueAccessor, allBindings), allBindings, viewModel);
     },
     update: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
         setNavigationLink(element, valueAccessor, allBindings);

--- a/NavigationKnockout/src/RefreshLink.ts
+++ b/NavigationKnockout/src/RefreshLink.ts
@@ -4,13 +4,7 @@ import ko = require('knockout');
 
 var RefreshLink = ko.bindingHandlers['refreshLink'] = {
     init: (element, valueAccessor: () => any, allBindings: KnockoutAllBindingsAccessor, viewModel: any) => {
-        var navigating = (e: MouseEvent) => {
-            var listener = ko.unwrap(allBindings.get('navigating'));
-            if (listener)
-                return listener.call(viewModel, viewModel, e);
-            return false;
-        }
-        LinkUtility.addListeners(element, () => setRefreshLink(element, valueAccessor, allBindings), !!allBindings.get('lazy'), navigating);
+        LinkUtility.addListeners(element, () => setRefreshLink(element, valueAccessor, allBindings), allBindings, viewModel);
     },
     update: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
         setRefreshLink(element, valueAccessor, allBindings);

--- a/NavigationKnockout/src/RefreshLink.ts
+++ b/NavigationKnockout/src/RefreshLink.ts
@@ -3,8 +3,14 @@ import Navigation = require('navigation');
 import ko = require('knockout');
 
 var RefreshLink = ko.bindingHandlers['refreshLink'] = {
-    init: (element, valueAccessor: () => any, allBindings: KnockoutAllBindingsAccessor) => {
-        LinkUtility.addListeners(element, () => setRefreshLink(element, valueAccessor, allBindings), !!allBindings.get('lazy'));
+    init: (element, valueAccessor: () => any, allBindings: KnockoutAllBindingsAccessor, viewModel: any) => {
+        var navigating = (e: MouseEvent) => {
+            var listener = ko.unwrap(allBindings.get('navigating'));
+            if (listener)
+                return listener.call(viewModel, viewModel, e);
+            return false;
+        }
+        LinkUtility.addListeners(element, () => setRefreshLink(element, valueAccessor, allBindings), !!allBindings.get('lazy'), navigating);
     },
     update: (element, valueAccessor, allBindings: KnockoutAllBindingsAccessor) => {
         setRefreshLink(element, valueAccessor, allBindings);

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -45,7 +45,7 @@ class LinkUtility {
                 component.forceUpdate();
                 href = getLink();
                 if (href)
-                    element.href = getLink();
+                    element.href = href;
             }
             if (!e.ctrlKey && !e.shiftKey && !e.metaKey && !e.altKey && !e.button) {
                 if (href) {

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -36,8 +36,9 @@ class LinkUtility {
             props.href = null;        
     }
     
-    static addListeners(component: React.Component<any, any>, props: any, getLink: () => string, lazy: boolean) {
-        props.onClick = (e: MouseEvent) => {
+    static addListeners(component: React.Component<any, any>, props: any, getLink: () => string) {
+        var lazy = !!props.lazy;
+        props.onClick = (e: MouseEvent, domId: string) => {
             var element = <HTMLAnchorElement> React.findDOMNode(component);
             var href = element.href;
             if (lazy) {
@@ -48,13 +49,26 @@ class LinkUtility {
             }
             if (!e.ctrlKey && !e.shiftKey && !e.metaKey && !e.altKey && !e.button) {
                 if (href) {
-                    e.preventDefault();
-                    Navigation.StateController.navigateLink(Navigation.settings.historyManager.getUrl(element));
+                    var link = Navigation.settings.historyManager.getUrl(element);
+                    var navigating = this.getNavigating(props, domId, link);
+                    if (navigating(e)) {
+                        e.preventDefault();
+                        Navigation.StateController.navigateLink(link);
+                    }
                 }
             }
         };
         if (lazy)
             props.onContextMenu = (e: MouseEvent) => component.forceUpdate();
+    }
+
+    static getNavigating(props: any, domId: string, link: string): (e: MouseEvent) => boolean {
+        return (e: MouseEvent) => {
+            var listener = props.navigating;
+            if (listener)
+                return listener(e, domId, link);
+            return true;
+        }
     }
 }
 export = LinkUtility;

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -50,8 +50,8 @@ class LinkUtility {
             if (!e.ctrlKey && !e.shiftKey && !e.metaKey && !e.altKey && !e.button) {
                 if (href) {
                     var link = Navigation.settings.historyManager.getUrl(element);
-                    var navigating = this.getNavigating(props, domId, link);
-                    if (navigating(e)) {
+                    var navigating = this.getNavigating(props);
+                    if (navigating(e, domId, link)) {
                         e.preventDefault();
                         Navigation.StateController.navigateLink(link);
                     }
@@ -62,8 +62,8 @@ class LinkUtility {
             props.onContextMenu = (e: MouseEvent) => component.forceUpdate();
     }
 
-    static getNavigating(props: any, domId: string, link: string): (e: MouseEvent) => boolean {
-        return (e: MouseEvent) => {
+    static getNavigating(props: any): (e: MouseEvent, domId: string, link: string) => boolean {
+        return (e: MouseEvent, domId: string, link: string) => {
             var listener = props.navigating;
             if (listener)
                 return listener(e, domId, link);

--- a/NavigationReact/src/NavigationBackLink.ts
+++ b/NavigationReact/src/NavigationBackLink.ts
@@ -22,7 +22,7 @@ var NavigationBackLink = React.createClass({
         for(var key in this.props)
             props[key] = this.props[key];
         props.href = this.getNavigationBackLink();
-        LinkUtility.addListeners(this, props, () => this.getNavigationBackLink(), !!this.props.lazy);
+        LinkUtility.addListeners(this, props, () => this.getNavigationBackLink());
         return React.createElement(props.href ? 'a' : 'span', props);
     }
 });

--- a/NavigationReact/src/NavigationLink.ts
+++ b/NavigationReact/src/NavigationLink.ts
@@ -31,7 +31,7 @@ var NavigationLink = React.createClass({
             active = active && LinkUtility.isActive(key, this.props.toData[key]);
         }
         props.href = this.getNavigationLink();
-        LinkUtility.addListeners(this, props, () => this.getNavigationLink(), !!this.props.lazy);
+        LinkUtility.addListeners(this, props, () => this.getNavigationLink());
         active = active && !!props.href && this.isActive(this.props.action);
         LinkUtility.setActive(props, active, this.props.activeCssClass, this.props.disableActive);
         return React.createElement(props.href ? 'a' : 'span', props);

--- a/NavigationReact/src/RefreshLink.ts
+++ b/NavigationReact/src/RefreshLink.ts
@@ -27,7 +27,7 @@ var RefreshLink = React.createClass({
             active = active && LinkUtility.isActive(key, this.props.toData[key]);
         }
         props.href = this.getRefreshLink();
-        LinkUtility.addListeners(this, props, () => this.getRefreshLink(), !!this.props.lazy);
+        LinkUtility.addListeners(this, props, () => this.getRefreshLink());
         active = active && !!props.href;
         LinkUtility.setActive(props, active, this.props.activeCssClass, this.props.disableActive);
         return React.createElement(props.href ? 'a' : 'span', props);


### PR DESCRIPTION
Think of the twitter example, where clicking on someone's name in your timeline brings up a dialog and doesn't change the Url, but Ctrl+click will go to that person's timeline. Equivalent to overriding the the Navigation Links' default navigation.

Added a navigating attribute to the Navigation Links that acts like an onClick listener. The presence of a navigating listener cancels the navigation. To continue with the navigation return true from the listener. To cancel the hyperlink click preventDefault on the event passed in.

The parameters and 'this' context for the navigating listener are different across plugins. It's more important to honour the normal event listener parameters and context native to the library than to be consistent across plugins. For example, 'this' in the knockout plugin is the viewModel and in angular it's the scope. Added the Url as an extra parameter to all listeners to support continuing the navigation manually.
