### PR TITLE
Allowed URL Encoding customisation

### DIFF
--- a/NavigationJS/src/IStateHandler.ts
+++ b/NavigationJS/src/IStateHandler.ts
@@ -6,5 +6,7 @@ interface IStateHandler {
     navigateLink(oldState: State, state: State, url: string): void;
     getNavigationData(state: State, url: string, queryStringData?: any): any;
     truncateCrumbTrail(state: State, crumbs: Crumb[]): Crumb[];
+    urlEncode?(state: State, key: string, val: string, queryString: boolean): string;
+    urlDecode?(state: State, key: string, val: string, queryString: boolean): string;
 }
 export = IStateHandler;

--- a/NavigationJS/src/IStateHandler.ts
+++ b/NavigationJS/src/IStateHandler.ts
@@ -5,8 +5,8 @@ interface IStateHandler {
     getNavigationLink(state: State, data: any, queryStringData?: { [index: string]: string[] }): string;
     navigateLink(oldState: State, state: State, url: string): void;
     getNavigationData(state: State, url: string, queryStringData?: any): any;
-    truncateCrumbTrail(state: State, crumbs: Crumb[]): Crumb[];
     urlEncode?(state: State, key: string, val: string, queryString: boolean): string;
     urlDecode?(state: State, key: string, val: string, queryString: boolean): string;
+    truncateCrumbTrail(state: State, crumbs: Crumb[]): Crumb[];
 }
 export = IStateHandler;

