### PR TITLE
Added History Action to Navigation Api

### DIFF
--- a/NavigationAngular/sample/server.js
+++ b/NavigationAngular/sample/server.js
@@ -1,0 +1,22 @@
+var http = require('http');
+var fs = require('fs');
+
+http.createServer(function(req, res) {
+	if (req.url === '/favicon.ico') {
+		res.statusCode = 404;
+		res.end();
+		return true;
+	}
+	var fileName;
+	if (req.url === '/') {
+		fileName = 'app.html'
+		res.setHeader('content-type', 'text/html');
+	} else {
+		if (req.url.indexOf('/', 1) !== -1)
+			fileName = '../..' + req.url;
+		else
+			fileName = req.url.substring(1);
+		res.setHeader('content-type', 'text/javascript');
+	}
+	fs.createReadStream(fileName).pipe(res);
+}).listen(8080);

--- a/NavigationAngular/src/LinkUtility.ts
+++ b/NavigationAngular/src/LinkUtility.ts
@@ -48,7 +48,10 @@ class LinkUtility {
                     var navigating = this.getNavigating($parse, attrs, scope);
                     if (navigating(e, link)) {
                         e.preventDefault();
-                        Navigation.StateController.navigateLink(link);
+                        var historyAction = scope.$eval(attrs['historyAction']);
+                        if (typeof historyAction === 'string')
+                            historyAction = Navigation.HistoryAction[historyAction];
+                        Navigation.StateController.navigateLink(link, false, historyAction);
                     }
                 }
             }

--- a/NavigationAngular/src/navigation.d.ts
+++ b/NavigationAngular/src/navigation.d.ts
@@ -279,9 +279,21 @@ declare module Navigation {
         static build(dialogs: IDialog<string, IState<ITransition<string>[]>[]>[]): void;
     }
     
+    /**
+     * Determines the effect on browser history after a successful navigation
+     */
     enum HistoryAction {
+        /**
+         * Creates a new browser history entry
+         */
         Add = 0,
+        /**
+         * Changes the current browser history entry
+         */
         Replace = 1,
+        /**
+         * Leaves browser history unchanged
+         */
         None = 2,
     }    
 
@@ -301,7 +313,15 @@ declare module Navigation {
         /**
          * Adds browser history
          * @param state The State navigated to
-         * @param url The current url 
+         * @param url The current url
+         */
+        addHistory(state: State, url: string): void;
+        /**
+         * Adds browser history
+         * @param state The State navigated to
+         * @param url The current url
+         * @param replace A value indicating whether to replace the current
+         * browser history entry
          */
         addHistory(state: State, url: string, replace: boolean): void;
         /**
@@ -344,6 +364,14 @@ declare module Navigation {
          * @param state The State navigated to
          * @param url The current url 
          */
+        addHistory(state: State, url: string): void;
+        /**
+         * Sets the browser Url's hash to the url
+         * @param state The State navigated to
+         * @param url The current url 
+         * @param replace A value indicating whether to replace the current
+         * browser history entry
+         */
         addHistory(state: State, url: string, replace: boolean): void;
         /**
          * Gets the current location
@@ -379,6 +407,14 @@ declare module Navigation {
          * Sets the browser Url to the url using pushState
          * @param state The State navigated to
          * @param url The current url 
+         */
+        addHistory(state: State, url: string): void;
+        /**
+         * Sets the browser Url to the url using pushState
+         * @param state The State navigated to
+         * @param url The current url 
+         * @param replace A value indicating whether to replace the current
+         * browser history entry
          */
         addHistory(state: State, url: string, replace: boolean): void;
         /**
@@ -724,6 +760,19 @@ declare module Navigation {
          * @throws A mandatory route parameter has not been supplied a value
          */
         static navigate(action: string, toData: any): void;
+        /**
+         * Navigates to a State. Depending on the action will either navigate
+         * to the 'to' State of a Transition or the 'initial' State of a
+         * Dialog
+         * @param action The key of a child Transition or the key of a Dialog
+         * @param toData The NavigationData to be passed to the next State and
+         * stored in the StateContext
+         * @param A value determining the effect on browser history
+         * @throws action does not match the key of a child Transition or the
+         * key of a Dialog; or there is NavigationData that cannot be converted
+         * to a String
+         * @throws A mandatory route parameter has not been supplied a value
+         */
         static navigate(action: string, toData: any, historyAction: HistoryAction): void;
         /**
          * Gets a Url to navigate to a State. Depending on the action will
@@ -764,6 +813,16 @@ declare module Navigation {
          * @throws A mandatory route parameter has not been supplied a value
          */
         static navigateBack(distance: number): void;
+        /**
+         * Navigates back to the Crumb contained in the crumb trail,
+         * represented by the Crumbs collection, as specified by the distance.
+         * In the crumb trail no two crumbs can have the same State but all
+         * must have the same Dialog
+         * @param distance Starting at 1, the number of Crumb steps to go back
+         * @param A value determining the effect on browser history
+         * @throws canNavigateBack returns false for this distance
+         * @throws A mandatory route parameter has not been supplied a value
+         */
         static navigateBack(distance: number, historyAction: HistoryAction): void;
         /**
          * Gets a Url to navigate to a Crumb contained in the crumb trail, 
@@ -787,6 +846,14 @@ declare module Navigation {
          * @throws A mandatory route parameter has not been supplied a value
          */
         static refresh(toData: any): void;
+        /**
+         * Navigates to the current State
+         * @param toData The NavigationData to be passed to the current State
+         * and stored in the StateContext
+         * @param A value determining the effect on browser history
+         * @throws There is NavigationData that cannot be converted to a String
+         * @throws A mandatory route parameter has not been supplied a value
+         */
         static refresh(toData: any, historyAction: HistoryAction): void;
         /**
          * Gets a Url to navigate to the current State passing no 
@@ -812,6 +879,12 @@ declare module Navigation {
          * @param history A value indicating whether browser history was used
          */
         static navigateLink(url: string, history: boolean): void;
+        /**
+         * Navigates to the url
+         * @param url The target location
+         * @param history A value indicating whether browser history was used
+         * @param A value determining the effect on browser history
+         */
         static navigateLink(url: string, history: boolean, historyAction: HistoryAction): void;
         /**
          * Gets the next State. Depending on the action will either return the

--- a/NavigationAngular/src/navigation.d.ts
+++ b/NavigationAngular/src/navigation.d.ts
@@ -278,6 +278,12 @@ declare module Navigation {
          */
         static build(dialogs: IDialog<string, IState<ITransition<string>[]>[]>[]): void;
     }
+    
+    enum HistoryAction {
+        Add = 0,
+        Replace = 1,
+        None = 2,
+    }    
 
     /**
      * Defines a contract a class must implement in order to manage the browser
@@ -297,7 +303,7 @@ declare module Navigation {
          * @param state The State navigated to
          * @param url The current url 
          */
-        addHistory(state: State, url: string): void;
+        addHistory(state: State, url: string, replace: boolean): void;
         /**
          * Gets the current location
          */
