### PR TITLE
Repeated Array Query String Parameters

### DIFF
--- a/NavigationAngular/src/navigation.d.ts
+++ b/NavigationAngular/src/navigation.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for Navigation 1.1.0
+﻿// Type definitions for Navigation 1.2.0
 // Project: http://grahammendick.github.io/navigation/
 // Definitions by: Graham Mendick <https://github.com/grahammendick>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -31,6 +31,10 @@ declare module Navigation {
          * Gets the textual description of the dialog
          */
         title?: string;
+        /**
+         * Gets the additional dialog attributes
+         */
+        [extras: string]: any;
     }
 
     /**
@@ -75,6 +79,10 @@ declare module Navigation {
          * preserved when navigating
          */
         trackTypes?: boolean;
+        /**
+         * Gets the additional state attributes
+         */
+        [extras: string]: any;
     }
 
     /**
@@ -522,6 +530,14 @@ declare module Navigation {
          */
         getNavigationLink(state: State, data: any): string;
         /**
+         * Gets a link that navigates to the state passing the data
+         * @param state The State to navigate to
+         * @param data The data to pass when navigating
+         * @param queryStringData The query string array data
+         * @returns The navigation link
+         */
+        getNavigationLink(state: State, data: any, queryStringData: { [index: string]: string[]; }): string;
+        /**
          * Navigates to the url
          * @param oldState The current State
          * @param state The State to navigate to
@@ -535,6 +551,14 @@ declare module Navigation {
          * @returns The navigation data
          */
         getNavigationData(state: State, url: string): any;
+        /**
+         * Gets the data parsed from the url
+         * @param state The State navigated to
+         * @param url The current url
+         * @param queryStringData Stores query string keys
+         * @returns The navigation data
+         */
+        getNavigationData(state: State, url: string, queryStringData: any): any;
         /**
          * Truncates the crumb trail
          * @param The State navigated to
@@ -634,6 +658,11 @@ declare module Navigation {
          * navigating back or refreshing and combineCrumbTrail is false 
          */
         trackAllPreviousData: boolean;
+        /**
+         * Gets or sets a value indicating whether arrays should be stored in
+         * a single query string parameter
+         */
+        combineArray: boolean;
     }
 
     /**
@@ -682,6 +711,10 @@ declare module Navigation {
          * Gets the current Url
          */
         static url: string;
+        /**
+         * Gets or sets the current title
+         */
+        static title: string;
         /** 
          * Combines the data with all the current NavigationData
          * @param The data to add to the current NavigationData
@@ -908,6 +941,14 @@ declare module Navigation {
          */
         getNavigationLink(state: State, data: any): string;
         /**
+         * Gets a link that navigates to the state passing the data
+         * @param state The State to navigate to
+         * @param data The data to pass when navigating
+         * @param queryStringData The query string array data
+         * @returns The navigation link
+         */
+        getNavigationLink(state: State, data: any, queryStringData: { [index: string]: string[]; }): string;
+        /**
          * Navigates to the url
          * @param oldState The current State
          * @param state The State to navigate to
@@ -921,6 +962,14 @@ declare module Navigation {
          * @returns The navigation data
          */
         getNavigationData(state: State, url: string): any;