--- a/NavigationJS/src/StateHandler.ts
+++ b/NavigationJS/src/StateHandler.ts
@@ -14,11 +14,12 @@ class StateHandler implements IStateHandler {
         for (var key in data) {
             if (key !== settings.stateIdKey && !routeInfo.data[key]) {
                 var arr = queryStringData[key];
+                var encodedKey = this.urlEncode(state, null, key, true);
                 if (!arr) {
-                    query.push(encodeURIComponent(key) + '=' + encodeURIComponent(data[key]));
+                    query.push(encodedKey + '=' + this.urlEncode(state, key, data[key], true));
                 } else {
                     for(var i = 0; i < arr.length; i++)
-                        query.push(encodeURIComponent(key) + '=' + encodeURIComponent(arr[i]));
+                        query.push(encodedKey + '=' + this.urlEncode(state, key, arr[i], true));
                 }
             }
         }
@@ -40,8 +41,8 @@ class StateHandler implements IStateHandler {
             var params = query.split('&');
             for (var i = 0; i < params.length; i++) {
                 var param = params[i].split('=');
-                var key = decodeURIComponent(param[0]);
-                var val = decodeURIComponent(param[1]);
+                var key = this.urlDecode(state, null, param[0], true);
+                var val = this.urlDecode(state, key, param[1], true);
                 queryStringData[key] = true;
                 var arr = data[key];
                 if (!arr) {
@@ -54,6 +55,14 @@ class StateHandler implements IStateHandler {
             }
         }
         return data;
+    }
+    
+    urlEncode(state: State, key: string, val: string, queryString: boolean): string {
+        return encodeURIComponent(val);
+    }
+    
+    urlDecode(state: State, key: string, val: string, queryString: boolean): string {
+        return decodeURIComponent(val);
     }
 
     truncateCrumbTrail(state: State, crumbs: Crumb[]): Crumb[] {

--- a/NavigationJS/src/StateHandler.ts
+++ b/NavigationJS/src/StateHandler.ts
@@ -15,10 +15,10 @@ class StateHandler implements IStateHandler {
             if (key !== settings.stateIdKey && !routeInfo.data[key]) {
                 var arr = queryStringData[key];
                 if (!arr) {
-                    query.push(this.urlEncode(key, data[key], true));
+                    query.push(encodeURIComponent(key) + '=' + encodeURIComponent(data[key]));
                 } else {
                     for(var i = 0; i < arr.length; i++)
-                        query.push(this.urlEncode(key, arr[i], true));
+                        query.push(encodeURIComponent(key) + '=' + encodeURIComponent(arr[i]));
                 }
             }
         }
@@ -39,7 +39,9 @@ class StateHandler implements IStateHandler {
             var query = url.substring(queryIndex + 1);
             var params = query.split('&');
             for (var i = 0; i < params.length; i++) {
-                var { key, val } = this.urlDecode(params[i], true);
+                var param = params[i].split('=');
+                var key = decodeURIComponent(param[0]);
+                var val = decodeURIComponent(param[1]);
                 queryStringData[key] = true;
                 var arr = data[key];
                 if (!arr) {
@@ -52,22 +54,6 @@ class StateHandler implements IStateHandler {
             }
         }
         return data;
-    }
-    
-    urlEncode(key: string, val: string, queryString: boolean): string {
-        if (queryString)
-            return encodeURIComponent(key) + '=' + encodeURIComponent(val);
-        else
-            return encodeURIComponent(val);
-    }
-    
-    urlDecode(param: string, queryString: boolean): { key?: string, val: string } {
-        if (queryString) {
-            var vals = param.split('=');
-            return { key: decodeURIComponent(vals[0]), val: decodeURIComponent(vals[1]) };
-        } else {
-            return { val: decodeURIComponent(param) };
-        }
     }
 
     truncateCrumbTrail(state: State, crumbs: Crumb[]): Crumb[] {

--- a/NavigationJS/src/StateHandler.ts
+++ b/NavigationJS/src/StateHandler.ts
@@ -15,10 +15,10 @@ class StateHandler implements IStateHandler {
             if (key !== settings.stateIdKey && !routeInfo.data[key]) {
                 var arr = queryStringData[key];
                 if (!arr) {
-                    query.push(encodeURIComponent(key) + '=' + encodeURIComponent(data[key]));
+                    query.push(this.urlEncode(key, data[key], true));
                 } else {
                     for(var i = 0; i < arr.length; i++)
-                        query.push(encodeURIComponent(key) + '=' + encodeURIComponent(arr[i]));
+                        query.push(this.urlEncode(key, arr[i], true));
                 }
             }
         }
@@ -39,9 +39,7 @@ class StateHandler implements IStateHandler {
             var query = url.substring(queryIndex + 1);
             var params = query.split('&');
             for (var i = 0; i < params.length; i++) {
-                var param = params[i].split('=');
-                var key = decodeURIComponent(param[0]);
-                var val = decodeURIComponent(param[1]);
+                var { key, val } = this.urlDecode(params[i], true);
                 queryStringData[key] = true;
                 var arr = data[key];
                 if (!arr) {
@@ -54,6 +52,22 @@ class StateHandler implements IStateHandler {
             }
         }
         return data;
+    }
+    
+    urlEncode(key: string, val: string, queryString: boolean): string {
+        if (queryString)
+            return encodeURIComponent(key) + '=' + encodeURIComponent(val);
+        else
+            return encodeURIComponent(val);
+    }
+    
+    urlDecode(param: string, queryString: boolean): { key?: string, val: string } {
+        if (queryString) {
+            var vals = param.split('=');
+            return { key: decodeURIComponent(vals[0]), val: decodeURIComponent(vals[1]) };
+        } else {
+            return { val: decodeURIComponent(param) };
+        }
     }
 
     truncateCrumbTrail(state: State, crumbs: Crumb[]): Crumb[] {

--- a/NavigationJS/src/StateRouter.ts
+++ b/NavigationJS/src/StateRouter.ts
@@ -11,8 +11,14 @@ class StateRouter implements IRouter {
     supportsDefaults: boolean = true;
 
     getData(route: string): { state: State; data: any } {
-        var match = this.router.match(route);
-        return { state: match.route['_state'], data: this.router.match(route).data };
+        var match = this.router.match(route, (route, name, val) => {
+            var state: State = route['_state'];
+            if (state.stateHandler.urlDecode)
+                return state.stateHandler.urlDecode(state, name, val, false);
+            else
+                return decodeURIComponent(val);
+        });
+        return { state: match.route['_state'], data: match.data };
     }
 
     getRoute(state: State, data: any): { route: string; data: any } {

--- a/NavigationJS/src/StateRouter.ts
+++ b/NavigationJS/src/StateRouter.ts
@@ -26,7 +26,7 @@ class StateRouter implements IRouter {
         var routeMatch: { route: Route; data: any; } = routeInfo.matches[paramsKey];
         var routePath: string = null;
         if (routeMatch) {
-            routePath = routeMatch.route.build(data);
+            routePath = routeMatch.route.build(data, StateRouter.urlEncode);
         } else {
             var bestMatch = StateRouter.findBestMatch(routeInfo.routes, data);
             if (bestMatch) {
@@ -43,7 +43,7 @@ class StateRouter implements IRouter {
         var bestMatchCount = -1;
         for(var i = 0; i < routes.length; i++) {
             var route = routes[i];
-            var routePath = route.build(data);
+            var routePath = route.build(data, StateRouter.urlEncode);
             if (routePath) {
                 var count = 0;
                 var routeData = {};
@@ -61,7 +61,15 @@ class StateRouter implements IRouter {
         }
         return bestMatch;
     }
-    
+
+    private static urlEncode(route: Route, name: string, val: string): string {
+        var state: State = route['_state'];
+        if (state.stateHandler.urlEncode)
+            return state.stateHandler.urlEncode(state, name, val, false);
+        else
+            return encodeURIComponent(val);
+    }
+
     private static urlDecode(route: Route, name: string, val: string): string {
         var state: State = route['_state'];
         if (state.stateHandler.urlDecode)

--- a/NavigationJS/src/StateRouter.ts
+++ b/NavigationJS/src/StateRouter.ts
@@ -11,13 +11,7 @@ class StateRouter implements IRouter {
     supportsDefaults: boolean = true;
 
     getData(route: string): { state: State; data: any } {
-        var match = this.router.match(route, (route, name, val) => {
-            var state: State = route['_state'];
-            if (state.stateHandler.urlDecode)
-                return state.stateHandler.urlDecode(state, name, val, false);
-            else
-                return decodeURIComponent(val);
-        });
+        var match = this.router.match(route, StateRouter.urlDecode);
         return { state: match.route['_state'], data: match.data };
     }
 
@@ -66,6 +60,14 @@ class StateRouter implements IRouter {
             }
         }
         return bestMatch;
+    }
+    
+    private static urlDecode(route: Route, name: string, val: string): string {
+        var state: State = route['_state'];
+        if (state.stateHandler.urlDecode)
+            return state.stateHandler.urlDecode(state, name, val, false);
+        else
+            return decodeURIComponent(val);
     }
 
     addRoutes(dialogs: Dialog[]) {

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -559,7 +559,21 @@ declare module Navigation {
          * @returns The navigation data
          */
         getNavigationData(state: State, url: string, queryStringData: any): any;
+        /**
+         * Encodes the Url value
+         * @param state The State navigated to
+         * @param key The key of the navigation data item
+         * @param val The Url value of the navigation data item
+         * @param queryString A value indicating the Url value's location
+         */
         urlEncode?(state: State, key: string, val: string, queryString: boolean): string;
+        /**
+         * Decodes the Url value
+         * @param state The State navigated to
+         * @param key The key of the navigation data item
+         * @param val The Url value of the navigation data item
+         * @param queryString A value indicating the Url value's location
+         */
         urlDecode?(state: State, key: string, val: string, queryString: boolean): string;
         /**
          * Truncates the crumb trail
@@ -972,7 +986,21 @@ declare module Navigation {
          * @returns The navigation data
          */
         getNavigationData(state: State, url: string, queryStringData: any): any;
+        /**
+         * Encodes the Url value
+         * @param state The State navigated to
+         * @param key The key of the navigation data item
+         * @param val The Url value of the navigation data item
+         * @param queryString A value indicating the Url value's location
+         */
         urlEncode(state: State, key: string, val: string, queryString: boolean): string;
+        /**
+         * Decodes the Url value
+         * @param state The State navigated to
+         * @param key The key of the navigation data item
+         * @param val The Url value of the navigation data item
+         * @param queryString A value indicating the Url value's location
+         */
         urlDecode(state: State, key: string, val: string, queryString: boolean): string;
         /**
          * Truncates the crumb trail whenever a repeated or initial State is
@@ -1084,6 +1112,12 @@ declare module Navigation {
          * @returns The matched data or null if there's no match
          */
         match(path: string): any;
+        /**
+         * Gets the matching data for the path
+         * @param path The path to match
+         * @param urlDecode The function to decode the Url value
+         * @returns The matched data or null if there's no match
+         */
         match(path: string, urlDecode: (route: Route, name: string, val: string) => string): any;
         /**
          * Gets the route populated with default values
@@ -1092,10 +1126,16 @@ declare module Navigation {
         build(): string;
         /**
          * Gets the route populated with data and default values
-         * @param The data for the route parameters
+         * @param data The data for the route parameters
          * @returns The built route
          */
         build(data: any): string;
+        /**
+         * Gets the route populated with data and default values
+         * @param data The data for the route parameters
+         * @param urlEncode The function to encode the Url value
+         * @returns The built route
+         */
         build(data: any, urlEncode: (route: Route, name: string, val: string) => string): string;
     }
 
@@ -1118,10 +1158,16 @@ declare module Navigation {
         addRoute(path: string, defaults: any): Route;
         /**
          * Gets the matching route and data for the path
-         * @param route The path to match
+         * @param path The path to match
          * @returns The matched route and data
          */
         match(path: string): { route: Route; data: any; };
+        /**
+         * Gets the matching route and data for the path
+         * @param path The path to match
+         * @param urlDecode The function to decode the Url value
+         * @returns The matched route and data
+         */
         match(path: string, urlDecode: (route: Route, name: string, val: string) => string): { route: Route; data: any; };
         /**
          * Sorts the routes by the comparer

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -559,6 +559,8 @@ declare module Navigation {
          * @returns The navigation data
          */
         getNavigationData(state: State, url: string, queryStringData: any): any;
+        urlEncode?(state: State, key: string, val: string, queryString: boolean): string;
+        urlDecode?(state: State, key: string, val: string, queryString: boolean): string;
         /**
          * Truncates the crumb trail
          * @param The State navigated to
@@ -970,6 +972,8 @@ declare module Navigation {
          * @returns The navigation data
          */
         getNavigationData(state: State, url: string, queryStringData: any): any;
+        urlEncode(state: State, key: string, val: string, queryString: boolean): string;
+        urlDecode(state: State, key: string, val: string, queryString: boolean): string;
         /**
          * Truncates the crumb trail whenever a repeated or initial State is
          * encountered
@@ -1080,6 +1084,7 @@ declare module Navigation {
          * @returns The matched data or null if there's no match
          */
         match(path: string): any;
+        match(path: string, urlDecode: (route: Route, name: string, val: string) => string): any;
         /**
          * Gets the route populated with default values
          * @returns The built route
@@ -1091,6 +1096,7 @@ declare module Navigation {
          * @returns The built route
          */
         build(data: any): string;
+        build(data: any, urlEncode: (route: Route, name: string, val: string) => string): string;
     }
 
     /**
@@ -1116,6 +1122,7 @@ declare module Navigation {
          * @returns The matched route and data
          */
         match(path: string): { route: Route; data: any; };
+        match(path: string, urlDecode: (route: Route, name: string, val: string) => string): { route: Route; data: any; };
         /**
          * Sorts the routes by the comparer
          * @param compare The route comparer function

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -1115,7 +1115,7 @@ declare module Navigation {
         /**
          * Gets the matching data for the path
          * @param path The path to match
-         * @param urlDecode The function to decode the Url value
+         * @param urlDecode The function that decodes the Url value
          * @returns The matched data or null if there's no match
          */
         match(path: string, urlDecode: (route: Route, name: string, val: string) => string): any;
@@ -1133,7 +1133,7 @@ declare module Navigation {
         /**
          * Gets the route populated with data and default values
          * @param data The data for the route parameters
-         * @param urlEncode The function to encode the Url value
+         * @param urlEncode The function that encodes the Url value
          * @returns The built route
          */
         build(data: any, urlEncode: (route: Route, name: string, val: string) => string): string;
@@ -1165,7 +1165,7 @@ declare module Navigation {
         /**
          * Gets the matching route and data for the path
          * @param path The path to match
-         * @param urlDecode The function to decode the Url value
+         * @param urlDecode The function that decodes the Url value
          * @returns The matched route and data
          */
         match(path: string, urlDecode: (route: Route, name: string, val: string) => string): { route: Route; data: any; };

--- a/NavigationJS/src/routing/Route.ts
+++ b/NavigationJS/src/routing/Route.ts
@@ -30,7 +30,9 @@ class Route {
         this.pattern = new RegExp('^' + pattern + '$', 'i');
     }
 
-    match(path: string): any {
+    match(path: string, urlDecode?: (route: Route, name: string, val: string) => string): any {
+        if (!urlDecode)
+            urlDecode = (name, val) => decodeURIComponent(val); 
         var matches = this.pattern.exec(path);
         if (!matches)
             return null;
@@ -38,7 +40,7 @@ class Route {
         for (var i = 1; i < matches.length; i++) {
             var param = this.params[i - 1];
             if (matches[i])
-                data[param.name] = decodeURIComponent(!param.optional ? matches[i] : matches[i].substring(1));
+                data[param.name] = urlDecode(this, param.name, !param.optional ? matches[i] : matches[i].substring(1));
         }
         return data;
     }

--- a/NavigationJS/src/routing/Route.ts
+++ b/NavigationJS/src/routing/Route.ts
@@ -32,7 +32,7 @@ class Route {
 
     match(path: string, urlDecode?: (route: Route, name: string, val: string) => string): any {
         if (!urlDecode)
-            urlDecode = (name, val) => decodeURIComponent(val); 
+            urlDecode = (route, name, val) => decodeURIComponent(val); 
         var matches = this.pattern.exec(path);
         if (!matches)
             return null;
@@ -45,13 +45,15 @@ class Route {
         return data;
     }
 
-    build(data?: any): string {
+    build(data?: any, urlEncode?: (route: Route, name: string, val: string) => string): string {
+        if (!urlEncode)
+            urlEncode = (route, name, val) => encodeURIComponent(val);
         data = data != null ? data : {};
         var route = '';
         var optional = true;
         for (var i = this.segments.length - 1; i >= 0; i--) {
             var segment = this.segments[i];
-            var pathInfo = segment.build(data);
+            var pathInfo = segment.build(data, (name, val) => urlEncode(this, name, val));
             optional = optional && pathInfo.optional;
             if (!optional) {
                 if (pathInfo.path == null)

--- a/NavigationJS/src/routing/Router.ts
+++ b/NavigationJS/src/routing/Router.ts
@@ -11,12 +11,12 @@ class Router {
         return route;
     }
 
-    match(path: string): { route: Route; data: any } {
+    match(path: string, urlDecode?: (route: Route, name: string, val: string) => string): { route: Route; data: any } {
         path = path.slice(-1) === '/' ? path.substring(0, path.length - 1) : path;
         path = (path.substring(0, 1) === '/' || path.length === 0) ? path : '/' + path;
         for (var i = 0; i < this.routes.length; i++) {
             var route = this.routes[i];
-            var data = route.match(path);
+            var data = route.match(path, urlDecode);
             if (data)
                 return { route: route, data: data };
         }

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -53,7 +53,8 @@
                 optional = optional && (!val || val === defaultVal);
                 val = val ? val : defaultVal;
                 blank = blank || !val;
-                routePath += urlEncode(subSegment.name, val);
+                if (val)
+                    routePath += urlEncode(subSegment.name, val);
             }
         }
         return { path: !blank ? routePath : null, optional: optional };

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -39,7 +39,7 @@
             this.pattern = '\/' + this.pattern;
     }
 
-    build(data?: any): { path: string; optional: boolean } {
+    build(data: any = {}, urlEncode: (name: string, val: string) => string): { path: string; optional: boolean } {
         var routePath = '';
         var optional = this.optional;
         var blank = false;
@@ -53,7 +53,7 @@
                 optional = optional && (!val || val === defaultVal);
                 val = val ? val : defaultVal;
                 blank = blank || !val;
-                routePath += encodeURIComponent(val);
+                routePath += urlEncode(subSegment.name, val);
             }
         }
         return { path: !blank ? routePath : null, optional: optional };

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -39,7 +39,7 @@
             this.pattern = '\/' + this.pattern;
     }
 
-    build(data: any = {}, urlEncode: (name: string, val: string) => string): { path: string; optional: boolean } {
+    build(data: any, urlEncode: (name: string, val: string) => string): { path: string; optional: boolean } {
         var routePath = '';
         var optional = this.optional;
         var blank = false;

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -5523,5 +5523,55 @@ describe('Navigation Data', function () {
             });
         }
     });
+
+    describe('Url Encode Data Back', function() {
+        beforeEach(function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'a/{s}', transitions: [
+                        { key: 't', to: 's1' }]},
+                    { key: 's1', route: 'b' }]},
+                ]);
+            var dialog = Navigation.StateInfoConfig.dialogs['d'];
+            for(var key in dialog.states) {
+                var state = dialog.states[key];
+                state.stateHandler.urlEncode = (state, key, val) => {
+                    return state == dialog.states['s0'] ? val.replace(' ', '+') : encodeURIComponent(val);
+                }
+                state.stateHandler.urlDecode = (state, key, val) => {
+                    return state == dialog.states['s0'] ? val.replace('+', ' ') : decodeURIComponent(val);
+                }
+            }
+        });
+        var data = {};
+        data['s'] = 'He llo';
+
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d', data);
+                Navigation.StateController.navigate('t');
+                Navigation.StateController.navigateBack(1);
+            });
+            test();
+        });
+        
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d', data);
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t');
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationBackLink(1);
+                Navigation.StateController.navigateLink(link);
+            });            
+            test();
+        });
+        
+        function test(){
+            it('should populate data', function() {
+                assert.strictEqual(Navigation.StateContext.data.s, 'He llo');
+            });
+        }
+    });
 });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3133,10 +3133,10 @@ describe('MatchTest', function () {
                     { key: 's', route: '{x}', trackCrumbTrail: false }]}
                 ]);
             var state = Navigation.StateInfoConfig.dialogs['d'].states['s'];
-            state.stateHandler.urlEncode = (state, key, val, queryString) =>  {
+            state.stateHandler.urlEncode = (state, key, val) =>  {
                 return key === 'y' ? val.replace(' ', '+') : encodeURIComponent(val);
             }  
-            state.stateHandler.urlDecode = (state, key, val, queryString) => {
+            state.stateHandler.urlDecode = (state, key, val) => {
                 return key === 'y' ? val.replace('+', ' ') : decodeURIComponent(val);
             }  
         });
@@ -3159,10 +3159,10 @@ describe('MatchTest', function () {
                     { key: 's', route: '{x}', trackCrumbTrail: false }]}
                 ]);
             var state = Navigation.StateInfoConfig.dialogs['d'].states['s'];
-            state.stateHandler.urlEncode = (state, key, val, queryString) => {
+            state.stateHandler.urlEncode = (state, key, val) => {
                 return key === 'x' ? val.replace(' ', '+') : encodeURIComponent(val);
             }
-            state.stateHandler.urlDecode = (state, key, val, queryString) => {
+            state.stateHandler.urlDecode = (state, key, val) => {
                 return key === 'x' ? val.replace('+', ' ') : decodeURIComponent(val);
             }
         });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3060,6 +3060,39 @@ describe('MatchTest', function () {
         });
     });
 
