### PR TITLE
Added Hot Loading

### DIFF
--- a/NavigationJS/src/config/StateInfoConfig.ts
+++ b/NavigationJS/src/config/StateInfoConfig.ts
@@ -12,8 +12,8 @@ class StateInfoConfig {
     static _dialogs: Dialog[] = [];
     static dialogs: { [index: string]: Dialog } = {};
     static build(dialogs: IDialog<string, IState<ITransition<string>[]>[]>[]) {
-        this._dialogs = [];
-        this.dialogs = {};
+        var _builtDialogs = [];
+        var builtDialogs: { [index: string]: Dialog } = {};
         for (var i = 0; i < dialogs.length; i++) {
             var dialogObject = dialogs[i];
             var dialog = new Dialog();
@@ -24,10 +24,10 @@ class StateInfoConfig {
             }
             if (!dialog.key)
                 throw new Error('key is mandatory for a Dialog');
-            if (this.dialogs[dialog.key])
+            if (builtDialogs[dialog.key])
                 throw new Error('A Dialog with key ' + dialog.key + ' already exists');
-            this._dialogs.push(dialog);
-            this.dialogs[dialog.key] = dialog;
+            _builtDialogs.push(dialog);
+            builtDialogs[dialog.key] = dialog;
             this.processStates(dialog, dialogObject);
             this.processTransitions(dialog, dialogObject);
             dialog.initial = dialog.states[dialogObject.initial];
@@ -36,6 +36,8 @@ class StateInfoConfig {
             if (!dialog.initial)
                 throw new Error(dialog.key + ' Dialog\'s initial key of ' + dialogObject.initial + ' does not match a child State key');
         }
+        this._dialogs = _builtDialogs;
+        this.dialogs = builtDialogs;
         settings.router.addRoutes(this._dialogs);
     }
 

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -4614,5 +4614,229 @@ describe('Navigation', function () {
             assert.ok(!called);
         });
     });