+        /**
+         * Gets the data parsed from the url
+         * @param state The State navigated to
+         * @param url The current url
+         * @param queryStringData Stores query string keys
+         * @returns The navigation data
+         */
+        getNavigationData(state: State, url: string, queryStringData: any): any;
         /**
          * Truncates the crumb trail whenever a repeated or initial State is
          * encountered

--- a/NavigationJS/src/ArrayConverter.ts
+++ b/NavigationJS/src/ArrayConverter.ts
@@ -39,20 +39,20 @@ class ArrayConverter extends TypeConverter {
     }
 
     convertTo(val: any): { val: string, vals?: string[] } {
-        var formatArray = [];
-        var formatValsArray = [];
+        var valArray = [];
+        var vals = [];
         var arr: any[] = val;
         for (var i = 0; i < arr.length; i++) {
             if (arr[i] != null && arr[i].toString()) {
                 var convertedValue = this.converter.convertTo(arr[i]).val;
-                formatValsArray.push(convertedValue);
-                formatArray.push(convertedValue.replace(new RegExp(ArrayConverter.SEPARATOR, 'g'), ArrayConverter.SEPARATOR2));
+                vals.push(convertedValue);
+                valArray.push(convertedValue.replace(new RegExp(ArrayConverter.SEPARATOR, 'g'), ArrayConverter.SEPARATOR2));
             } else {
-                formatValsArray.push('');
-                formatArray.push('');
+                vals.push('');
+                valArray.push('');
             }
         }
-        return { val: formatArray.join(ArrayConverter.SEPARATOR1), vals: formatValsArray };
+        return { val: valArray.join(ArrayConverter.SEPARATOR1), vals: vals };
     }
 }
 export = ArrayConverter;

--- a/NavigationJS/src/ArrayConverter.ts
+++ b/NavigationJS/src/ArrayConverter.ts
@@ -15,7 +15,7 @@ class ArrayConverter extends TypeConverter {
         return this.converter.getType() + 'array';
     }
 
-    convertFrom(val: string): any {
+    convertFrom(val: string | string[]): any {
         var arr = [];
         if (typeof val === 'string') {
             if (val.length !== 0) {

--- a/NavigationJS/src/ArrayConverter.ts
+++ b/NavigationJS/src/ArrayConverter.ts
@@ -17,14 +17,20 @@ class ArrayConverter extends TypeConverter {
 
     convertFrom(val: string): any {
         var arr = [];
-        if (val.length !== 0) {
-            var vals = val.split(ArrayConverter.SEPARATOR1);
-            for (var i = 0; i < vals.length; i++) {
-                if (vals[i].length !== 0)
-                    arr.push(this.converter.convertFrom(vals[i].replace(new RegExp(ArrayConverter.SEPARATOR2, 'g'), ArrayConverter.SEPARATOR)));
-                else
-                    arr.push(null);
+        if (typeof val === 'string') {
+            if (val.length !== 0) {
+                var vals = val.split(ArrayConverter.SEPARATOR1);
+                for (var i = 0; i < vals.length; i++) {
+                    if (vals[i].length !== 0)
+                        arr.push(this.converter.convertFrom(vals[i].replace(new RegExp(ArrayConverter.SEPARATOR2, 'g'), ArrayConverter.SEPARATOR)));
+                    else
+                        arr.push(null);
+                }
             }
+        } else {
+            for(var i = 0; i < val.length; i++) {
+                arr.push(this.converter.convertFrom(val[i]));
+            }            
         }
         return arr;
     }

--- a/NavigationJS/src/ArrayConverter.ts
+++ b/NavigationJS/src/ArrayConverter.ts
@@ -29,14 +29,18 @@ class ArrayConverter extends TypeConverter {
         return arr;
     }
 
-    convertTo(val: any): string {
+    convertTo(val: any): { val: string, vals?: string[] } {
         var formatArray = [];
+        var formatValsArray = [];
         var arr: any[] = val;
         for (var i = 0; i < arr.length; i++) {
-            if (arr[i] != null)
-                formatArray.push(this.converter.convertTo(arr[i]).replace(new RegExp(ArrayConverter.SEPARATOR, 'g'), ArrayConverter.SEPARATOR2));
+            if (arr[i] != null) {
+                var convertedValue = this.converter.convertTo(arr[i]).val;
+                formatValsArray.push(convertedValue);
+                formatArray.push(convertedValue.replace(new RegExp(ArrayConverter.SEPARATOR, 'g'), ArrayConverter.SEPARATOR2));
+            }
         }
-        return formatArray.join(ArrayConverter.SEPARATOR1);
+        return { val: formatArray.join(ArrayConverter.SEPARATOR1), vals: formatValsArray };
     }
 }
 export = ArrayConverter;

--- a/NavigationJS/src/ArrayConverter.ts
+++ b/NavigationJS/src/ArrayConverter.ts
@@ -18,14 +18,12 @@ class ArrayConverter extends TypeConverter {
     convertFrom(val: string | string[]): any {
         var arr = [];
         if (typeof val === 'string') {
-            if (val.length !== 0) {
-                var vals = val.split(ArrayConverter.SEPARATOR1);
-                for (var i = 0; i < vals.length; i++) {
-                    if (vals[i].length !== 0)
-                        arr.push(this.converter.convertFrom(vals[i].replace(new RegExp(ArrayConverter.SEPARATOR2, 'g'), ArrayConverter.SEPARATOR)));
-                    else
-                        arr.push(null);
-                }
+            var vals = val.split(ArrayConverter.SEPARATOR1);
+            for (var i = 0; i < vals.length; i++) {
+                if (vals[i].length !== 0)
+                    arr.push(this.converter.convertFrom(vals[i].replace(new RegExp(ArrayConverter.SEPARATOR2, 'g'), ArrayConverter.SEPARATOR)));
+                else
+                    arr.push(null);
             }
         } else {
             for(var i = 0; i < val.length; i++) {

--- a/NavigationJS/src/ArrayConverter.ts
+++ b/NavigationJS/src/ArrayConverter.ts
@@ -35,7 +35,7 @@ class ArrayConverter extends TypeConverter {
                     arr.push(this.converter.convertFrom(val[i]));
                 else
                     arr.push(null);
-            }            
+            }
         }
         return arr;
     }

--- a/NavigationJS/src/ArrayConverter.ts
+++ b/NavigationJS/src/ArrayConverter.ts
@@ -29,7 +29,10 @@ class ArrayConverter extends TypeConverter {
             }
         } else {
             for(var i = 0; i < val.length; i++) {
-                arr.push(this.converter.convertFrom(val[i]));
+                if (val[i].length !== 0)
+                    arr.push(this.converter.convertFrom(val[i]));
+                else
+                    arr.push(null);
             }            
         }
         return arr;
@@ -40,10 +43,13 @@ class ArrayConverter extends TypeConverter {
         var formatValsArray = [];
         var arr: any[] = val;
         for (var i = 0; i < arr.length; i++) {
-            if (arr[i] != null) {
+            if (arr[i] != null && arr[i].toString()) {
                 var convertedValue = this.converter.convertTo(arr[i]).val;
                 formatValsArray.push(convertedValue);
                 formatArray.push(convertedValue.replace(new RegExp(ArrayConverter.SEPARATOR, 'g'), ArrayConverter.SEPARATOR2));
+            } else {
+                formatValsArray.push('');
+                formatArray.push('');
             }
         }
         return { val: formatArray.join(ArrayConverter.SEPARATOR1), vals: formatValsArray };

--- a/NavigationJS/src/ArrayConverter.ts
+++ b/NavigationJS/src/ArrayConverter.ts
@@ -18,12 +18,16 @@ class ArrayConverter extends TypeConverter {
     convertFrom(val: string | string[], queryString: boolean): any {
         var arr = [];
         if (typeof val === 'string') {
-            var vals = val.split(ArrayConverter.SEPARATOR1);
-            for (var i = 0; i < vals.length; i++) {
-                if (vals[i].length !== 0)
-                    arr.push(this.converter.convertFrom(vals[i].replace(new RegExp(ArrayConverter.SEPARATOR2, 'g'), ArrayConverter.SEPARATOR)));
-                else
-                    arr.push(null);
+            if (!queryString) {
+                var vals = val.split(ArrayConverter.SEPARATOR1);
+                for (var i = 0; i < vals.length; i++) {
+                    if (vals[i].length !== 0)
+                        arr.push(this.converter.convertFrom(vals[i].replace(new RegExp(ArrayConverter.SEPARATOR2, 'g'), ArrayConverter.SEPARATOR)));
+                    else
+                        arr.push(null);
+                }
+            } else {
+                arr.push(this.converter.convertFrom(val));
             }
         } else {
             for(var i = 0; i < val.length; i++) {

--- a/NavigationJS/src/ArrayConverter.ts
+++ b/NavigationJS/src/ArrayConverter.ts
@@ -15,7 +15,7 @@ class ArrayConverter extends TypeConverter {
         return this.converter.getType() + 'array';
     }
 
-    convertFrom(val: string | string[]): any {
+    convertFrom(val: string | string[], queryString: boolean): any {
         var arr = [];
         if (typeof val === 'string') {
             var vals = val.split(ArrayConverter.SEPARATOR1);
@@ -36,21 +36,20 @@ class ArrayConverter extends TypeConverter {
         return arr;
     }
 
-    convertTo(val: any): { val: string, vals?: string[] } {
-        var valArray = [];
+    convertTo(val: any[]): { val: string, queryStringVal?: string[] } {
         var vals = [];
-        var arr: any[] = val;
-        for (var i = 0; i < arr.length; i++) {
-            if (arr[i] != null && arr[i].toString()) {
-                var convertedValue = this.converter.convertTo(arr[i]).val;
-                vals.push(convertedValue);
-                valArray.push(convertedValue.replace(new RegExp(ArrayConverter.SEPARATOR, 'g'), ArrayConverter.SEPARATOR2));
+        var arr = [];
+        for (var i = 0; i < val.length; i++) {
+            if (val[i] != null && val[i].toString()) {
+                var convertedValue = this.converter.convertTo(val[i]).val;
+                arr.push(convertedValue);
+                vals.push(convertedValue.replace(new RegExp(ArrayConverter.SEPARATOR, 'g'), ArrayConverter.SEPARATOR2));
             } else {
+                arr.push('');
                 vals.push('');
-                valArray.push('');
             }
         }
-        return { val: valArray.join(ArrayConverter.SEPARATOR1), vals: vals };
+        return { val: vals.join(ArrayConverter.SEPARATOR1), queryStringVal: arr };
     }
 }
 export = ArrayConverter;

--- a/NavigationJS/src/ArrayConverter.ts
+++ b/NavigationJS/src/ArrayConverter.ts
@@ -1,4 +1,5 @@
-﻿import TypeConverter = require('./TypeConverter');
+﻿import settings = require('./settings');
+import TypeConverter = require('./TypeConverter');
 
 class ArrayConverter extends TypeConverter {
     private converter: TypeConverter;
@@ -18,7 +19,7 @@ class ArrayConverter extends TypeConverter {
     convertFrom(val: string | string[], queryString: boolean): any {
         var arr = [];
         if (typeof val === 'string') {
-            if (!queryString) {
+            if (!queryString || settings.combineArray) {
                 var vals = val.split(ArrayConverter.SEPARATOR1);
                 for (var i = 0; i < vals.length; i++) {
                     if (vals[i].length !== 0)
@@ -53,7 +54,7 @@ class ArrayConverter extends TypeConverter {
                 vals.push('');
             }
         }
-        return { val: vals.join(ArrayConverter.SEPARATOR1), queryStringVal: arr };
+        return { val: vals.join(ArrayConverter.SEPARATOR1), queryStringVal: !settings.combineArray ? arr : null };
     }
 }
 export = ArrayConverter;

--- a/NavigationJS/src/BooleanConverter.ts
+++ b/NavigationJS/src/BooleanConverter.ts
@@ -11,8 +11,8 @@ class BooleanConverter extends TypeConverter {
         return val === 'true';
     }
 
-    convertTo(val: any): string {
-        return val.toString();
+    convertTo(val: any): { val: string, vals?: string[] } {
+        return { val: val.toString() };
     }
 }
 export = BooleanConverter;

--- a/NavigationJS/src/BooleanConverter.ts
+++ b/NavigationJS/src/BooleanConverter.ts
@@ -11,7 +11,7 @@ class BooleanConverter extends TypeConverter {
         return val === 'true';
     }
 
-    convertTo(val: any): { val: string, vals?: string[] } {
+    convertTo(val: any): { val: string, queryStringVal?: string[] } {
         return { val: val.toString() };
     }
 }

--- a/NavigationJS/src/ConverterFactory.ts
+++ b/NavigationJS/src/ConverterFactory.ts
@@ -27,8 +27,8 @@ class ConverterFactory {
     static getKey(type: string) {
         return this.typeToKeyList[type];
     }
-
-    static getKeyFromObject(obj: any) {
+    
+    static getType(obj: any) {
         var fullType = typeof obj;
         var type2: string;
         if (Object.prototype.toString.call(obj) === '[object Array]') {
@@ -42,8 +42,13 @@ class ConverterFactory {
             }
             fullType = type2 + 'array';
         }
+        return fullType;
+    }
+
+    static getKeyFromObject(obj: any) {
+        var fullType = this .getType(obj);
         if (!this.typeToKeyList[fullType])
-            throw new Error('No TypeConverter found for ' + !type2 ? fullType : type2);
+            throw new Error('No TypeConverter found for ' + fullType);
         return this.typeToKeyList[fullType];
     }
 

--- a/NavigationJS/src/ConverterFactory.ts
+++ b/NavigationJS/src/ConverterFactory.ts
@@ -30,17 +30,17 @@ class ConverterFactory {
     
     static getType(obj: any) {
         var fullType = typeof obj;
-        var type2: string;
+        var subType: string;
         if (Object.prototype.toString.call(obj) === '[object Array]') {
             var arr: any[] = obj;
-            type2 = 'string';
+            subType = 'string';
             for (var i = 0; i < arr.length; i++) {
                 if (arr[i] != null && arr[i].toString()) {
-                    type2 = typeof arr[i];
+                    subType = typeof arr[i];
                     break;
                 }
             }
-            fullType = type2 + 'array';
+            fullType = subType + 'array';
         }
         return fullType;
     }

--- a/NavigationJS/src/ConverterFactory.ts
+++ b/NavigationJS/src/ConverterFactory.ts
@@ -35,7 +35,7 @@ class ConverterFactory {
             var arr: any[] = obj;
             type2 = 'string';
             for (var i = 0; i < arr.length; i++) {
-                if (arr[i] != null) {
+                if (arr[i] != null && arr[i].toString()) {
                     type2 = typeof arr[i];
                     break;
                 }

--- a/NavigationJS/src/CrumbTrailManager.ts
+++ b/NavigationJS/src/CrumbTrailManager.ts
@@ -74,11 +74,11 @@ class CrumbTrailManager {
         for (var key in navigationData) {
             var val = navigationData[key]; 
             if (val != null && val.toString()) {
-                var formattedVals = ReturnDataManager.formatURLObject(key, val, state);
-                val = formattedVals.val;
+                var formattedData = ReturnDataManager.formatURLObject(key, val, state);
+                val = formattedData.val;
                 if (!settings.router.supportsDefaults || val !== state.formattedDefaults[key]) {
                     data[key] = val;
-                    arrayData[key] = formattedVals.vals;
+                    arrayData[key] = formattedData.vals;
                 }
             }
         }

--- a/NavigationJS/src/CrumbTrailManager.ts
+++ b/NavigationJS/src/CrumbTrailManager.ts
@@ -70,7 +70,7 @@ class CrumbTrailManager {
             navigationData = NavigationData.clone(navigationData);
             NavigationData.setDefaults(navigationData, state.defaults);
         }
-        var arrayData = {};
+        var queryStringData: { [index: string]: string[] } = {};
         for (var key in navigationData) {
             var val = navigationData[key]; 
             if (val != null && val.toString()) {
@@ -78,7 +78,7 @@ class CrumbTrailManager {
                 val = formattedData.val;
                 if (!settings.router.supportsDefaults || val !== state.formattedDefaults[key]) {
                     data[key] = val;
-                    arrayData[key] = formattedData.vals;
+                    queryStringData[key] = formattedData.queryStringVal;
                 }
             }
         }
@@ -91,7 +91,7 @@ class CrumbTrailManager {
         }
         if (this.crumbTrailKey && state.trackCrumbTrail)
             data[settings.crumbTrailKey] = this.crumbTrailKey;
-        return state.stateHandler.getNavigationLink(state, data, arrayData);
+        return state.stateHandler.getNavigationLink(state, data, queryStringData);
     }
 
     static getRefreshHref(refreshData: any): string {

--- a/NavigationJS/src/CrumbTrailManager.ts
+++ b/NavigationJS/src/CrumbTrailManager.ts
@@ -73,7 +73,7 @@ class CrumbTrailManager {
         for (var key in navigationData) {
             var val = navigationData[key]; 
             if (val != null && val.toString()) {
-                val = ReturnDataManager.formatURLObject(key, val, state);
+                val = ReturnDataManager.formatURLObject(key, val, state).val;
                 if (!settings.router.supportsDefaults || val !== state.formattedDefaults[key])
                     data[key] = val;
             }

--- a/NavigationJS/src/CrumbTrailManager.ts
+++ b/NavigationJS/src/CrumbTrailManager.ts
@@ -70,12 +70,16 @@ class CrumbTrailManager {
             navigationData = NavigationData.clone(navigationData);
             NavigationData.setDefaults(navigationData, state.defaults);
         }
+        var arrayData = {};
         for (var key in navigationData) {
             var val = navigationData[key]; 
             if (val != null && val.toString()) {
-                val = ReturnDataManager.formatURLObject(key, val, state).val;
+                var formattedVals = ReturnDataManager.formatURLObject(key, val, state);
+                val = formattedVals.val;
                 if (!settings.router.supportsDefaults || val !== state.formattedDefaults[key])
                     data[key] = val;
+                if (formattedVals.vals)
+                    arrayData[key] = formattedVals.vals;
             }
         }
         if (!settings.combineCrumbTrail && state.trackCrumbTrail && StateContext.state) {
@@ -87,7 +91,7 @@ class CrumbTrailManager {
         }
         if (this.crumbTrailKey && state.trackCrumbTrail)
             data[settings.crumbTrailKey] = this.crumbTrailKey;
-        return state.stateHandler.getNavigationLink(state, data);
+        return state.stateHandler.getNavigationLink(state, data, arrayData);
     }
 
     static getRefreshHref(refreshData: any): string {

--- a/NavigationJS/src/CrumbTrailManager.ts
+++ b/NavigationJS/src/CrumbTrailManager.ts
@@ -76,10 +76,10 @@ class CrumbTrailManager {
             if (val != null && val.toString()) {
                 var formattedVals = ReturnDataManager.formatURLObject(key, val, state);
                 val = formattedVals.val;
-                if (!settings.router.supportsDefaults || val !== state.formattedDefaults[key])
+                if (!settings.router.supportsDefaults || val !== state.formattedDefaults[key]) {
                     data[key] = val;
-                if (formattedVals.vals)
                     arrayData[key] = formattedVals.vals;
+                }
             }
         }
         if (!settings.combineCrumbTrail && state.trackCrumbTrail && StateContext.state) {

--- a/NavigationJS/src/IStateHandler.ts
+++ b/NavigationJS/src/IStateHandler.ts
@@ -2,7 +2,7 @@
 import State = require('./config/State');
 
 interface IStateHandler {
-    getNavigationLink(state: State, data: any): string;
+    getNavigationLink(state: State, data: any, arrayData?: any): string;
     navigateLink(oldState: State, state: State, url: string): void;
     getNavigationData(state: State, url: string): any;
     truncateCrumbTrail(state: State, crumbs: Crumb[]): Crumb[];

--- a/NavigationJS/src/IStateHandler.ts
+++ b/NavigationJS/src/IStateHandler.ts
@@ -2,9 +2,9 @@
 import State = require('./config/State');
 
 interface IStateHandler {
-    getNavigationLink(state: State, data: any, arrayData?: any): string;
+    getNavigationLink(state: State, data: any, queryStringData?: { [index: string]: string[] }): string;
     navigateLink(oldState: State, state: State, url: string): void;
-    getNavigationData(state: State, url: string): any;
+    getNavigationData(state: State, url: string, queryStringData?: any): any;
     truncateCrumbTrail(state: State, crumbs: Crumb[]): Crumb[];
 }
 export = IStateHandler;

--- a/NavigationJS/src/NavigationSettings.ts
+++ b/NavigationJS/src/NavigationSettings.ts
@@ -15,5 +15,6 @@ class NavigationSettings {
     applicationPath: string = '';
     combineCrumbTrail: boolean = false;
     trackAllPreviousData: boolean = true;
+    combineArray: boolean = false;
 }
 export = NavigationSettings;

--- a/NavigationJS/src/NumberConverter.ts
+++ b/NavigationJS/src/NumberConverter.ts
@@ -11,8 +11,8 @@ class NumberConverter extends TypeConverter {
         return +val;
     }
 
-    convertTo(val: any): string {
-        return val.toString();
+    convertTo(val: any): { val: string, vals?: string[] } {
+        return { val: val.toString() };
     }
 }
 export = NumberConverter;

--- a/NavigationJS/src/ReturnDataManager.ts
+++ b/NavigationJS/src/ReturnDataManager.ts
@@ -40,7 +40,7 @@ class ReturnDataManager {
             if (formattedValues)
                 formattedValues[0] = this.encodeUrlValue(formattedValues[0]);
         }
-        if (state.trackTypes && typeof urlObject !== defaultType) {
+        if (state.trackTypes && ConverterFactory.getType(urlObject) !== defaultType) {
             formattedValue += this.RET_2_SEP + converterKey;
             if (formattedValues)
                 formattedValues[0] = formattedValues[0] + this.RET_2_SEP + converterKey;

--- a/NavigationJS/src/ReturnDataManager.ts
+++ b/NavigationJS/src/ReturnDataManager.ts
@@ -32,7 +32,7 @@ class ReturnDataManager {
         encode = encode || state.trackTypes;
         var defaultType: string = state.defaultTypes[key] ? state.defaultTypes[key] : 'string';
         var converterKey = ConverterFactory.getKeyFromObject(urlObject);
-        var formattedValue = ConverterFactory.getConverter(converterKey).convertTo(urlObject);
+        var formattedValue = ConverterFactory.getConverter(converterKey).convertTo(urlObject).val;
         if (encode)
             formattedValue = this.encodeUrlValue(formattedValue);
         if (state.trackTypes && typeof urlObject !== defaultType)

--- a/NavigationJS/src/ReturnDataManager.ts
+++ b/NavigationJS/src/ReturnDataManager.ts
@@ -28,7 +28,7 @@ class ReturnDataManager {
         return urlValue.replace(new RegExp(this.SEPARATOR, 'g'), '0' + this.SEPARATOR);
     }
 
-    static formatURLObject(key: string, urlObject: any, state: State, encode?: boolean): { val: string, queryStringVal?: string[] } {
+    static formatURLObject(key: string, urlObject: any, state: State, encode = false): { val: string, queryStringVal?: string[] } {
         encode = encode || state.trackTypes;
         var defaultType: string = state.defaultTypes[key] ? state.defaultTypes[key] : 'string';
         var converterKey = ConverterFactory.getKeyFromObject(urlObject);

--- a/NavigationJS/src/ReturnDataManager.ts
+++ b/NavigationJS/src/ReturnDataManager.ts
@@ -48,7 +48,7 @@ class ReturnDataManager {
         return { val: formattedValue, queryStringVal: formattedArray };
     }
 
-    static parseURLString(key: string, val: string | string[], state: State, decode?: boolean, queryString = false): any {
+    static parseURLString(key: string, val: string | string[], state: State, decode = false, queryString = false): any {
         decode = decode || state.trackTypes;
         var defaultType: string = state.defaultTypes[key] ? state.defaultTypes[key] : 'string';
         var urlValue = typeof val === 'string' ? val : val[0];

--- a/NavigationJS/src/ReturnDataManager.ts
+++ b/NavigationJS/src/ReturnDataManager.ts
@@ -12,7 +12,7 @@ class ReturnDataManager {
         var returnDataArray: string[] = [];
         for (var key in returnData) {
             if (returnData[key] != null && returnData[key].toString()) {
-                var val = this.formatURLObject(key, returnData[key], state, true);
+                var val = this.formatURLObject(key, returnData[key], state, true).val;
                 if (!settings.router.supportsDefaults || val !== state.formattedDefaults[key])
                     returnDataArray.push(this.encodeUrlValue(key) + this.RET_1_SEP + val);
             }
@@ -28,16 +28,21 @@ class ReturnDataManager {
         return urlValue.replace(new RegExp(this.SEPARATOR, 'g'), '0' + this.SEPARATOR);
     }
 
-    static formatURLObject(key: string, urlObject: any, state: State, encode?: boolean) {
+    static formatURLObject(key: string, urlObject: any, state: State, encode?: boolean): { val: string, vals?: string[] } {
         encode = encode || state.trackTypes;
         var defaultType: string = state.defaultTypes[key] ? state.defaultTypes[key] : 'string';
         var converterKey = ConverterFactory.getKeyFromObject(urlObject);
-        var formattedValue = ConverterFactory.getConverter(converterKey).convertTo(urlObject).val;
+        var convertedValue = ConverterFactory.getConverter(converterKey).convertTo(urlObject);
+        var formattedValue = convertedValue.val;
+        var formattedValues = convertedValue.vals;
         if (encode)
             formattedValue = this.encodeUrlValue(formattedValue);
-        if (state.trackTypes && typeof urlObject !== defaultType)
+        if (state.trackTypes && typeof urlObject !== defaultType) {
             formattedValue += this.RET_2_SEP + converterKey;
-        return formattedValue;
+            if (formattedValues)
+                formattedValues[0] = formattedValues[0] + this.RET_2_SEP + converterKey;
+        }
+        return { val: formattedValue, vals: formattedValues };
     }
 
     static parseURLString(key: string, val: string, state: State, decode?: boolean): any {

--- a/NavigationJS/src/ReturnDataManager.ts
+++ b/NavigationJS/src/ReturnDataManager.ts
@@ -35,8 +35,11 @@ class ReturnDataManager {
         var convertedValue = ConverterFactory.getConverter(converterKey).convertTo(urlObject);
         var formattedValue = convertedValue.val;
         var formattedValues = convertedValue.vals;
-        if (encode)
+        if (encode) {
             formattedValue = this.encodeUrlValue(formattedValue);
+            if (formattedValues)
+                formattedValues[0] = this.encodeUrlValue(formattedValues[0]);
+        }
         if (state.trackTypes && typeof urlObject !== defaultType) {
             formattedValue += this.RET_2_SEP + converterKey;
             if (formattedValues)
@@ -45,18 +48,23 @@ class ReturnDataManager {
         return { val: formattedValue, vals: formattedValues };
     }
 
-    static parseURLString(key: string, val: string, state: State, decode?: boolean): any {
+    static parseURLString(key: string, val: any, state: State, decode?: boolean): any {
         decode = decode || state.trackTypes;
         var defaultType: string = state.defaultTypes[key] ? state.defaultTypes[key] : 'string';
-        var urlValue = val;
+        var urlValue = typeof val === 'string' ? val : val[0];
         var converterKey = ConverterFactory.getKey(defaultType);
-        if (state.trackTypes && val.indexOf(this.RET_2_SEP) > -1) {
-            var arr = val.split(this.RET_2_SEP);
+        if (state.trackTypes && urlValue.indexOf(this.RET_2_SEP) > -1) {
+            var arr = urlValue.split(this.RET_2_SEP);
             urlValue = arr[0];
             converterKey = arr[1];
         }
-        if (decode)
+        if (decode) {
             urlValue = this.decodeUrlValue(urlValue);
+        }
+        if (typeof val !== 'string') {
+            val[0] = urlValue;
+            urlValue = val;
+        }
         return ConverterFactory.getConverter(converterKey).convertFrom(urlValue);
     }
 

--- a/NavigationJS/src/ReturnDataManager.ts
+++ b/NavigationJS/src/ReturnDataManager.ts
@@ -48,7 +48,7 @@ class ReturnDataManager {
         return { val: formattedValue, vals: formattedValues };
     }
 
-    static parseURLString(key: string, val: any, state: State, decode?: boolean): any {
+    static parseURLString(key: string, val: string | string[], state: State, decode?: boolean): any {
         decode = decode || state.trackTypes;
         var defaultType: string = state.defaultTypes[key] ? state.defaultTypes[key] : 'string';
         var urlValue = typeof val === 'string' ? val : val[0];
@@ -58,14 +58,13 @@ class ReturnDataManager {
             urlValue = arr[0];
             converterKey = arr[1];
         }
-        if (decode) {
+        if (decode)
             urlValue = this.decodeUrlValue(urlValue);
-        }
-        if (typeof val !== 'string') {
+        if (typeof val === 'string')
+            val =  urlValue;
+        else
             val[0] = urlValue;
-            urlValue = val;
-        }
-        return ConverterFactory.getConverter(converterKey).convertFrom(urlValue);
+        return ConverterFactory.getConverter(converterKey).convertFrom(val);
     }
 
     static parseReturnData(returnData: string, state: State): any {

--- a/NavigationJS/src/ReturnDataManager.ts
+++ b/NavigationJS/src/ReturnDataManager.ts
@@ -28,27 +28,27 @@ class ReturnDataManager {
         return urlValue.replace(new RegExp(this.SEPARATOR, 'g'), '0' + this.SEPARATOR);
     }
 
-    static formatURLObject(key: string, urlObject: any, state: State, encode?: boolean): { val: string, vals?: string[] } {
+    static formatURLObject(key: string, urlObject: any, state: State, encode?: boolean): { val: string, queryStringVal?: string[] } {
         encode = encode || state.trackTypes;
         var defaultType: string = state.defaultTypes[key] ? state.defaultTypes[key] : 'string';
         var converterKey = ConverterFactory.getKeyFromObject(urlObject);
         var convertedValue = ConverterFactory.getConverter(converterKey).convertTo(urlObject);
         var formattedValue = convertedValue.val;
-        var formattedValues = convertedValue.vals;
+        var formattedArray = convertedValue.queryStringVal;
         if (encode) {
             formattedValue = this.encodeUrlValue(formattedValue);
-            if (formattedValues)
-                formattedValues[0] = this.encodeUrlValue(formattedValues[0]);
+            if (formattedArray)
+                formattedArray[0] = this.encodeUrlValue(formattedArray[0]);
         }
         if (state.trackTypes && ConverterFactory.getType(urlObject) !== defaultType) {
             formattedValue += this.RET_2_SEP + converterKey;
-            if (formattedValues)
-                formattedValues[0] = formattedValues[0] + this.RET_2_SEP + converterKey;
+            if (formattedArray)
+                formattedArray[0] = formattedArray[0] + this.RET_2_SEP + converterKey;
         }
-        return { val: formattedValue, vals: formattedValues };
+        return { val: formattedValue, queryStringVal: formattedArray };
     }
 
-    static parseURLString(key: string, val: string | string[], state: State, decode?: boolean): any {
+    static parseURLString(key: string, val: string | string[], state: State, decode?: boolean, queryString = false): any {
         decode = decode || state.trackTypes;
         var defaultType: string = state.defaultTypes[key] ? state.defaultTypes[key] : 'string';
         var urlValue = typeof val === 'string' ? val : val[0];
@@ -64,7 +64,7 @@ class ReturnDataManager {
             val =  urlValue;
         else
             val[0] = urlValue;
-        return ConverterFactory.getConverter(converterKey).convertFrom(val);
+        return ConverterFactory.getConverter(converterKey).convertFrom(val, queryString);
     }
 
     static parseReturnData(returnData: string, state: State): any {

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -22,8 +22,9 @@ class StateController {
             StateContext.url = url;
             StateContext.dialog = state.parent;
             StateContext.title = state.title;
-            var data = state.stateHandler.getNavigationData(state, url);
-            StateContext.data = this.parseData(data, state);
+            var queryStringData = {};
+            var data = state.stateHandler.getNavigationData(state, url, queryStringData);
+            StateContext.data = this.parseData(data, state, queryStringData);
             StateContext.previousState = null;
             StateContext.previousDialog = null;
             StateContext.previousData = {};
@@ -144,8 +145,9 @@ class StateController {
     private static _navigateLink(url: string, state: State, history = false, historyAction = HistoryAction.Add) {
         try {
             var oldUrl = StateContext.url;
-            var data = state.stateHandler.getNavigationData(state, url);
-            data = this.parseData(data, state);
+            var queryStringData = {};
+            var data = state.stateHandler.getNavigationData(state, url, queryStringData);
+            data = this.parseData(data, state, queryStringData);
         } catch (e) {
             throw new Error('The Url is invalid\n' + e.message);
         }
@@ -182,12 +184,12 @@ class StateController {
         };
     }
 
-    private static parseData(data: any, state: State): any {
+    private static parseData(data: any, state: State, queryStringData: any): any {
         var newData = {};
         for (var key in data) {
             if (key !== settings.previousStateIdKey && key !== settings.returnDataKey
                 && key !== settings.crumbTrailKey && data[key] !== state.formattedDefaults[key])
-                newData[key] = ReturnDataManager.parseURLString(key, data[key], state);
+                newData[key] = ReturnDataManager.parseURLString(key, data[key], state, false, !!queryStringData[key]);
         }
         NavigationData.setDefaults(newData, state.defaults);
         return newData;

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -185,7 +185,8 @@ class StateController {
     private static parseData(data: any, state: State): any {
         var newData = {};
         for (var key in data) {
-            if (key !== settings.previousStateIdKey && key !== settings.returnDataKey && key !== settings.crumbTrailKey)
+            if (key !== settings.previousStateIdKey && key !== settings.returnDataKey
+                && key !== settings.crumbTrailKey && data[key] !== state.formattedDefaults[key])
                 newData[key] = ReturnDataManager.parseURLString(key, data[key], state);
         }
         NavigationData.setDefaults(newData, state.defaults);

--- a/NavigationJS/src/StateHandler.ts
+++ b/NavigationJS/src/StateHandler.ts
@@ -12,8 +12,15 @@ class StateHandler implements IStateHandler {
             return null;
         var query: string[] = [];
         for (var key in data) {
-            if (key !== settings.stateIdKey && !routeInfo.data[key])
-                query.push(encodeURIComponent(key) + '=' + encodeURIComponent(data[key]));
+            if (key !== settings.stateIdKey && !routeInfo.data[key]) {
+                var arrVals: string[] = arrayData[key];
+                if (!arrVals)
+                    query.push(encodeURIComponent(key) + '=' + encodeURIComponent(data[key]));
+                else {
+                    for(var i = 0; i < arrVals.length; i++)
+                        query.push(encodeURIComponent(key) + '=' + encodeURIComponent(arrVals[i]));
+                }
+            }
         }
         if (query.length > 0)
             routeInfo.route += '?' + query.join('&');

--- a/NavigationJS/src/StateHandler.ts
+++ b/NavigationJS/src/StateHandler.ts
@@ -6,7 +6,7 @@ import StateContext = require('./StateContext');
 import StateController = require('./StateController');
 
 class StateHandler implements IStateHandler {
-    getNavigationLink(state: State, data: any): string {
+    getNavigationLink(state: State, data: any, arrayData: any): string {
         var routeInfo = settings.router.getRoute(state, data);
         if (routeInfo.route == null)
             return null;

--- a/NavigationJS/src/StateHandler.ts
+++ b/NavigationJS/src/StateHandler.ts
@@ -39,8 +39,21 @@ class StateHandler implements IStateHandler {
             var params = query.split('&');
             for (var i = 0; i < params.length; i++) {
                 var param = params[i].split('=');
-                data[decodeURIComponent(param[0])] = decodeURIComponent(param[1]);
+                var key = decodeURIComponent(param[0]);
+                var val = decodeURIComponent(param[1]);
+                var arr = data[key];
+                if (!arr)
+                    data[key] = val;
+                else {
+                    if (typeof arr === 'string')
+                        data[key] = arr = [arr];
+                    arr.push(val);
+                }
             }
+        }
+        for (var defKey in state.formattedDefaults) {
+            if (!data[defKey])
+                data[defKey] = state.formattedDefaults[defKey];
         }
         return data;
     }

--- a/NavigationJS/src/StateHandler.ts
+++ b/NavigationJS/src/StateHandler.ts
@@ -54,7 +54,7 @@ class StateHandler implements IStateHandler {
             }
         }
         return data;
-    }    
+    }
 
     truncateCrumbTrail(state: State, crumbs: Crumb[]): Crumb[] {
         var newCrumbs: Crumb[] = [];

--- a/NavigationJS/src/StateHandler.ts
+++ b/NavigationJS/src/StateHandler.ts
@@ -32,7 +32,8 @@ class StateHandler implements IStateHandler {
 
     getNavigationData(state: State, url: string, queryStringData: any = {}): any {
         var queryIndex = url.indexOf('?');
-        var data = settings.router.getData(queryIndex < 0 ? url : url.substring(0, queryIndex)).data;
+        var route = queryIndex < 0 ? url : url.substring(0, queryIndex);
+        var data = settings.router.getData(route).data;
         data = data ? data : {};
         if (queryIndex >= 0) {
             var query = url.substring(queryIndex + 1);

--- a/NavigationJS/src/StateHandler.ts
+++ b/NavigationJS/src/StateHandler.ts
@@ -14,9 +14,9 @@ class StateHandler implements IStateHandler {
         for (var key in data) {
             if (key !== settings.stateIdKey && !routeInfo.data[key]) {
                 var arr = queryStringData[key];
-                if (!arr)
+                if (!arr) {
                     query.push(encodeURIComponent(key) + '=' + encodeURIComponent(data[key]));
-                else {
+                } else {
                     for(var i = 0; i < arr.length; i++)
                         query.push(encodeURIComponent(key) + '=' + encodeURIComponent(arr[i]));
                 }
@@ -44,9 +44,9 @@ class StateHandler implements IStateHandler {
                 var val = decodeURIComponent(param[1]);
                 queryStringData[key] = true;
                 var arr = data[key];
-                if (!arr)
+                if (!arr) {
                     data[key] = val;
-                else {
+                } else {
                     if (typeof arr === 'string')
                         data[key] = arr = [arr];
                     arr.push(val);

--- a/NavigationJS/src/StateHandler.ts
+++ b/NavigationJS/src/StateHandler.ts
@@ -51,10 +51,6 @@ class StateHandler implements IStateHandler {
                 }
             }
         }
-        for (var defKey in state.formattedDefaults) {
-            if (!data[defKey])
-                data[defKey] = state.formattedDefaults[defKey];
-        }
         return data;
     }
 

--- a/NavigationJS/src/StateHandler.ts
+++ b/NavigationJS/src/StateHandler.ts
@@ -6,19 +6,19 @@ import StateContext = require('./StateContext');
 import StateController = require('./StateController');
 
 class StateHandler implements IStateHandler {
-    getNavigationLink(state: State, data: any, arrayData: any): string {
+    getNavigationLink(state: State, data: any, queryStringData: { [index: string]: string[] } = {}): string {
         var routeInfo = settings.router.getRoute(state, data);
         if (routeInfo.route == null)
             return null;
         var query: string[] = [];
         for (var key in data) {
             if (key !== settings.stateIdKey && !routeInfo.data[key]) {
-                var arrVals: string[] = arrayData[key];
-                if (!arrVals)
+                var arr = queryStringData[key];
+                if (!arr)
                     query.push(encodeURIComponent(key) + '=' + encodeURIComponent(data[key]));
                 else {
-                    for(var i = 0; i < arrVals.length; i++)
-                        query.push(encodeURIComponent(key) + '=' + encodeURIComponent(arrVals[i]));
+                    for(var i = 0; i < arr.length; i++)
+                        query.push(encodeURIComponent(key) + '=' + encodeURIComponent(arr[i]));
                 }
             }
         }
@@ -30,7 +30,7 @@ class StateHandler implements IStateHandler {
     navigateLink(oldState: State, state: State, url: string) {
     }
 
-    getNavigationData(state: State, url: string): any {
+    getNavigationData(state: State, url: string, queryStringData: any = {}): any {
         var queryIndex = url.indexOf('?');
         var data = settings.router.getData(queryIndex < 0 ? url : url.substring(0, queryIndex)).data;
         data = data ? data : {};
@@ -41,6 +41,7 @@ class StateHandler implements IStateHandler {
                 var param = params[i].split('=');
                 var key = decodeURIComponent(param[0]);
                 var val = decodeURIComponent(param[1]);
+                queryStringData[key] = true;
                 var arr = data[key];
                 if (!arr)
                     data[key] = val;
@@ -52,7 +53,7 @@ class StateHandler implements IStateHandler {
             }
         }
         return data;
-    }
+    }    
 
     truncateCrumbTrail(state: State, crumbs: Crumb[]): Crumb[] {
         var newCrumbs: Crumb[] = [];

--- a/NavigationJS/src/StringConverter.ts
+++ b/NavigationJS/src/StringConverter.ts
@@ -9,8 +9,8 @@ class StringConverter extends TypeConverter {
         return val;
     }
 
-    convertTo(val: any): string {
-        return val.toString();
+    convertTo(val: any): { val: string, vals?: string[] } {
+        return { val: val.toString() };
     }
 }
 export = StringConverter;

--- a/NavigationJS/src/StringConverter.ts
+++ b/NavigationJS/src/StringConverter.ts
@@ -5,7 +5,9 @@ class StringConverter extends TypeConverter {
         return 'string';
     }
 
-    convertFrom(val: string): any {
+    convertFrom(val: string | string[]): any {
+        if (typeof val !== 'string')
+            throw Error(val + ' is not a valid string');
         return val;
     }
 

--- a/NavigationJS/src/StringConverter.ts
+++ b/NavigationJS/src/StringConverter.ts
@@ -11,7 +11,7 @@ class StringConverter extends TypeConverter {
         return val;
     }
 
-    convertTo(val: any): { val: string, vals?: string[] } {
+    convertTo(val: any): { val: string, queryStringVal?: string[] } {
         return { val: val.toString() };
     }
 }

--- a/NavigationJS/src/TypeConverter.ts
+++ b/NavigationJS/src/TypeConverter.ts
@@ -3,7 +3,7 @@
         return null;
     }
 
-    convertFrom(val: string): any {
+    convertFrom(val: string | string[]): any {
         return null;
     }
 

--- a/NavigationJS/src/TypeConverter.ts
+++ b/NavigationJS/src/TypeConverter.ts
@@ -3,11 +3,11 @@
         return null;
     }
 
-    convertFrom(val: string | string[]): any {
+    convertFrom(val: string | string[], queryString = false): any {
         return null;
     }
 
-    convertTo(val: any): { val: string, vals?: string[] } {
+    convertTo(val: any): { val: string, queryStringVal?: string[] } {
         return null;
     }
 }

--- a/NavigationJS/src/TypeConverter.ts
+++ b/NavigationJS/src/TypeConverter.ts
@@ -7,7 +7,7 @@
         return null;
     }
 
-    convertTo(val: any): string {
+    convertTo(val: any): { val: string, vals?: string[] } {
         return null;
     }
 }

--- a/NavigationJS/src/config/StateInfoConfig.ts
+++ b/NavigationJS/src/config/StateInfoConfig.ts
@@ -1,5 +1,6 @@
 ﻿import Dialog = require('./Dialog');
 import IDialog = require('./IDialog');
+import ConverterFactory = require('../ConverterFactory');
 import ReturnDataManager = require('../ReturnDataManager');
 import settings = require('../settings');
 import State = require('./State');
@@ -51,7 +52,7 @@ class StateInfoConfig {
             }
             for (var key in state.defaults) {
                 if (!state.defaultTypes[key])
-                    state.defaultTypes[key] = typeof state.defaults[key];
+                    state.defaultTypes[key] = ConverterFactory.getType(state.defaults[key]);
                 state.formattedDefaults[key] = ReturnDataManager.formatURLObject(key, state.defaults[key], state).val;
             }
             if (!state.key)

--- a/NavigationJS/src/config/StateInfoConfig.ts
+++ b/NavigationJS/src/config/StateInfoConfig.ts
@@ -52,7 +52,7 @@ class StateInfoConfig {
             for (var key in state.defaults) {
                 if (!state.defaultTypes[key])
                     state.defaultTypes[key] = typeof state.defaults[key];
-                state.formattedDefaults[key] = ReturnDataManager.formatURLObject(key, state.defaults[key], state);
+                state.formattedDefaults[key] = ReturnDataManager.formatURLObject(key, state.defaults[key], state).val;
             }
             if (!state.key)
                 throw new Error('key is mandatory for a State');

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -530,6 +530,14 @@ declare module Navigation {
          */
         getNavigationLink(state: State, data: any): string;
         /**
+         * Gets a link that navigates to the state passing the data
+         * @param state The State to navigate to
+         * @param data The data to pass when navigating
+         * @param queryStringData The query string array data
+         * @returns The navigation link
+         */
+        getNavigationLink(state: State, data: any, queryStringData: { [index: string]: string[]; }): string;
+        /**
          * Navigates to the url
          * @param oldState The current State
          * @param state The State to navigate to
@@ -543,6 +551,14 @@ declare module Navigation {
          * @returns The navigation data
          */
         getNavigationData(state: State, url: string): any;