+    describe('No Param One Segment State Encode', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd0', initial: 's', states: [
+                    { key: 's', route: 'a', trackCrumbTrail: false }]},
+                { key: 'd1', initial: 's', states: [
+                    { key: 's', route: 'b', trackCrumbTrail: false }]}
+                ]);
+            var dialogs = Navigation.StateInfoConfig.dialogs;
+            for(var key in dialogs) {
+                var state = dialogs[key].states['s'];
+                state.stateHandler.urlEncode = (state, key, val) => {
+                    return state.parent == dialogs['d0'] ? val.replace(' ', '+') : encodeURIComponent(val);
+                }
+                state.stateHandler.urlDecode = (state, key, val) => {
+                    return state.parent == dialogs['d0'] ? val.replace('+', ' ') : decodeURIComponent(val);
+                }
+            }
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/a?x=c+d');
+            assert.strictEqual(Navigation.StateContext.data.x, 'c d');
+            Navigation.StateController.navigateLink('/b?x=c%20d');
+            assert.strictEqual(Navigation.StateContext.data.x, 'c d');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d0', { x: 'c d' }), '/a?x=c+d');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d1', { x: 'c d' }), '/b?x=c%20d');
+        });
+    });
+
     describe('One Param State Encode', function () {
         beforeEach(function () {
             Navigation.StateInfoConfig.build([

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3059,4 +3059,37 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'a b', y: 'c d' }), '/a+b?y=c%20d');
         });
     });