+
+    describe('Reload Error Dialog', function() {
+        beforeEach(function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'r' }]}
+                ]);
+            try {
+                Navigation.StateInfoConfig.build([
+                    { key: '', initial: 's', states: [
+                        { key: 's', route: 'r' }]}
+                    ]);
+            } catch(e) {
+            }
+        });
+
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d');
+            });
+            test();
+        });
+        
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d');
+                Navigation.StateController.navigateLink(link);
+            });            
+            test();
+        });
+        
+        function test(){
+            it('should go to initial State', function() {
+                assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d'].initial);
+                assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig.dialogs['d']);
+            });
+            it('should have no crumb trail', function() {
+                assert.equal(Navigation.StateController.crumbs.length, 0);
+            });
+        }
+    });
+
+    describe('Reload Error Transition', function() {
+        beforeEach(function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1' }]}
+                ]);
+            try {
+                Navigation.StateInfoConfig.build([
+                    { key: '', initial: 's', states: [
+                        { key: 's', route: 'r' }]}
+                    ]);
+            } catch(e) {
+            }
+        });
+
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d');
+                Navigation.StateController.navigate('t');
+            });
+            test();
+        });
+        
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d');
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t');
+                Navigation.StateController.navigateLink(link);
+            });
+            test();
+        });
+        
+        function test() {            
+            it('should go to to State', function() {
+                assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
+                assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig.dialogs['d']);
+            });
+            it('should populate old State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d'].states['s0']);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateInfoConfig.dialogs['d']);
+            });
+            it('should populate previous State', function() {
+                assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d'].states['s0']);
+                assert.equal(Navigation.StateContext.previousDialog, Navigation.StateInfoConfig.dialogs['d']);
+            });
+            it('should have crumb trail of length 1', function() {
+                assert.equal(Navigation.StateController.crumbs.length, 1);
+                assert.equal(Navigation.StateController.crumbs[0].state, Navigation.StateContext.dialog.initial);
+                assert.ok(Navigation.StateController.crumbs[0].last);
+            });
+        }
+    });
+    
+    describe('Reload Error Refresh', function() {
+        beforeEach(function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1' }]}
+                ]);
+            try {
+                Navigation.StateInfoConfig.build([
+                    { key: '', initial: 's', states: [
+                        { key: 's', route: 'r' }]}
+                    ]);
+            } catch(e) {
+            }
+        });
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d');
+                Navigation.StateController.navigate('t');
+                Navigation.StateController.refresh();
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d');
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t');
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getRefreshLink();
+                Navigation.StateController.navigateLink(link);
+            });
+            test();
+        });
+        
+        function test() {            
+            it('should go to current State', function() {
+                assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
+                assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig.dialogs['d']);
+            });
+            it('should populate old State with current State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateInfoConfig.dialogs['d']);
+            });
+            it('should populate previous State with current State', function() {
+                assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
+                assert.equal(Navigation.StateContext.previousDialog, Navigation.StateInfoConfig.dialogs['d']);
+            });
+            it('should not change crumb trail', function() {
+                assert.equal(Navigation.StateController.crumbs.length, 1);
+                assert.equal(Navigation.StateController.crumbs[0].state, Navigation.StateInfoConfig.dialogs['d'].states['s0']);
+                assert.ok(Navigation.StateController.crumbs[0].last);
+            });
+        }
+    });
+    
+    describe('Reload Error Back', function() {
+        beforeEach(function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't0', to: 's1' }
+                    ]},
+                    { key: 's1', route: 'r1', transitions: [
+                        { key: 't1', to: 's2' }
+                    ]},
+                    { key: 's2', route: 'r2' }]}
+                ]);
+            try {
+                Navigation.StateInfoConfig.build([
+                    { key: '', initial: 's', states: [
+                        { key: 's', route: 'r' }]}
+                    ]);
+            } catch(e) {
+            }
+        });
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d');
+                Navigation.StateController.navigate('t0');
+                Navigation.StateController.navigate('t1');
+                Navigation.StateController.navigateBack(1);
+            });
+            test();
+        });
+        
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d');
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t0');
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationLink('t1');
+                Navigation.StateController.navigateLink(link);
+                link = Navigation.StateController.getNavigationBackLink(1);
+                Navigation.StateController.navigateLink(link);
+            });
+            test();
+        });
+        
+        function test() {
+            it('should go to previous State', function() {
+                assert.equal(Navigation.StateContext.state, Navigation.StateInfoConfig.dialogs['d'].states['s1']);
+                assert.equal(Navigation.StateContext.dialog, Navigation.StateInfoConfig.dialogs['d']);
+            });
+            it('should populate old State with current State', function() {
+                assert.equal(Navigation.StateContext.oldState, Navigation.StateInfoConfig.dialogs['d'].states['s2']);
+                assert.equal(Navigation.StateContext.oldDialog, Navigation.StateInfoConfig.dialogs['d']);
+            });
+            it('should populate previous State with current State', function() {
+                assert.equal(Navigation.StateContext.previousState, Navigation.StateInfoConfig.dialogs['d'].states['s2']);
+                assert.equal(Navigation.StateContext.previousDialog, Navigation.StateInfoConfig.dialogs['d']);
+            });
+            it('should reduce crumb trail by one', function() {
+                assert.equal(Navigation.StateController.crumbs.length, 1);
+                assert.equal(Navigation.StateController.crumbs[0].state, Navigation.StateInfoConfig.dialogs['d'].states['s0']);
+                assert.ok(Navigation.StateController.crumbs[0].last);
+            });
+        }
+    });
 });
 });

--- a/NavigationJS/test/StateInfoTest.ts
+++ b/NavigationJS/test/StateInfoTest.ts
@@ -516,4 +516,107 @@ describe('StateInfoTest', function () {
             }, /mandatory/, '');
         })
     });
