### PR TITLE
Added old State details to StateContext

### DIFF
--- a/NavigationJS/src/CrumbTrailManager.ts
+++ b/NavigationJS/src/CrumbTrailManager.ts
@@ -79,7 +79,7 @@ class CrumbTrailManager {
             }
         }
         if (!settings.combineCrumbTrail && state.trackCrumbTrail && StateContext.state) {
-            if (!returnData && settings.trackPreviousData)
+            if (!returnData && settings.trackAllPreviousData)
                 returnData = StateContext.data;
             var returnDataString = ReturnDataManager.formatReturnData(StateContext.state, returnData);
             if (returnDataString)

--- a/NavigationJS/src/CrumbTrailManager.ts
+++ b/NavigationJS/src/CrumbTrailManager.ts
@@ -7,7 +7,6 @@ import StateContext = require('./StateContext');
 import StateInfoConfig = require('./config/StateInfoConfig');
 
 class CrumbTrailManager {
-    static returnData: any;
     static crumbTrail: string;
     static crumbTrailKey: string;
     private static CRUMB_1_SEP = '4_';
@@ -16,7 +15,7 @@ class CrumbTrailManager {
     static buildCrumbTrail(uncombined: boolean) {
         var crumbs = this.getCrumbs(false);
         if (uncombined)
-            crumbs.push(new Crumb(this.returnData, StateContext.previousState, this.getHref(StateContext.previousState, this.returnData, null), false));        
+            crumbs.push(new Crumb(StateContext.previousData, StateContext.previousState, this.getHref(StateContext.previousState, StateContext.previousData, null), false));        
         crumbs = StateContext.state.stateHandler.truncateCrumbTrail(StateContext.state, crumbs);
         if (settings.combineCrumbTrail)
             crumbs.push(new Crumb(StateContext.data, StateContext.state, this.getHref(StateContext.state, StateContext.data, null), false));

--- a/NavigationJS/src/CrumbTrailManager.ts
+++ b/NavigationJS/src/CrumbTrailManager.ts
@@ -15,10 +15,10 @@ class CrumbTrailManager {
     static buildCrumbTrail(uncombined: boolean) {
         var crumbs = this.getCrumbs(false);
         if (uncombined)
-            crumbs.push(new Crumb(StateContext.previousData, StateContext.previousState, this.getHref(StateContext.previousState, StateContext.previousData), false));        
+            crumbs.push(new Crumb(StateContext.previousData, StateContext.previousState, this.getHref(StateContext.previousState, StateContext.previousData, null), false));        
         crumbs = StateContext.state.stateHandler.truncateCrumbTrail(StateContext.state, crumbs);
         if (settings.combineCrumbTrail)
-            crumbs.push(new Crumb(StateContext.data, StateContext.state, this.getHref(StateContext.state, StateContext.data), false));
+            crumbs.push(new Crumb(StateContext.data, StateContext.state, this.getHref(StateContext.state, StateContext.data, null), false));
         crumbs.reverse();
         var trailString: string = '';
         for (var i = 0; i < crumbs.length; i++) {
@@ -45,7 +45,7 @@ class CrumbTrailManager {
             var nextTrailStart = trail.indexOf(this.CRUMB_1_SEP, 1);
             trail = nextTrailStart != -1 ? trail.substring(nextTrailStart) : '';
             if (!skipLatest) {
-                crumbTrailArray.push(new Crumb(navigationData, state, this.getHref(state, navigationData), setLast && last));
+                crumbTrailArray.push(new Crumb(navigationData, state, this.getHref(state, navigationData, null), setLast && last));
                 last = false;
             }
             skipLatest = false;
@@ -61,7 +61,7 @@ class CrumbTrailManager {
         return StateInfoConfig._dialogs[+ids[0]]._states[+ids[1]];
     }
 
-    static getHref(state: State, navigationData: any): string {
+    static getHref(state: State, navigationData: any, returnData: any): string {
         var data = {};
         data[settings.stateIdKey] = state.id;
         if (!settings.combineCrumbTrail && state.trackCrumbTrail && StateContext.state)
@@ -79,7 +79,9 @@ class CrumbTrailManager {
             }
         }
         if (!settings.combineCrumbTrail && state.trackCrumbTrail && StateContext.state) {
-            var returnDataString = ReturnDataManager.formatReturnData(StateContext.state, StateContext.data);
+            if (!returnData && settings.trackPreviousData)
+                returnData = StateContext.data;
+            var returnDataString = ReturnDataManager.formatReturnData(StateContext.state, returnData);
             if (returnDataString)
                 data[settings.returnDataKey] = returnDataString;
         }
@@ -89,7 +91,7 @@ class CrumbTrailManager {
     }
 
     static getRefreshHref(refreshData: any): string {
-        return this.getHref(StateContext.state, refreshData);
+        return this.getHref(StateContext.state, refreshData, null);
     }
 }
 export = CrumbTrailManager;

--- a/NavigationJS/src/CrumbTrailManager.ts
+++ b/NavigationJS/src/CrumbTrailManager.ts
@@ -79,7 +79,7 @@ class CrumbTrailManager {
             }
         }
         if (!settings.combineCrumbTrail && state.trackCrumbTrail && StateContext.state) {
-            if (!returnData && settings.trackAllPreviousData)
+            if (settings.trackAllPreviousData)
                 returnData = StateContext.data;
             var returnDataString = ReturnDataManager.formatReturnData(StateContext.state, returnData);
             if (returnDataString)

--- a/NavigationJS/src/CrumbTrailManager.ts
+++ b/NavigationJS/src/CrumbTrailManager.ts
@@ -15,10 +15,10 @@ class CrumbTrailManager {
     static buildCrumbTrail(uncombined: boolean) {
         var crumbs = this.getCrumbs(false);
         if (uncombined)
-            crumbs.push(new Crumb(StateContext.previousData, StateContext.previousState, this.getHref(StateContext.previousState, StateContext.previousData, null), false));        
+            crumbs.push(new Crumb(StateContext.previousData, StateContext.previousState, this.getHref(StateContext.previousState, StateContext.previousData), false));        
         crumbs = StateContext.state.stateHandler.truncateCrumbTrail(StateContext.state, crumbs);
         if (settings.combineCrumbTrail)
-            crumbs.push(new Crumb(StateContext.data, StateContext.state, this.getHref(StateContext.state, StateContext.data, null), false));
+            crumbs.push(new Crumb(StateContext.data, StateContext.state, this.getHref(StateContext.state, StateContext.data), false));
         crumbs.reverse();
         var trailString: string = '';
         for (var i = 0; i < crumbs.length; i++) {
@@ -45,7 +45,7 @@ class CrumbTrailManager {
             var nextTrailStart = trail.indexOf(this.CRUMB_1_SEP, 1);
             trail = nextTrailStart != -1 ? trail.substring(nextTrailStart) : '';
             if (!skipLatest) {
-                crumbTrailArray.push(new Crumb(navigationData, state, this.getHref(state, navigationData, null), setLast && last));
+                crumbTrailArray.push(new Crumb(navigationData, state, this.getHref(state, navigationData), setLast && last));
                 last = false;
             }
             skipLatest = false;
@@ -61,7 +61,7 @@ class CrumbTrailManager {
         return StateInfoConfig._dialogs[+ids[0]]._states[+ids[1]];
     }
 
-    static getHref(state: State, navigationData: any, returnData: any): string {
+    static getHref(state: State, navigationData: any): string {
         var data = {};
         data[settings.stateIdKey] = state.id;
         if (!settings.combineCrumbTrail && state.trackCrumbTrail && StateContext.state)
@@ -79,7 +79,7 @@ class CrumbTrailManager {
             }
         }
         if (!settings.combineCrumbTrail && state.trackCrumbTrail && StateContext.state) {
-            var returnDataString = ReturnDataManager.formatReturnData(StateContext.state, returnData);
+            var returnDataString = ReturnDataManager.formatReturnData(StateContext.state, StateContext.data);
             if (returnDataString)
                 data[settings.returnDataKey] = returnDataString;
         }
@@ -89,7 +89,7 @@ class CrumbTrailManager {
     }
 
     static getRefreshHref(refreshData: any): string {
-        return this.getHref(StateContext.state, refreshData, null);
+        return this.getHref(StateContext.state, refreshData);
     }
 }
 export = CrumbTrailManager;

--- a/NavigationJS/src/NavigationSettings.ts
+++ b/NavigationJS/src/NavigationSettings.ts
@@ -14,6 +14,6 @@ class NavigationSettings {
     crumbTrailKey: string = 'c3';
     applicationPath: string = '';
     combineCrumbTrail: boolean = false;
-    trackPreviousData: boolean = true;
+    trackAllPreviousData: boolean = true;
 }
 export = NavigationSettings;

--- a/NavigationJS/src/NavigationSettings.ts
+++ b/NavigationJS/src/NavigationSettings.ts
@@ -14,5 +14,6 @@ class NavigationSettings {
     crumbTrailKey: string = 'c3';
     applicationPath: string = '';
     combineCrumbTrail: boolean = false;
+    trackPreviousData: boolean = true;
 }
 export = NavigationSettings;

--- a/NavigationJS/src/StateContext.ts
+++ b/NavigationJS/src/StateContext.ts
@@ -4,6 +4,7 @@ import State = require('./config/State');
 class StateContext {
     static previousState: State;
     static previousDialog: Dialog;
+    static previousData: any;
     static state: State;
     static dialog: Dialog;
     static data: any;

--- a/NavigationJS/src/StateContext.ts
+++ b/NavigationJS/src/StateContext.ts
@@ -2,6 +2,9 @@
 import State = require('./config/State');
 
 class StateContext {
+    static oldState: State;
+    static oldDialog: Dialog;
+    static oldData: any;
     static previousState: State;
     static previousDialog: Dialog;
     static previousData: any;

--- a/NavigationJS/src/StateContext.ts
+++ b/NavigationJS/src/StateContext.ts
@@ -4,13 +4,13 @@ import State = require('./config/State');
 class StateContext {
     static oldState: State;
     static oldDialog: Dialog;
-    static oldData: any;
+    static oldData: any = {};
     static previousState: State;
     static previousDialog: Dialog;
-    static previousData: any;
+    static previousData: any = {};
     static state: State;
     static dialog: Dialog;
-    static data: any;
+    static data: any = {};
     static url: string;
 
     static includeCurrentData(data: any, keys?: string[]): any {

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -16,6 +16,9 @@ class StateController {
 
     static setStateContext(state: State, url: string) {
         try {
+            StateContext.oldState = StateContext.state;
+            StateContext.oldDialog = StateContext.dialog;
+            StateContext.oldData = StateContext.data;
             StateContext.state = state;
             StateContext.url = url;
             StateContext.dialog = state.parent;
@@ -35,6 +38,9 @@ class StateController {
     }
 
     static clearStateContext() {
+        StateContext.oldState = null;
+        StateContext.oldDialog = null;
+        StateContext.oldData = null;
         StateContext.previousState = null;
         StateContext.previousDialog = null;
         StateContext.previousData = null;

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -97,7 +97,7 @@ class StateController {
     }
 
     static getNavigationLink(action: string, toData?: any): string {
-        return CrumbTrailManager.getHref(this.getNextState(action), toData, StateContext.data);
+        return CrumbTrailManager.getHref(this.getNextState(action), toData);
     }
 
     static canNavigateBack(distance: number) {

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -97,7 +97,7 @@ class StateController {
     }
 
     static getNavigationLink(action: string, toData?: any): string {
-        return CrumbTrailManager.getHref(this.getNextState(action), toData);
+        return CrumbTrailManager.getHref(this.getNextState(action), toData, StateContext.data);
     }
 
     static canNavigateBack(distance: number) {

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -23,7 +23,7 @@ class StateController {
             StateContext.data = this.parseData(data, state);
             StateContext.previousState = null;
             StateContext.previousDialog = null;
-            CrumbTrailManager.returnData = {};
+            StateContext.previousData = {};
             CrumbTrailManager.crumbTrail = settings.crumbTrailPersister.load(data[settings.crumbTrailKey]);
             var uncombined = !!data[settings.previousStateIdKey];
             this.setPreviousStateContext(uncombined, data);
@@ -37,11 +37,11 @@ class StateController {
     static clearStateContext() {
         StateContext.previousState = null;
         StateContext.previousDialog = null;
+        StateContext.previousData = null;
         StateContext.state = null;
         StateContext.dialog = null;
         StateContext.data = null;
         StateContext.url = null;
-        CrumbTrailManager.returnData = null;
         CrumbTrailManager.crumbTrail = null;
         CrumbTrailManager.crumbTrailKey = null;
     }
@@ -52,13 +52,13 @@ class StateController {
             if (StateContext.previousState)
                 StateContext.previousDialog = StateContext.previousState.parent;
             if (data[settings.returnDataKey])
-                CrumbTrailManager.returnData = ReturnDataManager.parseReturnData(data[settings.returnDataKey], StateContext.previousState);
+                StateContext.previousData = ReturnDataManager.parseReturnData(data[settings.returnDataKey], StateContext.previousState);
         } else {
             var previousStateCrumb = CrumbTrailManager.getCrumbs(false).pop();
             if (previousStateCrumb){
                 StateContext.previousState = previousStateCrumb.state;
                 StateContext.previousDialog = StateContext.previousState.parent;
-                CrumbTrailManager.returnData = previousStateCrumb.data;
+                StateContext.previousData = previousStateCrumb.data;
             }
         }
     }

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -38,13 +38,13 @@ class StateController {
     static clearStateContext() {
         StateContext.oldState = null;
         StateContext.oldDialog = null;
-        StateContext.oldData = null;
+        StateContext.oldData = {};
         StateContext.previousState = null;
         StateContext.previousDialog = null;
-        StateContext.previousData = null;
+        StateContext.previousData = {};
         StateContext.state = null;
         StateContext.dialog = null;
-        StateContext.data = null;
+        StateContext.data = {};
         StateContext.url = null;
         CrumbTrailManager.crumbTrail = null;
         CrumbTrailManager.crumbTrailKey = null;

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -16,9 +16,7 @@ class StateController {
 
     static setStateContext(state: State, url: string) {
         try {
-            StateContext.oldState = StateContext.state;
-            StateContext.oldDialog = StateContext.dialog;
-            StateContext.oldData = StateContext.data;
+            this.setOldStateContext();
             StateContext.state = state;
             StateContext.url = url;
             StateContext.dialog = state.parent;
@@ -52,7 +50,16 @@ class StateController {
         CrumbTrailManager.crumbTrailKey = null;
     }
     
-    private static setPreviousStateContext(uncombined: boolean, data: any){
+    private static setOldStateContext() {
+        if (StateContext.state) {
+            StateContext.oldState = StateContext.state;
+            StateContext.oldDialog = StateContext.dialog;
+            StateContext.oldData = StateContext.data;
+            NavigationData.setDefaults(StateContext.oldData, StateContext.oldState.defaults);
+        }
+    }
+    
+    private static setPreviousStateContext(uncombined: boolean, data: any) {
         if (uncombined){
             StateContext.previousState = CrumbTrailManager.getState(data[settings.previousStateIdKey]);
             if (StateContext.previousState)

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -54,7 +54,7 @@ class StateController {
         if (StateContext.state) {
             StateContext.oldState = StateContext.state;
             StateContext.oldDialog = StateContext.dialog;
-            StateContext.oldData = StateContext.data;
+            StateContext.oldData = NavigationData.clone(StateContext.data);
             NavigationData.setDefaults(StateContext.oldData, StateContext.oldState.defaults);
         }
     }

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -587,6 +587,11 @@ declare module Navigation {
          * ReturnData should be part of the CrumbTrail
          */
         combineCrumbTrail: boolean;
+        /**
+         * Gets or sets a value indicating whether to track PreviousData when
+         * navigating back or refreshing and combineCrumbTrail is false 
+         */
+        trackAllPreviousData: boolean;
     }
 
     /**
@@ -596,6 +601,18 @@ declare module Navigation {
      */
     class StateContext {
         /**
+         * Gets the previously displayed State
+         */
+        static oldState: State;
+        /**
+         * Gets the parent of the OldState property
+         */
+        static oldDialog: Dialog;
+        /**
+         * Gets the NavigationData for the OldState
+         */
+        static oldData: any;
+        /**
          * Gets the State navigated away from to reach the current State
          */
         static previousState: State;
@@ -603,6 +620,10 @@ declare module Navigation {
          * Gets the parent of the PreviousState property
          */
         static previousDialog: Dialog;
+        /**
+         * Gets the NavigationData for the PreviousState
+         */
+        static previousData: any;
         /**
          * Gets the current State
          */
@@ -612,8 +633,7 @@ declare module Navigation {
          */
         static dialog: Dialog;
         /**
-         * Gets the NavigationData for the current State. It can be accessed.
-         * Will become the data stored in a Crumb when part of a crumb trail
+         * Gets the NavigationData for the current State
          */
         static data: any;
         /**

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -601,7 +601,7 @@ declare module Navigation {
      */
     class StateContext {
         /**
-         * Gets the State displayed before the current State
+         * Gets the State last displayed before the current State
          */
         static oldState: State;
         /**

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -609,7 +609,7 @@ declare module Navigation {
          */
         static oldDialog: Dialog;
         /**
-         * Gets the NavigationData for the OldState
+         * Gets the NavigationData for the previously displayed State
          */
         static oldData: any;
         /**
@@ -621,7 +621,7 @@ declare module Navigation {
          */
         static previousDialog: Dialog;
         /**
-         * Gets the NavigationData for the PreviousState
+         * Gets the NavigationData for the navigated away from State
          */
         static previousData: any;
         /**

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -601,7 +601,7 @@ declare module Navigation {
      */
     class StateContext {
         /**
-         * Gets the previously displayed State
+         * Gets the State displayed before the current State
          */
         static oldState: State;
         /**
@@ -609,7 +609,7 @@ declare module Navigation {
          */
         static oldDialog: Dialog;
         /**
-         * Gets the NavigationData for the previously displayed State
+         * Gets the NavigationData for the last displayed State
          */
         static oldData: any;
         /**

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -601,7 +601,7 @@ declare module Navigation {
      */
     class StateContext {
         /**
-         * Gets the State last displayed before the current State
+         * Gets the last State displayed before the current State
          */
         static oldState: State;
         /**

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -355,43 +355,6 @@ describe('Navigation Data', function () {
         }
     });
 
-    describe('Invalid Context Data Refresh', function() {
-        beforeEach(function() {
-            Navigation.StateInfoConfig.build([
-                { key: 'd', initial: 's', states: [
-                    { key: 's', route: 'r' }]}
-                ]);
-        });
-        var data = {};
-        data['s'] = 'Hello';
-        
-        describe('Navigate', function() {
-            beforeEach(function() {
-                Navigation.StateController.navigate('d');
-                Navigation.StateContext.data['item'] = new Date();
-                Navigation.StateController.refresh(data);
-            });
-            test();
-        });
-
-        describe('Navigate Link', function() {
-            beforeEach(function() {
-                var link = Navigation.StateController.getNavigationLink('d');
-                Navigation.StateController.navigateLink(link);
-                Navigation.StateContext.data['item'] = new Date();
-                link = Navigation.StateController.getRefreshLink(data);
-                Navigation.StateController.navigateLink(link);
-            });
-            test();
-        });
-
-        function test() {
-            it('should populate data', function () {
-                assert.strictEqual(Navigation.StateContext.data['s'], 'Hello');
-            });
-        }
-    });
-
     describe('Invalid Data Without Trail', function() {
         beforeEach(function() {
             Navigation.StateInfoConfig.build([
@@ -3665,6 +3628,100 @@ describe('Navigation Data', function () {
                 assert.strictEqual(Navigation.StateController.crumbs[1].data['string'], 'World');
                 assert.strictEqual(Navigation.StateController.crumbs[1].data['_bool'], true);
                 assert.strictEqual(Navigation.StateController.crumbs[1].data['number'], 0);
+            });
+        }
+    });
+
+    describe('Old and Previous Data Back', function() {
+        beforeEach(function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1' }]}
+                ]);
+         });
+        var data = {};
+        data['s'] = 'Hello';
+        data['t'] = 1;
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d');
+                Navigation.StateController.navigate('t', data);
+                Navigation.StateController.navigateBack(1);
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d');
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t', data);
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationBackLink(1);
+                Navigation.StateController.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate data', function () {
+                assert.strictEqual(Navigation.StateContext.oldData['s'], 'Hello');
+                assert.strictEqual(Navigation.StateContext.oldData['t'], 1);
+                assert.strictEqual(Navigation.StateContext.previousData['s'], 'Hello');
+                assert.strictEqual(Navigation.StateContext.previousData['t'], 1);
+                assert.strictEqual(Navigation.StateContext.data['s'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['t'], undefined);
+            });
+        }
+    });
+
+    describe('Old and Previous Data Refresh', function() {
+        beforeEach(function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1' }]}
+                ]);
+         });
+        var data = {};
+        data['s'] = 'Hello';
+        data['t'] = 1;
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d');
+                Navigation.StateController.navigate('t', data);
+                Navigation.StateController.refresh();
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d');
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t', data);
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getRefreshLink();
+                Navigation.StateController.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate data', function () {
+                assert.strictEqual(Navigation.StateContext.oldData['s'], 'Hello');
+                assert.strictEqual(Navigation.StateContext.oldData['t'], 1);
+                assert.strictEqual(Navigation.StateContext.previousData['s'], 'Hello');
+                assert.strictEqual(Navigation.StateContext.previousData['t'], 1);
+                assert.strictEqual(Navigation.StateContext.data['s'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['t'], undefined);
             });
         }
     });

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -3676,6 +3676,50 @@ describe('Navigation Data', function () {
         }
     });
 
+    describe('Navigate Previous Data Without Trail', function() {
+        beforeEach(function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1', trackCrumbTrail: false }]}
+                ]);
+         });
+        var data = {};
+        data['s'] = 'Hello';
+        data['t'] = 1;
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d', data);
+                Navigation.StateController.navigate('t');
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d', data);
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t');
+                Navigation.StateController.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate old and previous data', function () {
+                assert.strictEqual(Navigation.StateContext.oldData['s'], 'Hello');
+                assert.strictEqual(Navigation.StateContext.oldData['t'], 1);
+                assert.strictEqual(Navigation.StateContext.previousData['s'], undefined);
+                assert.strictEqual(Navigation.StateContext.previousData['t'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['s'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['t'], undefined);
+            });
+        }
+    });
+
     describe('Navigate Previous Data Back', function() {
         beforeEach(function() {
             Navigation.StateInfoConfig.build([
@@ -3717,6 +3761,53 @@ describe('Navigation Data', function () {
                 assert.strictEqual(Navigation.StateContext.oldData['t'], 1);
                 assert.strictEqual(Navigation.StateContext.previousData['s'], 'Hello');
                 assert.strictEqual(Navigation.StateContext.previousData['t'], 1);
+                assert.strictEqual(Navigation.StateContext.data['s'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['t'], undefined);
+            });
+        }
+    });
+
+    describe('Navigate Previous Data Back Without Trail', function() {
+        beforeEach(function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', trackCrumbTrail: false, transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1' }]}
+                ]);
+         });
+        var data = {};
+        data['s'] = 'Hello';
+        data['t'] = 1;
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d');
+                Navigation.StateController.navigate('t', data);
+                Navigation.StateController.navigateBack(1);
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d');
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t', data);
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationBackLink(1);
+                Navigation.StateController.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate old and previous data', function () {
+                assert.strictEqual(Navigation.StateContext.oldData['s'], 'Hello');
+                assert.strictEqual(Navigation.StateContext.oldData['t'], 1);
+                assert.strictEqual(Navigation.StateContext.previousData['s'], undefined);
+                assert.strictEqual(Navigation.StateContext.previousData['t'], undefined);
                 assert.strictEqual(Navigation.StateContext.data['s'], undefined);
                 assert.strictEqual(Navigation.StateContext.data['t'], undefined);
             });
@@ -3775,6 +3866,65 @@ describe('Navigation Data', function () {
                 assert.strictEqual(Navigation.StateContext.previousData['s'], 'World');
                 assert.strictEqual(Navigation.StateContext.previousData['t1'], undefined);
                 assert.strictEqual(Navigation.StateContext.previousData['t2'], 2);
+                assert.strictEqual(Navigation.StateContext.data['s'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['t1'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['t2'], undefined);
+            });
+        }
+    });
+
+    describe('Navigate Previous Data Back Two Without Trail', function() {
+        beforeEach(function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', trackCrumbTrail: false, transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1', transitions: [
+                        { key: 't', to: 's2' }
+                    ]},
+                    { key: 's2', route: 'r2' }]}
+                ]);
+         });
+        var data1 = {};
+        data1['s'] = 'Hello';
+        data1['t1'] = 1;
+        var data2 = {};
+        data2['s'] = 'World';
+        data2['t2'] = 2;
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d');
+                Navigation.StateController.navigate('t', data1);
+                Navigation.StateController.navigate('t', data2);
+                Navigation.StateController.navigateBack(2);
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d');
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t', data1);
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t', data2);
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationBackLink(2);
+                Navigation.StateController.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate old and previous data', function () {
+                assert.strictEqual(Navigation.StateContext.oldData['s'], 'World');
+                assert.strictEqual(Navigation.StateContext.oldData['t1'], undefined);
+                assert.strictEqual(Navigation.StateContext.oldData['t2'], 2);
+                assert.strictEqual(Navigation.StateContext.previousData['s'], undefined);
+                assert.strictEqual(Navigation.StateContext.previousData['t1'], undefined);
+                assert.strictEqual(Navigation.StateContext.previousData['t2'], undefined);
                 assert.strictEqual(Navigation.StateContext.data['s'], undefined);
                 assert.strictEqual(Navigation.StateContext.data['t1'], undefined);
                 assert.strictEqual(Navigation.StateContext.data['t2'], undefined);
@@ -3844,6 +3994,68 @@ describe('Navigation Data', function () {
         }
     });
 
+    describe('Navigate Previous Data One By One Without Trail', function() {
+        beforeEach(function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', trackCrumbTrail: false, transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1', transitions: [
+                        { key: 't', to: 's2' }
+                    ]},
+                    { key: 's2', route: 'r2' }]}
+                ]);
+         });
+        var data1 = {};
+        data1['s'] = 'Hello';
+        data1['t1'] = 1;
+        var data2 = {};
+        data2['s'] = 'World';
+        data2['t2'] = 2;
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d');
+                Navigation.StateController.navigate('t', data1);
+                Navigation.StateController.navigate('t', data2);
+                Navigation.StateController.navigateBack(1);
+                Navigation.StateController.navigateBack(1);
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d');
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t', data1);
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t', data2);
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationBackLink(1);
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationBackLink(1);
+                Navigation.StateController.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate old and previous data', function () {
+                assert.strictEqual(Navigation.StateContext.oldData['s'], 'Hello');
+                assert.strictEqual(Navigation.StateContext.oldData['t1'], 1);
+                assert.strictEqual(Navigation.StateContext.oldData['t2'], undefined);
+                assert.strictEqual(Navigation.StateContext.previousData['s'], undefined);
+                assert.strictEqual(Navigation.StateContext.previousData['t1'], undefined);
+                assert.strictEqual(Navigation.StateContext.previousData['t2'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['s'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['t2'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['t1'], undefined);
+            });
+        }
+    });
+
     describe('Navigate Previous Data Refresh', function() {
         beforeEach(function() {
             Navigation.StateInfoConfig.build([
@@ -3885,6 +4097,75 @@ describe('Navigation Data', function () {
                 assert.strictEqual(Navigation.StateContext.oldData['t'], 1);
                 assert.strictEqual(Navigation.StateContext.previousData['s'], 'Hello');
                 assert.strictEqual(Navigation.StateContext.previousData['t'], 1);
+                assert.strictEqual(Navigation.StateContext.data['s'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['t'], undefined);
+            });
+        }
+    });
+
+    describe('Link Defaults Navigate', function() {
+        it('should not include defaults in link', function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r', defaults: { 'string': 'Hello', _bool: true, 'number': 1 } }]}
+                ]);
+            var data = {};
+            data['_bool'] = null;
+            data['string'] = 'Hello';
+            data['number'] = 1;
+            Navigation.StateController.navigate('d');
+            var link = Navigation.StateController.getNavigationLink('t', data);
+            assert.equal(link.indexOf('string'), -1);
+            assert.equal(link.indexOf('_bool'), -1);
+            assert.equal(link.indexOf('number'), -1);
+            assert.notEqual(link.indexOf('r?'), -1);
+        });
+    });
+
+    describe('Navigate Previous Data Refresh Without Trail', function() {
+        beforeEach(function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1', trackCrumbTrail: false }]}
+                ]);
+         });
+        var data = {};
+        data['s'] = 'Hello';
+        data['t'] = 1;
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d');
+                Navigation.StateController.navigate('t', data);
+                Navigation.StateController.refresh();
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d');
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t', data);
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getRefreshLink();
+                Navigation.StateController.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate old and previous data', function () {
+                assert.strictEqual(Navigation.StateContext.oldData['s'], 'Hello');
+                assert.strictEqual(Navigation.StateContext.oldData['t'], 1);
+                assert.strictEqual(Navigation.StateContext.previousData['s'], undefined);
+                assert.strictEqual(Navigation.StateContext.previousData['t'], undefined);
                 assert.strictEqual(Navigation.StateContext.data['s'], undefined);
                 assert.strictEqual(Navigation.StateContext.data['t'], undefined);
             });

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -3632,7 +3632,7 @@ describe('Navigation Data', function () {
         }
     });
 
-    describe('Old and Previous Data Back', function() {
+    describe('Navigate Previous Data Back', function() {
         beforeEach(function() {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's0', states: [
@@ -3668,7 +3668,7 @@ describe('Navigation Data', function () {
         });
 
         function test() {
-            it('should populate data', function () {
+            it('should populate old and previous data', function () {
                 assert.strictEqual(Navigation.StateContext.oldData['s'], 'Hello');
                 assert.strictEqual(Navigation.StateContext.oldData['t'], 1);
                 assert.strictEqual(Navigation.StateContext.previousData['s'], 'Hello');
@@ -3679,7 +3679,7 @@ describe('Navigation Data', function () {
         }
     });
 
-    describe('Old and Previous Data Refresh', function() {
+    describe('Navigate Previous Data Refresh', function() {
         beforeEach(function() {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's0', states: [
@@ -3715,7 +3715,7 @@ describe('Navigation Data', function () {
         });
 
         function test() {
-            it('should populate data', function () {
+            it('should populate old and previous data', function () {
                 assert.strictEqual(Navigation.StateContext.oldData['s'], 'Hello');
                 assert.strictEqual(Navigation.StateContext.oldData['t'], 1);
                 assert.strictEqual(Navigation.StateContext.previousData['s'], 'Hello');

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -4215,6 +4215,114 @@ describe('Navigation Data', function () {
         }
     });
 
+    describe('Navigate Previous Data Defaults', function() {
+        beforeEach(function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1', defaults: { x: 2 }, transitions: [
+                        { key: 't', to: 's2' }
+                    ]},
+                    { key: 's2', route: 'r2' }]}
+                ]);
+         });
+        var data = {};
+        data['s'] = 'Hello';
+        data['t'] = 1;
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d');
+                Navigation.StateController.navigate('t', data);
+                Navigation.StateController.navigate('t');
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d');
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t', data);
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t');
+                Navigation.StateController.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate old and previous data', function () {
+                assert.strictEqual(Navigation.StateContext.oldData['s'], 'Hello');
+                assert.strictEqual(Navigation.StateContext.oldData['t'], 1);
+                assert.strictEqual(Navigation.StateContext.oldData['x'], 2);
+                assert.strictEqual(Navigation.StateContext.previousData['s'], 'Hello');
+                assert.strictEqual(Navigation.StateContext.previousData['t'], 1);
+                assert.strictEqual(Navigation.StateContext.previousData['x'], 2);
+                assert.strictEqual(Navigation.StateContext.data['s'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['t'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['x'], undefined);
+            });
+        }
+    });
+
+    describe('Navigate Previous Data Clear Defaults', function() {
+        beforeEach(function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1', defaults: { x: 2 }, transitions: [
+                        { key: 't', to: 's2' }
+                    ]},
+                    { key: 's2', route: 'r2' }]}
+                ]);
+         });
+        var data = {};
+        data['s'] = 'Hello';
+        data['t'] = 1;
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d');
+                Navigation.StateController.navigate('t', data);
+                Navigation.StateContext.data.x = null;
+                Navigation.StateController.navigate('t');
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d');
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t', data);
+                Navigation.StateController.navigateLink(link);
+                Navigation.StateContext.data.x = null;
+                link = Navigation.StateController.getNavigationLink('t');
+                Navigation.StateController.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate old and previous data', function () {
+                assert.strictEqual(Navigation.StateContext.oldData['s'], 'Hello');
+                assert.strictEqual(Navigation.StateContext.oldData['t'], 1);
+                assert.strictEqual(Navigation.StateContext.oldData['x'], 2);
+                assert.strictEqual(Navigation.StateContext.previousData['s'], 'Hello');
+                assert.strictEqual(Navigation.StateContext.previousData['t'], 1);
+                assert.strictEqual(Navigation.StateContext.previousData['x'], 2);
+                assert.strictEqual(Navigation.StateContext.data['s'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['t'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['x'], undefined);
+            });
+        }
+    });
+
     describe('Link Defaults Navigate', function() {
         it('should not include defaults in link', function() {
             Navigation.StateInfoConfig.build([

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -4103,28 +4103,6 @@ describe('Navigation Data', function () {
         }
     });
 
-    describe('Link Defaults Navigate', function() {
-        it('should not include defaults in link', function() {
-            Navigation.StateInfoConfig.build([
-                { key: 'd', initial: 's0', states: [
-                    { key: 's0', route: 'r0', transitions: [
-                        { key: 't', to: 's1' }
-                    ]},
-                    { key: 's1', route: 'r', defaults: { 'string': 'Hello', _bool: true, 'number': 1 } }]}
-                ]);
-            var data = {};
-            data['_bool'] = null;
-            data['string'] = 'Hello';
-            data['number'] = 1;
-            Navigation.StateController.navigate('d');
-            var link = Navigation.StateController.getNavigationLink('t', data);
-            assert.equal(link.indexOf('string'), -1);
-            assert.equal(link.indexOf('_bool'), -1);
-            assert.equal(link.indexOf('number'), -1);
-            assert.notEqual(link.indexOf('r?'), -1);
-        });
-    });
-
     describe('Navigate Previous Data Refresh Without Trail', function() {
         beforeEach(function() {
             Navigation.StateInfoConfig.build([
@@ -4170,6 +4148,28 @@ describe('Navigation Data', function () {
                 assert.strictEqual(Navigation.StateContext.data['t'], undefined);
             });
         }
+    });
+
+    describe('Link Defaults Navigate', function() {
+        it('should not include defaults in link', function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r', defaults: { 'string': 'Hello', _bool: true, 'number': 1 } }]}
+                ]);
+            var data = {};
+            data['_bool'] = null;
+            data['string'] = 'Hello';
+            data['number'] = 1;
+            Navigation.StateController.navigate('d');
+            var link = Navigation.StateController.getNavigationLink('t', data);
+            assert.equal(link.indexOf('string'), -1);
+            assert.equal(link.indexOf('_bool'), -1);
+            assert.equal(link.indexOf('number'), -1);
+            assert.notEqual(link.indexOf('r?'), -1);
+        });
     });
 
     describe('Link Defaults Navigate', function() {

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -4323,6 +4323,96 @@ describe('Navigation Data', function () {
         }
     });
 
+    describe('Navigate Previous Data Bookmarked Link', function() {
+        it('should populate old but not previous data', function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1', transitions: [
+                        { key: 't', to: 's2' }
+                    ]},
+                    { key: 's2', route: 'r2' }]}
+                ]);
+            var data = {};
+            data['s'] = 'Hello';
+            data['t'] = 1;
+            Navigation.StateController.navigate('d');
+            var link = Navigation.StateController.getNavigationLink('t'); 
+            Navigation.StateController.navigate('t', data);
+            Navigation.StateController.navigateLink(link);
+            assert.strictEqual(Navigation.StateContext.oldData['s'], 'Hello');
+            assert.strictEqual(Navigation.StateContext.oldData['t'], 1);
+            assert.strictEqual(Navigation.StateContext.previousData['s'], undefined);
+            assert.strictEqual(Navigation.StateContext.previousData['t'], undefined);
+            assert.strictEqual(Navigation.StateContext.data['s'], undefined);
+            assert.strictEqual(Navigation.StateContext.data['t'], undefined);
+        });
+    });
+
+    describe('Navigate Bookmarked Previous Data Link', function() {
+        it('should populate previous but not old data', function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1', transitions: [
+                        { key: 't', to: 's2' }
+                    ]},
+                    { key: 's2', route: 'r2' }]}
+                ]);
+            var data = {};
+            data['s'] = 'Hello';
+            data['t'] = 1;
+            Navigation.StateController.navigate('d', data);
+            var link = Navigation.StateController.getNavigationLink('t'); 
+            Navigation.StateController.navigate('t');
+            Navigation.StateController.navigateLink(link);
+            assert.strictEqual(Navigation.StateContext.oldData['s'], undefined);
+            assert.strictEqual(Navigation.StateContext.oldData['t'], undefined);
+            assert.strictEqual(Navigation.StateContext.previousData['s'], 'Hello');
+            assert.strictEqual(Navigation.StateContext.previousData['t'], 1);
+            assert.strictEqual(Navigation.StateContext.data['s'], undefined);
+            assert.strictEqual(Navigation.StateContext.data['t'], undefined);
+        });
+    });
+
+    describe('Navigate Previous Data Bookmarked Previous Data Link', function() {
+        it('should populate old and previous data', function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1', transitions: [
+                        { key: 't', to: 's2' }
+                    ]},
+                    { key: 's2', route: 'r2' }]}
+                ]);
+            var data1 = {};
+            data1['s'] = 'Hello';
+            data1['t1'] = 1;
+            var data2 = {};
+            data2['s'] = 'World';
+            data2['t2'] = 2;
+            Navigation.StateController.navigate('d', data1);
+            var link = Navigation.StateController.getNavigationLink('t'); 
+            Navigation.StateController.navigate('t', data2);
+            Navigation.StateController.navigateLink(link);
+            assert.strictEqual(Navigation.StateContext.oldData['s'], 'World');
+            assert.strictEqual(Navigation.StateContext.oldData['t1'], undefined);
+            assert.strictEqual(Navigation.StateContext.oldData['t2'], 2);
+            assert.strictEqual(Navigation.StateContext.previousData['s'], 'Hello');
+            assert.strictEqual(Navigation.StateContext.previousData['t1'], 1);
+            assert.strictEqual(Navigation.StateContext.previousData['t2'], undefined);
+            assert.strictEqual(Navigation.StateContext.data['s'], undefined);
+            assert.strictEqual(Navigation.StateContext.data['t1'], undefined);
+            assert.strictEqual(Navigation.StateContext.data['t2'], undefined);
+        });
+    });
+
     describe('Link Defaults Navigate', function() {
         it('should not include defaults in link', function() {
             Navigation.StateInfoConfig.build([

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -5202,10 +5202,17 @@ describe('Navigation Data', function () {
         
         function test(){
             it('should clear State context', function() {
+                function isEmpty(data) {
+                    var i = 0;
+                    for (var key in data) {
+                        i++;
+                    }
+                    return i === 0;
+                }
                 Navigation.StateController.clearStateContext();
-                assert.deepEqual(Navigation.StateContext.oldData, {});
-                assert.deepEqual(Navigation.StateContext.previousData, {});
-                assert.deepEqual(Navigation.StateContext.data, {});
+                assert.ok(isEmpty(Navigation.StateContext.oldData));
+                assert.ok(isEmpty(Navigation.StateContext.previousData));
+                assert.ok(isEmpty(Navigation.StateContext.data));
             });
         }
     });

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -3679,6 +3679,127 @@ describe('Navigation Data', function () {
         }
     });
 
+    describe('Navigate Previous Data Back Two', function() {
+        beforeEach(function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1', transitions: [
+                        { key: 't', to: 's2' }
+                    ]},
+                    { key: 's2', route: 'r2' }]}
+                ]);
+         });
+        var data1 = {};
+        data1['s'] = 'Hello';
+        data1['t1'] = 1;
+        var data2 = {};
+        data2['s'] = 'World';
+        data2['t2'] = 2;
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d');
+                Navigation.StateController.navigate('t', data1);
+                Navigation.StateController.navigate('t', data2);
+                Navigation.StateController.navigateBack(2);
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d');
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t', data1);
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t', data2);
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationBackLink(2);
+                Navigation.StateController.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate old and previous data', function () {
+                assert.strictEqual(Navigation.StateContext.oldData['s'], 'World');
+                assert.strictEqual(Navigation.StateContext.oldData['t1'], undefined);
+                assert.strictEqual(Navigation.StateContext.oldData['t2'], 2);
+                assert.strictEqual(Navigation.StateContext.previousData['s'], 'World');
+                assert.strictEqual(Navigation.StateContext.previousData['t1'], undefined);
+                assert.strictEqual(Navigation.StateContext.previousData['t2'], 2);
+                assert.strictEqual(Navigation.StateContext.data['s'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['t1'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['t2'], undefined);
+            });
+        }
+    });
+
+    describe('Navigate Previous Data One By One', function() {
+        beforeEach(function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1', transitions: [
+                        { key: 't', to: 's2' }
+                    ]},
+                    { key: 's2', route: 'r2' }]}
+                ]);
+         });
+        var data1 = {};
+        data1['s'] = 'Hello';
+        data1['t1'] = 1;
+        var data2 = {};
+        data2['s'] = 'World';
+        data2['t2'] = 2;
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d');
+                Navigation.StateController.navigate('t', data1);
+                Navigation.StateController.navigate('t', data2);
+                Navigation.StateController.navigateBack(1);
+                Navigation.StateController.navigateBack(1);
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d');
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t', data1);
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t', data2);
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationBackLink(1);
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationBackLink(1);
+                Navigation.StateController.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate old and previous data', function () {
+                assert.strictEqual(Navigation.StateContext.oldData['s'], 'Hello');
+                assert.strictEqual(Navigation.StateContext.oldData['t1'], 1);
+                assert.strictEqual(Navigation.StateContext.oldData['t2'], undefined);
+                assert.strictEqual(Navigation.StateContext.previousData['s'], 'Hello');
+                assert.strictEqual(Navigation.StateContext.previousData['t1'], 1);
+                assert.strictEqual(Navigation.StateContext.previousData['t2'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['s'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['t2'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['t1'], undefined);
+            });
+        }
+    });
+
     describe('Navigate Previous Data Refresh', function() {
         beforeEach(function() {
             Navigation.StateInfoConfig.build([

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -3632,6 +3632,50 @@ describe('Navigation Data', function () {
         }
     });
 
+    describe('Navigate Previous Data', function() {
+        beforeEach(function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1' }]}
+                ]);
+         });
+        var data = {};
+        data['s'] = 'Hello';
+        data['t'] = 1;
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d', data);
+                Navigation.StateController.navigate('t');
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d', data);
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t');
+                Navigation.StateController.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate old and previous data', function () {
+                assert.strictEqual(Navigation.StateContext.oldData['s'], 'Hello');
+                assert.strictEqual(Navigation.StateContext.oldData['t'], 1);
+                assert.strictEqual(Navigation.StateContext.previousData['s'], 'Hello');
+                assert.strictEqual(Navigation.StateContext.previousData['t'], 1);
+                assert.strictEqual(Navigation.StateContext.data['s'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['t'], undefined);
+            });
+        }
+    });
+
     describe('Navigate Previous Data Back', function() {
         beforeEach(function() {
             Navigation.StateInfoConfig.build([

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -4056,6 +4056,71 @@ describe('Navigation Data', function () {
         }
     });
 
+    describe('Navigate Previous Data One By One Custom Trail', function() {
+        beforeEach(function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd0', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1' }]},
+                { key: 'd1', initial: 's0', states: [
+                    { key: 's0', route: 'r2' }]}
+                ]);
+            var state = Navigation.StateInfoConfig.dialogs['d1'].states['s0'];
+            state.stateHandler.truncateCrumbTrail = (state: State, crumbs: Crumb[]): Crumb[] => {
+                return crumbs;
+            };
+         });
+        var data1 = {};
+        data1['s'] = 'Hello';
+        data1['t1'] = 1;
+        var data2 = {};
+        data2['s'] = 'World';
+        data2['t2'] = 2;
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d0');
+                Navigation.StateController.navigate('t', data1);
+                Navigation.StateController.navigate('d1', data2);
+                Navigation.StateController.navigateBack(1);
+                Navigation.StateController.navigateBack(1);
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d0');
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t', data1);
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('d1', data2);
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationBackLink(1);
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationBackLink(1);
+                Navigation.StateController.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate old and previous data', function () {
+                assert.strictEqual(Navigation.StateContext.oldData['s'], 'Hello');
+                assert.strictEqual(Navigation.StateContext.oldData['t1'], 1);
+                assert.strictEqual(Navigation.StateContext.oldData['t2'], undefined);
+                assert.strictEqual(Navigation.StateContext.previousData['s'], 'Hello');
+                assert.strictEqual(Navigation.StateContext.previousData['t1'], 1);
+                assert.strictEqual(Navigation.StateContext.previousData['t2'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['s'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['t2'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['t1'], undefined);
+            });
+        }
+    });
+
     describe('Navigate Previous Data Refresh', function() {
         beforeEach(function() {
             Navigation.StateInfoConfig.build([

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -1275,6 +1275,10 @@ describe('Navigation Data', function () {
 
         function test() {
             it('should populate data', function () {
+                assert.strictEqual(Navigation.StateContext.oldData['s'], 'Hello');
+                assert.strictEqual(Navigation.StateContext.oldData['n'], 5);
+                assert.strictEqual(Navigation.StateContext.previousData['s'], 'Hello');
+                assert.strictEqual(Navigation.StateContext.previousData['n'], 5);
                 assert.strictEqual(Navigation.StateController.crumbs[1].data['s'], 'Hello');
                 assert.strictEqual(Navigation.StateController.crumbs[1].data['n'], 5);
                 assert.strictEqual(Navigation.StateContext.data['s'], 'Hello');
@@ -1330,6 +1334,10 @@ describe('Navigation Data', function () {
 
         function test() {
             it('should populate data', function () {
+                assert.strictEqual(Navigation.StateContext.oldData['s'], 2);
+                assert.strictEqual(Navigation.StateContext.oldData['t'], '2');
+                assert.strictEqual(Navigation.StateContext.previousData['s'], 2);
+                assert.strictEqual(Navigation.StateContext.previousData['t'], '2');
                 assert.strictEqual(Navigation.StateController.crumbs[0].data['s'], 1);
                 assert.strictEqual(Navigation.StateController.crumbs[0].data['t'], undefined);
                 assert.strictEqual(Navigation.StateController.crumbs[1].data['s'], 2);
@@ -1383,6 +1391,8 @@ describe('Navigation Data', function () {
 
         function test() {
             it('should populate data', function () {
+                assert.strictEqual(Navigation.StateContext.oldData.s, '2');
+                assert.strictEqual(Navigation.StateContext.previousData.s, '2');
                 assert.strictEqual(Navigation.StateController.crumbs[0].data.s, 1);
                 assert.strictEqual(Navigation.StateController.crumbs[0].data['s'], 1);
                 assert.strictEqual(Navigation.StateController.crumbs[1].data.s, '2');
@@ -1446,6 +1456,10 @@ describe('Navigation Data', function () {
 
         function test() {
             it('should populate data', function () {
+                assert.strictEqual(Navigation.StateContext.oldData['s'], '22');
+                assert.strictEqual(Navigation.StateContext.oldData['t'], '2');
+                assert.strictEqual(Navigation.StateContext.previousData['s'], '22');
+                assert.strictEqual(Navigation.StateContext.previousData['t'], '2');
                 assert.strictEqual(Navigation.StateController.crumbs[0].data['s'], 11);
                 assert.strictEqual(Navigation.StateController.crumbs[0].data['t'], undefined);
                 assert.strictEqual(Navigation.StateController.crumbs[1].data['s'], '22');
@@ -2416,6 +2430,9 @@ describe('Navigation Data', function () {
 
         function test() {
             it('should populate data', function () {
+                assert.strictEqual(Navigation.StateContext.previousData['emptyString'], '');
+                assert.strictEqual(Navigation.StateContext.previousData['number'], 4);
+                assert.strictEqual(Navigation.StateContext.previousData['char'], 7);
                 assert.strictEqual(Navigation.StateController.crumbs[0].data['string'], undefined);
                 assert.strictEqual(Navigation.StateController.crumbs[0].data['_bool'], undefined);
                 assert.strictEqual(Navigation.StateController.crumbs[1].data['string'], 'Hello');
@@ -2471,6 +2488,9 @@ describe('Navigation Data', function () {
 
         function test() {
             it('should populate data', function () {
+                assert.strictEqual(Navigation.StateContext.previousData['emptyString'], '');
+                assert.strictEqual(Navigation.StateContext.previousData['number'], 4);
+                assert.strictEqual(Navigation.StateContext.previousData['char'], 7);
                 assert.strictEqual(Navigation.StateController.crumbs[0].data['string'], undefined);
                 assert.strictEqual(Navigation.StateController.crumbs[0].data['_bool'], undefined);
                 assert.strictEqual(Navigation.StateController.crumbs[1].data['string'], 'Hello');
@@ -2521,6 +2541,9 @@ describe('Navigation Data', function () {
 
         function test() {
             it('should populate data', function () {
+                assert.strictEqual(Navigation.StateContext.previousData['number'], 1);
+                assert.strictEqual(Navigation.StateContext.previousData['s'], 1);
+                assert.strictEqual(Navigation.StateContext.previousData['t'], '2');
                 assert.strictEqual(Navigation.StateController.crumbs[0].data['string'], undefined);
                 assert.strictEqual(Navigation.StateController.crumbs[0].data['s'], undefined);
                 assert.strictEqual(Navigation.StateController.crumbs[1].data['string'], 'Hello');
@@ -2570,6 +2593,11 @@ describe('Navigation Data', function () {
 
         function test() {
             it('should populate data', function () {
+                assert.strictEqual(Navigation.StateContext.previousData['string'], 'Hello');
+                assert.strictEqual(Navigation.StateContext.previousData['_bool'], true);
+                assert.strictEqual(Navigation.StateContext.previousData['number'], 1);
+                assert.strictEqual(Navigation.StateContext.previousData['s'], 1);
+                assert.strictEqual(Navigation.StateContext.previousData['t'], '2');
                 assert.strictEqual(Navigation.StateController.crumbs[0].data['string'], undefined);
                 assert.strictEqual(Navigation.StateController.crumbs[0].data['s'], undefined);
                 assert.strictEqual(Navigation.StateController.crumbs[1].data['string'], 'Hello');
@@ -2621,6 +2649,9 @@ describe('Navigation Data', function () {
 
         function test() {
             it('should populate data', function () {
+                assert.strictEqual(Navigation.StateContext.previousData['string'], 'World');
+                assert.strictEqual(Navigation.StateContext.previousData['_bool'], true);
+                assert.strictEqual(Navigation.StateContext.previousData['number'], 0);
                 assert.strictEqual(Navigation.StateController.crumbs[1].data['string'], 'World');
                 assert.strictEqual(Navigation.StateController.crumbs[1].data['_bool'], true);
                 assert.strictEqual(Navigation.StateController.crumbs[1].data['number'], 0);
@@ -2668,6 +2699,9 @@ describe('Navigation Data', function () {
 
         function test() {
             it('should populate data', function () {
+                assert.strictEqual(Navigation.StateContext.previousData['string'], 'World');
+                assert.strictEqual(Navigation.StateContext.previousData['_bool'], true);
+                assert.strictEqual(Navigation.StateContext.previousData['number'], 0);
                 assert.strictEqual(Navigation.StateController.crumbs[1].data['string'], 'World');
                 assert.strictEqual(Navigation.StateController.crumbs[1].data['_bool'], true);
                 assert.strictEqual(Navigation.StateController.crumbs[1].data['number'], 0);
@@ -2716,6 +2750,9 @@ describe('Navigation Data', function () {
                 var crumb = Navigation.StateController.crumbs[1];
                 crumb.data['string'] = 'Hello';
                 crumb.data['number'] = 0;
+                assert.strictEqual(Navigation.StateContext.previousData['string'], 'Hello');
+                assert.strictEqual(Navigation.StateContext.previousData['_bool'], true);
+                assert.strictEqual(Navigation.StateContext.previousData['number'], 1);
                 assert.strictEqual(Navigation.StateController.crumbs[1].data['string'], 'Hello');
                 assert.strictEqual(Navigation.StateController.crumbs[1].data['_bool'], true);
                 assert.strictEqual(Navigation.StateController.crumbs[1].data['number'], 0);
@@ -2764,6 +2801,9 @@ describe('Navigation Data', function () {
                 var crumb = Navigation.StateController.crumbs[1];
                 crumb.data['string'] = 'Hello';
                 crumb.data['number'] = 0;
+                assert.strictEqual(Navigation.StateContext.previousData['string'], 'Hello');
+                assert.strictEqual(Navigation.StateContext.previousData['_bool'], true);
+                assert.strictEqual(Navigation.StateContext.previousData['number'], 1);
                 assert.strictEqual(Navigation.StateController.crumbs[1].data['string'], 'Hello');
                 assert.strictEqual(Navigation.StateController.crumbs[1].data['_bool'], true);
                 assert.strictEqual(Navigation.StateController.crumbs[1].data['number'], 0);

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -4405,5 +4405,43 @@ describe('Navigation Data', function () {
             assert.strictEqual(Navigation.StateContext.data.y[2], '4');
         });
     });
+
+    describe('Clear State Context', function() {
+        beforeEach(function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'r' }]}
+                ]);
+        });
+        var data = {};
+        data['s'] = 'Hello';
+
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d', data);
+                Navigation.StateController.refresh(data);
+            });
+            test();
+        });
+        
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d', data);
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getRefreshLink(data);
+                Navigation.StateController.navigateLink(link);
+            });            
+            test();
+        });
+        
+        function test(){
+            it('should clear State context', function() {
+                Navigation.StateController.clearStateContext();
+                assert.deepEqual(Navigation.StateContext.oldData, {});
+                assert.deepEqual(Navigation.StateContext.previousData, {});
+                assert.deepEqual(Navigation.StateContext.data, {});
+            });
+        }
+    });
 });
 });

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -3709,7 +3709,7 @@ describe('Navigation Data', function () {
         });
 
         function test() {
-            it('should populate old and previous data', function () {
+            it('should populate old but not previous data', function () {
                 assert.strictEqual(Navigation.StateContext.oldData['s'], 'Hello');
                 assert.strictEqual(Navigation.StateContext.oldData['t'], 1);
                 assert.strictEqual(Navigation.StateContext.previousData['s'], undefined);
@@ -3803,7 +3803,7 @@ describe('Navigation Data', function () {
         });
 
         function test() {
-            it('should populate old and previous data', function () {
+            it('should populate old but not previous data', function () {
                 assert.strictEqual(Navigation.StateContext.oldData['s'], 'Hello');
                 assert.strictEqual(Navigation.StateContext.oldData['t'], 1);
                 assert.strictEqual(Navigation.StateContext.previousData['s'], undefined);
@@ -3918,7 +3918,7 @@ describe('Navigation Data', function () {
         });
 
         function test() {
-            it('should populate old and previous data', function () {
+            it('should populate old but not previous data', function () {
                 assert.strictEqual(Navigation.StateContext.oldData['s'], 'World');
                 assert.strictEqual(Navigation.StateContext.oldData['t1'], undefined);
                 assert.strictEqual(Navigation.StateContext.oldData['t2'], 2);
@@ -4042,7 +4042,7 @@ describe('Navigation Data', function () {
         });
 
         function test() {
-            it('should populate old and previous data', function () {
+            it('should populate old but not previous data', function () {
                 assert.strictEqual(Navigation.StateContext.oldData['s'], 'Hello');
                 assert.strictEqual(Navigation.StateContext.oldData['t1'], 1);
                 assert.strictEqual(Navigation.StateContext.oldData['t2'], undefined);
@@ -4204,7 +4204,7 @@ describe('Navigation Data', function () {
         });
 
         function test() {
-            it('should populate old and previous data', function () {
+            it('should populate old but not previous data', function () {
                 assert.strictEqual(Navigation.StateContext.oldData['s'], 'Hello');
                 assert.strictEqual(Navigation.StateContext.oldData['t'], 1);
                 assert.strictEqual(Navigation.StateContext.previousData['s'], undefined);

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -2159,7 +2159,7 @@ describe('Navigation', function () {
     });
 
     describe('Bookmarked Link Navigate', function() {
-        it ('should return to State', function() {
+        it ('should populate old and previous States', function() {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's0', states: [
                     { key: 's0', route: 'r0', transitions: [
@@ -2182,7 +2182,7 @@ describe('Navigation', function () {
     });
 
     describe('Bookmarked Link Without Trail Navigate', function() {
-        it ('should return to State', function() {
+        it ('should populate old but not previous States', function() {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's0', states: [
                     { key: 's0', route: 'r0', transitions: [
@@ -2200,6 +2200,32 @@ describe('Navigation', function () {
             Navigation.StateController.navigateLink(link);
             assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d'].states['s2']);
             assert.equal(Navigation.StateContext.previousState, null);
+            assert.equal(Navigation.StateContext.previousDialog, null);
+            assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
+        })
+    });
+
+    describe('Bookmarked Link Clear Navigate', function() {
+        it ('should populate previous but not old States', function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1', transitions: [
+                        { key: 't', to: 's2' }
+                    ]},
+                    { key: 's2', route: 'r2' }]}
+                ]);
+            Navigation.StateController.navigate('d');
+            var link = Navigation.StateController.getNavigationLink('t');
+            Navigation.StateController.navigate('t');
+            Navigation.StateController.navigate('t');
+            Navigation.StateController.clearStateContext();
+            Navigation.StateController.navigateLink(link);
+            assert.equal(Navigation.StateContext.oldState, undefined);
+            assert.equal(Navigation.StateContext.oldDialog, undefined);
+            assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d'].states['s0']);
             assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
         })
     });

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -391,6 +391,10 @@ describe('Navigation', function () {
                 assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d'].states['s2']);
                 assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig.dialogs['d']);
             });
+            it('should populate old State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d'].states['s0']);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateInfoConfig.dialogs['d']);
+            });
             it('should populate previous State', function() {
                 assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d'].states['s0']);
                 assert.equal(Navigation.StateContext.previousDialog, Navigation.StateInfoConfig.dialogs['d']);
@@ -490,6 +494,9 @@ describe('Navigation', function () {
             it('should go to to State', function() {
                 assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
             });
+            it('should populate old State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateContext.dialog.initial);
+            });
             it('should populate previous State', function() {
                 assert.equal(Navigation.StateContext.previousState, Navigation.StateContext.dialog.initial);
             });
@@ -539,6 +546,9 @@ describe('Navigation', function () {
         function test() {
             it('should go to to State', function() {
                 assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d'].states['s2']);
+            });
+            it('should populate old State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
             });
             it('should populate previous State', function() {
                 assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
@@ -591,6 +601,10 @@ describe('Navigation', function () {
             it('should go to to State', function() {
                 assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d'].states['s2']);
             });
+            it('should populate old State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateInfoConfig.dialogs['d']);
+            });
             it('should not populate previous State', function() {
                 assert.equal(Navigation.StateContext.previousState, null);
                 assert.equal(Navigation.StateContext.previousDialog, null);
@@ -634,6 +648,10 @@ describe('Navigation', function () {
             it('should go to to State', function() {
                 assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
                 assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig.dialogs['d']);
+            });
+            it('should populate old State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d'].states['s0']);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateInfoConfig.dialogs['d']);
             });
             it('should populate previous State', function() {
                 assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d'].states['s0']);
@@ -684,6 +702,10 @@ describe('Navigation', function () {
                 assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
                 assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig.dialogs['d']);
             });
+            it('should populate old State with current State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateInfoConfig.dialogs['d']);
+            });
             it('should populate previous State with current State', function() {
                 assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
                 assert.equal(Navigation.StateContext.previousDialog, Navigation.StateInfoConfig.dialogs['d']);
@@ -732,6 +754,10 @@ describe('Navigation', function () {
             it('should go to current State', function() {
                 assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
                 assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig.dialogs['d']);
+            });
+            it('should populate old State with current State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateInfoConfig.dialogs['d']);
             });
             it('should not populate previous State', function() {
                 assert.equal(Navigation.StateContext.previousState, null);
@@ -785,6 +811,10 @@ describe('Navigation', function () {
             it('should go to previous State', function() {
                 assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
                 assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig.dialogs['d']);
+            });
+            it('should populate old State with current State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d'].states['s2']);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateInfoConfig.dialogs['d']);
             });
             it('should populate previous State with current State', function() {
                 assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d'].states['s2']);
@@ -840,6 +870,10 @@ describe('Navigation', function () {
             it('should go to previous State', function() {
                 assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
                 assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig.dialogs['d']);
+            });
+            it('should populate old State with current State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d'].states['s2']);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateInfoConfig.dialogs['d']);
             });
             it('should not populate previous State', function() {
                 assert.equal(Navigation.StateContext.previousState, null);
@@ -905,6 +939,10 @@ describe('Navigation', function () {
             it('should go to previous previous State', function() {
                 assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig._dialogs[0]._states[2]);
                 assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig._dialogs[0]);
+            });
+            it('should populate old State with current State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig._dialogs[0]._states[4]);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateInfoConfig._dialogs[0]);
             });
             it('should populate previous State with current State', function() {
                 assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig._dialogs[0]._states[4]);
@@ -975,6 +1013,10 @@ describe('Navigation', function () {
             it('should go to previous previous State', function() {
                 assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig._dialogs[0]._states[2]);
                 assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig._dialogs[0]);
+            });
+            it('should populate old State with current State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig._dialogs[0]._states[4]);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateInfoConfig._dialogs[0]);
             });
             it('should not populate previous State', function() {
                 assert.equal(Navigation.StateContext.previousState, null);

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -3643,11 +3643,14 @@ describe('Navigation', function () {
             Navigation.StateController.navigate('d');
             Navigation.StateInfoConfig.dialogs['d'].states['s1'].navigated = (data, asyncData) => {
                 assert.equal(asyncData, 0);
-                done();
             }
             var i = 0;
             Navigation.StateInfoConfig.dialogs['d'].states['s1'].navigating = (data, url, navigate) => {
-                ((count) => setTimeout(() => navigate(count), 0))(i);
+                ((count) => setTimeout(() => {
+                    navigate(count);
+                    if (count === 1)
+                        done();
+                }, 0))(i);
                 i++;
             }
             Navigation.StateController.navigate('t');
@@ -3672,7 +3675,7 @@ describe('Navigation', function () {
             Navigation.StateInfoConfig.dialogs['d'].states['s1'].navigating = (data, url, navigate) => {
                 ((count) => setTimeout(() => { 
                     navigate(count);
-                    if (count == 0)
+                    if (count === 0)
                         done();
                 }, 5 - 5 * count))(i);
                 i++;

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -4027,7 +4027,7 @@ describe('Navigation', function () {
                 assert.strictEqual(Navigation.StateContext.previousDialog, null);
                 assert.strictEqual(Navigation.StateContext.state, null);
                 assert.strictEqual(Navigation.StateContext.dialog, null);
-                assert.strictEqual(Navigation.StateContext.data, null);
+                assert.deepEqual(Navigation.StateContext.data, {});
                 assert.strictEqual(Navigation.StateContext.url, null);
                 assert.equal(Navigation.StateController.crumbs.length, 0);
             });

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -3065,6 +3065,7 @@ describe('Navigation', function () {
             assert.strictEqual(unloading, true);
             assert.strictEqual(navigated10, undefined);
             assert.strictEqual(navigated01, true);
+            assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d0'].states['s2']);
             assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
             assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
         });
@@ -3101,6 +3102,7 @@ describe('Navigation', function () {
             assert.strictEqual(navigating, true);
             assert.strictEqual(navigated10, undefined);
             assert.strictEqual(navigated01, true);
+            assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d0'].states['s2']);
             assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
             assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
         });
@@ -3402,6 +3404,7 @@ describe('Navigation', function () {
                 navigate();
             }
             Navigation.StateController.navigate('d1', { x: true });
+            assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
             assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
             assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s2']);
             assert.strictEqual(navigating, undefined);
@@ -3435,6 +3438,7 @@ describe('Navigation', function () {
                 navigate();
             }
             Navigation.StateController.navigate('d1');
+            assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
             assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
             assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
             assert.strictEqual(navigating, 1);
@@ -3462,6 +3466,7 @@ describe('Navigation', function () {
                 navigate();
             }
             Navigation.StateController.navigate('d1');
+            assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
             assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d0'].states['s1']);
             assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d0'].states['s2']);
         });
@@ -3497,6 +3502,7 @@ describe('Navigation', function () {
             Navigation.StateController.offNavigate(navigatedHandler);
             assert.equal(hits, 1);
             assert.equal(navigatedState, Navigation.StateContext.state);
+            assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
             assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d1'].states['s0']);
             assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].states['s1']);
         });
@@ -3672,6 +3678,7 @@ describe('Navigation', function () {
             Navigation.StateController.navigateLink(link);
             assert.notEqual(link.indexOf('aaa'), -1);
             assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig._dialogs[0]._states[1]);
+            assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig._dialogs[0]._states[0]);
             assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig._dialogs[0]._states[0]);
             assert.equal(Navigation.StateController.crumbs.length, 1);
         });
@@ -3698,6 +3705,7 @@ describe('Navigation', function () {
             Navigation.StateController.navigateLink(link);
             assert.notEqual(link.indexOf('bbb'), -1);
             assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig._dialogs[1]._states[2]);
+            assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig._dialogs[1]._states[1]);
             assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig._dialogs[1]._states[1]);
             assert.equal(Navigation.StateController.crumbs.length, 2);
         });
@@ -3869,6 +3877,7 @@ describe('Navigation', function () {
                 Navigation.StateController.navigate('d');
             }
             Navigation.StateController.navigateLink(link);
+            assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig._dialogs[0]._states[0]);
             assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig._dialogs[0]._states[0]);
             assert.equal(Navigation.StateController.crumbs.length, 1);
         });
@@ -3910,6 +3919,7 @@ describe('Navigation', function () {
             Navigation.StateController.navigateLink(link);
             assert.equal(link.indexOf('aaa'), -1);
             assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig._dialogs[0]._states[1]);
+            assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig._dialogs[0]._states[0]);
             assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig._dialogs[0]._states[0]);
             assert.equal(Navigation.StateController.crumbs.length, 1);
         });
@@ -3930,6 +3940,7 @@ describe('Navigation', function () {
             Navigation.StateController.navigateLink(link);
             assert.notEqual(link.indexOf('aaa'), -1);
             assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig._dialogs[0]._states[1]);
+            assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig._dialogs[0]._states[0]);
             assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig._dialogs[0]._states[0]);
             assert.equal(Navigation.StateController.crumbs.length, 1);
         });
@@ -3977,6 +3988,7 @@ describe('Navigation', function () {
             Navigation.StateController.navigateLink(link);
             assert.notEqual(link.indexOf('c3=x'), -1);
             assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig._dialogs[0]._states[1]);
+            assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig._dialogs[0]._states[0]);
             assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig._dialogs[0]._states[0]);
             assert.equal(Navigation.StateController.crumbs.length, 1);
         });
@@ -4000,6 +4012,7 @@ describe('Navigation', function () {
             var link = Navigation.StateController.getNavigationLink('t');
             Navigation.settings.combineCrumbTrail = true;
             Navigation.StateController.navigateLink(link);
+            assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig._dialogs[0]._states[1]);
             assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig._dialogs[0]._states[1]);
             assert.equal(Navigation.StateController.crumbs.length, 2);
         });
@@ -4023,6 +4036,7 @@ describe('Navigation', function () {
             var link = Navigation.StateController.getNavigationLink('t');
             Navigation.settings.combineCrumbTrail = false;
             Navigation.StateController.navigateLink(link);
+            assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig._dialogs[0]._states[1]);
             assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig._dialogs[0]._states[1]);
             assert.equal(Navigation.StateController.crumbs.length, 2);
         });

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -2158,7 +2158,7 @@ describe('Navigation', function () {
         }
     });
 
-    describe('Old Link Navigate', function() {
+    describe('Bookmarked Link Navigate', function() {
         it ('should return to State', function() {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's0', states: [
@@ -2181,7 +2181,7 @@ describe('Navigation', function () {
         })
     });
 
-    describe('Old Link Without Trail Navigate', function() {
+    describe('Bookmarked Link Without Trail Navigate', function() {
         it ('should return to State', function() {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's0', states: [

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -4182,13 +4182,10 @@ describe('Navigation', function () {
                 Navigation.StateController.clearStateContext();
                 assert.strictEqual(Navigation.StateContext.oldState, null);
                 assert.strictEqual(Navigation.StateContext.oldDialog, null);
-                assert.deepEqual(Navigation.StateContext.oldData, {});
                 assert.strictEqual(Navigation.StateContext.previousState, null);
                 assert.strictEqual(Navigation.StateContext.previousDialog, null);
-                assert.deepEqual(Navigation.StateContext.previousData, {});
                 assert.strictEqual(Navigation.StateContext.state, null);
                 assert.strictEqual(Navigation.StateContext.dialog, null);
-                assert.deepEqual(Navigation.StateContext.data, {});
                 assert.strictEqual(Navigation.StateContext.url, null);
                 assert.equal(Navigation.StateController.crumbs.length, 0);
             });

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -3521,11 +3521,14 @@ describe('Navigation', function () {
             Navigation.StateController.navigate('d');
             Navigation.StateInfoConfig.dialogs['d'].states['s1'].navigated = (data, asyncData) => {
                 assert.equal(asyncData, 1);
-                done();
             }
             var i = 0;
             Navigation.StateInfoConfig.dialogs['d'].states['s1'].navigating = (data, url, navigate) => {
-                ((count) => setTimeout(() => navigate(count), 5 - 5 * count))(i);
+                ((count) => setTimeout(() => { 
+                    navigate(count);
+                    if (count == 0)
+                        done();
+                }, 5 - 5 * count))(i);
                 i++;
             }
             Navigation.StateController.navigate('t');

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -1074,6 +1074,10 @@ describe('Navigation', function () {
                 assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig._dialogs[0]._states[0]);
                 assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig._dialogs[0]);
             });
+            it('should populate old State with previous State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig._dialogs[0]._states[1]);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateInfoConfig._dialogs[0]);
+            });
             it('should populate previous State with previous State', function() {
                 assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig._dialogs[0]._states[1]);
                 assert.equal(Navigation.StateContext.previousDialog, Navigation.StateInfoConfig._dialogs[0]);
@@ -1129,6 +1133,10 @@ describe('Navigation', function () {
             it('should go to previous previous State', function() {
                 assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig._dialogs[0]._states[0]);
                 assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig._dialogs[0]);
+            });
+            it('should populate old State with previous State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig._dialogs[0]._states[1]);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateInfoConfig._dialogs[0]);
             });
             it('should not populate previous State', function() {
                 assert.equal(Navigation.StateContext.previousState, null);
@@ -1442,6 +1450,10 @@ describe('Navigation', function () {
                 assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig._dialogs[0].states['s0']);
                 assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig._dialogs[0]);
             });
+            it('should populate old State with previous State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig._dialogs[0].states['s0']);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateInfoConfig._dialogs[0]);
+            });
             it('should populate previous State with previous State', function() {
                 assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig._dialogs[0].states['s0']);
                 assert.equal(Navigation.StateContext.previousDialog, Navigation.StateInfoConfig._dialogs[0]);
@@ -1491,6 +1503,10 @@ describe('Navigation', function () {
             it('should go to previous State', function() {
                 assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig._dialogs[0].states['s0']);
                 assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig._dialogs[0]);
+            });
+            it('should populate old State with previous State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig._dialogs[0].states['s0']);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateInfoConfig._dialogs[0]);
             });
             it('should note populate previous State', function() {
                 assert.equal(Navigation.StateContext.previousState, null);
@@ -1552,6 +1568,10 @@ describe('Navigation', function () {
             it('should go to to State', function() {
                 assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d'].states['s3']);
                 assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig.dialogs['d']);
+            });
+            it('should populate old State with previous State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateInfoConfig.dialogs['d']);
             });
             it('should populate previous State with previous State', function() {
                 assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
@@ -1619,6 +1639,10 @@ describe('Navigation', function () {
                 assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d'].states['s3']);
                 assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig.dialogs['d']);
             });
+            it('should populate old State with previous State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateInfoConfig.dialogs['d']);
+            });
             it('should populate previous State with previous State', function() {
                 assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
                 assert.equal(Navigation.StateContext.previousDialog, Navigation.StateInfoConfig.dialogs['d']);
@@ -1670,6 +1694,10 @@ describe('Navigation', function () {
             it('should go to to State', function() {
                 assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d'].states['s2']);
                 assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig.dialogs['d']);
+            });
+            it('should populate old State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateInfoConfig.dialogs['d']);
             });
             it('should populate previous State', function() {
                 assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d'].states['s1']);

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -2158,6 +2158,52 @@ describe('Navigation', function () {
         }
     });
 
+    describe('Old Link Navigate', function() {
+        it ('should return to State', function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1', transitions: [
+                        { key: 't', to: 's2' }
+                    ]},
+                    { key: 's2', route: 'r2' }]}
+                ]);
+            Navigation.StateController.navigate('d');
+            var link = Navigation.StateController.getNavigationLink('t');
+            Navigation.StateController.navigate('t');
+            Navigation.StateController.navigate('t');
+            Navigation.StateController.navigateLink(link);
+            assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d'].states['s2']);
+            assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d'].states['s0']);
+            assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
+        })
+    });
+
+    describe('Old Link Without Trail Navigate', function() {
+        it ('should return to State', function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1', trackCrumbTrail: false, transitions: [
+                        { key: 't', to: 's2' }
+                    ]},
+                    { key: 's2', route: 'r2', trackCrumbTrail: false }]}
+                ]);
+            Navigation.StateController.navigate('d');
+            var link = Navigation.StateController.getNavigationLink('t');
+            Navigation.StateController.navigate('t');
+            Navigation.StateController.navigate('t');
+            Navigation.StateController.navigateLink(link);
+            assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d'].states['s2']);
+            assert.equal(Navigation.StateContext.previousState, null);
+            assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
+        })
+    });
+
     describe('Dialog Next', function() {
         it ('should return initial State', function() {
             Navigation.StateInfoConfig.build([

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -102,6 +102,10 @@ describe('Navigation', function () {
                 assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].initial);
                 assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig.dialogs['d1']);
             });
+            it('should populate old State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateInfoConfig.dialogs['d0']);
+            });
             it('should populate previous State', function() {
                 assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d0'].states['s0']);
                 assert.equal(Navigation.StateContext.previousDialog, Navigation.StateInfoConfig.dialogs['d0']);
@@ -145,6 +149,10 @@ describe('Navigation', function () {
                 assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d1'].initial);
                 assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig.dialogs['d1']);
             });
+            it('should populate old State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d0'].initial);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateInfoConfig.dialogs['d0']);
+            });
             it('should not populate previous State', function() {
                 assert.equal(Navigation.StateContext.previousState, null);
                 assert.equal(Navigation.StateContext.previousDialog, null);
@@ -186,6 +194,10 @@ describe('Navigation', function () {
                 assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d'].initial);
                 assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig.dialogs['d']);
             });
+            it('should populate old State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateContext.state);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateContext.dialog);
+            });
             it('should populate previous State', function() {
                 assert.equal(Navigation.StateContext.previousState, Navigation.StateContext.state);
                 assert.equal(Navigation.StateContext.previousDialog, Navigation.StateContext.dialog);
@@ -226,6 +238,10 @@ describe('Navigation', function () {
             it('should go to initial State', function() {
                 assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d'].initial);
                 assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig.dialogs['d']);
+            });
+            it('should populate old State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d'].initial);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateInfoConfig.dialogs['d']);
             });
             it('should not populate previous State', function() {
                 assert.equal(Navigation.StateContext.previousState, null);
@@ -270,6 +286,10 @@ describe('Navigation', function () {
             it('should go to to State', function() {
                 assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
                 assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig.dialogs['d']);
+            });
+            it('should populate old State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d'].states['s0']);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateInfoConfig.dialogs['d']);
             });
             it('should populate previous State', function() {
                 assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d'].states['s0']);
@@ -318,6 +338,10 @@ describe('Navigation', function () {
             it('should go to to State', function() {
                 assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
                 assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig.dialogs['d']);
+            });
+            it('should populate old State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d'].states['s0']);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateInfoConfig.dialogs['d']);
             });
             it('should populate previous State', function() {
                 assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d'].states['s0']);

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -4023,8 +4023,12 @@ describe('Navigation', function () {
         function test(){
             it('should clear State context', function() {
                 Navigation.StateController.clearStateContext();
+                assert.strictEqual(Navigation.StateContext.oldState, null);
+                assert.strictEqual(Navigation.StateContext.oldDialog, null);
+                assert.deepEqual(Navigation.StateContext.oldData, {});
                 assert.strictEqual(Navigation.StateContext.previousState, null);
                 assert.strictEqual(Navigation.StateContext.previousDialog, null);
+                assert.deepEqual(Navigation.StateContext.previousData, {});
                 assert.strictEqual(Navigation.StateContext.state, null);
                 assert.strictEqual(Navigation.StateContext.dialog, null);
                 assert.deepEqual(Navigation.StateContext.data, {});

--- a/NavigationJS/test/navigation-tests.ts
+++ b/NavigationJS/test/navigation-tests.ts
@@ -126,9 +126,13 @@ module NavigationTests {
 	personList === Navigation.StateContext.state;
 	var url: string = Navigation.StateContext.url;
 	var page: number = Navigation.StateContext.data.page;
+	Navigation.StateController.refresh({ page: 2 });
+	person = Navigation.StateContext.oldDialog;
+	personList = Navigation.StateContext.oldState;
+	page = Navigation.StateContext.oldData.page;
+	page = Navigation.StateContext.previousData.page;
 	
 	// Navigation Data
-	Navigation.StateController.refresh({ page: 2 });
 	var data = Navigation.StateContext.includeCurrentData({ sort: 'name' }, ['page']);
 	Navigation.StateController.refresh(data);
 	Navigation.StateContext.clear('sort');


### PR DESCRIPTION
To match the current State details on State Context, added old State, old Dialog and old NavigationData to the StateContext. Didn't store the old url because don't want to allow navigation to the old State. Set the defaults on the old NavigationData to safeguard against a default having been cleared directly on the current data.

Added previous NavigationData to the StateContext for consistency. Didn't need to set the defaults because the crumb processing handled it already, although slightly differently for the combineCrumbTrail true and false cases. When true, the defaults are set in the buildCrumbTrail call after setting up the previous data - creating a Crumb from the previous data sets the defaults. When false, the previous data is taken from the Crumb so already has the defaults set.

Changing the combineCrumbTrail setting caused another difference in the previous data handling. When true, the previous data was always set but, when false, it wasn't set when navigating back or refreshing. The decision not to pass previous for those navigations goes back to beginning of project but never realised that combining the crumb trail changed this decision. It's because the combined trail is built up front and this same trail is included for all navigations. So, changed to pass previous data always for all navigations. This is a breaking change because it changes the Url, so added a trackAllPreviousData Navigation setting to revert this behaviour.