+
+    describe('One Param State Encode', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd0', initial: 's', states: [
+                    { key: 's', route: 'a/{x}', trackCrumbTrail: false }]},
+                { key: 'd1', initial: 's', states: [
+                    { key: 's', route: 'b/{x}', trackCrumbTrail: false }]}
+                ]);
+            var dialogs = Navigation.StateInfoConfig.dialogs;
+            for(var key in dialogs) {
+                var state = dialogs[key].states['s'];
+                state.stateHandler.urlEncode = (state, key, val) =>  {
+                    return state.parent == dialogs['d0'] ? val.replace(' ', '+') : encodeURIComponent(val);
+                }  
+                state.stateHandler.urlDecode = (state, key, val) => {
+                    return state.parent == dialogs['d0'] ? val.replace('+', ' ') : decodeURIComponent(val);
+                }  
+            }
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/a/c+d');
+            assert.strictEqual(Navigation.StateContext.data.x, 'c d');
+            Navigation.StateController.navigateLink('/b/c%20d');
+            assert.strictEqual(Navigation.StateContext.data.x, 'c d');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d0', { x: 'c d' }), '/a/c+d');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d1', { x: 'c d' }), '/b/c%20d');
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3007,4 +3007,56 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'a b' }), '/a+b');
         });
     });