+
+    describe('Reload Error State Info', function () {
+        it('should keep State Info', function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd0', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't0', to: 's1' },
+                        { key: 't1', to: 's2' }]},
+                    { key: 's1', route: 'r1' },
+                    { key: 's2', route: 'r2' }]},
+                { key: 'd1', initial: 's0', states: [
+                    { key: 's0', route: 'r3' }]}
+                ]);
+            try {
+                Navigation.StateInfoConfig.build([
+                    { key: 'd', initial: 's', states: [
+                        { key: 'xxx', route: 'r' }]}
+                    ]);
+            } catch(e) {
+            }
+            var dialog0 = Navigation.StateInfoConfig._dialogs[0];
+            var dialog1 = Navigation.StateInfoConfig._dialogs[1];
+            var state0 = dialog0._states[0];
+            var state1 = dialog0._states[1];
+            var state2 = dialog0._states[2];
+            assert.equal(dialog0._states.length, 3);
+            assert.equal(dialog0.initial, state0);
+            assert.equal(state0.key, 's0');
+            assert.equal(state0.route, 'r0');
+            assert.equal(state0.index, 0);
+            assert.equal(state1.key, 's1');
+            assert.equal(state1.route, 'r1');
+            assert.equal(state1.index, 1);
+            assert.equal(state2.key, 's2');
+            assert.equal(state2.route, 'r2');
+            assert.equal(state2.index, 2);
+            var transition0 = state0._transitions[0];
+            var transition1 = state0._transitions[1];
+            assert.equal(state0._transitions.length, 2);
+            assert.equal(transition0.key, 't0');
+            assert.equal(transition0.index, 0);
+            assert.equal(transition0.to, state1);
+            assert.equal(transition1.key, 't1');
+            assert.equal(transition1.index, 1);
+            assert.equal(transition1.to, state2);
+            state0 = dialog1._states[0];
+            assert.equal(dialog1._states.length, 1);
+            assert.equal(dialog1.initial, state0);
+            assert.equal(state0.key, 's0');
+            assert.equal(state0.route, 'r3');
+            assert.equal(state0.index, 0);
+        })
+    });
+
+    describe('Reload State Info', function () {
+        it('should configure State Info', function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'r' }]}
+                ]);
+            Navigation.StateInfoConfig.build([
+                { key: 'd0', initial: 's0', states: [
+                    { key: 's0', route: 'r0', transitions: [
+                        { key: 't0', to: 's1' },
+                        { key: 't1', to: 's2' }]},
+                    { key: 's1', route: 'r1' },
+                    { key: 's2', route: 'r2' }]},
+                { key: 'd1', initial: 's0', states: [
+                    { key: 's0', route: 'r3' }]}
+                ]);
+            var dialog0 = Navigation.StateInfoConfig._dialogs[0];
+            var dialog1 = Navigation.StateInfoConfig._dialogs[1];
+            var state0 = dialog0._states[0];
+            var state1 = dialog0._states[1];
+            var state2 = dialog0._states[2];
+            assert.equal(dialog0._states.length, 3);
+            assert.equal(dialog0.initial, state0);
+            assert.equal(state0.key, 's0');
+            assert.equal(state0.route, 'r0');
+            assert.equal(state0.index, 0);
+            assert.equal(state1.key, 's1');
+            assert.equal(state1.route, 'r1');
+            assert.equal(state1.index, 1);
+            assert.equal(state2.key, 's2');
+            assert.equal(state2.route, 'r2');
+            assert.equal(state2.index, 2);
+            var transition0 = state0._transitions[0];
+            var transition1 = state0._transitions[1];
+            assert.equal(state0._transitions.length, 2);
+            assert.equal(transition0.key, 't0');
+            assert.equal(transition0.index, 0);
+            assert.equal(transition0.to, state1);
+            assert.equal(transition1.key, 't1');
+            assert.equal(transition1.index, 1);
+            assert.equal(transition1.to, state2);
+            state0 = dialog1._states[0];
+            assert.equal(dialog1._states.length, 1);
+            assert.equal(dialog1.initial, state0);
+            assert.equal(state0.key, 's0');
+            assert.equal(state0.route, 'r3');
+            assert.equal(state0.index, 0);
+        })
+    });
  });

--- a/NavigationJS/test/StateInfoTest.ts
+++ b/NavigationJS/test/StateInfoTest.ts
@@ -517,7 +517,7 @@ describe('StateInfoTest', function () {
         })
     });
 