+        /**
+         * Gets the data parsed from the url
+         * @param state The State navigated to
+         * @param url The current url
+         * @param queryStringData Stores query string keys
+         * @returns The navigation data
+         */
+        getNavigationData(state: State, url: string, queryStringData: any): any;
         /**
          * Truncates the crumb trail
          * @param The State navigated to
@@ -642,6 +658,11 @@ declare module Navigation {
          * navigating back or refreshing and combineCrumbTrail is false 
          */
         trackAllPreviousData: boolean;
+        /**
+         * Gets or sets a value indicating whether arrays should be stored in
+         * a single query string parameter
+         */
+        combineArray: boolean;
     }
 
     /**
@@ -920,6 +941,14 @@ declare module Navigation {
          */
         getNavigationLink(state: State, data: any): string;
         /**
+         * Gets a link that navigates to the state passing the data
+         * @param state The State to navigate to
+         * @param data The data to pass when navigating
+         * @param queryStringData The query string array data
+         * @returns The navigation link
+         */
+        getNavigationLink(state: State, data: any, queryStringData: { [index: string]: string[]; }): string;
+        /**
          * Navigates to the url
          * @param oldState The current State
          * @param state The State to navigate to
@@ -933,6 +962,14 @@ declare module Navigation {
          * @returns The navigation data
          */
         getNavigationData(state: State, url: string): any;