+
+    describe('One Param Query String Encode', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{x}', trackCrumbTrail: false }]}
+                ]);
+            var state = Navigation.StateInfoConfig.dialogs['d'].states['s'];
+            state.stateHandler.urlEncode = (state, key, val, queryString) =>  {
+                return queryString ? val.replace(' ', '+') : encodeURIComponent(val);
+            }  
+            state.stateHandler.urlDecode = (state, key, val, queryString) => {
+                return queryString ? val.replace('+', ' ') : decodeURIComponent(val);
+            }  
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/a%20b?y=c+d');
+            assert.strictEqual(Navigation.StateContext.data.x, 'a b');
+            assert.strictEqual(Navigation.StateContext.data.y, 'c d');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'a b', y: 'c d' }), '/a%20b?y=c+d');
+        });
+    });
+
+    describe('One Param Route Encode', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{x}', trackCrumbTrail: false }]}
+                ]);
+            var state = Navigation.StateInfoConfig.dialogs['d'].states['s'];
+            state.stateHandler.urlEncode = (state, key, val, queryString) =>  {
+                return !queryString ? val.replace(' ', '+') : encodeURIComponent(val);
+            }  
+            state.stateHandler.urlDecode = (state, key, val, queryString) => {
+                return !queryString ? val.replace('+', ' ') : decodeURIComponent(val);
+            }  
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/a+b?y=c%20d');
+            assert.strictEqual(Navigation.StateContext.data.x, 'a b');
+            assert.strictEqual(Navigation.StateContext.data.y, 'c d');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'a b', y: 'c d' }), '/a+b?y=c%20d');
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3125,4 +3125,56 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d1', { x: 'c d' }), '/b/c%20d');
         });
     });