-    describe('Reload Error State Info', function () {
+    describe('Reload Error', function () {
         it('should keep State Info', function() {
             Navigation.StateInfoConfig.build([
                 { key: 'd0', initial: 's0', states: [
@@ -570,7 +570,7 @@ describe('StateInfoTest', function () {
         })
     });
 
-    describe('Reload State Info', function () {
+    describe('Reload', function () {
         it('should configure State Info', function() {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's', states: [

--- a/NavigationReact/sample/hotloader/Component.js
+++ b/NavigationReact/sample/hotloader/Component.js
@@ -1,0 +1,56 @@
+var React = require('react');
+var NavigationReact = require('navigation-react');
+var NavigationLink = NavigationReact.NavigationLink;
+var RefreshLink = NavigationReact.RefreshLink;
+var NavigationBackLink = NavigationReact.NavigationBackLink;
+
+exports.Listing = React.createClass({
+	render: function() {
+		var people = this.props.people.map(function (person) {
+	        return (
+                React.createElement("tr", null, 
+                    React.createElement("td", null, React.createElement(NavigationLink, {action: "select", toData: { id: person.id}}, person.name)), 
+                    React.createElement("td", null, person.dateOfBirth)
+                )
+            );
+        });
+        return (
+            React.createElement("div", {id: "listing"}, 
+                React.createElement("table", null, 
+                    React.createElement("thead", null, 
+                        React.createElement("tr", null, 
+                            React.createElement("th", null, "Name"), 
+                            React.createElement("th", null, "Date of Birth")
+                        )
+                    ), 
+                    React.createElement("tbody", null, people)
+                ), 
+                React.createElement("div", {id: "pager"}, 
+                    "Go to page", 
+                    React.createElement(RefreshLink, {toData: { pageNumber: 1}, disableActive: true}, "1"), 
+                    React.createElement(RefreshLink, {toData: { pageNumber: 2}, disableActive: true}, "2")
+                )
+            )
+        );
+	}
+})
+
+exports.Details = React.createClass({
+    render: function() {
+        var person = this.props.person;
+        return (
+            React.createElement("div", {id: "details"}, 
+                React.createElement(NavigationBackLink, {distance: 1}, "People"), 
+                React.createElement("div", {id: "info"}, 
+                    React.createElement("h2", null, person.name), 
+                    React.createElement("div", {className: "label"}, "Date of Birth"), 
+                    React.createElement("div", null, person.dateOfBirth), 
+                    React.createElement("div", {className: "label"}, "Email"), 
+                    React.createElement("div", null, person.email), 
+                    React.createElement("div", {className: "label"}, "Phone"), 
+                    React.createElement("div", null, person.phone)
+                )
+            )
+        );
+    }
+})

--- a/NavigationReact/sample/hotloader/Data.js
+++ b/NavigationReact/sample/hotloader/Data.js
@@ -1,0 +1,29 @@
+var people = [
+	{ id: 1, name: 'Bell Halvorson', dateOfBirth: '01/01/1980', email: 'bell@navigation.com', phone: '555 0001' },
+	{ id: 2, name: 'Aditya Larson', dateOfBirth: '01/02/1980', email: 'aditya@navigation.com', phone: '555 0002' },
+	{ id: 3, name: 'Rashawn Schamberger', dateOfBirth: '01/03/1980', email: 'rashawn@navigation.com', phone: '555 0003' },
+	{ id: 4, name: 'Rupert Grant', dateOfBirth: '01/04/1980', email: 'rupert@navigation.com', phone: '555 0004' },
+	{ id: 5, name: 'Opal Carter', dateOfBirth: '01/05/1980', email: 'opal@navigation.com', phone: '555 0005' },
+	{ id: 6, name: 'Candida Christiansen', dateOfBirth: '01/06/1980', email: 'candida@navigation.com', phone: '555 0006' },
+	{ id: 7, name: 'Haven Stroman', dateOfBirth: '01/07/1980', email: 'haven@navigation.com', phone: '555 0007' },
+	{ id: 8, name: 'Celine Leannon', dateOfBirth: '01/08/1980', email: 'celine@navigation.com', phone: '555 0008' },
+	{ id: 9, name: 'Ryan Ruecker', dateOfBirth: '01/09/1980', email: 'ryan@navigation.com', phone: '555 0009' },
+	{ id: 10, name: 'Kaci Hoppe', dateOfBirth: '01/10/1980', email: 'kaci@navigation.com', phone: '555 0010' },
+	{ id: 11, name: 'Fernando Dietrich', dateOfBirth: '01/11/1980', email: 'fernando@navigation.com', phone: '555 0011' },
+	{ id: 12, name: 'Emelie Lueilwitz', dateOfBirth: '01/12/1980', email: 'emelie@navigation.com', phone: '555 0012' }
+];
+
+exports.searchPeople = function(pageNumber) {
+	var start = (pageNumber - 1) * 10;
+	return people.slice(start, start + 10);
+};
+
+exports.getPerson = function(id, callback) {
+	var details = null;
+	for (var i = 0; i < people.length; i++) {
+		var person = people[i];
+		if (person.id === id)
+			details = person;
+	}
+    return details;
+}

--- a/NavigationReact/sample/hotloader/README.md
+++ b/NavigationReact/sample/hotloader/README.md
@@ -1,0 +1,10 @@
+# Navigation Hot Loader
+Turbo charge your developer experience by using Navigation React together with Webpack's Hot Module Replacement.
+
+## Run
+Once you've cloned the repository, you can install the dependencies and start the hot loader example:
+
+    npm install
+    npm run build
+	
+Then, visit http://localhost:8080/app.html in your browser to see hot loading Navigation in action. Change a route in the StateInfo.js file and watch the browser Url and all Hyperlinks automatically update without refreshing the page.

--- a/NavigationReact/sample/hotloader/StateInfo.js
+++ b/NavigationReact/sample/hotloader/StateInfo.js
@@ -1,0 +1,11 @@
+var Navigation = require('navigation');
+
+exports.configureStateInfo = function() {
+    Navigation.StateInfoConfig.build([
+        { key: 'masterDetails', initial: 'listing', states: [
+            { key: 'listing', route: '{pageNumber}', defaults: { pageNumber: 1 }, trackCrumbTrail: false, transitions: [
+                { key: 'select', to: 'details' }]},
+            { key: 'details', route: 'person/{id}', defaults: { id: 0 } }]
+        }
+    ]);
+}

--- a/NavigationReact/sample/hotloader/StateNavigator.js
+++ b/NavigationReact/sample/hotloader/StateNavigator.js
@@ -1,0 +1,25 @@
+var Component = require('./Component');
+var Data = require('./Data');
+var Navigation = require('navigation');
+var React = require('react');
+var ReactDOM = require('react-dom');
+
+exports.configureStateNavigator = function() {
+    var masterDetails = Navigation.StateInfoConfig.dialogs.masterDetails;
+
+    masterDetails.states.listing.navigated = function(data) {
+        var people = Data.searchPeople(data.pageNumber);
+        ReactDOM.render(
+            React.createElement(Component.Listing, { people: people }),
+            document.getElementById('content')
+        );		
+    }
+
+    masterDetails.states.details.navigated = function(data) {
+        var person = Data.getPerson(data.id);
+        ReactDOM.render(
+            React.createElement(Component.Details, { person: person }),
+            document.getElementById('content')
+        );		
+    }
+}

--- a/NavigationReact/sample/hotloader/app.html
+++ b/NavigationReact/sample/hotloader/app.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Navigation React</title>
+    <style>
+        table{border-collapse:collapse;}table,td,th{border:1px #000 solid;}
+        ul{list-style-type:none;padding:0;margin:0;}li{float:left;padding-right:3px;}
+        .active{font-weight:bold;}
+    </style>
+</head>
+<body>
+    <div id="content"></div>
+    <script src="bundle.js"></script>
+</body>

--- a/NavigationReact/sample/hotloader/app.html
+++ b/NavigationReact/sample/hotloader/app.html
@@ -10,5 +10,5 @@
 </head>
 <body>
     <div id="content"></div>
-    <script src="bundle.js"></script>
+    <script src="app.js"></script>
 </body>

--- a/NavigationReact/sample/hotloader/index.js
+++ b/NavigationReact/sample/hotloader/index.js
@@ -19,7 +19,7 @@ if (module.hot) {
             if (state) {
                 dialog = Navigation.StateInfoConfig.dialogs[dialog.key];
                 Navigation.StateContext[dialogProp] = dialog;
-                Navigation.StateContext[stateProp] = dialog.states[state.key];       
+                Navigation.StateContext[stateProp] = dialog.states[state.key];
             }
         }
         var currentData = Navigation.StateContext.includeCurrentData({});

--- a/NavigationReact/sample/hotloader/index.js
+++ b/NavigationReact/sample/hotloader/index.js
@@ -23,5 +23,5 @@ if (module.hot) {
         reloadContext('previousState', 'previousDialog');
         var currentData = Navigation.StateContext.includeCurrentData({});
         Navigation.StateController.refresh(currentData);
-    })
+    });
 }

--- a/NavigationReact/sample/hotloader/index.js
+++ b/NavigationReact/sample/hotloader/index.js
@@ -11,9 +11,9 @@ if (module.hot) {
         require('./StateInfo').configureStateInfo();
         require('./StateNavigator').configureStateNavigator();
         var contextProps = [
-            { state: 'state', dialog: 'dialog '}, 
-            { state: 'oldState', dialog: 'oldDialog '}, 
-            { state: 'previousState', dialog: 'previousDialog '} 
+            { state: 'state', dialog: 'dialog'}, 
+            { state: 'oldState', dialog: 'oldDialog'}, 
+            { state: 'previousState', dialog: 'previousDialog'} 
         ];
         for(var i = 0; i < contextProps.length; i++) {
             var state = Navigation.StateContext[contextProps[i].state];

--- a/NavigationReact/sample/hotloader/index.js
+++ b/NavigationReact/sample/hotloader/index.js
@@ -12,12 +12,17 @@ if (module.hot) {
         require('./StateNavigator').configureStateNavigator();
         var prefixes = ['', 'old', 'previous'];
         for(var i = 0; i < prefixes.length; i++) {
-            var dialog = prefixes[i] + 'dialog', state = prefixes[i] + 'state';
-            if (Navigation.StateContext[state]) {
-                Navigation.StateContext[dialog] = Navigation.StateInfoConfig.dialogs[Navigation.StateContext[dialog].key];
-                Navigation.StateContext[state] = Navigation.StateContext[dialog].states[Navigation.StateContext[state].key];       
+            var dialogProp = prefixes[i] + 'dialog';
+            var stateProp = prefixes[i] + 'state';
+            var dialog = Navigation.StateContext[dialogProp];
+            var state = Navigation.StateContext[stateProp];
+            if (state) {
+                dialog = Navigation.StateInfoConfig.dialogs[dialog.key];
+                Navigation.StateContext[dialogProp] = dialog;
+                Navigation.StateContext[stateProp] = dialog.states[state.key];       
             }
         }
-        Navigation.StateController.refresh(Navigation.StateContext.includeCurrentData({}));
+        var currentData = Navigation.StateContext.includeCurrentData({});
+        Navigation.StateController.refresh(currentData);
     })
 }

--- a/NavigationReact/sample/hotloader/index.js
+++ b/NavigationReact/sample/hotloader/index.js
@@ -10,19 +10,17 @@ if (module.hot) {
     module.hot.accept(['./StateInfo', './StateNavigator'], function() {
         require('./StateInfo').configureStateInfo();
         require('./StateNavigator').configureStateNavigator();
-        var contextProps = [
-            { state: 'state', dialog: 'dialog' }, 
-            { state: 'oldState', dialog: 'oldDialog' }, 
-            { state: 'previousState', dialog: 'previousDialog' } 
-        ];
-        for(var i = 0; i < contextProps.length; i++) {
-            var state = Navigation.StateContext[contextProps[i].state];
+        function reloadContext(stateProp, dialogProp) {
+            var state = Navigation.StateContext[stateProp];
             if (state) {
                 var dialog = Navigation.StateInfoConfig.dialogs[state.parent.key];
-                Navigation.StateContext[contextProps[i].dialog] = dialog;
-                Navigation.StateContext[contextProps[i].state] = dialog.states[state.key];
+                Navigation.StateContext[dialogProp] = dialog;
+                Navigation.StateContext[stateProp] = dialog.states[state.key];
             }
         }
+        reloadContext('state', 'dialog');
+        reloadContext('oldState', 'oldDialog');
+        reloadContext('previousState', 'previousDialog');
         var currentData = Navigation.StateContext.includeCurrentData({});
         Navigation.StateController.refresh(currentData);
     })

--- a/NavigationReact/sample/hotloader/index.js
+++ b/NavigationReact/sample/hotloader/index.js
@@ -5,3 +5,19 @@ var StateNavigator = require('./StateNavigator');
 StateInfo.configureStateInfo();
 StateNavigator.configureStateNavigator();
 Navigation.start();
+
+if (module.hot) {
+    module.hot.accept(['./StateInfo', './StateNavigator'], function() {
+        require('./StateInfo').configureStateInfo();
+        require('./StateNavigator').configureStateNavigator();
+        var prefixes = ['', 'old', 'previous'];
+        for(var i = 0; i < prefixes.length; i++) {
+            var dialog = prefixes[i] + 'dialog', state = prefixes[i] + 'state';
+            if (Navigation.StateContext[state]) {
+                Navigation.StateContext[dialog] = Navigation.StateInfoConfig.dialogs[Navigation.StateContext[dialog].key];
+                Navigation.StateContext[state] = Navigation.StateContext[dialog].states[Navigation.StateContext[state].key];       
+            }
+        }
+        Navigation.StateController.refresh(Navigation.StateContext.includeCurrentData({}));
+    })
+}

--- a/NavigationReact/sample/hotloader/index.js
+++ b/NavigationReact/sample/hotloader/index.js
@@ -11,9 +11,9 @@ if (module.hot) {
         require('./StateInfo').configureStateInfo();
         require('./StateNavigator').configureStateNavigator();
         var contextProps = [
-            { state: 'state', dialog: 'dialog'}, 
-            { state: 'oldState', dialog: 'oldDialog'}, 
-            { state: 'previousState', dialog: 'previousDialog'} 
+            { state: 'state', dialog: 'dialog' }, 
+            { state: 'oldState', dialog: 'oldDialog' }, 
+            { state: 'previousState', dialog: 'previousDialog' } 
         ];
         for(var i = 0; i < contextProps.length; i++) {
             var state = Navigation.StateContext[contextProps[i].state];

--- a/NavigationReact/sample/hotloader/index.js
+++ b/NavigationReact/sample/hotloader/index.js
@@ -12,14 +12,11 @@ if (module.hot) {
         require('./StateNavigator').configureStateNavigator();
         var prefixes = ['', 'old', 'previous'];
         for(var i = 0; i < prefixes.length; i++) {
-            var dialogProp = prefixes[i] + 'dialog';
-            var stateProp = prefixes[i] + 'state';
-            var dialog = Navigation.StateContext[dialogProp];
-            var state = Navigation.StateContext[stateProp];
+            var state = Navigation.StateContext[prefixes[i] + 'state'];
             if (state) {
-                dialog = Navigation.StateInfoConfig.dialogs[dialog.key];
-                Navigation.StateContext[dialogProp] = dialog;
-                Navigation.StateContext[stateProp] = dialog.states[state.key];
+                var dialog = Navigation.StateInfoConfig.dialogs[state.parent.key];
+                Navigation.StateContext[prefixes[i] + 'dialog'] = dialog;
+                Navigation.StateContext[prefixes[i] + 'state'] = dialog.states[state.key];
             }
         }
         var currentData = Navigation.StateContext.includeCurrentData({});

--- a/NavigationReact/sample/hotloader/index.js
+++ b/NavigationReact/sample/hotloader/index.js
@@ -1,0 +1,7 @@
+var Navigation = require('navigation');
+var StateInfo = require('./StateInfo');
+var StateNavigator = require('./StateNavigator');
+
+StateInfo.configureStateInfo();
+StateNavigator.configureStateNavigator();
+Navigation.start();

--- a/NavigationReact/sample/hotloader/index.js
+++ b/NavigationReact/sample/hotloader/index.js
@@ -10,13 +10,17 @@ if (module.hot) {
     module.hot.accept(['./StateInfo', './StateNavigator'], function() {
         require('./StateInfo').configureStateInfo();
         require('./StateNavigator').configureStateNavigator();
-        var prefixes = ['', 'old', 'previous'];
-        for(var i = 0; i < prefixes.length; i++) {
-            var state = Navigation.StateContext[prefixes[i] + 'state'];
+        var contextProps = [
+            { state: 'state', dialog: 'dialog '}, 
+            { state: 'oldState', dialog: 'oldDialog '}, 
+            { state: 'previousState', dialog: 'previousDialog '} 
+        ];
+        for(var i = 0; i < contextProps.length; i++) {
+            var state = Navigation.StateContext[contextProps[i].state];
             if (state) {
                 var dialog = Navigation.StateInfoConfig.dialogs[state.parent.key];
-                Navigation.StateContext[prefixes[i] + 'dialog'] = dialog;
-                Navigation.StateContext[prefixes[i] + 'state'] = dialog.states[state.key];
+                Navigation.StateContext[contextProps[i].dialog] = dialog;
+                Navigation.StateContext[contextProps[i].state] = dialog.states[state.key];
             }
         }
         var currentData = Navigation.StateContext.includeCurrentData({});

--- a/NavigationReact/sample/hotloader/index.js
+++ b/NavigationReact/sample/hotloader/index.js
@@ -14,8 +14,8 @@ if (module.hot) {
             var state = Navigation.StateContext[stateProp];
             if (state) {
                 var dialog = Navigation.StateInfoConfig.dialogs[state.parent.key];
-                Navigation.StateContext[dialogProp] = dialog;
                 Navigation.StateContext[stateProp] = dialog.states[state.key];
+                Navigation.StateContext[dialogProp] = dialog;
             }
         }
         reloadContext('state', 'dialog');

--- a/NavigationReact/sample/hotloader/index.js
+++ b/NavigationReact/sample/hotloader/index.js
@@ -8,7 +8,12 @@ Navigation.start();
 
 if (module.hot) {
     module.hot.accept(['./StateInfo', './StateNavigator'], function() {
-        require('./StateInfo').configureStateInfo();
+        try {
+            require('./StateInfo').configureStateInfo();
+        } catch(e) {
+            console.error(e.message);
+            return;
+        }
         require('./StateNavigator').configureStateNavigator();
         function reloadContext(stateProp, dialogProp) {
             var state = Navigation.StateContext[stateProp];

--- a/NavigationReact/sample/hotloader/package.json
+++ b/NavigationReact/sample/hotloader/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "navigation-hot-loader",
+  "description": "Navigation React hot loader example",
+  "dependencies": {
+    "navigation": "^1.2.0",
+    "navigation-react": "^1.2.0",
+    "react": "^0.14.3",
+    "react-dom": "^0.14.3"
+  }
+}

--- a/NavigationReact/sample/hotloader/package.json
+++ b/NavigationReact/sample/hotloader/package.json
@@ -5,6 +5,10 @@
     "navigation": "^1.2.0",
     "navigation-react": "^1.2.0",
     "react": "^0.14.3",
-    "react-dom": "^0.14.3"
+    "react-dom": "^0.14.3",
+    "webpack": "^1.12.10"
+  },
+  "scripts": {
+      "build": "webpack"
   }
 }

--- a/NavigationReact/sample/hotloader/package.json
+++ b/NavigationReact/sample/hotloader/package.json
@@ -6,9 +6,10 @@
     "navigation-react": "^1.2.0",
     "react": "^0.14.3",
     "react-dom": "^0.14.3",
-    "webpack": "^1.12.10"
+    "webpack": "^1.12.10",
+    "webpack-dev-server": "^1.14.0"
   },
   "scripts": {
-      "build": "webpack"
+    "build": "webpack-dev-server --hot --inline"
   }
 }

--- a/NavigationReact/sample/hotloader/webpack.config.js
+++ b/NavigationReact/sample/hotloader/webpack.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+    entry: "./index.js",
+    output: {
+        path: __dirname,
+        filename: "bundle.js"
+    },
+};

--- a/NavigationReact/sample/hotloader/webpack.config.js
+++ b/NavigationReact/sample/hotloader/webpack.config.js
@@ -3,5 +3,5 @@ module.exports = {
     output: {
         path: __dirname,
         filename: "bundle.js"
-    },
+    }
 };

--- a/NavigationReact/sample/hotloader/webpack.config.js
+++ b/NavigationReact/sample/hotloader/webpack.config.js
@@ -2,6 +2,6 @@ module.exports = {
     entry: "./index.js",
     output: {
         path: __dirname,
-        filename: "bundle.js"
+        filename: "app.js"
     }
 };


### PR DESCRIPTION
Was already effectively hot loading the State Info in the unit tests but between each test the State Context was cleared. With full hot loading don't want the State Context cleared, want the State Context populated so a refresh navigation can be issued with the current data. This triggers a navigation, updating the browser Url and all Hyperlinks and firing the State Navigators so the right React component is loaded.

To issue a refresh navigation the States and Dialogs on the State Context must be updated to point at the new State Info rather than the old. Did this by using the Dialog and State keys to locate the corresponding Dialogs and States in the new State Info and directly set these onto the State Context. If the corresponding States and Dialogs aren't found, because the State Info keys have changed, then an exception is thrown and webpack reloads the page and picks up the new State Info.

There was one Navigation change needed to support hot loading fully. If the new State Info had a configuration error then it's no good throwing an exception to reload the page because the State Info error will still be there. Instead, caught and reported the error so that it an be fixed and then the fix hot loaded - all without a page reload. But, when the error was caught the page was in an inconsistent state because the invalid State Info was loaded and this stopped the page from working until the State Info was fixed. Changed the StateInfoConfig build function to only update the State Info if all valid. That way, the page is still usable with the old State Info, if the new State Info isn't valid.