### PR TITLE
Updated to TypeScript 1.7

### DIFF
--- a/NavigationAngular/src/LinkUtility.ts
+++ b/NavigationAngular/src/LinkUtility.ts
@@ -1,4 +1,7 @@
-﻿import Navigation = require('navigation');
+﻿/// <reference path="navigation.d.ts" />
+/// <reference path="angular.d.ts" />
+/// <reference path="jquery.d.ts" />
+import Navigation = require('navigation');
 import angular = require('angular');
 import jquery = require('jquery');
 

--- a/NavigationJS/src/config/IDialog.ts
+++ b/NavigationJS/src/config/IDialog.ts
@@ -3,5 +3,6 @@ interface IDialog<TState, TStates> {
     initial: TState;
     key: string;
     title?: string;
+    [extras: string]: any;
 }
 export = IDialog;

--- a/NavigationJS/src/config/IState.ts
+++ b/NavigationJS/src/config/IState.ts
@@ -7,5 +7,6 @@ interface IState<TTransitions> {
     route: string | string[];
     trackCrumbTrail?: boolean;
     trackTypes?: boolean;
+    [extras: string]: any;
 }
 export = IState;

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -31,6 +31,10 @@ declare module Navigation {
          * Gets the textual description of the dialog
          */
         title?: string;
+        /**
+         * Gets the additional dialog attributes
+         */
+        [extras: string]: any;
     }
 
     /**
@@ -75,6 +79,10 @@ declare module Navigation {
          * preserved when navigating
          */
         trackTypes?: boolean;
+        /**
+         * Gets the additional state attributes
+         */
+        [extras: string]: any;
     }
 
     /**

--- a/NavigationJS/test/navigation-tests.ts
+++ b/NavigationJS/test/navigation-tests.ts
@@ -38,8 +38,8 @@ module NavigationTests {
 	
 	// Configuration
 	Navigation.StateInfoConfig.build([
-		{ key: 'home', initial: 'page', states: [
-			{ key: 'page', route: '' }
+		{ key: 'home', initial: 'page', help: 'home.htm', states: [
+			{ key: 'page', route: '', help: 'page.htm' }
 		]},
 		{ key: 'person', initial: 'list', states: [
 			{ key: 'list', route: ['people/{page}', 'people/{page}/sort/{sort}'], transitions: [

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -1,4 +1,6 @@
-﻿import Navigation = require('navigation');
+﻿/// <reference path="navigation.d.ts" />
+/// <reference path="knockout.d.ts" />
+import Navigation = require('navigation');
 import ko = require('knockout');
 
 class LinkUtility {

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -1,4 +1,6 @@
-﻿import Navigation = require('navigation');
+﻿/// <reference path="navigation.d.ts" />
+/// <reference path="react.d.ts" />
+import Navigation = require('navigation');
 import React = require('react');
 
 class LinkUtility {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "gulp-header": "^1.2.2",
     "gulp-mocha": "^2.0.0",
     "gulp-rename": "^1.2.0",
-    "gulp-tsc": "^0.10.1",
+    "gulp-tsc": "^1.1.4",
     "gulp-uglify": "^1.1.0",
-    "tsify": "^0.8.1",
+    "tsify": "^0.13.1",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"
   },


### PR DESCRIPTION
Tried to update React but the React 0.14 typings brought in namespaces so required a TypeScript update.

Added explicit references to d.ts in plugins because TypeScript 1.6 changed the way that modules are loaded.