### PR TITLE
Set document title after history added (Fix)

### DIFF
--- a/NavigationJS/src/StateContext.ts
+++ b/NavigationJS/src/StateContext.ts
@@ -12,6 +12,7 @@ class StateContext {
     static dialog: Dialog;
     static data: any = {};
     static url: string;
+    static title: string;
 
     static includeCurrentData(data: any, keys?: string[]): any {
         if (!keys) {

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -173,8 +173,11 @@ class StateController {
                     if (url === StateContext.url)
                         this.navigateHandlers[id](oldState, state, StateContext.data);
                 }
-                if (url === StateContext.url && historyAction !== HistoryAction.None)
-                    settings.historyManager.addHistory(state, url, historyAction === HistoryAction.Replace);
+                if (url === StateContext.url)
+                    if (historyAction !== HistoryAction.None)
+                        settings.historyManager.addHistory(state, url, historyAction === HistoryAction.Replace);
+                    if (StateContext.title && (typeof document !== 'undefined'))
+                        document.title = state.title;
             }
         };
     }

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -173,11 +173,12 @@ class StateController {
                     if (url === StateContext.url)
                         this.navigateHandlers[id](oldState, state, StateContext.data);
                 }
-                if (url === StateContext.url)
+                if (url === StateContext.url) {
                     if (historyAction !== HistoryAction.None)
                         settings.historyManager.addHistory(state, url, historyAction === HistoryAction.Replace);
                     if (StateContext.title && (typeof document !== 'undefined'))
                         document.title = StateContext.title;
+                }
             }
         };
     }

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -177,7 +177,7 @@ class StateController {
                     if (historyAction !== HistoryAction.None)
                         settings.historyManager.addHistory(state, url, historyAction === HistoryAction.Replace);
                     if (StateContext.title && (typeof document !== 'undefined'))
-                        document.title = state.title;
+                        document.title = StateContext.title;
             }
         };
     }

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -21,6 +21,7 @@ class StateController {
             StateContext.state = state;
             StateContext.url = url;
             StateContext.dialog = state.parent;
+            StateContext.title = state.title;
             var data = state.stateHandler.getNavigationData(state, url);
             StateContext.data = this.parseData(data, state);
             StateContext.previousState = null;
@@ -47,6 +48,7 @@ class StateController {
         StateContext.dialog = null;
         StateContext.data = {};
         StateContext.url = null;
+        StateContext.title = null;
         CrumbTrailManager.crumbTrail = null;
         CrumbTrailManager.crumbTrailKey = null;
     }

--- a/NavigationJS/src/history/HTML5HistoryManager.ts
+++ b/NavigationJS/src/history/HTML5HistoryManager.ts
@@ -14,8 +14,6 @@ class HTML5HistoryManager implements IHistoryManager {
 
     addHistory(state: State, url: string, replace?: boolean) {
         url = url != null ? url : StateContext.url;
-        if (state && state.title && (typeof document !== 'undefined'))
-            document.title = state.title;
         url = settings.applicationPath + url;
         if (!this.disabled && location.pathname + location.search !== url) {
             if (!replace)            

--- a/NavigationJS/src/history/HashHistoryManager.ts
+++ b/NavigationJS/src/history/HashHistoryManager.ts
@@ -18,8 +18,6 @@ class HashHistoryManager implements IHistoryManager {
 
     addHistory(state: State, url: string, replace?: boolean) {
         url = url != null ? url : StateContext.url;
-        if (state && state.title && (typeof document !== 'undefined'))
-            document.title = state.title;
         url = '#' + this.encode(url);
         if (!this.disabled && location.hash !== url) {
             if (!replace)            

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -682,6 +682,10 @@ declare module Navigation {
          * Gets the current Url
          */
         static url: string;
+        /**
+         * Gets or sets the current title
+         */
+        static title: string;
         /** 
          * Combines the data with all the current NavigationData
          * @param The data to add to the current NavigationData

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -4503,5 +4503,25 @@ describe('Navigation', function () {
             assert.strictEqual(replaceHistory, undefined);
         });
     });
+
+    describe('History Navigated Navigate', function () {
+        it('should not call history manager', function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd0', initial: 's', states: [
+                    { key: 's', route: 'r0' }]},
+                { key: 'd1', initial: 's', states: [
+                    { key: 's', route: 'r1' }]}
+                ]);
+            var called = false;
+            Navigation.settings.historyManager.addHistory = (state: State, url: string, replace: boolean) => {
+                called = true;
+            }
+            Navigation.StateInfoConfig.dialogs['d0'].states['s'].navigated = () => {
+                Navigation.StateController.navigate('d1', null, Navigation.HistoryAction.None);
+            }
+            Navigation.StateController.navigate('d0');
+            assert.ok(!called);
+        });
+    });
 });
 });

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -4214,6 +4214,7 @@ describe('Navigation', function () {
                 assert.strictEqual(Navigation.StateContext.state, null);
                 assert.strictEqual(Navigation.StateContext.dialog, null);
                 assert.strictEqual(Navigation.StateContext.url, null);
+                assert.strictEqual(Navigation.StateContext.title, null);
                 assert.equal(Navigation.StateController.crumbs.length, 0);
             });
         }

--- a/NavigationJS/test/navigation-tests.ts
+++ b/NavigationJS/test/navigation-tests.ts
@@ -128,6 +128,7 @@ module NavigationTests {
 	person === Navigation.StateContext.dialog;
 	personList === Navigation.StateContext.state;
 	var url: string = Navigation.StateContext.url;
+	var title: string = Navigation.StateContext.title;
 	var page: number = Navigation.StateContext.data.page;
 	Navigation.StateController.refresh({ page: 2 });
 	person = Navigation.StateContext.oldDialog;


### PR DESCRIPTION
The document title was set before the history was added which meant the browser history entry had the wrong name. Moved the setting to after the history added.

Also, moved the title setting out of the history managers because, if the history action is None, then the history manager isn't even called. 

Added the title to the StateContext rather than read it from the State. Don't want to have context data on StateInfo because it causes problems on the server side. All context data must be clearable by calling clearStateContext, to guarantee no navigation traces of previous user left behind.