+        /**
+         * Gets the data parsed from the url
+         * @param state The State navigated to
+         * @param url The current url
+         * @param queryStringData Stores query string keys
+         * @returns The navigation data
+         */
+        getNavigationData(state: State, url: string, queryStringData: any): any;
         /**
          * Truncates the crumb trail whenever a repeated or initial State is
          * encountered

--- a/NavigationJS/src/routing/Router.ts
+++ b/NavigationJS/src/routing/Router.ts
@@ -17,13 +17,8 @@ class Router {
         for (var i = 0; i < this.routes.length; i++) {
             var route = this.routes[i];
             var data = route.match(path);
-            if (data) {
-                for (var key in route.defaults) {
-                    if (!data[key])
-                        data[key] = route.defaults[key];
-                }
+            if (data)
                 return { route: route, data: data };
-            }
         }
         return null;
     }

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -141,11 +141,8 @@ describe('Navigation Data', function () {
     describe('Array Data', function() {
         beforeEach(function() {
             Navigation.StateInfoConfig.build([
-                { key: 'd', initial: 's0', states: [
-                    { key: 's0', route: 'r0', transitions: [
-                        { key: 't', to: 's1' }
-                    ]},
-                    { key: 's1', route: 'r1' }]}
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'r' }]}
                 ]);
         });
         var arrayNavigationData = {};
@@ -158,8 +155,6 @@ describe('Navigation Data', function () {
         describe('Navigate', function() {
             beforeEach(function() {
                 Navigation.StateController.navigate('d', arrayNavigationData);
-                Navigation.StateController.navigate('t');
-                Navigation.StateController.navigateBack(1);
             });
             test();
         });
@@ -167,10 +162,6 @@ describe('Navigation Data', function () {
         describe('Navigate Link', function() {
             beforeEach(function() {
                 var link = Navigation.StateController.getNavigationLink('d', arrayNavigationData);
-                Navigation.StateController.navigateLink(link);
-                link = Navigation.StateController.getNavigationLink('t');
-                Navigation.StateController.navigateLink(link);
-                link = Navigation.StateController.getNavigationBackLink(1);
                 Navigation.StateController.navigateLink(link);
             });
             test();
@@ -207,11 +198,8 @@ describe('Navigation Data', function () {
     describe('Array Data Route', function() {
         beforeEach(function() {
             Navigation.StateInfoConfig.build([
-                { key: 'd', initial: 's0', states: [
-                    { key: 's0', route: 'r0/{array_string}/{array_boolean}/{array_number}/{array_blank}/{array_empty?}', transitions: [
-                        { key: 't', to: 's1' }
-                    ]},
-                    { key: 's1', route: 'r1' }]}
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'r0/{array_string}/{array_boolean}/{array_number}/{array_blank}/{array_empty?}' }]}
                 ]);
         });
         var arrayNavigationData = {};
@@ -224,8 +212,6 @@ describe('Navigation Data', function () {
         describe('Navigate', function() {
             beforeEach(function() {
                 Navigation.StateController.navigate('d', arrayNavigationData);
-                Navigation.StateController.navigate('t');
-                Navigation.StateController.navigateBack(1);
             });
             test();
         });
@@ -233,10 +219,6 @@ describe('Navigation Data', function () {
         describe('Navigate Link', function() {
             beforeEach(function() {
                 var link = Navigation.StateController.getNavigationLink('d', arrayNavigationData);
-                Navigation.StateController.navigateLink(link);
-                link = Navigation.StateController.getNavigationLink('t');
-                Navigation.StateController.navigateLink(link);
-                link = Navigation.StateController.getNavigationBackLink(1);
                 Navigation.StateController.navigateLink(link);
             });
             test();
@@ -720,6 +702,52 @@ describe('Navigation Data', function () {
         }
     });
 
+    describe('Navigate Array Data Back', function() {
+        beforeEach(function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1' }]}
+                ]);
+        });
+        var data = {};
+        data['s'] = ['Hello', 'World'];
+        data['t'] = [1, 2, 4];
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d', data);
+                Navigation.StateController.navigate('t');
+                Navigation.StateController.navigateBack(1);
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d', data);
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t');
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationBackLink(1);
+                Navigation.StateController.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate data', function () {
+                assert.strictEqual(Navigation.StateContext.data['s'][0], 'Hello');
+                assert.strictEqual(Navigation.StateContext.data['s'][1], 'World');
+                assert.strictEqual(Navigation.StateContext.data['t'][0], 1);
+                assert.strictEqual(Navigation.StateContext.data['t'][1], 2);
+                assert.strictEqual(Navigation.StateContext.data['t'][2], 4);
+            });
+        }
+    });
+
     describe('Change Data Back', function() {
         beforeEach(function() {
             Navigation.StateInfoConfig.build([
@@ -992,6 +1020,48 @@ describe('Navigation Data', function () {
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(Navigation.StateContext.data['s'], 'Hello');
+            });
+        }
+    });
+
+    describe('Refresh Array Data', function() {
+        beforeEach(function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1' }]}
+                ]);
+        });
+        var data = {};
+        data['s'] = ['Hello', 'World'];
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d');
+                Navigation.StateController.navigate('t');
+                Navigation.StateController.refresh(data);
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d');
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t');
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getRefreshLink(data);
+                Navigation.StateController.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate data', function () {
+                assert.strictEqual(Navigation.StateContext.data['s'][0], 'Hello');
+                assert.strictEqual(Navigation.StateContext.data['s'][1], 'World');
             });
         }
     });

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -153,6 +153,7 @@ describe('Navigation Data', function () {
         arrayNavigationData['array_boolean'] = ['', true, false];
         arrayNavigationData['array_number'] = [1, null, undefined, 2];
         arrayNavigationData['array_blank'] = ['', null, undefined];
+        arrayNavigationData['array_empty'] = [];
         
         describe('Navigate', function() {
             beforeEach(function() {
@@ -197,6 +198,7 @@ describe('Navigation Data', function () {
                 assert.strictEqual(Navigation.StateContext.data['array_blank'][1], null);
                 assert.strictEqual(Navigation.StateContext.data['array_blank'][2], null);
                 assert.strictEqual(Navigation.StateContext.data['array_blank'].length, 3);
+                assert.strictEqual(Navigation.StateContext.data['array_empty'], undefined);
                 assert.equal(i, 4);
             });
         }
@@ -206,7 +208,7 @@ describe('Navigation Data', function () {
         beforeEach(function() {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's0', states: [
-                    { key: 's0', route: 'r0/{array_string}/{array_boolean}/{array_number}/{array_blank}', transitions: [
+                    { key: 's0', route: 'r0/{array_string}/{array_boolean}/{array_number}/{array_blank}/{array_empty?}', transitions: [
                         { key: 't', to: 's1' }
                     ]},
                     { key: 's1', route: 'r1' }]}
@@ -217,6 +219,7 @@ describe('Navigation Data', function () {
         arrayNavigationData['array_boolean'] = ['', true, false];
         arrayNavigationData['array_number'] = [1, null, undefined, 2];
         arrayNavigationData['array_blank'] = ['', null, undefined];
+        arrayNavigationData['array_empty'] = [];
         
         describe('Navigate', function() {
             beforeEach(function() {
@@ -231,7 +234,6 @@ describe('Navigation Data', function () {
             beforeEach(function() {
                 var link = Navigation.StateController.getNavigationLink('d', arrayNavigationData);
                 Navigation.StateController.navigateLink(link);
-                console.log(link);
                 link = Navigation.StateController.getNavigationLink('t');
                 Navigation.StateController.navigateLink(link);
                 link = Navigation.StateController.getNavigationBackLink(1);
@@ -262,6 +264,7 @@ describe('Navigation Data', function () {
                 assert.strictEqual(Navigation.StateContext.data['array_blank'][1], null);
                 assert.strictEqual(Navigation.StateContext.data['array_blank'][2], null);
                 assert.strictEqual(Navigation.StateContext.data['array_blank'].length, 3);
+                assert.strictEqual(Navigation.StateContext.data['array_empty'], undefined);
                 assert.equal(i, 4);
             });
         }

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -150,8 +150,9 @@ describe('Navigation Data', function () {
         });
         var arrayNavigationData = {};
         arrayNavigationData['array_string'] = ['He-llo', 'World'];
-        arrayNavigationData['array_boolean'] = [true, false];
-        arrayNavigationData['array_number'] = [1, 2];
+        arrayNavigationData['array_boolean'] = ['', true, false];
+        arrayNavigationData['array_number'] = [1, null, undefined, 2];
+        arrayNavigationData['array_blank'] = ['', null, undefined];
         
         describe('Navigate', function() {
             beforeEach(function() {
@@ -182,11 +183,21 @@ describe('Navigation Data', function () {
                 }
                 assert.strictEqual(Navigation.StateContext.data['array_string'][0], 'He-llo');
                 assert.strictEqual(Navigation.StateContext.data['array_string'][1], 'World');
-                assert.strictEqual(Navigation.StateContext.data['array_boolean'][0], true);
-                assert.strictEqual(Navigation.StateContext.data['array_boolean'][1], false);
+                assert.strictEqual(Navigation.StateContext.data['array_string'].length, 2);
+                assert.strictEqual(Navigation.StateContext.data['array_boolean'][0], null);
+                assert.strictEqual(Navigation.StateContext.data['array_boolean'][1], true);
+                assert.strictEqual(Navigation.StateContext.data['array_boolean'][2], false);
+                assert.strictEqual(Navigation.StateContext.data['array_boolean'].length, 3);
                 assert.strictEqual(Navigation.StateContext.data['array_number'][0], 1);
-                assert.strictEqual(Navigation.StateContext.data['array_number'][1], 2);
-                assert.equal(i, 3);
+                assert.strictEqual(Navigation.StateContext.data['array_number'][1], null);
+                assert.strictEqual(Navigation.StateContext.data['array_number'][2], null);
+                assert.strictEqual(Navigation.StateContext.data['array_number'][3], 2);
+                assert.strictEqual(Navigation.StateContext.data['array_number'].length, 4);
+                assert.strictEqual(Navigation.StateContext.data['array_blank'][0], null);
+                assert.strictEqual(Navigation.StateContext.data['array_blank'][1], null);
+                assert.strictEqual(Navigation.StateContext.data['array_blank'][2], null);
+                assert.strictEqual(Navigation.StateContext.data['array_blank'].length, 3);
+                assert.equal(i, 4);
             });
         }
     });

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -150,7 +150,6 @@ describe('Navigation Data', function () {
         arrayNavigationData['array_boolean'] = ['', true, false];
         arrayNavigationData['array_number'] = [1, null, undefined, 2];
         arrayNavigationData['array_blank'] = ['', null, undefined];
-        arrayNavigationData['array_empty'] = [];
         
         describe('Navigate', function() {
             beforeEach(function() {
@@ -189,7 +188,6 @@ describe('Navigation Data', function () {
                 assert.strictEqual(Navigation.StateContext.data['array_blank'][1], null);
                 assert.strictEqual(Navigation.StateContext.data['array_blank'][2], null);
                 assert.strictEqual(Navigation.StateContext.data['array_blank'].length, 3);
-                assert.strictEqual(Navigation.StateContext.data['array_empty'], undefined);
                 assert.equal(i, 4);
             });
         }
@@ -207,7 +205,6 @@ describe('Navigation Data', function () {
         arrayNavigationData['array_boolean'] = ['', true, false];
         arrayNavigationData['array_number'] = [1, null, undefined, 2];
         arrayNavigationData['array_blank'] = ['', null, undefined];
-        arrayNavigationData['array_empty'] = [];
         
         describe('Navigate', function() {
             beforeEach(function() {
@@ -246,7 +243,6 @@ describe('Navigation Data', function () {
                 assert.strictEqual(Navigation.StateContext.data['array_blank'][1], null);
                 assert.strictEqual(Navigation.StateContext.data['array_blank'][2], null);
                 assert.strictEqual(Navigation.StateContext.data['array_blank'].length, 3);
-                assert.strictEqual(Navigation.StateContext.data['array_empty'], undefined);
                 assert.equal(i, 4);
             });
         }
@@ -590,6 +586,40 @@ describe('Navigation Data', function () {
             it('should populate data', function () {
                 assert.strictEqual(Navigation.StateContext.data['s'], undefined);
                 assert.strictEqual(Navigation.StateContext.data['t'], '1');
+            });
+        }
+    });
+
+    describe('Empty Array Data', function() {
+        beforeEach(function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'r' }]}
+                ]);
+        });
+        var data = {};
+        data['s'] = [];
+        data['t'] = ['1'];
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d', data);
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d', data);
+                Navigation.StateController.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate data', function () {
+                assert.strictEqual(Navigation.StateContext.data['s'], undefined);
+                assert.strictEqual(Navigation.StateContext.data['t'][0], '1');
             });
         }
     });

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -202,6 +202,71 @@ describe('Navigation Data', function () {
         }
     });
 
+    describe('Array Data Route', function() {
+        beforeEach(function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0/{array_string}/{array_boolean}/{array_number}/{array_blank}', transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1' }]}
+                ]);
+        });
+        var arrayNavigationData = {};
+        arrayNavigationData['array_string'] = ['He-llo', 'World'];
+        arrayNavigationData['array_boolean'] = ['', true, false];
+        arrayNavigationData['array_number'] = [1, null, undefined, 2];
+        arrayNavigationData['array_blank'] = ['', null, undefined];
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d', arrayNavigationData);
+                Navigation.StateController.navigate('t');
+                Navigation.StateController.navigateBack(1);
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d', arrayNavigationData);
+                Navigation.StateController.navigateLink(link);
+                console.log(link);
+                link = Navigation.StateController.getNavigationLink('t');
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationBackLink(1);
+                Navigation.StateController.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate data', function () {
+                var i = 0;
+                for (var key in Navigation.StateContext.data) {
+                    i++;
+                }
+                assert.strictEqual(Navigation.StateContext.data['array_string'][0], 'He-llo');
+                assert.strictEqual(Navigation.StateContext.data['array_string'][1], 'World');
+                assert.strictEqual(Navigation.StateContext.data['array_string'].length, 2);
+                assert.strictEqual(Navigation.StateContext.data['array_boolean'][0], null);
+                assert.strictEqual(Navigation.StateContext.data['array_boolean'][1], true);
+                assert.strictEqual(Navigation.StateContext.data['array_boolean'][2], false);
+                assert.strictEqual(Navigation.StateContext.data['array_boolean'].length, 3);
+                assert.strictEqual(Navigation.StateContext.data['array_number'][0], 1);
+                assert.strictEqual(Navigation.StateContext.data['array_number'][1], null);
+                assert.strictEqual(Navigation.StateContext.data['array_number'][2], null);
+                assert.strictEqual(Navigation.StateContext.data['array_number'][3], 2);
+                assert.strictEqual(Navigation.StateContext.data['array_number'].length, 4);
+                assert.strictEqual(Navigation.StateContext.data['array_blank'][0], null);
+                assert.strictEqual(Navigation.StateContext.data['array_blank'][1], null);
+                assert.strictEqual(Navigation.StateContext.data['array_blank'][2], null);
+                assert.strictEqual(Navigation.StateContext.data['array_blank'].length, 3);
+                assert.equal(i, 4);
+            });
+        }
+    });
+
     describe('Invalid Data', function() {
         beforeEach(function() {
             Navigation.StateInfoConfig.build([

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -5282,17 +5282,10 @@ describe('Navigation Data', function () {
         
         function test(){
             it('should clear State context', function() {
-                function isEmpty(data) {
-                    var i = 0;
-                    for (var key in data) {
-                        i++;
-                    }
-                    return i === 0;
-                }
                 Navigation.StateController.clearStateContext();
-                assert.ok(isEmpty(Navigation.StateContext.oldData));
-                assert.ok(isEmpty(Navigation.StateContext.previousData));
-                assert.ok(isEmpty(Navigation.StateContext.data));
+                assert.strictEqual(Object.keys(Navigation.StateContext.oldData).length, 0);
+                assert.strictEqual(Object.keys(Navigation.StateContext.previousData).length, 0);
+                assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 0);
             });
         }
     });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2207,9 +2207,9 @@ describe('MatchTest', function () {
         });
         
         it('should match', function() {
-            Navigation.StateController.navigateLink('/?x=Hello&x=World');
-            assert.strictEqual(Navigation.StateContext.data.x[0], 'Hello');
-            assert.strictEqual(Navigation.StateContext.data.x[1], 'World');
+            Navigation.StateController.navigateLink('/?x=He_llo&x=Wor-ld');
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'He_llo');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'Wor-ld');
             assert.strictEqual(Navigation.StateContext.data.x.length, 2);
             Navigation.StateController.navigateLink('/?x=1&x=2&x=4');
             assert.strictEqual(Navigation.StateContext.data.x[0], '1');
@@ -2219,7 +2219,7 @@ describe('MatchTest', function () {
         });
         
         it('should build', function() {
-            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['Hello', 'World'] }), '/?x=Hello&x=World');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['He_llo', 'Wor-ld'] }), '/?x=He_llo&x=Wor-ld');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [1, 2, 4] }), '/?x=1&x=2&x=4');
         });
     });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2198,11 +2198,11 @@ describe('MatchTest', function () {
         });
     });
 
-    describe('Without Types Array Query String', function () {
+    describe('Without Types Array Query String Default Type', function () {
         beforeEach(function () {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's', states: [
-                    { key: 's', route: '', trackTypes: false, trackCrumbTrail: false }]}
+                    { key: 's', route: '', trackTypes: false, defaultTypes: { x: 'stringarray' }, trackCrumbTrail: false }]}
                 ]);
         });
         

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2141,7 +2141,7 @@ describe('MatchTest', function () {
         beforeEach(function () {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's', states: [
-                    { key: 's', route: '', trackCrumbTrail: false, defaultTypes: { x: 'stringarray' } }]}
+                    { key: 's', route: '', defaultTypes: { x: 'stringarray' }, trackCrumbTrail: false }]}
                 ]);
         });
         
@@ -2161,7 +2161,7 @@ describe('MatchTest', function () {
         beforeEach(function () {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's', states: [
-                    { key: 's', route: '', trackCrumbTrail: false, defaultTypes: { x: 'numberarray' } }]}
+                    { key: 's', route: '', defaultTypes: { x: 'numberarray' }, trackCrumbTrail: false }]}
                 ]);
         });
         
@@ -2174,6 +2174,32 @@ describe('MatchTest', function () {
         });
         
         it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [1, 2, 4] }), '/?x=1&x=2&x=4');
+        });
+    });
+
+    describe('Without Types Array Query String', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '', trackTypes: false, trackCrumbTrail: false }]}
+                ]);
+        });
+        
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/?x=Hello&x=World');
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'Hello');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'World');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            Navigation.StateController.navigateLink('/?x=1&x=2&x=4');
+            assert.strictEqual(Navigation.StateContext.data.x[0], '1');
+            assert.strictEqual(Navigation.StateContext.data.x[1], '2');
+            assert.strictEqual(Navigation.StateContext.data.x[2], '4');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 3);
+        });
+        
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['Hello', 'World'] }), '/?x=Hello&x=World');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [1, 2, 4] }), '/?x=1&x=2&x=4');
         });
     });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -834,6 +834,47 @@ describe('MatchTest', function () {
         });
     });
 
+    describe('One Param One Segment Default Boolean', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{x}', defaults: { x: true }, trackCrumbTrail: false }]}
+                ]);
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/false');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x, false);
+            Navigation.StateController.navigateLink('/false?z=true');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x, false);
+            assert.strictEqual(Navigation.StateContext.data.z, 'true');
+            Navigation.StateController.navigateLink('/');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x, true);
+            Navigation.StateController.navigateLink('/?z=false');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x, true);
+            assert.strictEqual(Navigation.StateContext.data.z, 'false');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => Navigation.StateController.navigateLink('/false/true'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/false//'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/false?x=true'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: false }), '/false');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: false, z: 'true' }), '/false?z=true');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: true }), '/');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: true, z: 'false' }), '/?z=false');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { z: 'false' }), '/?z=false');
+        });
+    });
+
     describe('No Param One Segment Default Type Number', function () {
         beforeEach(function () {
             Navigation.StateInfoConfig.build([
@@ -866,6 +907,41 @@ describe('MatchTest', function () {
         it('should build', function() {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/abc');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 12 }), '/abc?x=12');
+        });
+    });
+
+    describe('No Param One Segment Default Type Boolean', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'abc', defaultTypes: { x: 'boolean' }, trackCrumbTrail: false }]}
+                ]);
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/abc');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 0);
+            Navigation.StateController.navigateLink('/abc?x=true');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x, true);
+        });
+
+        it('should not match', function() {
+            assert.throws(() => Navigation.StateController.navigateLink('/ abc'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/abc '), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/abd'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/abd'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/dbc'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/ab/c'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/adc'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/aabc'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/abc?x=true&x=false'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/abc');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: true }), '/abc?x=true');
         });
     });
 

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2178,6 +2178,26 @@ describe('MatchTest', function () {
         });
     });
 
+    describe('Array Query String Default Type Boolean', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '', defaultTypes: { x: 'booleanarray' }, trackCrumbTrail: false }]}
+                ]);
+        });
+        
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/?x=true&x=false');
+            assert.strictEqual(Navigation.StateContext.data.x[0], true);
+            assert.strictEqual(Navigation.StateContext.data.x[1], false);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+        });
+        
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [true, false] }), '/?x=true&x=false');
+        });
+    });
+
     describe('Without Types Array Query String', function () {
         beforeEach(function () {
             Navigation.StateInfoConfig.build([

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1929,7 +1929,7 @@ describe('MatchTest', function () {
 
         it('should match', function() {
             Navigation.StateController.navigateLink('/');
-            assert.strictEqual(Navigation.StateContext.data.x, 2);
+            assert.strictEqual(Navigation.StateContext.data.x, '2');
             Navigation.StateController.navigateLink('/3');
             assert.strictEqual(Navigation.StateContext.data.x, 3);
         });
@@ -1949,12 +1949,19 @@ describe('MatchTest', function () {
     });
 
     describe('Without Types Conflicing Default And Default Type', function () {
-        it('should not match', function() {
+        beforeEach(function () {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's', states: [
                     { key: 's', route: '{x}', trackTypes: false, defaults: { x: 'a' }, defaultTypes: { x: 'number' }, trackCrumbTrail: false }]}
                 ]);
-            assert.throws(() => Navigation.StateController.navigateLink('/'), /not a valid number/, '');
+        });
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/');
+            assert.strictEqual(Navigation.StateContext.data.x, 'a');
+            Navigation.StateController.navigateLink('/a');
+            assert.strictEqual(Navigation.StateContext.data.x, 'a');
+        });
+        it('should not match', function() {
             assert.throws(() => Navigation.StateController.navigateLink('/b'), /not a valid number/, '');
         });
     });
@@ -2048,7 +2055,7 @@ describe('MatchTest', function () {
 
         it('should match', function() {
             Navigation.StateController.navigateLink('/');
-            assert.strictEqual(Navigation.StateContext.data.x, 2);
+            assert.strictEqual(Navigation.StateContext.data.x, '2');
             Navigation.StateController.navigateLink('/?x=3');
             assert.strictEqual(Navigation.StateContext.data.x, 3);
         });
@@ -2068,12 +2075,19 @@ describe('MatchTest', function () {
     });
 
     describe('Without Types Query String Conflicing Default And Default Type', function () {
-        it('should match', function() {
+        beforeEach(function () {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's', states: [
                     { key: 's', route: '', trackTypes: false, defaults: { x: 'a' }, defaultTypes: { x: 'number' }, trackCrumbTrail: false }]}
                 ]);
-            assert.throws(() => Navigation.StateController.navigateLink('/'), /not a valid number/, '');
+        });
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/');
+            assert.strictEqual(Navigation.StateContext.data.x, 'a');
+            Navigation.StateController.navigateLink('/?x=a');
+            assert.strictEqual(Navigation.StateContext.data.x, 'a');
+        });
+        it('should not match', function() {
             assert.throws(() => Navigation.StateController.navigateLink('/?x=b'), /not a valid number/, '');
         });
     });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2089,6 +2089,7 @@ describe('MatchTest', function () {
                     { key: 's', route: '', trackTypes: false, defaults: { x: 'a' }, defaultTypes: { x: 'number' }, trackCrumbTrail: false }]}
                 ]);
         });
+        
         it('should match', function() {
             Navigation.StateController.navigateLink('/');
             assert.strictEqual(Navigation.StateContext.data.x, 'a');
@@ -2133,6 +2134,47 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '2' }), '/');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: 1 }), '/a/1');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 1, y: 2 }), '/1?y=2');
+        });
+    });
+
+    describe('Array Query String Default Type', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '', trackCrumbTrail: false, defaultTypes: { x: 'stringarray' } }]}
+                ]);
+        });
+        
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/?x=Hello&x=World');
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'Hello');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'World');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+        });
+        
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['Hello', 'World'] }), '/?x=Hello&x=World');
+        });
+    });
+
+    describe('Array Query String Default Type Number', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '', trackCrumbTrail: false, defaultTypes: { x: 'numberarray' } }]}
+                ]);
+        });
+        
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/?x=1&x=2&x=4');
+            assert.strictEqual(Navigation.StateContext.data.x[0], 1);
+            assert.strictEqual(Navigation.StateContext.data.x[1], 2);
+            assert.strictEqual(Navigation.StateContext.data.x[2], 4);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 3);
+        });
+        
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [1, 2, 4] }), '/?x=1&x=2&x=4');
         });
     });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1961,8 +1961,16 @@ describe('MatchTest', function () {
             Navigation.StateController.navigateLink('/a');
             assert.strictEqual(Navigation.StateContext.data.x, 'a');
         });
+        
         it('should not match', function() {
             assert.throws(() => Navigation.StateController.navigateLink('/b'), /not a valid number/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'a' }), '/');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3 }), '/3');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '3' }), '/3');
         });
     });
 
@@ -2087,8 +2095,16 @@ describe('MatchTest', function () {
             Navigation.StateController.navigateLink('/?x=a');
             assert.strictEqual(Navigation.StateContext.data.x, 'a');
         });
+        
         it('should not match', function() {
             assert.throws(() => Navigation.StateController.navigateLink('/?x=b'), /not a valid number/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'a' }), '/');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3 }), '/?x=3');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '3' }), '/?x=3');
         });
     });
 

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2150,10 +2150,23 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateContext.data.x[0], 'Hello');
             assert.strictEqual(Navigation.StateContext.data.x[1], 'World');
             assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            Navigation.StateController.navigateLink('/?x=H1-ello&x=W2-orld');
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'H1-ello');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'W2-orld');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            Navigation.StateController.navigateLink('/?x=H1-ello');
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'H1-ello');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            Navigation.StateController.navigateLink('/?x=H2-ello');
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'H2-ello');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
         });
         
         it('should build', function() {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['Hello', 'World'] }), '/?x=Hello&x=World');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['H1-ello', 'W2-orld'] }), '/?x=H1-ello&x=W2-orld');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['H1-ello'] }), '/?x=H1-ello');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['H2-ello'] }), '/?x=H2-ello');
         });
     });
 

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2223,4 +2223,26 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [1, 2, 4] }), '/?x=1&x=2&x=4');
         });
     });
+
+    describe('Array Query String Default', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '', defaults: { x: ['Hello', 'World'] }, trackCrumbTrail: false }]}
+                ]);
+        });
+        
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/?x=World&x=Hello');
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'World');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'Hello');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+        });
+        
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['Hello'] }), '/?x=Hello');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['Hello', 'World'] }), '/');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['World', 'Hello'] }), '/?x=World&x=Hello');
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -793,6 +793,82 @@ describe('MatchTest', function () {
         });
     });
 
+    describe('One Param One Segment Default Number', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{x}', defaults: { x: 345 }, trackCrumbTrail: false }]}
+                ]);
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/12');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x, 12);
+            Navigation.StateController.navigateLink('/12?z=34');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x, 12);
+            assert.strictEqual(Navigation.StateContext.data.z, '34');
+            Navigation.StateController.navigateLink('/');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x, 345);
+            Navigation.StateController.navigateLink('/?z=67');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x, 345);
+            assert.strictEqual(Navigation.StateContext.data.z, '67');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => Navigation.StateController.navigateLink('/12/34'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/12//'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/12?x=34'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 12 }), '/12');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 12, z: '34' }), '/12?z=34');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 345 }), '/');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 345, z: '67' }), '/?z=67');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { z: '67' }), '/?z=67');
+        });
+    });
+
+    describe('No Param One Segment Default Type Number', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'abc', defaultTypes: { x: 'number' }, trackCrumbTrail: false }]}
+                ]);
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/abc');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 0);
+            Navigation.StateController.navigateLink('/abc?x=12');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x, 12);
+        });
+
+        it('should not match', function() {
+            assert.throws(() => Navigation.StateController.navigateLink('/ abc'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/abc '), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/abd'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/abd'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/dbc'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/ab/c'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/adc'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/aabc'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/abc?x=12&x=345'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/abc');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 12 }), '/abc?x=12');
+        });
+    });
+
     describe('One Param Two Segment Default', function () {
         beforeEach(function () {
             Navigation.StateInfoConfig.build([

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2245,4 +2245,27 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['World', 'Hello'] }), '/?x=World&x=Hello');
         });
     });
+
+    describe('Array Query String Default Number', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '', defaults: { x: [1, 2, 4] }, trackCrumbTrail: false }]}
+                ]);
+        });
+        
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/?x=1&x=4&x=2');
+            assert.strictEqual(Navigation.StateContext.data.x[0], 1);
+            assert.strictEqual(Navigation.StateContext.data.x[1], 4);
+            assert.strictEqual(Navigation.StateContext.data.x[2], 2);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 3);
+        });
+        
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [1, 2] }), '/?x=1&x=2');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [1, 2, 4] }), '/');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [1, 4, 2] }), '/?x=1&x=4&x=2');
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -24,6 +24,7 @@ describe('MatchTest', function () {
             assert.throws(() => Navigation.StateController.navigateLink('/ '), /Url is invalid/, '');
             assert.throws(() => Navigation.StateController.navigateLink('/a'), /Url is invalid/, '');
             assert.throws(() => Navigation.StateController.navigateLink('//'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/?x=a&x=b'), /Url is invalid/, '');
         });
 
         it('should build', function() {
@@ -122,6 +123,7 @@ describe('MatchTest', function () {
             assert.throws(() => Navigation.StateController.navigateLink('/ab/cd'), /Url is invalid/, '');
             assert.throws(() => Navigation.StateController.navigateLink('/ab//'), /Url is invalid/, '');
             assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/a?x=b'), /Url is invalid/, '');
         });
 
         it('should build', function() {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2172,6 +2172,39 @@ describe('MatchTest', function () {
         });
     });
 
+    describe('Array Param Default Type', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{x}', defaultTypes: { x: 'stringarray' }, trackCrumbTrail: false }]}
+                ]);
+        });
+        
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/Hello1-World');
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'Hello');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'World');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            Navigation.StateController.navigateLink('/H12-ello1-W22-orld');
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'H1-ello');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'W2-orld');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            Navigation.StateController.navigateLink('/H12-ello');
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'H1-ello');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            Navigation.StateController.navigateLink('/H22-ello');
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'H2-ello');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+        });
+        
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['Hello', 'World'] }), '/Hello1-World');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['H1-ello', 'W2-orld'] }), '/H12-ello1-W22-orld');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['H1-ello'] }), '/H12-ello');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['H2-ello'] }), '/H22-ello');
+        });
+    });
+
     describe('Array Query String Default Type Number', function () {
         beforeEach(function () {
             Navigation.StateInfoConfig.build([

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2468,4 +2468,41 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [1, 4, 2] }), '/?x=1&x=4&x=2');
         });
     });
+
+    describe('Combine Array Query String Default Type', function () {
+        beforeEach(function () {
+            Navigation.settings.combineArray = true;
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '', defaultTypes: { x: 'stringarray' }, trackCrumbTrail: false }]}
+                ]);
+        });
+        afterEach(function() {
+            Navigation.settings.combineArray = false;
+        });
+        
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/?x=Hello1-World');
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'Hello');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'World');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            Navigation.StateController.navigateLink('/?x=H12-ello1-W22-orld');
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'H1-ello');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'W2-orld');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            Navigation.StateController.navigateLink('/?x=H12-ello');
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'H1-ello');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            Navigation.StateController.navigateLink('/?x=H22-ello');
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'H2-ello');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+        });
+        
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['Hello', 'World'] }), '/?x=Hello1-World');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['H1-ello', 'W2-orld'] }), '/?x=H12-ello1-W22-orld');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['H1-ello'] }), '/?x=H12-ello');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['H2-ello'] }), '/?x=H22-ello');
+        });
+    });
 });

--- a/NavigationJS/test/navigation-tests.ts
+++ b/NavigationJS/test/navigation-tests.ts
@@ -78,9 +78,13 @@ module NavigationTests {
 	
 	// State Handler
 	class LogStateHandler extends Navigation.StateHandler {
+		getNavigationLink(state: Navigation.State, data: any): string {
+			console.log('get navigation link');
+			return super.getNavigationLink(state, data, { ids: [] });
+		}
 	    getNavigationData(state: Navigation.State, url: string): any {
 			console.log('get navigation data');
-			super.getNavigationData(state, url);
+			super.getNavigationData(state, url, {});
 	    }
 	}
 	homePage.stateHandler = new LogStateHandler();

--- a/NavigationKnockout/src/navigation.d.ts
+++ b/NavigationKnockout/src/navigation.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for Navigation 1.1.0
+﻿// Type definitions for Navigation 1.2.0
 // Project: http://grahammendick.github.io/navigation/
 // Definitions by: Graham Mendick <https://github.com/grahammendick>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -31,6 +31,10 @@ declare module Navigation {
          * Gets the textual description of the dialog
          */
         title?: string;