@@ -338,7 +344,7 @@ declare module Navigation {
          * @param state The State navigated to
          * @param url The current url 
          */
-        addHistory(state: State, url: string): void;
+        addHistory(state: State, url: string, replace: boolean): void;
         /**
          * Gets the current location
          */
@@ -374,7 +380,7 @@ declare module Navigation {
          * @param state The State navigated to
          * @param url The current url 
          */
-        addHistory(state: State, url: string): void;
+        addHistory(state: State, url: string, replace: boolean): void;
         /**
          * Gets the current location
          */
@@ -587,6 +593,11 @@ declare module Navigation {
          * ReturnData should be part of the CrumbTrail
          */
         combineCrumbTrail: boolean;
+        /**
+         * Gets or sets a value indicating whether to track PreviousData when
+         * navigating back or refreshing and combineCrumbTrail is false 
+         */
+        trackAllPreviousData: boolean;
     }
 
     /**
@@ -596,6 +607,18 @@ declare module Navigation {
      */
     class StateContext {
         /**
+         * Gets the last State displayed before the current State
+         */
+        static oldState: State;
+        /**
+         * Gets the parent of the OldState property
+         */
+        static oldDialog: Dialog;
+        /**
+         * Gets the NavigationData for the last displayed State
+         */
+        static oldData: any;
+        /**
          * Gets the State navigated away from to reach the current State
          */
         static previousState: State;
@@ -603,6 +626,10 @@ declare module Navigation {
          * Gets the parent of the PreviousState property
          */
         static previousDialog: Dialog;
+        /**
+         * Gets the NavigationData for the navigated away from State
+         */
+        static previousData: any;
         /**
          * Gets the current State
          */
@@ -612,8 +639,7 @@ declare module Navigation {
          */
         static dialog: Dialog;
         /**
-         * Gets the NavigationData for the current State. It can be accessed.
-         * Will become the data stored in a Crumb when part of a crumb trail
+         * Gets the NavigationData for the current State
          */
         static data: any;
         /**
@@ -698,6 +724,7 @@ declare module Navigation {
          * @throws A mandatory route parameter has not been supplied a value
          */
         static navigate(action: string, toData: any): void;
+        static navigate(action: string, toData: any, historyAction: HistoryAction): void;
         /**
          * Gets a Url to navigate to a State. Depending on the action will
          * either navigate to the 'to' State of a Transition or the 'initial'
@@ -737,6 +764,7 @@ declare module Navigation {
          * @throws A mandatory route parameter has not been supplied a value
          */
         static navigateBack(distance: number): void;
+        static navigateBack(distance: number, historyAction: HistoryAction): void;
         /**
          * Gets a Url to navigate to a Crumb contained in the crumb trail, 
          * represented by the Crumbs collection, as specified by the distance.
@@ -759,6 +787,7 @@ declare module Navigation {
          * @throws A mandatory route parameter has not been supplied a value
          */
         static refresh(toData: any): void;
+        static refresh(toData: any, historyAction: HistoryAction): void;
         /**
          * Gets a Url to navigate to the current State passing no 
          * NavigationData
@@ -783,6 +812,7 @@ declare module Navigation {
          * @param history A value indicating whether browser history was used
          */
         static navigateLink(url: string, history: boolean): void;
+        static navigateLink(url: string, history: boolean, historyAction: HistoryAction): void;
         /**
          * Gets the next State. Depending on the action will either return the
          * 'to' State of a Transition or the 'initial' State of a Dialog

--- a/NavigationJS/src/Navigation.ts
+++ b/NavigationJS/src/Navigation.ts
@@ -4,6 +4,7 @@ import Dialog = require('./config/Dialog');
 import State = require('./config/State');
 import Transition = require('./config/Transition');
 import StateInfoConfig = require('./config/StateInfoConfig');
+import HistoryAction = require('./history/HistoryAction');
 import HistoryNavigator = require('./history/HistoryNavigator');
 import HashHistoryManager = require('./history/HashHistoryManager');
 import HTML5HistoryManager = require('./history/HTML5HistoryManager');
@@ -22,6 +23,7 @@ class Navigation {
     static State = State;
     static Transition = Transition;
     static StateInfoConfig = StateInfoConfig;
+    static HistoryAction = HistoryAction;
     static HashHistoryManager = HashHistoryManager;
     static HTML5HistoryManager = HTML5HistoryManager;
     static CrumbTrailPersister = CrumbTrailPersister;

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -172,7 +172,7 @@ class StateController {
                         this.navigateHandlers[id](oldState, state, StateContext.data);
                 }
                 if (url === StateContext.url && historyAction !== HistoryAction.None)
-                    settings.historyManager.addHistory(state, url);
+                    settings.historyManager.addHistory(state, url, historyAction === HistoryAction.Replace);
             }
         };
     }

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -108,35 +108,35 @@ class StateController {
             return canNavigate
         }
 
-    static navigateBack(distance: number) {
+    static navigateBack(distance: number, historyAction?: HistoryAction) {
         var url = this.getNavigationBackLink(distance);
         if (url == null)
             throw new Error('Invalid route data, a mandatory route parameter has not been supplied a value');
-        this._navigateLink(url, this.getCrumb(distance).state);
+        this._navigateLink(url, this.getCrumb(distance).state, false, historyAction);
     }
 
     static getNavigationBackLink(distance: number): string {
         return this.getCrumb(distance).navigationLink;
     }
 
-    static refresh(toData?: any) {
+    static refresh(toData?: any, historyAction?: HistoryAction) {
         var url = this.getRefreshLink(toData);
         if (url == null)
             throw new Error('Invalid route data, a mandatory route parameter has not been supplied a value');
-        this._navigateLink(url, StateContext.state);
+        this._navigateLink(url, StateContext.state, false, historyAction);
     }
 
     static getRefreshLink(toData?: any): string {
         return CrumbTrailManager.getRefreshHref(toData);
     }
 
-    static navigateLink(url: string, history?: boolean) {
+    static navigateLink(url: string, history?: boolean, historyAction?: HistoryAction) {
         try {
             var state = settings.router.getData(url.split('?')[0]).state;
         } catch (e) {
             throw new Error('The Url is invalid\n' + e.message);
         }
-        this._navigateLink(url, state, history);
+        this._navigateLink(url, state, history, historyAction);
     }
 
     private static _navigateLink(url: string, state: State, history = false, historyAction = HistoryAction.Add) {

--- a/NavigationJS/src/history/HTML5HistoryManager.ts
+++ b/NavigationJS/src/history/HTML5HistoryManager.ts
@@ -12,7 +12,7 @@ class HTML5HistoryManager implements IHistoryManager {
             window.addEventListener('popstate', HistoryNavigator.navigateHistory);
     }
 
-    addHistory(state: State, url: string) {
+    addHistory(state: State, url: string, replace: boolean) {
         url = url != null ? url : StateContext.url;
         if (state && state.title && (typeof document !== 'undefined'))
             document.title = state.title;

--- a/NavigationJS/src/history/HTML5HistoryManager.ts
+++ b/NavigationJS/src/history/HTML5HistoryManager.ts
@@ -12,7 +12,7 @@ class HTML5HistoryManager implements IHistoryManager {
             window.addEventListener('popstate', HistoryNavigator.navigateHistory);
     }
 
-    addHistory(state: State, url: string, replace: boolean) {
+    addHistory(state: State, url: string, replace?: boolean) {
         url = url != null ? url : StateContext.url;
         if (state && state.title && (typeof document !== 'undefined'))
             document.title = state.title;

--- a/NavigationJS/src/history/HTML5HistoryManager.ts
+++ b/NavigationJS/src/history/HTML5HistoryManager.ts
@@ -17,8 +17,12 @@ class HTML5HistoryManager implements IHistoryManager {
         if (state && state.title && (typeof document !== 'undefined'))
             document.title = state.title;
         url = settings.applicationPath + url;
-        if (!this.disabled && location.pathname + location.search !== url)
-            window.history.pushState(null, null, url);
+        if (!this.disabled && location.pathname + location.search !== url) {
+            if (!replace)            
+                window.history.pushState(null, null, url);
+            else
+                window.history.replaceState(null, null, url);
+        }
     }
 
     getCurrentUrl(): string {

--- a/NavigationJS/src/history/HashHistoryManager.ts
+++ b/NavigationJS/src/history/HashHistoryManager.ts
@@ -21,8 +21,12 @@ class HashHistoryManager implements IHistoryManager {
         if (state && state.title && (typeof document !== 'undefined'))
             document.title = state.title;
         url = this.encode(url);
-        if (!this.disabled && location.hash.substring(1) !== url)
-            location.hash = url;
+        if (!this.disabled && location.hash.substring(1) !== url) {
+            if (!replace)            
+                location.hash = url;
+            else
+                location.replace(url);
+        }
     }
 
     getCurrentUrl(): string {

--- a/NavigationJS/src/history/HashHistoryManager.ts
+++ b/NavigationJS/src/history/HashHistoryManager.ts
@@ -16,7 +16,7 @@ class HashHistoryManager implements IHistoryManager {
         }
     }
 
-    addHistory(state: State, url: string, replace: boolean) {
+    addHistory(state: State, url: string, replace?: boolean) {
         url = url != null ? url : StateContext.url;
         if (state && state.title && (typeof document !== 'undefined'))
             document.title = state.title;

--- a/NavigationJS/src/history/HashHistoryManager.ts
+++ b/NavigationJS/src/history/HashHistoryManager.ts
@@ -20,8 +20,8 @@ class HashHistoryManager implements IHistoryManager {
         url = url != null ? url : StateContext.url;
         if (state && state.title && (typeof document !== 'undefined'))
             document.title = state.title;
-        url = this.encode(url);
-        if (!this.disabled && location.hash.substring(1) !== url) {
+        url = '#' + this.encode(url);
+        if (!this.disabled && location.hash !== url) {
             if (!replace)            
                 location.hash = url;
             else

--- a/NavigationJS/src/history/HashHistoryManager.ts
+++ b/NavigationJS/src/history/HashHistoryManager.ts
@@ -16,7 +16,7 @@ class HashHistoryManager implements IHistoryManager {
         }
     }
 
-    addHistory(state: State, url: string) {
+    addHistory(state: State, url: string, replace: boolean) {
         url = url != null ? url : StateContext.url;
         if (state && state.title && (typeof document !== 'undefined'))
             document.title = state.title;

--- a/NavigationJS/src/history/HistoryAction.ts
+++ b/NavigationJS/src/history/HistoryAction.ts
@@ -1,0 +1,6 @@
+enum HistoryAction {
+	Add,
+	Replace,
+	None
+}
+export = HistoryAction;

--- a/NavigationJS/src/history/IHistoryManager.ts
+++ b/NavigationJS/src/history/IHistoryManager.ts
@@ -3,7 +3,7 @@
 interface IHistoryManager {
     disabled: boolean;
     init();
-    addHistory(state: State, url: string, replace: boolean): void;
+    addHistory(state: State, url: string, replace?: boolean): void;
     getCurrentUrl(): string;
     getHref(url: string): string;
     getUrl(anchor: HTMLAnchorElement): string;

--- a/NavigationJS/src/history/IHistoryManager.ts
+++ b/NavigationJS/src/history/IHistoryManager.ts
@@ -3,7 +3,7 @@
 interface IHistoryManager {
     disabled: boolean;
     init();
-    addHistory(state: State, url: string): void;
+    addHistory(state: State, url: string, replace: boolean): void;
     getCurrentUrl(): string;
     getHref(url: string): string;
     getUrl(anchor: HTMLAnchorElement): string;

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -314,10 +314,16 @@ declare module Navigation {
          * Adds browser history
          * @param state The State navigated to
          * @param url The current url
+         */
+        addHistory(state: State, url: string): void;
+        /**
+         * Adds browser history
+         * @param state The State navigated to
+         * @param url The current url
          * @param replace A value indicating whether to replace the current
          * browser history entry
          */
-        addHistory(state: State, url: string, replace?: boolean): void;
+        addHistory(state: State, url: string, replace: boolean): void;
         /**
          * Gets the current location
          */
@@ -357,10 +363,16 @@ declare module Navigation {
          * Sets the browser Url's hash to the url
          * @param state The State navigated to
          * @param url The current url 
+         */
+        addHistory(state: State, url: string): void;
+        /**
+         * Sets the browser Url's hash to the url
+         * @param state The State navigated to
+         * @param url The current url 
          * @param replace A value indicating whether to replace the current
          * browser history entry
          */
-        addHistory(state: State, url: string, replace?: boolean): void;
+        addHistory(state: State, url: string, replace: boolean): void;
         /**
          * Gets the current location
          */
@@ -395,10 +407,16 @@ declare module Navigation {
          * Sets the browser Url to the url using pushState
          * @param state The State navigated to
          * @param url The current url 
+         */
+        addHistory(state: State, url: string): void;
+        /**
+         * Sets the browser Url to the url using pushState
+         * @param state The State navigated to
+         * @param url The current url 
          * @param replace A value indicating whether to replace the current
          * browser history entry
          */
-        addHistory(state: State, url: string, replace?: boolean): void;
+        addHistory(state: State, url: string, replace: boolean): void;
         /**
          * Gets the current location
          */

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -317,7 +317,7 @@ declare module Navigation {
          * @param replace A value indicating whether to replace the current
          * browser history entry
          */
-        addHistory(state: State, url: string, replace: boolean): void;
+        addHistory(state: State, url: string, replace?: boolean): void;
         /**
          * Gets the current location
          */
@@ -360,7 +360,7 @@ declare module Navigation {
          * @param replace A value indicating whether to replace the current
          * browser history entry
          */
-        addHistory(state: State, url: string, replace: boolean): void;
+        addHistory(state: State, url: string, replace?: boolean): void;
         /**
          * Gets the current location
          */
@@ -398,7 +398,7 @@ declare module Navigation {
          * @param replace A value indicating whether to replace the current
          * browser history entry
          */
-        addHistory(state: State, url: string, replace: boolean): void;
+        addHistory(state: State, url: string, replace?: boolean): void;
         /**
          * Gets the current location
          */

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -278,6 +278,12 @@ declare module Navigation {
          */
         static build(dialogs: IDialog<string, IState<ITransition<string>[]>[]>[]): void;
     }
+    
+    enum HistoryAction {
+        Add = 0,
+        Replace = 1,
+        None = 2,
+    }    
 
     /**
      * Defines a contract a class must implement in order to manage the browser
@@ -297,7 +303,7 @@ declare module Navigation {
          * @param state The State navigated to
          * @param url The current url 
          */
-        addHistory(state: State, url: string): void;
+        addHistory(state: State, url: string, replace: boolean): void;
         /**
          * Gets the current location
          */
@@ -338,7 +344,7 @@ declare module Navigation {
          * @param state The State navigated to
          * @param url The current url 
          */
-        addHistory(state: State, url: string): void;
+        addHistory(state: State, url: string, replace: boolean): void;
         /**
          * Gets the current location
          */
@@ -374,7 +380,7 @@ declare module Navigation {
          * @param state The State navigated to
          * @param url The current url 
          */
-        addHistory(state: State, url: string): void;
+        addHistory(state: State, url: string, replace: boolean): void;
         /**
          * Gets the current location
          */
@@ -718,6 +724,7 @@ declare module Navigation {
          * @throws A mandatory route parameter has not been supplied a value
          */
         static navigate(action: string, toData: any): void;
+        static navigate(action: string, toData: any, historyAction: HistoryAction): void;
         /**
          * Gets a Url to navigate to a State. Depending on the action will
          * either navigate to the 'to' State of a Transition or the 'initial'
@@ -757,6 +764,7 @@ declare module Navigation {
          * @throws A mandatory route parameter has not been supplied a value
          */
         static navigateBack(distance: number): void;
+        static navigateBack(distance: number, historyAction: HistoryAction): void;
         /**
          * Gets a Url to navigate to a Crumb contained in the crumb trail, 
          * represented by the Crumbs collection, as specified by the distance.
@@ -779,6 +787,7 @@ declare module Navigation {
          * @throws A mandatory route parameter has not been supplied a value
          */
         static refresh(toData: any): void;
+        static refresh(toData: any, historyAction: HistoryAction): void;
         /**
          * Gets a Url to navigate to the current State passing no 
          * NavigationData
@@ -803,6 +812,7 @@ declare module Navigation {
          * @param history A value indicating whether browser history was used
          */
         static navigateLink(url: string, history: boolean): void;
+        static navigateLink(url: string, history: boolean, historyAction: HistoryAction): void;
         /**
          * Gets the next State. Depending on the action will either return the
          * 'to' State of a Transition or the 'initial' State of a Dialog

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -279,9 +279,21 @@ declare module Navigation {
         static build(dialogs: IDialog<string, IState<ITransition<string>[]>[]>[]): void;
     }
     
+    /**
+     * Determines the effect on browser history after a successful navigation
+     */
     enum HistoryAction {
+        /**
+         * Creates a new browser history entry
+         */
         Add = 0,
+        /**
+         * Changes the current browser history entry
+         */
         Replace = 1,
+        /**
+         * Leaves browser history unchanged
+         */
         None = 2,
     }    
 
@@ -301,7 +313,9 @@ declare module Navigation {
         /**
          * Adds browser history
          * @param state The State navigated to
-         * @param url The current url 
+         * @param url The current url
+         * @param replace A value indicating whether to replace the current
+         * browser history entry
          */
         addHistory(state: State, url: string, replace: boolean): void;
         /**
@@ -343,6 +357,8 @@ declare module Navigation {
          * Sets the browser Url's hash to the url
          * @param state The State navigated to
          * @param url The current url 
+         * @param replace A value indicating whether to replace the current
+         * browser history entry
          */
         addHistory(state: State, url: string, replace: boolean): void;
         /**
@@ -379,6 +395,8 @@ declare module Navigation {
          * Sets the browser Url to the url using pushState
          * @param state The State navigated to
          * @param url The current url 
+         * @param replace A value indicating whether to replace the current
+         * browser history entry
          */
         addHistory(state: State, url: string, replace: boolean): void;
         /**
@@ -724,6 +742,19 @@ declare module Navigation {
          * @throws A mandatory route parameter has not been supplied a value
          */
         static navigate(action: string, toData: any): void;
+        /**
+         * Navigates to a State. Depending on the action will either navigate
+         * to the 'to' State of a Transition or the 'initial' State of a
+         * Dialog
+         * @param action The key of a child Transition or the key of a Dialog
+         * @param toData The NavigationData to be passed to the next State and
+         * stored in the StateContext
+         * @param A value determining the effect on browser history
+         * @throws action does not match the key of a child Transition or the
+         * key of a Dialog; or there is NavigationData that cannot be converted
+         * to a String
+         * @throws A mandatory route parameter has not been supplied a value
+         */
         static navigate(action: string, toData: any, historyAction: HistoryAction): void;
         /**
          * Gets a Url to navigate to a State. Depending on the action will
@@ -764,6 +795,16 @@ declare module Navigation {
          * @throws A mandatory route parameter has not been supplied a value
          */
         static navigateBack(distance: number): void;
+        /**
+         * Navigates back to the Crumb contained in the crumb trail,
+         * represented by the Crumbs collection, as specified by the distance.
+         * In the crumb trail no two crumbs can have the same State but all
+         * must have the same Dialog
+         * @param distance Starting at 1, the number of Crumb steps to go back
+         * @param A value determining the effect on browser history
+         * @throws canNavigateBack returns false for this distance
+         * @throws A mandatory route parameter has not been supplied a value
+         */
         static navigateBack(distance: number, historyAction: HistoryAction): void;
         /**
          * Gets a Url to navigate to a Crumb contained in the crumb trail, 
@@ -787,6 +828,14 @@ declare module Navigation {
          * @throws A mandatory route parameter has not been supplied a value
          */
         static refresh(toData: any): void;
+        /**
+         * Navigates to the current State
+         * @param toData The NavigationData to be passed to the current State
+         * and stored in the StateContext
+         * @param A value determining the effect on browser history
+         * @throws There is NavigationData that cannot be converted to a String
+         * @throws A mandatory route parameter has not been supplied a value
+         */
         static refresh(toData: any, historyAction: HistoryAction): void;
         /**
          * Gets a Url to navigate to the current State passing no 
@@ -812,6 +861,12 @@ declare module Navigation {
          * @param history A value indicating whether browser history was used
          */
         static navigateLink(url: string, history: boolean): void;
+        /**
+         * Navigates to the url
+         * @param url The target location
+         * @param history A value indicating whether browser history was used
+         * @param A value determining the effect on browser history
+         */
         static navigateLink(url: string, history: boolean, historyAction: HistoryAction): void;
         /**
          * Gets the next State. Depending on the action will either return the

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -12,6 +12,7 @@ describe('Navigation Data', function () {
         Navigation.StateController.clearStateContext();
         Navigation.settings.crumbTrailPersister = new Navigation.CrumbTrailPersister();
         Navigation.settings.combineCrumbTrail = setting;
+        Navigation.settings.historyManager = new Navigation.HashHistoryManager();
     });
 
     describe('Individual Data', function() {

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -4265,7 +4265,7 @@ describe('Navigation', function () {
     });
 
     describe('History None Navigate', function () {
-        it('should pass replace true to history manager', function() {
+        it('should not call history manager', function() {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's', states: [
                     { key: 's', route: 'r' }]}
@@ -4301,7 +4301,7 @@ describe('Navigation', function () {
                 { key: 'd', initial: 's', states: [
                     { key: 's', route: 'r' }]}
                 ]);
-            Navigation.StateController.navigate('d', null, Navigation.HistoryAction.Add);
+            Navigation.StateController.navigate('d');
             var replaceHistory;
             Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
                 replaceHistory = replace;
@@ -4317,7 +4317,7 @@ describe('Navigation', function () {
                 { key: 'd', initial: 's', states: [
                     { key: 's', route: 'r' }]}
                 ]);
-            Navigation.StateController.navigate('d', null, Navigation.HistoryAction.Replace);
+            Navigation.StateController.navigate('d');
             var replaceHistory;
             Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
                 replaceHistory = replace;
@@ -4328,17 +4328,97 @@ describe('Navigation', function () {
     });
 
     describe('History None Refresh Navigate', function () {
-        it('should pass replace true to history manager', function() {
+        it('should not call history manager', function() {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's', states: [
                     { key: 's', route: 'r' }]}
                 ]);
-            Navigation.StateController.navigate('d', null, Navigation.HistoryAction.Replace);
+            Navigation.StateController.navigate('d');
             var replaceHistory;
             Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
                 replaceHistory = true;
             }
             Navigation.StateController.refresh(null, Navigation.HistoryAction.None);
+            assert.strictEqual(replaceHistory, undefined);
+        });
+    });
+
+    describe('History Null Back Navigate', function () {
+        it('should pass replace false to history manager', function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' },
+                    ]},
+                    { key: 's1', route: 'r1' }]}
+                ]);
+            Navigation.StateController.navigate('d');
+            Navigation.StateController.navigate('t');
+            var replaceHistory;
+            Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
+                replaceHistory = replace;
+            }
+            Navigation.StateController.navigateBack(1);
+            assert.strictEqual(replaceHistory, false);
+        });
+    });
+
+    describe('History Add Back Navigate', function () {
+        it('should pass replace false to history manager', function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' },
+                    ]},
+                    { key: 's1', route: 'r1' }]}
+                ]);
+            Navigation.StateController.navigate('d');
+            Navigation.StateController.navigate('t');
+            var replaceHistory;
+            Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
+                replaceHistory = replace;
+            }
+            Navigation.StateController.navigateBack(1, Navigation.HistoryAction.Add);
+            assert.strictEqual(replaceHistory, false);
+        });
+    });
+
+    describe('History Replace Refresh Navigate', function () {
+        it('should pass replace true to history manager', function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' },
+                    ]},
+                    { key: 's1', route: 'r1' }]}
+                ]);
+            Navigation.StateController.navigate('d');
+            Navigation.StateController.navigate('t');
+            var replaceHistory;
+            Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
+                replaceHistory = replace;
+            }
+            Navigation.StateController.navigateBack(1, Navigation.HistoryAction.Replace);
+            assert.strictEqual(replaceHistory, true);
+        });
+    });
+
+    describe('History None Refresh Navigate', function () {
+        it('should not call history manager', function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' },
+                    ]},
+                    { key: 's1', route: 'r1' }]}
+                ]);
+            Navigation.StateController.navigate('d');
+            Navigation.StateController.navigate('t');
+            var replaceHistory;
+            Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
+                replaceHistory = true;
+            }
+            Navigation.StateController.navigateBack(1, Navigation.HistoryAction.None);
             assert.strictEqual(replaceHistory, undefined);
         });
     });

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -4422,5 +4422,69 @@ describe('Navigation', function () {
             assert.strictEqual(replaceHistory, undefined);
         });
     });
+
+    describe('History Null Navigate Link', function () {
+        it('should pass replace false to history manager', function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'r' }]}
+                ]);
+            var replaceHistory;
+            Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
+                replaceHistory = replace;
+            }
+            var link = Navigation.StateController.getNavigationLink('d');
+            Navigation.StateController.navigateLink(link);
+            assert.strictEqual(replaceHistory, false);
+        });
+    });
+
+    describe('History Add Navigate Link', function () {
+        it('should pass replace false to history manager', function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'r' }]}
+                ]);
+            var replaceHistory;
+            Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
+                replaceHistory = replace;
+            }
+            var link = Navigation.StateController.getNavigationLink('d');
+            Navigation.StateController.navigateLink(link, false, Navigation.HistoryAction.Add);
+            assert.strictEqual(replaceHistory, false);
+        });
+    });
+
+    describe('History Replace Navigate Link', function () {
+        it('should pass replace true to history manager', function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'r' }]}
+                ]);
+            var replaceHistory;
+            Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
+                replaceHistory = replace;
+            }
+            var link = Navigation.StateController.getNavigationLink('d');
+            Navigation.StateController.navigateLink(link, false, Navigation.HistoryAction.Replace);
+            assert.strictEqual(replaceHistory, true);
+        });
+    });
+
+    describe('History None Navigate Link', function () {
+        it('should not call history manager', function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'r' }]}
+                ]);
+            var replaceHistory;
+            Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
+                replaceHistory = true;
+            }
+            var link = Navigation.StateController.getNavigationLink('d');
+            Navigation.StateController.navigateLink(link, false, Navigation.HistoryAction.None);
+            assert.strictEqual(replaceHistory, undefined);
+        });
+    });
 });
 });

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -4219,64 +4219,144 @@ describe('Navigation', function () {
         }
     });
 
-    describe('History Null Navigate', function () {
-        it('should pass replace false to history manager', function() {
+    describe('History Null', function () {
+        var replaceHistory;
+        beforeEach(function() {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's', states: [
                     { key: 's', route: 'r' }]}
                 ]);
-            var replaceHistory;
+            replaceHistory = undefined;
             Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
                 replaceHistory = replace;
             }
-            Navigation.StateController.navigate('d');
-            assert.strictEqual(replaceHistory, false);
         });
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d');
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d');
+                Navigation.StateController.navigateLink(link);
+            });
+            test();
+        });
+        
+        function test() {
+            it('should pass replace false to history manager', function() {
+                assert.strictEqual(replaceHistory, false);
+            });
+        }
     });
 
-    describe('History Add Navigate', function () {
-        it('should pass replace false to history manager', function() {
+    describe('History Add', function () {
+        var replaceHistory;
+        beforeEach(function() {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's', states: [
                     { key: 's', route: 'r' }]}
                 ]);
-            var replaceHistory;
+            replaceHistory = undefined;
             Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
                 replaceHistory = replace;
             }
-            Navigation.StateController.navigate('d', null, Navigation.HistoryAction.Add);
-            assert.strictEqual(replaceHistory, false);
         });
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d', null, Navigation.HistoryAction.Add);
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d');
+                Navigation.StateController.navigateLink(link, false, Navigation.HistoryAction.Add);
+            });
+            test();
+        });
+        
+        function test() {
+            it('should pass replace false to history manager', function() {
+                assert.strictEqual(replaceHistory, false);
+            });
+        }
     });
 
-    describe('History Replace Navigate', function () {
-        it('should pass replace true to history manager', function() {
+    describe('History Replace', function () {
+        var replaceHistory;
+        beforeEach(function() {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's', states: [
                     { key: 's', route: 'r' }]}
                 ]);
-            var replaceHistory;
+            replaceHistory = undefined;
             Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
                 replaceHistory = replace;
             }
-            Navigation.StateController.navigate('d', null, Navigation.HistoryAction.Replace);
-            assert.strictEqual(replaceHistory, true);
         });
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d', null, Navigation.HistoryAction.Replace);
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d');
+                Navigation.StateController.navigateLink(link, false, Navigation.HistoryAction.Replace);
+            });
+            test();
+        });
+        
+        function test() {
+            it('should pass replace true to history manager', function() {
+                assert.strictEqual(replaceHistory, true);
+            });
+        }
     });
 
-    describe('History None Navigate', function () {
-        it('should not call history manager', function() {
+    describe('History None', function () {
+        var replaceHistory;
+        beforeEach(function() {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's', states: [
                     { key: 's', route: 'r' }]}
                 ]);
-            var replaceHistory;
+            replaceHistory = undefined;
             Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
                 replaceHistory = true;
             }
-            Navigation.StateController.navigate('d', null, Navigation.HistoryAction.None);
-            assert.strictEqual(replaceHistory, undefined);
         });
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d', null, Navigation.HistoryAction.None);
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d');
+                Navigation.StateController.navigateLink(link, false, Navigation.HistoryAction.None);
+            });
+            test();
+        });
+        
+        function test() {
+            it('should not call history manager', function() {
+                assert.strictEqual(replaceHistory, undefined);
+            });
+        }
     });
 
     describe('History Null Refresh Navigate', function () {
@@ -4383,7 +4463,7 @@ describe('Navigation', function () {
         });
     });
 
-    describe('History Replace Refresh Navigate', function () {
+    describe('History Replace Back Navigate', function () {
         it('should pass replace true to history manager', function() {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's0', states: [
@@ -4403,7 +4483,7 @@ describe('Navigation', function () {
         });
     });
 
-    describe('History None Refresh Navigate', function () {
+    describe('History None Back Navigate', function () {
         it('should not call history manager', function() {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's0', states: [
@@ -4419,70 +4499,6 @@ describe('Navigation', function () {
                 replaceHistory = true;
             }
             Navigation.StateController.navigateBack(1, Navigation.HistoryAction.None);
-            assert.strictEqual(replaceHistory, undefined);
-        });
-    });
-
-    describe('History Null Navigate Link', function () {
-        it('should pass replace false to history manager', function() {
-            Navigation.StateInfoConfig.build([
-                { key: 'd', initial: 's', states: [
-                    { key: 's', route: 'r' }]}
-                ]);
-            var replaceHistory;
-            Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
-                replaceHistory = replace;
-            }
-            var link = Navigation.StateController.getNavigationLink('d');
-            Navigation.StateController.navigateLink(link);
-            assert.strictEqual(replaceHistory, false);
-        });
-    });
-
-    describe('History Add Navigate Link', function () {
-        it('should pass replace false to history manager', function() {
-            Navigation.StateInfoConfig.build([
-                { key: 'd', initial: 's', states: [
-                    { key: 's', route: 'r' }]}
-                ]);
-            var replaceHistory;
-            Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
-                replaceHistory = replace;
-            }
-            var link = Navigation.StateController.getNavigationLink('d');
-            Navigation.StateController.navigateLink(link, false, Navigation.HistoryAction.Add);
-            assert.strictEqual(replaceHistory, false);
-        });
-    });
-
-    describe('History Replace Navigate Link', function () {
-        it('should pass replace true to history manager', function() {
-            Navigation.StateInfoConfig.build([
-                { key: 'd', initial: 's', states: [
-                    { key: 's', route: 'r' }]}
-                ]);
-            var replaceHistory;
-            Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
-                replaceHistory = replace;
-            }
-            var link = Navigation.StateController.getNavigationLink('d');
-            Navigation.StateController.navigateLink(link, false, Navigation.HistoryAction.Replace);
-            assert.strictEqual(replaceHistory, true);
-        });
-    });
-
-    describe('History None Navigate Link', function () {
-        it('should not call history manager', function() {
-            Navigation.StateInfoConfig.build([
-                { key: 'd', initial: 's', states: [
-                    { key: 's', route: 'r' }]}
-                ]);
-            var replaceHistory;
-            Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
-                replaceHistory = true;
-            }
-            var link = Navigation.StateController.getNavigationLink('d');
-            Navigation.StateController.navigateLink(link, false, Navigation.HistoryAction.None);
             assert.strictEqual(replaceHistory, undefined);
         });
     });

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -12,6 +12,7 @@ describe('Navigation', function () {
         Navigation.StateController.clearStateContext();
         Navigation.settings.crumbTrailPersister = new Navigation.CrumbTrailPersister();
         Navigation.settings.combineCrumbTrail = setting;
+        Navigation.settings.historyManager = new Navigation.HashHistoryManager();
     });
 
     describe('Dialog', function() {
@@ -4216,6 +4217,51 @@ describe('Navigation', function () {
                 assert.equal(Navigation.StateController.crumbs.length, 0);
             });
         }
+    });
+
+    describe('History Null Navigate', function () {
+        it('should pass replace false to history manager', function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'r' }]}
+                ]);
+            var replaceHistory;
+            Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
+                replaceHistory = replace;
+            }
+            Navigation.StateController.navigate('d');
+            assert.strictEqual(replaceHistory, false);
+        });
+    });
+
+    describe('History Add Navigate', function () {
+        it('should pass replace false to history manager', function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'r' }]}
+                ]);
+            var replaceHistory;
+            Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
+                replaceHistory = replace;
+            }
+            Navigation.StateController.navigate('d', null, Navigation.HistoryAction.Add);
+            assert.strictEqual(replaceHistory, false);
+        });
+    });
+
+    describe('History Replace Navigate', function () {
+        it('should pass replace true to history manager', function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'r' }]}
+                ]);
+            var replaceHistory;
+            Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
+                replaceHistory = replace;
+            }
+            Navigation.StateController.navigate('d', null, Navigation.HistoryAction.Replace);
+            assert.strictEqual(replaceHistory, true);
+        });
     });
 });
 });

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -4263,5 +4263,84 @@ describe('Navigation', function () {
             assert.strictEqual(replaceHistory, true);
         });
     });
+
+    describe('History None Navigate', function () {
+        it('should pass replace true to history manager', function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'r' }]}
+                ]);
+            var replaceHistory;
+            Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
+                replaceHistory = true;
+            }
+            Navigation.StateController.navigate('d', null, Navigation.HistoryAction.None);
+            assert.strictEqual(replaceHistory, undefined);
+        });
+    });
+
+    describe('History Null Refresh Navigate', function () {
+        it('should pass replace false to history manager', function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'r' }]}
+                ]);
+            Navigation.StateController.navigate('d');
+            var replaceHistory;
+            Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
+                replaceHistory = replace;
+            }
+            Navigation.StateController.refresh();
+            assert.strictEqual(replaceHistory, false);
+        });
+    });
+
+    describe('History Add Refresh Navigate', function () {
+        it('should pass replace false to history manager', function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'r' }]}
+                ]);
+            Navigation.StateController.navigate('d', null, Navigation.HistoryAction.Add);
+            var replaceHistory;
+            Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
+                replaceHistory = replace;
+            }
+            Navigation.StateController.refresh(null, Navigation.HistoryAction.Add);
+            assert.strictEqual(replaceHistory, false);
+        });
+    });
+
+    describe('History Replace Refresh Navigate', function () {
+        it('should pass replace true to history manager', function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'r' }]}
+                ]);
+            Navigation.StateController.navigate('d', null, Navigation.HistoryAction.Replace);
+            var replaceHistory;
+            Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
+                replaceHistory = replace;
+            }
+            Navigation.StateController.refresh(null, Navigation.HistoryAction.Replace);
+            assert.strictEqual(replaceHistory, true);
+        });
+    });
+
+    describe('History None Refresh Navigate', function () {
+        it('should pass replace true to history manager', function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'r' }]}
+                ]);
+            Navigation.StateController.navigate('d', null, Navigation.HistoryAction.Replace);
+            var replaceHistory;
+            Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
+                replaceHistory = true;
+            }
+            Navigation.StateController.refresh(null, Navigation.HistoryAction.None);
+            assert.strictEqual(replaceHistory, undefined);
+        });
+    });
 });
 });

--- a/NavigationJS/test/navigation-tests.ts
+++ b/NavigationJS/test/navigation-tests.ts
@@ -97,8 +97,10 @@ module NavigationTests {
 	// Navigation
 	Navigation.start('home');
 	Navigation.StateController.navigate('person');
+	Navigation.StateController.navigate('person', null, Navigation.HistoryAction.Add);
 	Navigation.StateController.refresh();
-	Navigation.StateController.refresh({ page: 2 });
+	Navigation.StateController.refresh({ page: 3 });
+	Navigation.StateController.refresh({ page: 2 }, Navigation.HistoryAction.Replace);
 	Navigation.StateController.navigate('select', { id: 10 });
 	var canGoBack: boolean = Navigation.StateController.canNavigateBack(1);
 	Navigation.StateController.navigateBack(1);
@@ -108,14 +110,15 @@ module NavigationTests {
 	var link = Navigation.StateController.getNavigationLink('person');
 	link = Navigation.StateController.getRefreshLink();
 	link = Navigation.StateController.getRefreshLink({ page: 2 });
+	Navigation.StateController.navigateLink(link);
 	link = Navigation.StateController.getNavigationLink('select', { id: 10 });
 	var nextDialog = Navigation.StateController.getNextState('select').parent;
 	person = nextDialog;
-	Navigation.StateController.navigateLink(link);
+	Navigation.StateController.navigateLink(link, false);
 	link = Navigation.StateController.getNavigationBackLink(1);
 	var crumb = Navigation.StateController.crumbs[0];
 	link = crumb.navigationLink;
-	Navigation.StateController.navigateLink(link, true);
+	Navigation.StateController.navigateLink(link, true, Navigation.HistoryAction.None);
 	
 	// StateContext
 	Navigation.StateController.navigate('home');

--- a/NavigationKnockout/sample/server.js
+++ b/NavigationKnockout/sample/server.js
@@ -1,0 +1,22 @@
+var http = require('http');
+var fs = require('fs');
+
+http.createServer(function(req, res) {
+	if (req.url === '/favicon.ico') {
+		res.statusCode = 404;
+		res.end();
+		return true;
+	}
+	var fileName;
+	if (req.url === '/') {
+		fileName = 'app.html'
+		res.setHeader('content-type', 'text/html');
+	} else {
+		if (req.url.indexOf('/', 1) !== -1)
+			fileName = '../..' + req.url;
+		else
+			fileName = req.url.substring(1);
+		res.setHeader('content-type', 'text/javascript');
+	}
+	fs.createReadStream(fileName).pipe(res);
+}).listen(8080);

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -49,7 +49,10 @@ class LinkUtility {
                             e.preventDefault();
                         else
                             e['returnValue'] = false;
-                        Navigation.StateController.navigateLink(link, false, ko.unwrap(allBindings.get('historyAction')));
+                        var historyAction = ko.unwrap(allBindings.get('historyAction'));
+                        if (typeof historyAction === 'string')
+                            historyAction = Navigation.HistoryAction[historyAction];
+                        Navigation.StateController.navigateLink(link, false, historyAction);
                     }
                 }
             }

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -49,7 +49,7 @@ class LinkUtility {
                             e.preventDefault();
                         else
                             e['returnValue'] = false;
-                        Navigation.StateController.navigateLink(link);
+                        Navigation.StateController.navigateLink(link, false, ko.unwrap(allBindings.get('historyAction')));
                     }
                 }
             }

--- a/NavigationKnockout/src/navigation.d.ts
+++ b/NavigationKnockout/src/navigation.d.ts
@@ -279,9 +279,21 @@ declare module Navigation {
         static build(dialogs: IDialog<string, IState<ITransition<string>[]>[]>[]): void;
     }
     
+    /**
+     * Determines the effect on browser history after a successful navigation
+     */
     enum HistoryAction {
+        /**
+         * Creates a new browser history entry
+         */
         Add = 0,
+        /**
+         * Changes the current browser history entry
+         */
         Replace = 1,
+        /**
+         * Leaves browser history unchanged
+         */
         None = 2,
     }    
 
@@ -301,7 +313,15 @@ declare module Navigation {
         /**
          * Adds browser history
          * @param state The State navigated to
-         * @param url The current url 
+         * @param url The current url
+         */
+        addHistory(state: State, url: string): void;
+        /**
+         * Adds browser history
+         * @param state The State navigated to
+         * @param url The current url
+         * @param replace A value indicating whether to replace the current
+         * browser history entry
          */
         addHistory(state: State, url: string, replace: boolean): void;
         /**
@@ -344,6 +364,14 @@ declare module Navigation {
          * @param state The State navigated to
          * @param url The current url 
          */
+        addHistory(state: State, url: string): void;
+        /**
+         * Sets the browser Url's hash to the url
+         * @param state The State navigated to
+         * @param url The current url 
+         * @param replace A value indicating whether to replace the current
+         * browser history entry
+         */
         addHistory(state: State, url: string, replace: boolean): void;
         /**
          * Gets the current location
@@ -379,6 +407,14 @@ declare module Navigation {
          * Sets the browser Url to the url using pushState
          * @param state The State navigated to
          * @param url The current url 
+         */
+        addHistory(state: State, url: string): void;
+        /**
+         * Sets the browser Url to the url using pushState
+         * @param state The State navigated to
+         * @param url The current url 
+         * @param replace A value indicating whether to replace the current
+         * browser history entry
          */
         addHistory(state: State, url: string, replace: boolean): void;
         /**
@@ -724,6 +760,19 @@ declare module Navigation {
          * @throws A mandatory route parameter has not been supplied a value
          */
         static navigate(action: string, toData: any): void;
+        /**
+         * Navigates to a State. Depending on the action will either navigate
+         * to the 'to' State of a Transition or the 'initial' State of a
+         * Dialog
+         * @param action The key of a child Transition or the key of a Dialog
+         * @param toData The NavigationData to be passed to the next State and
+         * stored in the StateContext
+         * @param A value determining the effect on browser history
+         * @throws action does not match the key of a child Transition or the
+         * key of a Dialog; or there is NavigationData that cannot be converted
+         * to a String
+         * @throws A mandatory route parameter has not been supplied a value
+         */
         static navigate(action: string, toData: any, historyAction: HistoryAction): void;
         /**
          * Gets a Url to navigate to a State. Depending on the action will
@@ -764,6 +813,16 @@ declare module Navigation {
          * @throws A mandatory route parameter has not been supplied a value
          */
         static navigateBack(distance: number): void;
+        /**
+         * Navigates back to the Crumb contained in the crumb trail,
+         * represented by the Crumbs collection, as specified by the distance.
+         * In the crumb trail no two crumbs can have the same State but all
+         * must have the same Dialog
+         * @param distance Starting at 1, the number of Crumb steps to go back
+         * @param A value determining the effect on browser history
+         * @throws canNavigateBack returns false for this distance
+         * @throws A mandatory route parameter has not been supplied a value
+         */
         static navigateBack(distance: number, historyAction: HistoryAction): void;
         /**
          * Gets a Url to navigate to a Crumb contained in the crumb trail, 
@@ -787,6 +846,14 @@ declare module Navigation {
          * @throws A mandatory route parameter has not been supplied a value
          */
         static refresh(toData: any): void;
+        /**
+         * Navigates to the current State
+         * @param toData The NavigationData to be passed to the current State
+         * and stored in the StateContext
+         * @param A value determining the effect on browser history
+         * @throws There is NavigationData that cannot be converted to a String
+         * @throws A mandatory route parameter has not been supplied a value
+         */
         static refresh(toData: any, historyAction: HistoryAction): void;
         /**
          * Gets a Url to navigate to the current State passing no 
@@ -812,6 +879,12 @@ declare module Navigation {
          * @param history A value indicating whether browser history was used
          */
         static navigateLink(url: string, history: boolean): void;
+        /**
+         * Navigates to the url
+         * @param url The target location
+         * @param history A value indicating whether browser history was used
+         * @param A value determining the effect on browser history
+         */
         static navigateLink(url: string, history: boolean, historyAction: HistoryAction): void;
         /**
          * Gets the next State. Depending on the action will either return the

--- a/NavigationKnockout/src/navigation.d.ts
+++ b/NavigationKnockout/src/navigation.d.ts
@@ -278,6 +278,12 @@ declare module Navigation {
          */
         static build(dialogs: IDialog<string, IState<ITransition<string>[]>[]>[]): void;
     }
+    
+    enum HistoryAction {
+        Add = 0,
+        Replace = 1,
+        None = 2,
+    }    
 
     /**
      * Defines a contract a class must implement in order to manage the browser
@@ -297,7 +303,7 @@ declare module Navigation {
          * @param state The State navigated to
          * @param url The current url 
          */
-        addHistory(state: State, url: string): void;
+        addHistory(state: State, url: string, replace: boolean): void;
         /**
          * Gets the current location
          */
@@ -338,7 +344,7 @@ declare module Navigation {
          * @param state The State navigated to
          * @param url The current url 
          */
-        addHistory(state: State, url: string): void;
+        addHistory(state: State, url: string, replace: boolean): void;
         /**
          * Gets the current location
          */
@@ -374,7 +380,7 @@ declare module Navigation {
          * @param state The State navigated to
          * @param url The current url 
          */
-        addHistory(state: State, url: string): void;
+        addHistory(state: State, url: string, replace: boolean): void;
         /**
          * Gets the current location
          */
@@ -587,6 +593,11 @@ declare module Navigation {
          * ReturnData should be part of the CrumbTrail
          */
         combineCrumbTrail: boolean;
+        /**
+         * Gets or sets a value indicating whether to track PreviousData when
+         * navigating back or refreshing and combineCrumbTrail is false 
+         */
+        trackAllPreviousData: boolean;
     }
 
     /**
@@ -596,6 +607,18 @@ declare module Navigation {
      */
     class StateContext {
         /**
+         * Gets the last State displayed before the current State
+         */
+        static oldState: State;
+        /**
+         * Gets the parent of the OldState property
+         */
+        static oldDialog: Dialog;
+        /**
+         * Gets the NavigationData for the last displayed State
+         */
+        static oldData: any;
+        /**
          * Gets the State navigated away from to reach the current State
          */
         static previousState: State;
@@ -603,6 +626,10 @@ declare module Navigation {
          * Gets the parent of the PreviousState property
          */
         static previousDialog: Dialog;
+        /**
+         * Gets the NavigationData for the navigated away from State
+         */
+        static previousData: any;
         /**
          * Gets the current State
          */
@@ -612,8 +639,7 @@ declare module Navigation {
          */
         static dialog: Dialog;
         /**
-         * Gets the NavigationData for the current State. It can be accessed.
-         * Will become the data stored in a Crumb when part of a crumb trail
+         * Gets the NavigationData for the current State
          */
         static data: any;
         /**
@@ -698,6 +724,7 @@ declare module Navigation {
          * @throws A mandatory route parameter has not been supplied a value
          */
         static navigate(action: string, toData: any): void;
+        static navigate(action: string, toData: any, historyAction: HistoryAction): void;
         /**
          * Gets a Url to navigate to a State. Depending on the action will
          * either navigate to the 'to' State of a Transition or the 'initial'
@@ -737,6 +764,7 @@ declare module Navigation {
          * @throws A mandatory route parameter has not been supplied a value
          */
         static navigateBack(distance: number): void;
+        static navigateBack(distance: number, historyAction: HistoryAction): void;
         /**
          * Gets a Url to navigate to a Crumb contained in the crumb trail, 
          * represented by the Crumbs collection, as specified by the distance.
@@ -759,6 +787,7 @@ declare module Navigation {
          * @throws A mandatory route parameter has not been supplied a value
          */
         static refresh(toData: any): void;
+        static refresh(toData: any, historyAction: HistoryAction): void;
         /**
          * Gets a Url to navigate to the current State passing no 
          * NavigationData
@@ -783,6 +812,7 @@ declare module Navigation {
          * @param history A value indicating whether browser history was used
          */
         static navigateLink(url: string, history: boolean): void;
+        static navigateLink(url: string, history: boolean, historyAction: HistoryAction): void;
         /**
          * Gets the next State. Depending on the action will either return the
          * 'to' State of a Transition or the 'initial' State of a Dialog

--- a/NavigationReact/sample/isomorphic/NavigationServer.js
+++ b/NavigationReact/sample/isomorphic/NavigationServer.js
@@ -12,6 +12,7 @@ http.createServer(function(req, res) {
 	Navigation.StateController.navigateLink(req.url);
 	// Get the props data for the active State
 	getProps(function(props) {
+		res.setHeader('vary', 'content-type');
 		if (req.headers['content-type'] === 'application/json') {
 			res.write(JSON.stringify(props));
 		} else {

--- a/NavigationReact/sample/server.js
+++ b/NavigationReact/sample/server.js
@@ -1,0 +1,22 @@
+var http = require('http');
+var fs = require('fs');
+
+http.createServer(function(req, res) {
+	if (req.url === '/favicon.ico') {
+		res.statusCode = 404;
+		res.end();
+		return true;
+	}
+	var fileName;
+	if (req.url === '/') {
+		fileName = 'app.html'
+		res.setHeader('content-type', 'text/html');
+	} else {
+		if (req.url.indexOf('/', 1) !== -1)
+			fileName = '../..' + req.url;
+		else
+			fileName = req.url.substring(1);
+		res.setHeader('content-type', 'text/javascript');
+	}
+	fs.createReadStream(fileName).pipe(res);
+}).listen(8080);

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -53,7 +53,10 @@ class LinkUtility {
                     var navigating = this.getNavigating(props);
                     if (navigating(e, domId, link)) {
                         e.preventDefault();
-                        Navigation.StateController.navigateLink(link, false, props.historyAction);
+                        var historyAction = props.historyAction;
+                        if (typeof historyAction === 'string')
+                            historyAction = Navigation.HistoryAction[historyAction];
+                        Navigation.StateController.navigateLink(link, false, historyAction);
                     }
                 }
             }

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -53,7 +53,7 @@ class LinkUtility {
                     var navigating = this.getNavigating(props);
                     if (navigating(e, domId, link)) {
                         e.preventDefault();
-                        Navigation.StateController.navigateLink(link);
+                        Navigation.StateController.navigateLink(link, false, props.historyAction);
                     }
                 }
             }

--- a/NavigationReact/src/NavigationBackLink.ts
+++ b/NavigationReact/src/NavigationBackLink.ts
@@ -2,21 +2,26 @@
 import Navigation = require('navigation');
 import React = require('react');
 
-var NavigationBackLink = React.createClass({
-    onNavigate() {
-        this.forceUpdate();
-    },
-    getNavigationBackLink(): string {
+interface Props {
+    distance: number;
+    lazy?: boolean;
+}
+
+class NavigationBackLink extends React.Component<Props, {}> {
+    private getNavigationBackLink(): string {
         return LinkUtility.getLink(() => Navigation.StateController.getNavigationBackLink(this.props.distance));
-    },
+    }
+    
     componentDidMount() {
         if (!this.props.lazy)
-            Navigation.StateController.onNavigate(this.onNavigate);
-    },
+            Navigation.StateController.onNavigate(() => this.forceUpdate);
+    }
+    
     componentWillUnmount() {
         if (!this.props.lazy)
-            Navigation.StateController.offNavigate(this.onNavigate);
-    },
+            Navigation.StateController.offNavigate(() => this.forceUpdate);
+    }
+    
     render() {
         var props: any = {};
         for(var key in this.props)
@@ -25,5 +30,5 @@ var NavigationBackLink = React.createClass({
         LinkUtility.addListeners(this, props, () => this.getNavigationBackLink());
         return React.createElement(props.href ? 'a' : 'span', props);
     }
-});
+};
 export = NavigationBackLink;

--- a/NavigationReact/src/NavigationBackLink.ts
+++ b/NavigationReact/src/NavigationBackLink.ts
@@ -2,12 +2,7 @@
 import Navigation = require('navigation');
 import React = require('react');
 
-interface Props {
-    distance: number;
-    lazy?: boolean;
-}
-
-class NavigationBackLink extends React.Component<Props, {}> {
+class NavigationBackLink extends React.Component<any, any> {
     private getNavigationBackLink(): string {
         return LinkUtility.getLink(() => Navigation.StateController.getNavigationBackLink(this.props.distance));
     }

--- a/NavigationReact/src/NavigationLink.ts
+++ b/NavigationReact/src/NavigationLink.ts
@@ -2,26 +2,37 @@
 import Navigation = require('navigation');
 import React = require('react');
 
-var NavigationLink = React.createClass({
-    onNavigate() {
-        this.forceUpdate();
-    },
-    getNavigationLink(): string {
+interface Props {
+    action: string;
+    toData?: any;
+    includeCurrentData?: boolean;
+    currentDataKeys?: string;
+    lazy?: boolean;
+    activeCssClass?: string;
+    disableActive?: boolean;
+}
+
+class NavigationLink extends React.Component<Props, {}> {
+    private getNavigationLink(): string {
         var toData = LinkUtility.getData(this.props.toData, this.props.includeCurrentData, this.props.currentDataKeys);
         return LinkUtility.getLink(() => Navigation.StateController.getNavigationLink(this.props.action, toData));
-    },
-    isActive(action: string): boolean {
+    }
+    
+    private isActive(action: string): boolean {
         var nextState = Navigation.StateController.getNextState(action);
         return nextState === nextState.parent.initial && nextState.parent === Navigation.StateContext.dialog;
-    },
+    }
+    
     componentDidMount() {
         if (!this.props.lazy)
-            Navigation.StateController.onNavigate(this.onNavigate);
-    },
+            Navigation.StateController.onNavigate(() => this.forceUpdate());
+    }
+    
     componentWillUnmount() {
         if (!this.props.lazy)
-            Navigation.StateController.offNavigate(this.onNavigate);
-    },
+            Navigation.StateController.offNavigate(() => this.forceUpdate());
+    }
+    
     render() {
         var props: any = {};
         for(var key in this.props)
@@ -36,5 +47,5 @@ var NavigationLink = React.createClass({
         LinkUtility.setActive(props, active, this.props.activeCssClass, this.props.disableActive);
         return React.createElement(props.href ? 'a' : 'span', props);
     }
-});
+};
 export = NavigationLink;

--- a/NavigationReact/src/NavigationLink.ts
+++ b/NavigationReact/src/NavigationLink.ts
@@ -2,17 +2,7 @@
 import Navigation = require('navigation');
 import React = require('react');
 
-interface Props {
-    action: string;
-    toData?: any;
-    includeCurrentData?: boolean;
-    currentDataKeys?: string;
-    lazy?: boolean;
-    activeCssClass?: string;
-    disableActive?: boolean;
-}
-
-class NavigationLink extends React.Component<Props, {}> {
+class NavigationLink extends React.Component<any, any> {
     private getNavigationLink(): string {
         var toData = LinkUtility.getData(this.props.toData, this.props.includeCurrentData, this.props.currentDataKeys);
         return LinkUtility.getLink(() => Navigation.StateController.getNavigationLink(this.props.action, toData));

--- a/NavigationReact/src/RefreshLink.ts
+++ b/NavigationReact/src/RefreshLink.ts
@@ -2,22 +2,31 @@
 import Navigation = require('navigation');
 import React = require('react');
 
-var RefreshLink = React.createClass({
-    onNavigate() {
-        this.forceUpdate();
-    },
+interface Props {
+    toData?: any;
+    includeCurrentData?: boolean;
+    currentDataKeys?: string;
+    lazy?: boolean;
+    activeCssClass?: string;
+    disableActive?: boolean;    
+}
+
+class RefreshLink extends React.Component<Props, {}> {
     getRefreshLink(): string {
         var toData = LinkUtility.getData(this.props.toData, this.props.includeCurrentData, this.props.currentDataKeys);
         return LinkUtility.getLink(() => Navigation.StateController.getRefreshLink(toData));
-    },
+    }
+    
     componentDidMount() {
         if (!this.props.lazy)
-            Navigation.StateController.onNavigate(this.onNavigate);
-    },
+            Navigation.StateController.onNavigate(() => this.forceUpdate);
+    }
+    
     componentWillUnmount() {
         if (!this.props.lazy)
-            Navigation.StateController.offNavigate(this.onNavigate);
-    },
+            Navigation.StateController.offNavigate(() => this.forceUpdate);
+    }
+    
     render() {
         var props: any = {};
         for(var key in this.props)
@@ -32,5 +41,5 @@ var RefreshLink = React.createClass({
         LinkUtility.setActive(props, active, this.props.activeCssClass, this.props.disableActive);
         return React.createElement(props.href ? 'a' : 'span', props);
     }
-});
+};
 export = RefreshLink;

--- a/NavigationReact/src/RefreshLink.ts
+++ b/NavigationReact/src/RefreshLink.ts
@@ -2,16 +2,7 @@
 import Navigation = require('navigation');
 import React = require('react');
 
-interface Props {
-    toData?: any;
-    includeCurrentData?: boolean;
-    currentDataKeys?: string;
-    lazy?: boolean;
-    activeCssClass?: string;
-    disableActive?: boolean;    
-}
-
-class RefreshLink extends React.Component<Props, {}> {
+class RefreshLink extends React.Component<any, any> {
     getRefreshLink(): string {
         var toData = LinkUtility.getData(this.props.toData, this.props.includeCurrentData, this.props.currentDataKeys);
         return LinkUtility.getLink(() => Navigation.StateController.getRefreshLink(toData));

--- a/NavigationReact/src/navigation.d.ts
+++ b/NavigationReact/src/navigation.d.ts
@@ -279,9 +279,21 @@ declare module Navigation {
         static build(dialogs: IDialog<string, IState<ITransition<string>[]>[]>[]): void;
     }
     
+    /**
+     * Determines the effect on browser history after a successful navigation
+     */
     enum HistoryAction {
+        /**
+         * Creates a new browser history entry
+         */
         Add = 0,
+        /**
+         * Changes the current browser history entry
+         */
         Replace = 1,
+        /**
+         * Leaves browser history unchanged
+         */
         None = 2,
     }    
 
@@ -301,7 +313,15 @@ declare module Navigation {
         /**
          * Adds browser history
          * @param state The State navigated to
-         * @param url The current url 
+         * @param url The current url
+         */
+        addHistory(state: State, url: string): void;
+        /**
+         * Adds browser history
+         * @param state The State navigated to
+         * @param url The current url
+         * @param replace A value indicating whether to replace the current
+         * browser history entry
          */
         addHistory(state: State, url: string, replace: boolean): void;
         /**
@@ -344,6 +364,14 @@ declare module Navigation {
          * @param state The State navigated to
          * @param url The current url 
          */
+        addHistory(state: State, url: string): void;
+        /**
+         * Sets the browser Url's hash to the url
+         * @param state The State navigated to
+         * @param url The current url 
+         * @param replace A value indicating whether to replace the current
+         * browser history entry
+         */
         addHistory(state: State, url: string, replace: boolean): void;
         /**
          * Gets the current location
@@ -379,6 +407,14 @@ declare module Navigation {
          * Sets the browser Url to the url using pushState
          * @param state The State navigated to
          * @param url The current url 
+         */
+        addHistory(state: State, url: string): void;
+        /**
+         * Sets the browser Url to the url using pushState
+         * @param state The State navigated to
+         * @param url The current url 
+         * @param replace A value indicating whether to replace the current
+         * browser history entry
          */
         addHistory(state: State, url: string, replace: boolean): void;
         /**
@@ -724,6 +760,19 @@ declare module Navigation {
          * @throws A mandatory route parameter has not been supplied a value
          */
         static navigate(action: string, toData: any): void;
+        /**
+         * Navigates to a State. Depending on the action will either navigate
+         * to the 'to' State of a Transition or the 'initial' State of a
+         * Dialog
+         * @param action The key of a child Transition or the key of a Dialog
+         * @param toData The NavigationData to be passed to the next State and
+         * stored in the StateContext
+         * @param A value determining the effect on browser history
+         * @throws action does not match the key of a child Transition or the
+         * key of a Dialog; or there is NavigationData that cannot be converted
+         * to a String
+         * @throws A mandatory route parameter has not been supplied a value
+         */
         static navigate(action: string, toData: any, historyAction: HistoryAction): void;
         /**
          * Gets a Url to navigate to a State. Depending on the action will
@@ -764,6 +813,16 @@ declare module Navigation {
          * @throws A mandatory route parameter has not been supplied a value
          */
         static navigateBack(distance: number): void;
+        /**
+         * Navigates back to the Crumb contained in the crumb trail,
+         * represented by the Crumbs collection, as specified by the distance.
+         * In the crumb trail no two crumbs can have the same State but all
+         * must have the same Dialog
+         * @param distance Starting at 1, the number of Crumb steps to go back
+         * @param A value determining the effect on browser history
+         * @throws canNavigateBack returns false for this distance
+         * @throws A mandatory route parameter has not been supplied a value
+         */
         static navigateBack(distance: number, historyAction: HistoryAction): void;
         /**
          * Gets a Url to navigate to a Crumb contained in the crumb trail, 
@@ -787,6 +846,14 @@ declare module Navigation {
          * @throws A mandatory route parameter has not been supplied a value
          */
         static refresh(toData: any): void;
+        /**
+         * Navigates to the current State
+         * @param toData The NavigationData to be passed to the current State
+         * and stored in the StateContext
+         * @param A value determining the effect on browser history
+         * @throws There is NavigationData that cannot be converted to a String
+         * @throws A mandatory route parameter has not been supplied a value
+         */
         static refresh(toData: any, historyAction: HistoryAction): void;
         /**
          * Gets a Url to navigate to the current State passing no 
@@ -812,6 +879,12 @@ declare module Navigation {
          * @param history A value indicating whether browser history was used
          */
         static navigateLink(url: string, history: boolean): void;
+        /**
+         * Navigates to the url
+         * @param url The target location
+         * @param history A value indicating whether browser history was used
+         * @param A value determining the effect on browser history
+         */
         static navigateLink(url: string, history: boolean, historyAction: HistoryAction): void;
         /**
          * Gets the next State. Depending on the action will either return the

--- a/NavigationReact/src/navigation.d.ts
+++ b/NavigationReact/src/navigation.d.ts
@@ -278,6 +278,12 @@ declare module Navigation {
          */
         static build(dialogs: IDialog<string, IState<ITransition<string>[]>[]>[]): void;
     }
+    
+    enum HistoryAction {
+        Add = 0,
+        Replace = 1,
+        None = 2,
+    }    
 
     /**
      * Defines a contract a class must implement in order to manage the browser
@@ -297,7 +303,7 @@ declare module Navigation {
          * @param state The State navigated to
          * @param url The current url 
          */
-        addHistory(state: State, url: string): void;
+        addHistory(state: State, url: string, replace: boolean): void;
         /**
          * Gets the current location
          */
@@ -338,7 +344,7 @@ declare module Navigation {
          * @param state The State navigated to
          * @param url The current url 
          */
-        addHistory(state: State, url: string): void;
+        addHistory(state: State, url: string, replace: boolean): void;
         /**
          * Gets the current location
          */
@@ -374,7 +380,7 @@ declare module Navigation {
          * @param state The State navigated to
          * @param url The current url 
          */
-        addHistory(state: State, url: string): void;
+        addHistory(state: State, url: string, replace: boolean): void;
         /**
          * Gets the current location
          */
@@ -587,6 +593,11 @@ declare module Navigation {
          * ReturnData should be part of the CrumbTrail
          */
         combineCrumbTrail: boolean;
+        /**
+         * Gets or sets a value indicating whether to track PreviousData when
+         * navigating back or refreshing and combineCrumbTrail is false 
+         */
+        trackAllPreviousData: boolean;
     }
 
     /**
@@ -596,6 +607,18 @@ declare module Navigation {
      */
     class StateContext {
         /**
+         * Gets the last State displayed before the current State
+         */
+        static oldState: State;
+        /**
+         * Gets the parent of the OldState property
+         */
+        static oldDialog: Dialog;
+        /**
+         * Gets the NavigationData for the last displayed State
+         */
+        static oldData: any;
+        /**
          * Gets the State navigated away from to reach the current State
          */
         static previousState: State;
@@ -603,6 +626,10 @@ declare module Navigation {
          * Gets the parent of the PreviousState property
          */
         static previousDialog: Dialog;
+        /**
+         * Gets the NavigationData for the navigated away from State
+         */
+        static previousData: any;
         /**
          * Gets the current State
          */
@@ -612,8 +639,7 @@ declare module Navigation {
          */
         static dialog: Dialog;
         /**
-         * Gets the NavigationData for the current State. It can be accessed.
-         * Will become the data stored in a Crumb when part of a crumb trail
+         * Gets the NavigationData for the current State
          */
         static data: any;
         /**
@@ -698,6 +724,7 @@ declare module Navigation {
          * @throws A mandatory route parameter has not been supplied a value
          */
         static navigate(action: string, toData: any): void;
+        static navigate(action: string, toData: any, historyAction: HistoryAction): void;
         /**
          * Gets a Url to navigate to a State. Depending on the action will
          * either navigate to the 'to' State of a Transition or the 'initial'
@@ -737,6 +764,7 @@ declare module Navigation {
          * @throws A mandatory route parameter has not been supplied a value
          */
         static navigateBack(distance: number): void;
+        static navigateBack(distance: number, historyAction: HistoryAction): void;
         /**
          * Gets a Url to navigate to a Crumb contained in the crumb trail, 
          * represented by the Crumbs collection, as specified by the distance.
@@ -759,6 +787,7 @@ declare module Navigation {
          * @throws A mandatory route parameter has not been supplied a value
          */
         static refresh(toData: any): void;
+        static refresh(toData: any, historyAction: HistoryAction): void;
         /**
          * Gets a Url to navigate to the current State passing no 
          * NavigationData
@@ -783,6 +812,7 @@ declare module Navigation {
          * @param history A value indicating whether browser history was used
          */
         static navigateLink(url: string, history: boolean): void;
+        static navigateLink(url: string, history: boolean, historyAction: HistoryAction): void;
         /**
          * Gets the next State. Depending on the action will either return the
          * 'to' State of a Transition or the 'initial' State of a Dialog


### PR DESCRIPTION
The default history behaviour was to add a new history entry after a successful navigation. The only way to change this was to implement a custom history manager. But, the context of how that navigation happened isn't available to the addHistory function, making it hard to decide whether to add or replace the history entry.

Added a HistoryAction enum optional parameter to all navigation functions on the StateController. This enum has three values: Add, Replace and None. The default value of the parameter is Add so the current behaviour is retained. Changed the IHistoryManager by adding an optional replace boolean to the addHistory function. The only time this will be set to true is if Replace action is passed in. Passing an action of None means the history manager won't be called.

Also, changed the Navigation plugins so that the history action can be passed into the Link components. Angular didn't allow an enum to be passed as the value of the attribute binding because the context is always the Controller scope and not the window. So allowed a string to be passed in as the history action value: 'Add', 'Replace' or 'None'.