+
+    describe('One Param Query String Key Encode', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{x}', trackCrumbTrail: false }]}
+                ]);
+            var state = Navigation.StateInfoConfig.dialogs['d'].states['s'];
+            state.stateHandler.urlEncode = (state, key, val, queryString) =>  {
+                return key === 'y' ? val.replace(' ', '+') : encodeURIComponent(val);
+            }  
+            state.stateHandler.urlDecode = (state, key, val, queryString) => {
+                return key === 'y' ? val.replace('+', ' ') : decodeURIComponent(val);
+            }  
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/a%20b?y=c+d');
+            assert.strictEqual(Navigation.StateContext.data.x, 'a b');
+            assert.strictEqual(Navigation.StateContext.data.y, 'c d');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'a b', y: 'c d' }), '/a%20b?y=c+d');
+        });
+    });
+
+    describe('One Param Route Key Encode', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{x}', trackCrumbTrail: false }]}
+                ]);
+            var state = Navigation.StateInfoConfig.dialogs['d'].states['s'];
+            state.stateHandler.urlEncode = (state, key, val, queryString) => {
+                return key === 'x' ? val.replace(' ', '+') : encodeURIComponent(val);
+            }
+            state.stateHandler.urlDecode = (state, key, val, queryString) => {
+                return key === 'x' ? val.replace('+', ' ') : decodeURIComponent(val);
+            }
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/a+b?y=c%20d');
+            assert.strictEqual(Navigation.StateContext.data.x, 'a b');
+            assert.strictEqual(Navigation.StateContext.data.y, 'c d');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'a b', y: 'c d' }), '/a+b?y=c%20d');
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3229,4 +3229,29 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'a b', y: 'c d' }), '/?x=a%20b&y=c+d');
         });
     });
+
+    describe('No Param Key Encode', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '', trackCrumbTrail: false }]}
+                ]);
+            var state = Navigation.StateInfoConfig.dialogs['d'].states['s'];
+            state.stateHandler.urlEncode = (state, key, val) =>  {
+                return !key ? val.replace(' ', '+') : encodeURIComponent(val);
+            }  
+            state.stateHandler.urlDecode = (state, key, val) => {
+                return !key ? val.replace('+', ' ') : decodeURIComponent(val);
+            }  
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/?a+b=c%20d');
+            assert.strictEqual(Navigation.StateContext.data['a b'], 'c d');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { 'a b': 'c d' }), '/?a+b=c%20d');
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3177,4 +3177,56 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'a b', y: 'c d' }), '/a+b?y=c%20d');
         });
     });
+
+    describe('Two Param Route Key Encode', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{x}/{y}', trackCrumbTrail: false }]}
+                ]);
+            var state = Navigation.StateInfoConfig.dialogs['d'].states['s'];
+            state.stateHandler.urlEncode = (state, key, val) => {
+                return key === 'x' ? val.replace(' ', '+') : encodeURIComponent(val);
+            }
+            state.stateHandler.urlDecode = (state, key, val) => {
+                return key === 'x' ? val.replace('+', ' ') : decodeURIComponent(val);
+            }
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/a+b/c%20d');
+            assert.strictEqual(Navigation.StateContext.data.x, 'a b');
+            assert.strictEqual(Navigation.StateContext.data.y, 'c d');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'a b', y: 'c d' }), '/a+b/c%20d');
+        });
+    });
+
+    describe('No Param Two Query String Key Encode', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '', trackCrumbTrail: false }]}
+                ]);
+            var state = Navigation.StateInfoConfig.dialogs['d'].states['s'];
+            state.stateHandler.urlEncode = (state, key, val) =>  {
+                return key === 'y' ? val.replace(' ', '+') : encodeURIComponent(val);
+            }  
+            state.stateHandler.urlDecode = (state, key, val) => {
+                return key === 'y' ? val.replace('+', ' ') : decodeURIComponent(val);
+            }  
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/?x=a%20b&y=c+d');
+            assert.strictEqual(Navigation.StateContext.data.x, 'a b');
+            assert.strictEqual(Navigation.StateContext.data.y, 'c d');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'a b', y: 'c d' }), '/?x=a%20b&y=c+d');
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3528,12 +3528,8 @@ describe('MatchTest', function () {
                     { key: 's', route: '{x?}', trackCrumbTrail: false }]}
                 ]);
             var state = Navigation.StateInfoConfig.dialogs['d'].states['s'];
-            state.stateHandler.urlEncode = (state, key, val) => {
-                return val.replace(' ', '+');
-            }
-            state.stateHandler.urlDecode = (state, key, val) => {
-                return val.replace('+', ' ');
-            }
+            state.stateHandler.urlEncode = (state, key, val) => val.replace(' ', '+')
+            state.stateHandler.urlDecode = (state, key, val) => val.replace('+', ' ')
         });
         
         it('should match', function() {
@@ -3543,6 +3539,26 @@ describe('MatchTest', function () {
 
         it('should build', function() {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
+        });
+    });
+
+    describe('One Empty Param Route Encode', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{x}', trackCrumbTrail: false }]}
+                ]);
+            var state = Navigation.StateInfoConfig.dialogs['d'].states['s'];
+            state.stateHandler.urlEncode = (state, key, val) => val.replace(' ', '+')
+            state.stateHandler.urlDecode = (state, key, val) => val.replace('+', ' ')
+        });
+        
+        it('should not match', function() {
+            assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
+        });
+
+        it('should not build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
         });
     });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2965,4 +2965,46 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [new Date(2010, 3, 7), new Date(2011, 7, 3)] }), '/20102-042-071-20112-082-032_a3');
         });
     });