+        /**
+         * Gets the additional dialog attributes
+         */
+        [extras: string]: any;
     }
 
     /**
@@ -75,6 +79,10 @@ declare module Navigation {
          * preserved when navigating
          */
         trackTypes?: boolean;
+        /**
+         * Gets the additional state attributes
+         */
+        [extras: string]: any;
     }
 
     /**
@@ -522,6 +530,14 @@ declare module Navigation {
          */
         getNavigationLink(state: State, data: any): string;
         /**
+         * Gets a link that navigates to the state passing the data
+         * @param state The State to navigate to
+         * @param data The data to pass when navigating
+         * @param queryStringData The query string array data
+         * @returns The navigation link
+         */
+        getNavigationLink(state: State, data: any, queryStringData: { [index: string]: string[]; }): string;
+        /**
          * Navigates to the url
          * @param oldState The current State
          * @param state The State to navigate to
@@ -535,6 +551,14 @@ declare module Navigation {
          * @returns The navigation data
          */
         getNavigationData(state: State, url: string): any;
+        /**
+         * Gets the data parsed from the url
+         * @param state The State navigated to
+         * @param url The current url
+         * @param queryStringData Stores query string keys
+         * @returns The navigation data
+         */
+        getNavigationData(state: State, url: string, queryStringData: any): any;
         /**
          * Truncates the crumb trail
          * @param The State navigated to
@@ -634,6 +658,11 @@ declare module Navigation {
          * navigating back or refreshing and combineCrumbTrail is false 
          */
         trackAllPreviousData: boolean;
