### PR TITLE
Added Empty String to Active Link check

### DIFF
--- a/NavigationAngular/src/LinkUtility.ts
+++ b/NavigationAngular/src/LinkUtility.ts
@@ -22,10 +22,13 @@ class LinkUtility {
     static isActive(key: string, val: any): boolean {
         if (!Navigation.StateContext.state)
             return false;
-        if (val != null && val.toString()) {
+        if (val != null) {
             var trackTypes = Navigation.StateContext.state.trackTypes;
             var currentVal = Navigation.StateContext.data[key];
-            return currentVal != null && (trackTypes ? val === currentVal : val.toString() == currentVal.toString());
+            if (currentVal != null)
+                return trackTypes ? val === currentVal : val.toString() == currentVal.toString();
+            else
+                return val === '';
         }
         return true;
     }

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -21,10 +21,13 @@ class LinkUtility {
     static isActive(key: string, val: any): boolean {
         if (!Navigation.StateContext.state)
             return false;
-        if (val != null && val.toString()) {
+        if (val != null) {
             var trackTypes = Navigation.StateContext.state.trackTypes;
             var currentVal = Navigation.StateContext.data[key];
-            return currentVal != null && (trackTypes ? val === currentVal : val.toString() == currentVal.toString());
+            if (currentVal != null)
+                return trackTypes ? val === currentVal : val.toString() == currentVal.toString();
+            else
+                return val === '';
         }
         return true;
     }

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -21,10 +21,13 @@ class LinkUtility {
     static isActive(key: string, val: any): boolean {
         if (!Navigation.StateContext.state)
             return false;
-        if (val != null && val.toString()) {
+        if (val != null) {
             var trackTypes = Navigation.StateContext.state.trackTypes;
             var currentVal = Navigation.StateContext.data[key];
-            return currentVal != null && (trackTypes ? val === currentVal : val.toString() == currentVal.toString());
+            if (currentVal != null)
+                return trackTypes ? val === currentVal : val.toString() == currentVal.toString();
+            else
+                return val === '';
         }
         return true;
     }

--- a/NavigationReact/src/NavigationBackLink.ts
+++ b/NavigationReact/src/NavigationBackLink.ts
@@ -9,12 +9,12 @@ class NavigationBackLink extends React.Component<any, any> {
     
     componentDidMount() {
         if (!this.props.lazy)
-            Navigation.StateController.onNavigate(() => this.forceUpdate);
+            Navigation.StateController.onNavigate(() => this.forceUpdate());
     }
     
     componentWillUnmount() {
         if (!this.props.lazy)
-            Navigation.StateController.offNavigate(() => this.forceUpdate);
+            Navigation.StateController.offNavigate(() => this.forceUpdate());
     }
     
     render() {

--- a/NavigationReact/src/RefreshLink.ts
+++ b/NavigationReact/src/RefreshLink.ts
@@ -10,12 +10,12 @@ class RefreshLink extends React.Component<any, any> {
     
     componentDidMount() {
         if (!this.props.lazy)
-            Navigation.StateController.onNavigate(() => this.forceUpdate);
+            Navigation.StateController.onNavigate(() => this.forceUpdate());
     }
     
     componentWillUnmount() {
         if (!this.props.lazy)
-            Navigation.StateController.offNavigate(() => this.forceUpdate);
+            Navigation.StateController.offNavigate(() => this.forceUpdate());
     }
     
     render() {


### PR DESCRIPTION
Imagine a State with route={filter?} and the following Links

    <RefreshLink toData={filter: ''} activeCssClass="selected" />
    <RefreshLink toData={filter: 'completed'} activeCssClass="selected" />

When the completed link was clicked, both links were marked as selected. That's because passing an empty string was treated link like passing null and so was excluded from the active check.

Changed so that an empty string is considered as passing data. An empty string is then only considered active if the current value is null (can't be empty string).

There are two different ways to pass a default value. Either pass it as null or pass the actual default. Passing null will mean it doesn't take part in the active check, passing the actual value means it will. This is good because there's a difference between resetting and passing default. Resetting means not caring what the default is and so it shouldn't be part of the active check. Passing the default means caring and so it should take part. That means can change the default value in StateInfo configuration and the active check still works the same.