+
+    describe('No Param One Segment Encode', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'abc', trackCrumbTrail: false }]}
+                ]);
+            var state = Navigation.StateInfoConfig.dialogs['d'].states['s'];
+            state.stateHandler.urlEncode = (state, key, val) => val.replace(' ', '+')  
+            state.stateHandler.urlDecode = (state, key, val) => val.replace('+', ' ')  
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/abc?x=a+b');
+            assert.strictEqual(Navigation.StateContext.data.x, 'a b');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'a b' }), '/abc?x=a+b');
+        });
+    });
+
+    describe('One Param Encode', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{x}', trackCrumbTrail: false }]}
+                ]);
+            var state = Navigation.StateInfoConfig.dialogs['d'].states['s'];
+            state.stateHandler.urlEncode = (state, key, val) => val.replace(' ', '+')  
+            state.stateHandler.urlDecode = (state, key, val) => val.replace('+', ' ')  
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/a+b');
+            assert.strictEqual(Navigation.StateContext.data.x, 'a b');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'a b' }), '/a+b');
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3238,6 +3238,58 @@ describe('MatchTest', function () {
         });
     });
 
+    describe('One Optional Param Route Key Encode', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{x?}', trackCrumbTrail: false }]}
+                ]);
+            var state = Navigation.StateInfoConfig.dialogs['d'].states['s'];
+            state.stateHandler.urlEncode = (state, key, val) => {
+                return key === 'x' ? val.replace(' ', '+') : encodeURIComponent(val);
+            }
+            state.stateHandler.urlDecode = (state, key, val) => {
+                return key === 'x' ? val.replace('+', ' ') : decodeURIComponent(val);
+            }
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/a+b?y=c%20d');
+            assert.strictEqual(Navigation.StateContext.data.x, 'a b');
+            assert.strictEqual(Navigation.StateContext.data.y, 'c d');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'a b', y: 'c d' }), '/a+b?y=c%20d');
+        });
+    });
+
+    describe('One Mixed Param Route Key Encode', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'ab{x}', trackCrumbTrail: false }]}
+                ]);
+            var state = Navigation.StateInfoConfig.dialogs['d'].states['s'];
+            state.stateHandler.urlEncode = (state, key, val) => {
+                return key === 'x' ? val.replace(' ', '+') : encodeURIComponent(val);
+            }
+            state.stateHandler.urlDecode = (state, key, val) => {
+                return key === 'x' ? val.replace('+', ' ') : decodeURIComponent(val);
+            }
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/aba+b?y=c%20d');
+            assert.strictEqual(Navigation.StateContext.data.x, 'a b');
+            assert.strictEqual(Navigation.StateContext.data.y, 'c d');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'a b', y: 'c d' }), '/aba+b?y=c%20d');
+        });
+    });
+
     describe('No Param Two Query String Key Encode', function () {
         beforeEach(function () {
             Navigation.StateInfoConfig.build([

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3418,4 +3418,20 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d1', { x: ['a b', 'c de'] }), '/b?x=a%20b&x=c%20de');
         });
     });
+
+    describe('Router Empty Decode', function () {
+        it('should match', function() {
+            var router = new Navigation.Router();
+            var route = router.addRoute('{x}');
+            assert.strictEqual(router.match('/a%20b').data.x, 'a b');
+        })
+    });
+
+    describe('Router Empty Encode', function () {
+        it('should build', function() {
+            var router = new Navigation.Router();
+            var route = router.addRoute('{x}');
+            assert.strictEqual(route.build({ x: 'a b' }), '/a%20b');
+        })
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3280,4 +3280,26 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { 'a b': 'c d', 'e f': 'g h' }), '/?a+b=c%20d&e%20f=g%20h');
         });
     });
+
+    describe('One Param Empty Encode', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{x}', trackCrumbTrail: false }]}
+                ]);
+            var state = Navigation.StateInfoConfig.dialogs['d'].states['s'];
+            delete state.stateHandler.urlEncode;
+            delete state.stateHandler.urlDecode;
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/a%20b?y=c%20d');
+            assert.strictEqual(Navigation.StateContext.data.x, 'a b');
+            assert.strictEqual(Navigation.StateContext.data.y, 'c d');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'a b', y: 'c d' }), '/a%20b?y=c%20d');
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3254,4 +3254,30 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { 'a b': 'c d' }), '/?a+b=c%20d');
         });
     });
+
+    describe('No Param Two Key Encode', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '', trackCrumbTrail: false }]}
+                ]);
+            var state = Navigation.StateInfoConfig.dialogs['d'].states['s'];
+            state.stateHandler.urlEncode = (state, key, val) =>  {
+                return (!key && val == 'a b') ? val.replace(' ', '+') : encodeURIComponent(val);
+            }  
+            state.stateHandler.urlDecode = (state, key, val) => {
+                return (!key && val == 'a+b') ? val.replace('+', ' ') : decodeURIComponent(val);
+            }  
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/?a+b=c%20d&e%20f=g%20h');
+            assert.strictEqual(Navigation.StateContext.data['a b'], 'c d');
+            assert.strictEqual(Navigation.StateContext.data['e f'], 'g h');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { 'a b': 'c d', 'e f': 'g h' }), '/?a+b=c%20d&e%20f=g%20h');
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3561,4 +3561,24 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
         });
     });
+
+    describe('One Empty Mixed Param Route Encode', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'ab{x}', trackCrumbTrail: false }]}
+                ]);
+            var state = Navigation.StateInfoConfig.dialogs['d'].states['s'];
+            state.stateHandler.urlEncode = (state, key, val) => val.replace(' ', '+')
+            state.stateHandler.urlDecode = (state, key, val) => val.replace('+', ' ')
+        });
+        
+        it('should not match', function() {
+            assert.throws(() => Navigation.StateController.navigateLink('/ab'), /Url is invalid/, '');
+        });
+
+        it('should not build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3520,4 +3520,29 @@ describe('MatchTest', function () {
             assert.strictEqual(route.build({ x: 'a b' }), '/a%20b');
         })
     });