+        /**
+         * Gets or sets a value indicating whether arrays should be stored in
+         * a single query string parameter
+         */
+        combineArray: boolean;
     }
 
     /**
@@ -682,6 +711,10 @@ declare module Navigation {
          * Gets the current Url
          */
         static url: string;
+        /**
+         * Gets or sets the current title
+         */
+        static title: string;
         /** 
          * Combines the data with all the current NavigationData
          * @param The data to add to the current NavigationData
@@ -908,6 +941,14 @@ declare module Navigation {
          */
         getNavigationLink(state: State, data: any): string;
         /**
+         * Gets a link that navigates to the state passing the data
+         * @param state The State to navigate to
+         * @param data The data to pass when navigating
+         * @param queryStringData The query string array data
+         * @returns The navigation link
+         */
+        getNavigationLink(state: State, data: any, queryStringData: { [index: string]: string[]; }): string;
+        /**
          * Navigates to the url
          * @param oldState The current State
          * @param state The State to navigate to
@@ -921,6 +962,14 @@ declare module Navigation {
          * @returns The navigation data
          */
         getNavigationData(state: State, url: string): any;
+        /**
+         * Gets the data parsed from the url
+         * @param state The State navigated to
+         * @param url The current url
+         * @param queryStringData Stores query string keys
+         * @returns The navigation data
+         */
+        getNavigationData(state: State, url: string, queryStringData: any): any;
         /**
          * Truncates the crumb trail whenever a repeated or initial State is
          * encountered

--- a/NavigationReact/src/navigation.d.ts
+++ b/NavigationReact/src/navigation.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for Navigation 1.1.0
+﻿// Type definitions for Navigation 1.2.0
 // Project: http://grahammendick.github.io/navigation/
 // Definitions by: Graham Mendick <https://github.com/grahammendick>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -31,6 +31,10 @@ declare module Navigation {
          * Gets the textual description of the dialog
          */
         title?: string;
+        /**
+         * Gets the additional dialog attributes
+         */
+        [extras: string]: any;
     }
 
     /**
@@ -75,6 +79,10 @@ declare module Navigation {
          * preserved when navigating
          */
         trackTypes?: boolean;
+        /**
+         * Gets the additional state attributes
+         */
+        [extras: string]: any;
     }
 
     /**
@@ -522,6 +530,14 @@ declare module Navigation {
          */
         getNavigationLink(state: State, data: any): string;
         /**
+         * Gets a link that navigates to the state passing the data
+         * @param state The State to navigate to
+         * @param data The data to pass when navigating
+         * @param queryStringData The query string array data
+         * @returns The navigation link
+         */
+        getNavigationLink(state: State, data: any, queryStringData: { [index: string]: string[]; }): string;
+        /**
          * Navigates to the url
          * @param oldState The current State
          * @param state The State to navigate to
@@ -535,6 +551,14 @@ declare module Navigation {
          * @returns The navigation data
          */
         getNavigationData(state: State, url: string): any;
+        /**
+         * Gets the data parsed from the url
+         * @param state The State navigated to
+         * @param url The current url
+         * @param queryStringData Stores query string keys
+         * @returns The navigation data
+         */
+        getNavigationData(state: State, url: string, queryStringData: any): any;
         /**
          * Truncates the crumb trail
          * @param The State navigated to
@@ -634,6 +658,11 @@ declare module Navigation {
          * navigating back or refreshing and combineCrumbTrail is false 
          */
         trackAllPreviousData: boolean;