+
+    describe('One Optional Empty Param Route Encode', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{x?}', trackCrumbTrail: false }]}
+                ]);
+            var state = Navigation.StateInfoConfig.dialogs['d'].states['s'];
+            state.stateHandler.urlEncode = (state, key, val) => {
+                return val.replace(' ', '+');
+            }
+            state.stateHandler.urlDecode = (state, key, val) => {
+                return val.replace('+', ' ');
+            }
+        });
+        
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/');
+            assert.strictEqual(Navigation.StateContext.data.x, undefined);
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3303,7 +3303,7 @@ describe('MatchTest', function () {
         });
     });
 
-    describe('No Param String Array Encode', function () {
+    describe('No Param Array Encode', function () {
         beforeEach(function () {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's', states: [
@@ -3323,6 +3323,35 @@ describe('MatchTest', function () {
 
         it('should build', function() {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['a b', 'c de'] }), '/?x=a+b&x=c+de');
+        });
+    });
+
+    describe('No Param Array Key Encode', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '', defaultTypes: { x: 'stringarray', y: 'stringarray' }, trackCrumbTrail: false }]}
+                ]);
+            var state = Navigation.StateInfoConfig.dialogs['d'].states['s'];
+            state.stateHandler.urlEncode = (state, key, val) => {
+                return key === 'x' ? val.replace(' ', '+') : encodeURIComponent(val);
+            }
+            state.stateHandler.urlDecode = (state, key, val) => {
+                return key === 'x' ? val.replace('+', ' ') : decodeURIComponent(val);
+            }
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/?x=a+b&x=c+de&y=f%20g');
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'a b');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'c de');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.y[0], 'f g');
+            assert.strictEqual(Navigation.StateContext.data.y.length, 1);
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['a b', 'c de'], y: ['f g'] }), '/?x=a+b&x=c+de&y=f%20g');
         });
     });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3302,4 +3302,27 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'a b', y: 'c d' }), '/a%20b?y=c%20d');
         });
     });
+
+    describe('No Param String Array Encode', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '', defaultTypes: { x: 'stringarray' }, trackCrumbTrail: false }]}
+                ]);
+            var state = Navigation.StateInfoConfig.dialogs['d'].states['s'];
+            state.stateHandler.urlEncode = (state, key, val) => val.replace(' ', '+')
+            state.stateHandler.urlDecode = (state, key, val) => val.replace('+', ' ')
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/?x=a+b&x=c+de');
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'a b');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'c de');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['a b', 'c de'] }), '/?x=a+b&x=c+de');
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3041,12 +3041,12 @@ describe('MatchTest', function () {
                     { key: 's', route: '{x}', trackCrumbTrail: false }]}
                 ]);
             var state = Navigation.StateInfoConfig.dialogs['d'].states['s'];
-            state.stateHandler.urlEncode = (state, key, val, queryString) =>  {
+            state.stateHandler.urlEncode = (state, key, val, queryString) => {
                 return !queryString ? val.replace(' ', '+') : encodeURIComponent(val);
-            }  
+            }
             state.stateHandler.urlDecode = (state, key, val, queryString) => {
                 return !queryString ? val.replace('+', ' ') : decodeURIComponent(val);
-            }  
+            }
         });
 
         it('should match', function() {
@@ -3071,12 +3071,12 @@ describe('MatchTest', function () {
             var dialogs = Navigation.StateInfoConfig.dialogs;
             for(var key in dialogs) {
                 var state = dialogs[key].states['s'];
-                state.stateHandler.urlEncode = (state, key, val) =>  {
+                state.stateHandler.urlEncode = (state, key, val) => {
                     return state.parent == dialogs['d0'] ? val.replace(' ', '+') : encodeURIComponent(val);
-                }  
+                }
                 state.stateHandler.urlDecode = (state, key, val) => {
                     return state.parent == dialogs['d0'] ? val.replace('+', ' ') : decodeURIComponent(val);
-                }  
+                }
             }
         });
 

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3326,6 +3326,33 @@ describe('MatchTest', function () {
         });
     });
 
+    describe('No Param Array Query String Encode', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '', defaultTypes: { x: 'stringarray' }, trackCrumbTrail: false }]}
+                ]);
+            var state = Navigation.StateInfoConfig.dialogs['d'].states['s'];
+            state.stateHandler.urlEncode = (state, key, val, queryString) => {
+                return queryString ? val.replace(' ', '+') : encodeURIComponent(val);
+            }
+            state.stateHandler.urlDecode = (state, key, val, queryString) => {
+                return queryString ? val.replace('+', ' ') : decodeURIComponent(val);
+            }
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/?x=a+b&x=c+de');
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'a b');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'c de');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['a b', 'c de'] }), '/?x=a+b&x=c+de');
+        });
+    });
+
     describe('No Param Array Key Encode', function () {
         beforeEach(function () {
             Navigation.StateInfoConfig.build([

--- a/NavigationJS/test/navigation-tests.ts
+++ b/NavigationJS/test/navigation-tests.ts
@@ -86,6 +86,12 @@ module NavigationTests {
 			console.log('get navigation data');
 			super.getNavigationData(state, url, {});
 	    }
+        urlEncode(state: Navigation.State, key: string, val: string, queryString: boolean): string {
+            return queryString ? val.replace(/\s/g, '+') : super.urlEncode(state, key, val, queryString);
+        }
+        urlDecode(state: Navigation.State, key: string, val: string, queryString: boolean): string {
+            return queryString ? val.replace(/\+/g, ' ') : super.urlDecode(state, key, val, queryString);
+        }
 	}
 	homePage.stateHandler = new LogStateHandler();
 	personList.stateHandler = new LogStateHandler();


### PR DESCRIPTION
The default URL encoding uses encodeURIComponent. But this doesn't produce nice URLs, for example, it replaces space with %20 instead of +. Added urlEncode and urlDecode functions to StateHandler so the encoding can be customised.