+        /**
+         * Gets or sets a value indicating whether arrays should be stored in
+         * a single query string parameter
+         */
+        combineArray: boolean;
     }
 
     /**
@@ -682,6 +711,10 @@ declare module Navigation {
          * Gets the current Url
          */
         static url: string;
+        /**
+         * Gets or sets the current title
+         */
+        static title: string;
         /** 
          * Combines the data with all the current NavigationData
          * @param The data to add to the current NavigationData
@@ -908,6 +941,14 @@ declare module Navigation {
          */
         getNavigationLink(state: State, data: any): string;
         /**
+         * Gets a link that navigates to the state passing the data
+         * @param state The State to navigate to
+         * @param data The data to pass when navigating
+         * @param queryStringData The query string array data
+         * @returns The navigation link
+         */
+        getNavigationLink(state: State, data: any, queryStringData: { [index: string]: string[]; }): string;
+        /**
          * Navigates to the url
          * @param oldState The current State
          * @param state The State to navigate to
@@ -921,6 +962,14 @@ declare module Navigation {
          * @returns The navigation data
          */
         getNavigationData(state: State, url: string): any;
+        /**
+         * Gets the data parsed from the url
+         * @param state The State navigated to
+         * @param url The current url
+         * @param queryStringData Stores query string keys
+         * @returns The navigation data
+         */
+        getNavigationData(state: State, url: string, queryStringData: any): any;
         /**
          * Truncates the crumb trail whenever a repeated or initial State is
          * encountered

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,7 +25,7 @@ function testTask(file, to) {
 		.pipe(source(to))
 		.pipe(rename(to))
 		.pipe(gulp.dest('./build/dist'))
-        .pipe(mocha());
+		.pipe(mocha({ reporter: 'progress' }));
 }
 for (var i = 0; i < tests.length; i++) {
 	(function (test) {


### PR DESCRIPTION
Take an array in Navigation Data {x: ['a', b']}. Instead of storing this in a single query string parameter, /?x=a2-b (2- is the separator), changed to store it as repeated parameters, /?x=a&x=b. For route parameters and return data, retained formatting it to a single parameter.

To revert to old behaviour, set the new combineArray Navigation setting to false.

*Fixed an 'unrelated' bug concerning conflicting default value and defaultType, { x: 'a' } and { x: 'number' }. Instead of throwing an error, stopped the StateController from parsing default values.*