### PR TITLE
Added Splat Parameters

### DIFF
--- a/NavigationJS/src/CrumbTrailManager.ts
+++ b/NavigationJS/src/CrumbTrailManager.ts
@@ -70,7 +70,7 @@ class CrumbTrailManager {
             navigationData = NavigationData.clone(navigationData);
             NavigationData.setDefaults(navigationData, state.defaults);
         }
-        var queryStringData: { [index: string]: string[] } = {};
+        var arrayData: { [index: string]: string[] } = {};
         for (var key in navigationData) {
             var val = navigationData[key]; 
             if (val != null && val.toString()) {
@@ -78,7 +78,7 @@ class CrumbTrailManager {
                 val = formattedData.val;
                 if (!settings.router.supportsDefaults || val !== state.formattedDefaults[key]) {
                     data[key] = val;
-                    queryStringData[key] = formattedData.queryStringVal;
+                    arrayData[key] = formattedData.arrayVal;
                 }
             }
         }
@@ -91,7 +91,7 @@ class CrumbTrailManager {
         }
         if (this.crumbTrailKey && state.trackCrumbTrail)
             data[settings.crumbTrailKey] = this.crumbTrailKey;
-        return state.stateHandler.getNavigationLink(state, data, queryStringData);
+        return state.stateHandler.getNavigationLink(state, data, arrayData);
     }
 
     static getRefreshHref(refreshData: any): string {

--- a/NavigationJS/src/IRouter.ts
+++ b/NavigationJS/src/IRouter.ts
@@ -2,7 +2,7 @@
 import State = require('./config/State');
 
 interface IRouter {
-    getData(route: string, arrayData?: any): { state: State; data: any };
+    getData(route: string, separableData?: any): { state: State; data: any };
     getRoute(state: State, data: any, arrayData?: { [index: string]: string[] }): { route: string; data: any };
     supportsDefaults: boolean;
     addRoutes(dialogs: Dialog[]): void;

--- a/NavigationJS/src/IRouter.ts
+++ b/NavigationJS/src/IRouter.ts
@@ -2,8 +2,8 @@
 import State = require('./config/State');
 
 interface IRouter {
-    getData(route: string): { state: State; data: any };
-    getRoute(state: State, data: any): { route: string; data: any };
+    getData(route: string, arrayData?: any): { state: State; data: any };
+    getRoute(state: State, data: any, arrayData?: { [index: string]: string[] }): { route: string; data: any };
     supportsDefaults: boolean;
     addRoutes(dialogs: Dialog[]): void;
 }

--- a/NavigationJS/src/IStateHandler.ts
+++ b/NavigationJS/src/IStateHandler.ts
@@ -2,9 +2,9 @@
 import State = require('./config/State');
 
 interface IStateHandler {
-    getNavigationLink(state: State, data: any, queryStringData?: { [index: string]: string[] }): string;
+    getNavigationLink(state: State, data: any, arrayData?: { [index: string]: string[] }): string;
     navigateLink(oldState: State, state: State, url: string): void;
-    getNavigationData(state: State, url: string, queryStringData?: any): any;
+    getNavigationData(state: State, url: string, separableData?: any): any;
     urlEncode?(state: State, key: string, val: string, queryString: boolean): string;
     urlDecode?(state: State, key: string, val: string, queryString: boolean): string;
     truncateCrumbTrail(state: State, crumbs: Crumb[]): Crumb[];

--- a/NavigationJS/src/ReturnDataManager.ts
+++ b/NavigationJS/src/ReturnDataManager.ts
@@ -48,7 +48,7 @@ class ReturnDataManager {
         return { val: formattedValue, arrayVal: formattedArray };
     }
 
-    static parseURLString(key: string, val: string | string[], state: State, decode = false, queryString = false): any {
+    static parseURLString(key: string, val: string | string[], state: State, decode = false, separable = false): any {
         decode = decode || state.trackTypes;
         var defaultType: string = state.defaultTypes[key] ? state.defaultTypes[key] : 'string';
         var urlValue = typeof val === 'string' ? val : val[0];
@@ -64,7 +64,7 @@ class ReturnDataManager {
             val =  urlValue;
         else
             val[0] = urlValue;
-        return ConverterFactory.getConverterFromKey(converterKey).convertFrom(val, queryString);
+        return ConverterFactory.getConverterFromKey(converterKey).convertFrom(val, separable);
     }
 
     static parseReturnData(returnData: string, state: State): any {

--- a/NavigationJS/src/ReturnDataManager.ts
+++ b/NavigationJS/src/ReturnDataManager.ts
@@ -28,13 +28,13 @@ class ReturnDataManager {
         return urlValue.replace(new RegExp(this.SEPARATOR, 'g'), '0' + this.SEPARATOR);
     }
 
-    static formatURLObject(key: string, urlObject: any, state: State, encode = false): { val: string, queryStringVal?: string[] } {
+    static formatURLObject(key: string, urlObject: any, state: State, encode = false): { val: string, arrayVal?: string[] } {
         encode = encode || state.trackTypes;
         var defaultType: string = state.defaultTypes[key] ? state.defaultTypes[key] : 'string';
         var converter = ConverterFactory.getConverter(urlObject);
         var convertedValue = converter.convertTo(urlObject);
         var formattedValue = convertedValue.val;
-        var formattedArray = convertedValue.queryStringVal;
+        var formattedArray = convertedValue.arrayVal;
         if (encode) {
             formattedValue = this.encodeUrlValue(formattedValue);
             if (formattedArray)
@@ -45,7 +45,7 @@ class ReturnDataManager {
             if (formattedArray)
                 formattedArray[0] = formattedArray[0] + this.RET_2_SEP + converter.key;
         }
-        return { val: formattedValue, queryStringVal: formattedArray };
+        return { val: formattedValue, arrayVal: formattedArray };
     }
 
     static parseURLString(key: string, val: string | string[], state: State, decode = false, queryString = false): any {

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -201,7 +201,7 @@ class StateController {
         if (!separable || !arrayDefaultVal) {
             return val === state.formattedDefaults[key];
         } else {
-            if (val.length !== arrayDefaultVal.length) 
+            if (typeof val === 'string' || val.length !== arrayDefaultVal.length) 
                 return false;
             for(var i = 0; i < val.length; i++) {
                 if (val[i] !== arrayDefaultVal[i])

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -201,7 +201,9 @@ class StateController {
         if (!separable || !arrayDefaultVal) {
             return val === state.formattedDefaults[key];
         } else {
-            if (typeof val === 'string' || val.length !== arrayDefaultVal.length) 
+            if (typeof val === 'string')
+                val = [val];
+            if (val.length !== arrayDefaultVal.length) 
                 return false;
             for(var i = 0; i < val.length; i++) {
                 if (val[i] !== arrayDefaultVal[i])

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -196,9 +196,19 @@ class StateController {
     }
     
     private static isDefault(key: string, data: any, state: State, separable: boolean) {
-        if (!separable || !state.formattedArrayDefaults[key])
-            return data[key] === state.formattedDefaults[key];
-        return false;
+        var val = data[key]
+        var arrayDefaultVal = state.formattedArrayDefaults[key];
+        if (!separable || !arrayDefaultVal) {
+            return val === state.formattedDefaults[key];
+        } else {
+            if (val.length !== arrayDefaultVal.length) 
+                return false;
+            for(var i = 0; i < val.length; i++) {
+                if (val[i] !== arrayDefaultVal[i])
+                    return false;
+            }
+            return true;
+        }
     }
 
     static getNextState(action: string): State {

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -22,9 +22,9 @@ class StateController {
             StateContext.url = url;
             StateContext.dialog = state.parent;
             StateContext.title = state.title;
-            var queryStringData = {};
-            var data = state.stateHandler.getNavigationData(state, url, queryStringData);
-            StateContext.data = this.parseData(data, state, queryStringData);
+            var separableData = {};
+            var data = state.stateHandler.getNavigationData(state, url, separableData);
+            StateContext.data = this.parseData(data, state, separableData);
             StateContext.previousState = null;
             StateContext.previousDialog = null;
             StateContext.previousData = {};
@@ -145,9 +145,9 @@ class StateController {
     private static _navigateLink(url: string, state: State, history = false, historyAction = HistoryAction.Add) {
         try {
             var oldUrl = StateContext.url;
-            var queryStringData = {};
-            var data = state.stateHandler.getNavigationData(state, url, queryStringData);
-            data = this.parseData(data, state, queryStringData);
+            var separableData = {};
+            var data = state.stateHandler.getNavigationData(state, url, separableData);
+            data = this.parseData(data, state, separableData);
         } catch (e) {
             throw new Error('The Url is invalid\n' + e.message);
         }
@@ -184,12 +184,12 @@ class StateController {
         };
     }
 
-    private static parseData(data: any, state: State, queryStringData: any): any {
+    private static parseData(data: any, state: State, separableData: any): any {
         var newData = {};
         for (var key in data) {
             if (key !== settings.previousStateIdKey && key !== settings.returnDataKey
                 && key !== settings.crumbTrailKey && data[key] !== state.formattedDefaults[key])
-                newData[key] = ReturnDataManager.parseURLString(key, data[key], state, false, !!queryStringData[key]);
+                newData[key] = ReturnDataManager.parseURLString(key, data[key], state, false, !!separableData[key]);
         }
         NavigationData.setDefaults(newData, state.defaults);
         return newData;

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -188,11 +188,17 @@ class StateController {
         var newData = {};
         for (var key in data) {
             if (key !== settings.previousStateIdKey && key !== settings.returnDataKey
-                && key !== settings.crumbTrailKey && data[key] !== state.formattedDefaults[key])
+                && key !== settings.crumbTrailKey && !this.isDefault(key, data, state, !!separableData[key]))
                 newData[key] = ReturnDataManager.parseURLString(key, data[key], state, false, !!separableData[key]);
         }
         NavigationData.setDefaults(newData, state.defaults);
         return newData;
+    }
+    
+    private static isDefault(key: string, data: any, state: State, separable: boolean) {
+        if (!separable || !state.formattedArrayDefaults[key])
+            return data[key] === state.formattedDefaults[key];
+        return false;
     }
 
     static getNextState(action: string): State {

--- a/NavigationJS/src/StateHandler.ts
+++ b/NavigationJS/src/StateHandler.ts
@@ -6,14 +6,14 @@ import StateContext = require('./StateContext');
 import StateController = require('./StateController');
 
 class StateHandler implements IStateHandler {
-    getNavigationLink(state: State, data: any, queryStringData: { [index: string]: string[] } = {}): string {
-        var routeInfo = settings.router.getRoute(state, data, queryStringData);
+    getNavigationLink(state: State, data: any, arrayData: { [index: string]: string[] } = {}): string {
+        var routeInfo = settings.router.getRoute(state, data, arrayData);
         if (routeInfo.route == null)
             return null;
         var query: string[] = [];
         for (var key in data) {
             if (key !== settings.stateIdKey && !routeInfo.data[key]) {
-                var arr = queryStringData[key];
+                var arr = arrayData[key];
                 var encodedKey = this.urlEncode(state, null, key, true);
                 if (!arr) {
                     query.push(encodedKey + '=' + this.urlEncode(state, key, data[key], true));
@@ -31,10 +31,10 @@ class StateHandler implements IStateHandler {
     navigateLink(oldState: State, state: State, url: string) {
     }
 
-    getNavigationData(state: State, url: string, queryStringData: any = {}): any {
+    getNavigationData(state: State, url: string, separableData: any = {}): any {
         var queryIndex = url.indexOf('?');
         var route = queryIndex < 0 ? url : url.substring(0, queryIndex);
-        var data = settings.router.getData(route, queryStringData).data;
+        var data = settings.router.getData(route, separableData).data;
         data = data ? data : {};
         if (queryIndex >= 0) {
             var query = url.substring(queryIndex + 1);
@@ -43,7 +43,7 @@ class StateHandler implements IStateHandler {
                 var param = params[i].split('=');
                 var key = this.urlDecode(state, null, param[0], true);
                 var val = this.urlDecode(state, key, param[1], true);
-                queryStringData[key] = true;
+                separableData[key] = true;
                 var arr = data[key];
                 if (!arr) {
                     data[key] = val;

--- a/NavigationJS/src/StateHandler.ts
+++ b/NavigationJS/src/StateHandler.ts
@@ -7,7 +7,7 @@ import StateController = require('./StateController');
 
 class StateHandler implements IStateHandler {
     getNavigationLink(state: State, data: any, queryStringData: { [index: string]: string[] } = {}): string {
-        var routeInfo = settings.router.getRoute(state, data);
+        var routeInfo = settings.router.getRoute(state, data, queryStringData);
         if (routeInfo.route == null)
             return null;
         var query: string[] = [];
@@ -34,7 +34,7 @@ class StateHandler implements IStateHandler {
     getNavigationData(state: State, url: string, queryStringData: any = {}): any {
         var queryIndex = url.indexOf('?');
         var route = queryIndex < 0 ? url : url.substring(0, queryIndex);
-        var data = settings.router.getData(route).data;
+        var data = settings.router.getData(route, queryStringData).data;
         data = data ? data : {};
         if (queryIndex >= 0) {
             var query = url.substring(queryIndex + 1);

--- a/NavigationJS/src/StateRouter.ts
+++ b/NavigationJS/src/StateRouter.ts
@@ -133,7 +133,8 @@ class StateRouter implements IRouter {
             }
             routeInfo.routes.push(route);
             route['_state'] = state;
-            route['_splat'] = splat;
+            route['_splat'] = splat
+            route.defaults = StateRouter.getCombinedData(route, state.formattedDefaults, state.formattedArrayDefaults);
         }
         state['_routeInfo'] = routeInfo;
     }

--- a/NavigationJS/src/StateRouter.ts
+++ b/NavigationJS/src/StateRouter.ts
@@ -10,14 +10,14 @@ class StateRouter implements IRouter {
     router: Router;
     supportsDefaults: boolean = true;
 
-    getData(route: string, arrayData: any = {}): { state: State; data: any } {
+    getData(route: string, separableData: any = {}): { state: State; data: any } {
         var match = this.router.match(route, StateRouter.urlDecode);
         var state = match.route['_state'];
         var routeInfo: RouteInfo = state['_routeInfo'];
         for(var key in routeInfo.params) {
             var param = routeInfo.params[key];
             if (param.splat)
-                arrayData[key] = true;
+                separableData[key] = true;
         }
         return { state: state, data: match.data };
     }

--- a/NavigationJS/src/StateRouter.ts
+++ b/NavigationJS/src/StateRouter.ts
@@ -12,12 +12,14 @@ class StateRouter implements IRouter {
 
     getData(route: string, arrayData: any = {}): { state: State; data: any } {
         var match = this.router.match(route, StateRouter.urlDecode);
-        for(var i = 0; i < match.route.params.length; i++) {
-            var param = match.route.params[i];
+        var state = match.route['_state'];
+        var routeInfo: RouteInfo = state['_routeInfo'];
+        for(var key in routeInfo.params) {
+            var param = routeInfo.params[key];
             if (param.splat)
-                arrayData[param.name] = true;
+                arrayData[key] = true;
         }
-        return { state: match.route['_state'], data: match.data };
+        return { state: state, data: match.data };
     }
 
     getRoute(state: State, data: any, arrayData: { [index: string]: string[] } = {}): { route: string; data: any } {

--- a/NavigationJS/src/StateRouter.ts
+++ b/NavigationJS/src/StateRouter.ts
@@ -12,10 +12,12 @@ class StateRouter implements IRouter {
 
     getData(route: string, separableData: any = {}): { state: State; data: any } {
         var match = this.router.match(route, StateRouter.urlDecode);
-        for (var i = 0; i < match.route.params.length; i++) {
-            var param = match.route.params[i];
-            if (param.splat)
-                separableData[param.name] = true;
+        if (match.route['_splat']) {
+            for (var i = 0; i < match.route.params.length; i++) {
+                var param = match.route.params[i];
+                if (param.splat)
+                    separableData[param.name] = true;
+            }
         }
         return { state: match.route['_state'], data: match.data };
     }

--- a/NavigationJS/src/StateRouter.ts
+++ b/NavigationJS/src/StateRouter.ts
@@ -43,7 +43,7 @@ class StateRouter implements IRouter {
         }
         return { route: routePath, data: routeMatch ? routeMatch.data : {} };
     }
-    
+
     private static findBestMatch(routes: Route[], data: any, arrayData: { [index: string]: string[] }): MatchInfo {
         var bestMatch: MatchInfo;
         var bestMatchCount = -1;
@@ -55,7 +55,7 @@ class StateRouter implements IRouter {
                 var count = 0;
                 var routeData = {};
                 for (var j = 0; j < route.params.length; j++) {
-                    if (data[route.params[j].name]) {
+                    if (combinedData[route.params[j].name]) {
                         routeData[route.params[j].name] = {};
                         count++;
                     }
@@ -70,6 +70,8 @@ class StateRouter implements IRouter {
     }
     
     private static getCombinedData(route: Route, data: any, arrayData: { [index: string]: string[] }): any {
+        if (!route['_splat'])
+            return data;
         var combinedData = {};
         for(var key in data)
             combinedData[key] = data[key];
@@ -118,15 +120,18 @@ class StateRouter implements IRouter {
         var routes = StateRouter.getRoutes(state);
         for(var i = 0; i < routes.length; i++) {
             var route = this.router.addRoute(routes[i], state.formattedDefaults);
+            var splat = false;
             for(var j = 0; j < route.params.length; j++) {
                 var param = route.params[j];
                 if (!routeInfo.params[param.name]) {
                     routeInfo.params[param.name] = count;
                     count++;
                 }
+                splat = splat || param.splat;
             }
             routeInfo.routes.push(route);
             route['_state'] = state;
+            route['_splat'] = splat;
         }
         state['_routeInfo'] = routeInfo;
     }

--- a/NavigationJS/src/config/State.ts
+++ b/NavigationJS/src/config/State.ts
@@ -14,6 +14,7 @@ class State implements IState<{ [index: string]: Transition }> {
     defaults: any = {};
     defaultTypes: any = {};
     formattedDefaults: any = {};
+    formattedArrayDefaults: { [index: string]: string[] } = {};
     title: string;
     route: string | string[];
     trackCrumbTrail: boolean = true;

--- a/NavigationJS/src/config/StateInfoConfig.ts
+++ b/NavigationJS/src/config/StateInfoConfig.ts
@@ -55,7 +55,10 @@ class StateInfoConfig {
             for (var key in state.defaults) {
                 if (!state.defaultTypes[key])
                     state.defaultTypes[key] = ConverterFactory.getConverter(state.defaults[key]).name;
-                state.formattedDefaults[key] = ReturnDataManager.formatURLObject(key, state.defaults[key], state).val;
+                var formattedData = ReturnDataManager.formatURLObject(key, state.defaults[key], state); 
+                state.formattedDefaults[key] = formattedData.val;
+                if (formattedData.arrayVal)
+                    state.formattedArrayDefaults[key] = formattedData.arrayVal;
             }
             for (var key in state.defaultTypes) {
                 ConverterFactory.getConverterFromName(state.defaultTypes[key]);

--- a/NavigationJS/src/converter/ArrayConverter.ts
+++ b/NavigationJS/src/converter/ArrayConverter.ts
@@ -12,10 +12,10 @@ class ArrayConverter extends TypeConverter {
         this.converter = converter;
     }
 
-    convertFrom(val: string | string[], queryString: boolean): any {
+    convertFrom(val: string | string[], separable: boolean): any {
         var arr = [];
         if (typeof val === 'string') {
-            if (!queryString || settings.combineArray) {
+            if (!separable || settings.combineArray) {
                 var vals = val.split(ArrayConverter.SEPARATOR1);
                 for (var i = 0; i < vals.length; i++) {
                     if (vals[i].length !== 0)
@@ -37,7 +37,7 @@ class ArrayConverter extends TypeConverter {
         return arr;
     }
 
-    convertTo(val: any[]): { val: string, queryStringVal?: string[] } {
+    convertTo(val: any[]): { val: string, arrayVal?: string[] } {
         var vals = [];
         var arr = [];
         for (var i = 0; i < val.length; i++) {
@@ -50,7 +50,7 @@ class ArrayConverter extends TypeConverter {
                 vals.push('');
             }
         }
-        return { val: vals.join(ArrayConverter.SEPARATOR1), queryStringVal: !settings.combineArray ? arr : null };
+        return { val: vals.join(ArrayConverter.SEPARATOR1), arrayVal: !settings.combineArray ? arr : null };
     }
 }
 export = ArrayConverter;

--- a/NavigationJS/src/converter/BooleanConverter.ts
+++ b/NavigationJS/src/converter/BooleanConverter.ts
@@ -11,7 +11,7 @@ class BooleanConverter extends TypeConverter {
         return val === 'true';
     }
 
-    convertTo(val: any): { val: string, queryStringVal?: string[] } {
+    convertTo(val: any): { val: string, arrayVal?: string[] } {
         return { val: val.toString() };
     }
 }

--- a/NavigationJS/src/converter/DateConverter.ts
+++ b/NavigationJS/src/converter/DateConverter.ts
@@ -15,7 +15,7 @@ class DateConverter extends TypeConverter {
         return date;
     }
 
-    convertTo(val: Date): { val: string, vals?: string[] } {
+    convertTo(val: Date): { val: string, arrayVal?: string[] } {
         var year = val.getFullYear();
         var month = ('0' + (val.getMonth() + 1)).slice(-2);
         var day = ('0' + val.getDate()).slice(-2); 

--- a/NavigationJS/src/converter/NumberConverter.ts
+++ b/NavigationJS/src/converter/NumberConverter.ts
@@ -11,7 +11,7 @@ class NumberConverter extends TypeConverter {
         return +val;
     }
 
-    convertTo(val: any): { val: string, vals?: string[] } {
+    convertTo(val: any): { val: string, arrayVal?: string[] } {
         return { val: val.toString() };
     }
 }

--- a/NavigationJS/src/converter/StringConverter.ts
+++ b/NavigationJS/src/converter/StringConverter.ts
@@ -11,7 +11,7 @@ class StringConverter extends TypeConverter {
         return val;
     }
 
-    convertTo(val: any): { val: string, queryStringVal?: string[] } {
+    convertTo(val: any): { val: string, arrayVal?: string[] } {
         return { val: val.toString() };
     }
 }

--- a/NavigationJS/src/converter/TypeConverter.ts
+++ b/NavigationJS/src/converter/TypeConverter.ts
@@ -7,11 +7,11 @@
         this.name = name;
     }
     
-    convertFrom(val: string | string[], queryString = false): any {
+    convertFrom(val: string | string[], separable = false): any {
         return null;
     }
 
-    convertTo(val: any): { val: string, queryStringVal?: string[] } {
+    convertTo(val: any): { val: string, arrayVal?: string[] } {
         return null;
     }
     

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -960,10 +960,10 @@ declare module Navigation {
          * Gets a link that navigates to the state passing the data
          * @param state The State to navigate to
          * @param data The data to pass when navigating
-         * @param queryStringData The query string array data
+         * @param arrayData The query string and splat array data
          * @returns The navigation link
          */
-        getNavigationLink(state: State, data: any, queryStringData: { [index: string]: string[]; }): string;
+        getNavigationLink(state: State, data: any, arrayData: { [index: string]: string[]; }): string;
         /**
          * Navigates to the url
          * @param oldState The current State
@@ -982,10 +982,10 @@ declare module Navigation {
          * Gets the data parsed from the url
          * @param state The State navigated to
          * @param url The current url
-         * @param queryStringData Stores query string keys
+         * @param separableData Stores query string and splat keys
          * @returns The navigation data
          */
-        getNavigationData(state: State, url: string, queryStringData: any): any;
+        getNavigationData(state: State, url: string, separableData: any): any;
         /**
          * Encodes the Url value
          * @param state The State navigated to
@@ -1064,12 +1064,27 @@ declare module Navigation {
          */
         getData(route: string): { state: State; data: any; };
         /**
+         * Gets the matching State and data for the route
+         * @param route The route to match
+         * @param separableData Stores splat keys
+         * @returns The matched State and data
+         */
+        getData(route: string, separableData: any): { state: State; data: any; };
+        /**
          * Gets the matching route and data for the state and data
          * @param The state to match
          * @param The data to match
          * @returns The matched route and data
          */
         getRoute(state: State, data: any): { route: string; data: any; };
+        /**
+         * Gets the matching route and data for the state and data
+         * @param The state to match
+         * @param The data to match
+         * @param arrayData The splat array data
+         * @returns The matched route and data
+         */
+        getRoute(state: State, data: any, arrayData: { [index: string]: string[]; }): { route: string; data: any; };
         /**
          * Registers all route configuration information with the underlying
          * Navigation Router
@@ -1094,7 +1109,7 @@ declare module Navigation {
         /**
          * Gets the list of parameters
          */
-        params: { name: string; optional: boolean; }[];
+        params: { name: string; optional: boolean; splat: boolean; }[];
         /**
          * Initializes a new instance of the Route class
          * @param path The route pattern 

--- a/NavigationJS/src/routing/Route.ts
+++ b/NavigationJS/src/routing/Route.ts
@@ -5,7 +5,7 @@ class Route {
     defaults: any;
     private segments: Segment[] = [];
     private pattern: RegExp;
-    params: { name: string; optional: boolean }[] = [];
+    params: { name: string; optional: boolean; splat: boolean }[] = [];
 
     constructor(path: string, defaults?: any) {
         this.path = path;
@@ -21,9 +21,10 @@ class Route {
             segment = new Segment(subPaths[i], segment ? segment.optional : true, this.defaults);
             this.segments.unshift(segment);
             pattern = segment.pattern + pattern;
-            var params: { name: string; optional: boolean }[] = [];
+            var params: { name: string; optional: boolean; splat: boolean }[] = [];
             for (var j = 0; j < segment.params.length; j++) {
-                params.push({ name: segment.params[j], optional: segment.optional });
+                var param = segment.params[j];
+                params.push({ name: param.name, optional: segment.optional, splat: param.splat });
             }
             this.params = params.concat(this.params);
         }

--- a/NavigationJS/src/routing/Route.ts
+++ b/NavigationJS/src/routing/Route.ts
@@ -64,7 +64,7 @@ class Route {
         var optional = true;
         for (var i = this.segments.length - 1; i >= 0; i--) {
             var segment = this.segments[i];
-            var pathInfo = segment.build(data, (name, val) => urlEncode(this, name, val));
+            var pathInfo = segment.build(data, this.defaults, (name, val) => urlEncode(this, name, val));
             optional = optional && pathInfo.optional;
             if (!optional) {
                 if (pathInfo.path == null)

--- a/NavigationJS/src/routing/Route.ts
+++ b/NavigationJS/src/routing/Route.ts
@@ -40,8 +40,18 @@ class Route {
         var data = {};
         for (var i = 1; i < matches.length; i++) {
             var param = this.params[i - 1];
-            if (matches[i])
-                data[param.name] = urlDecode(this, param.name, !param.optional ? matches[i] : matches[i].substring(1));
+            if (matches[i]) {
+                var val = !param.optional ? matches[i] : matches[i].substring(1);
+                if (val.indexOf('/') === -1) {
+                    data[param.name] = urlDecode(this, param.name, val);
+                } else {
+                    var vals = val.split('/');
+                    var decodedVals = [];
+                    for(var j = 0; j < vals.length; j++)
+                        decodedVals[j] = urlDecode(this, param.name, vals[j]);
+                    data[param.name] = decodedVals;
+                }
+            }
         }
         return data;
     }

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -30,8 +30,8 @@
                 this.subSegments.push({ name: name, param: true, splat: splat });
                 var optionalOrDefault = param.slice(-1) === '?' || this.defaults[name];
                 this.optional = this.optional && this.path.length === subSegment.length && optionalOrDefault;
-                var subSegmentPattern = !splat ? '[^/]+' : '.+';
-                this.pattern += !this.optional ? `(${subSegmentPattern})` : `(\/${subSegmentPattern})?`;
+                var subPattern = !splat ? '[^/]+' : '.+';
+                this.pattern += !this.optional ? `(${subPattern})` : `(\/${subPattern})?`;
             } else {
                 this.optional = false;
                 this.subSegments.push({ name: subSegment, param: false, splat: false });

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -60,10 +60,10 @@
                     if (!subSegment.splat || typeof val === 'string' ) {
                         routePath += urlEncode(subSegment.name, val);
                     } else {
-                        var encodedArray = [];
+                        var encodedVals = [];
                         for(var i = 0; i < val.length; i++)
-                            encodedArray[i] = urlEncode(subSegment.name, val[i]); 
-                        routePath += encodedArray.join('/');
+                            encodedVals[i] = urlEncode(subSegment.name, val[i]); 
+                        routePath += encodedVals.join('/');
                     }
                 }
             }

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -3,7 +3,7 @@
     optional: boolean;
     defaults: any;
     pattern: string = '';
-    params: string[] = [];
+    params: { name: string; splat: boolean }[] = [];
     private subSegments: { name: string; param: boolean }[] = [];
     private subSegmentPattern: RegExp = /[{]{0,1}[^{}]+[}]{0,1}/g;
     private escapePattern: RegExp = /[\.+*\^$\[\](){}']/g;
@@ -24,7 +24,7 @@
             if (subSegment.charAt(0) == '{') {
                 var param = subSegment.substring(1, subSegment.length - 1);
                 var name = param.slice(-1) === '?' ? param.slice(0, -1) : param;
-                this.params.push(name);
+                this.params.push({ name: name, splat: false });
                 this.subSegments.push({ name: name, param: true });
                 var optionalOrDefault = param.slice(-1) === '?' || this.defaults[name];
                 this.optional = this.optional && this.path.length === subSegment.length && optionalOrDefault;

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -23,12 +23,13 @@
             var subSegment = matches[i];
             if (subSegment.charAt(0) == '{') {
                 var param = subSegment.substring(1, subSegment.length - 1);
-                var name = param.slice(-1) === '?' ? param.slice(0, -1) : param;
-                name = param.slice(0, 1) === '*' ? name.slice(1) : name;
+                var optional = param.slice(-1) === '?'; 
+                var name = optional ? param.slice(0, -1) : param;
                 var splat = param.slice(0, 1) === '*';
+                name = splat ? name.slice(1) : name;
                 this.params.push({ name: name, splat: splat });
                 this.subSegments.push({ name: name, param: true, splat: splat });
-                var optionalOrDefault = param.slice(-1) === '?' || this.defaults[name];
+                var optionalOrDefault = optional || this.defaults[name];
                 this.optional = this.optional && this.path.length === subSegment.length && optionalOrDefault;
                 var subPattern = !splat ? '[^/]+' : '.+';
                 this.pattern += !this.optional ? `(${subPattern})` : `(\/${subPattern})?`;

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -24,8 +24,8 @@
             if (subSegment.charAt(0) == '{') {
                 var param = subSegment.substring(1, subSegment.length - 1);
                 var optional = param.slice(-1) === '?'; 
-                var name = optional ? param.slice(0, -1) : param;
                 var splat = param.slice(0, 1) === '*';
+                var name = optional ? param.slice(0, -1) : param;
                 name = splat ? name.slice(1) : name;
                 this.params.push({ name: name, splat: splat });
                 this.subSegments.push({ name: name, param: true, splat: splat });

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -24,7 +24,8 @@
             if (subSegment.charAt(0) == '{') {
                 var param = subSegment.substring(1, subSegment.length - 1);
                 var name = param.slice(-1) === '?' ? param.slice(0, -1) : param;
-                this.params.push({ name: name, splat: false });
+                name = param.slice(0, 1) === '*' ? name.slice(0, 1) : name;
+                this.params.push({ name: name, splat: param.slice(0, 1) === '*' });
                 this.subSegments.push({ name: name, param: true });
                 var optionalOrDefault = param.slice(-1) === '?' || this.defaults[name];
                 this.optional = this.optional && this.path.length === subSegment.length && optionalOrDefault;

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -1,21 +1,19 @@
 ﻿class Segment {
     path: string;
     optional: boolean;
-    defaults: any;
     pattern: string = '';
     params: { name: string; splat: boolean }[] = [];
     private subSegments: { name: string; param: boolean; splat: boolean }[] = [];
     private subSegmentPattern: RegExp = /[{]{0,1}[^{}]+[}]{0,1}/g;
     private escapePattern: RegExp = /[\.+*\^$\[\](){}']/g;
 
-    constructor(path: string, optional: boolean, defaults?: any) {
+    constructor(path: string, optional: boolean, defaults: any) {
         this.path = path;
         this.optional = optional;
-        this.defaults = defaults;
-        this.parse();
+        this.parse(defaults);
     }
 
-    private parse() {
+    private parse(defaults: any) {
         if (this.path.length === 0)
             return;
         var matches = this.path.match(this.subSegmentPattern);
@@ -29,7 +27,7 @@
                 name = splat ? name.slice(1) : name;
                 this.params.push({ name: name, splat: splat });
                 this.subSegments.push({ name: name, param: true, splat: splat });
-                var optionalOrDefault = optional || this.defaults[name];
+                var optionalOrDefault = optional || defaults[name];
                 this.optional = this.optional && this.path.length === subSegment.length && optionalOrDefault;
                 var subPattern = !splat ? '[^/]+' : '.+';
                 this.pattern += !this.optional ? `(${subPattern})` : `(\/${subPattern})?`;
@@ -43,7 +41,7 @@
             this.pattern = '\/' + this.pattern;
     }
 
-    build(data: any, urlEncode: (name: string, val: string) => string): { path: string; optional: boolean } {
+    build(data: any, defaults: any, urlEncode: (name: string, val: string) => string): { path: string; optional: boolean } {
         var routePath = '';
         var optional = this.optional;
         var blank = false;
@@ -53,7 +51,7 @@
                 routePath += subSegment.name;
             } else {
                 var val = data[subSegment.name];
-                var defaultVal = this.defaults[subSegment.name];
+                var defaultVal = defaults[subSegment.name];
                 optional = optional && (!val || val === defaultVal);
                 val = val ? val : defaultVal;
                 blank = blank || !val;

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -25,11 +25,13 @@
                 var param = subSegment.substring(1, subSegment.length - 1);
                 var name = param.slice(-1) === '?' ? param.slice(0, -1) : param;
                 name = param.slice(0, 1) === '*' ? name.slice(1) : name;
-                this.params.push({ name: name, splat: param.slice(0, 1) === '*' });
+                var splat = param.slice(0, 1) === '*';
+                this.params.push({ name: name, splat: splat });
                 this.subSegments.push({ name: name, param: true });
                 var optionalOrDefault = param.slice(-1) === '?' || this.defaults[name];
                 this.optional = this.optional && this.path.length === subSegment.length && optionalOrDefault;
-                this.pattern += !this.optional ? '([^/]+)' : '(\/[^/]+)?';
+                var subSegmentPattern = !splat ? '[^/]+' : '.+';
+                this.pattern += !this.optional ? '(' + subSegmentPattern + ')' : '(\/' + subSegmentPattern + ')?';
             } else {
                 this.optional = false;
                 this.subSegments.push({ name: subSegment, param: false });

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -31,7 +31,7 @@
                 var optionalOrDefault = param.slice(-1) === '?' || this.defaults[name];
                 this.optional = this.optional && this.path.length === subSegment.length && optionalOrDefault;
                 var subSegmentPattern = !splat ? '[^/]+' : '.+';
-                this.pattern += !this.optional ? '(' + subSegmentPattern + ')' : '(\/' + subSegmentPattern + ')?';
+                this.pattern += !this.optional ? `(${subSegmentPattern})` : `(\/${subSegmentPattern})?`;
             } else {
                 this.optional = false;
                 this.subSegments.push({ name: subSegment, param: false, splat: false });

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -64,6 +64,8 @@
                         for(var i = 0; i < val.length; i++)
                             encodedVals[i] = urlEncode(subSegment.name, val[i]); 
                         routePath += encodedVals.join('/');
+                        if (routePath.slice(-1) === '/')
+                            routePath += '/';
                     }
                 }
             }

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -24,7 +24,7 @@
             if (subSegment.charAt(0) == '{') {
                 var param = subSegment.substring(1, subSegment.length - 1);
                 var name = param.slice(-1) === '?' ? param.slice(0, -1) : param;
-                name = param.slice(0, 1) === '*' ? name.slice(0, 1) : name;
+                name = param.slice(0, 1) === '*' ? name.slice(1) : name;
                 this.params.push({ name: name, splat: param.slice(0, 1) === '*' });
                 this.subSegments.push({ name: name, param: true });
                 var optionalOrDefault = param.slice(-1) === '?' || this.defaults[name];

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -266,7 +266,6 @@ describe('Navigation Data', function () {
         describe('Navigate Link', function() {
             beforeEach(function() {
                 var link = Navigation.StateController.getNavigationLink('d', arrayNavigationData);
-                console.log(link)
                 Navigation.StateController.navigateLink(link);
             });
             test();

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -242,6 +242,62 @@ describe('Navigation Data', function () {
         }
     });
 
+    describe('Array Data Splat', function() {
+        beforeEach(function() {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'r0/{*array_string}/a/{*array_boolean}/b/{*array_number}/c/{*array_date}/d/{*array_blank}' }]}
+                ]);
+        });
+        var arrayNavigationData = {};
+        arrayNavigationData['array_string'] = ['He-llo', 'World'];
+        arrayNavigationData['array_boolean'] = ['', true, false];
+        arrayNavigationData['array_number'] = [1, null, undefined, 2];
+        arrayNavigationData['array_date'] = [new Date(2010, 3, 7), new Date(2011, 7, 3)];
+        arrayNavigationData['array_blank'] = ['', null, undefined];
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                Navigation.StateController.navigate('d', arrayNavigationData);
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = Navigation.StateController.getNavigationLink('d', arrayNavigationData);
+                console.log(link)
+                Navigation.StateController.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate data', function () {
+                assert.strictEqual(Navigation.StateContext.data['array_string'][0], 'He-llo');
+                assert.strictEqual(Navigation.StateContext.data['array_string'][1], 'World');
+                assert.strictEqual(Navigation.StateContext.data['array_string'].length, 2);
+                assert.strictEqual(Navigation.StateContext.data['array_boolean'][0], null);
+                assert.strictEqual(Navigation.StateContext.data['array_boolean'][1], true);
+                assert.strictEqual(Navigation.StateContext.data['array_boolean'][2], false);
+                assert.strictEqual(Navigation.StateContext.data['array_boolean'].length, 3);
+                assert.strictEqual(Navigation.StateContext.data['array_number'][0], 1);
+                assert.strictEqual(Navigation.StateContext.data['array_number'][1], null);
+                assert.strictEqual(Navigation.StateContext.data['array_number'][2], null);
+                assert.strictEqual(Navigation.StateContext.data['array_number'][3], 2);
+                assert.strictEqual(Navigation.StateContext.data['array_number'].length, 4);
+                assert.strictEqual(+Navigation.StateContext.data['array_date'][0], +new Date(2010, 3, 7));
+                assert.strictEqual(+Navigation.StateContext.data['array_date'][1], +new Date(2011, 7, 3));
+                assert.strictEqual(Navigation.StateContext.data['array_date'].length, 2);
+                assert.strictEqual(Navigation.StateContext.data['array_blank'][0], null);
+                assert.strictEqual(Navigation.StateContext.data['array_blank'][1], null);
+                assert.strictEqual(Navigation.StateContext.data['array_blank'][2], null);
+                assert.strictEqual(Navigation.StateContext.data['array_blank'].length, 3);
+                assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 5);
+            });
+        }
+    });
+
     describe('Invalid Data', function() {
         beforeEach(function() {
             Navigation.StateInfoConfig.build([

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3626,4 +3626,40 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
         });
     });
+
+    describe('One Optional Splat Param One Segment Default Type', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{*x?}', defaultTypes: { x: 'stringarray' }, trackCrumbTrail: false }]}
+                ]);
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 0);
+            Navigation.StateController.navigateLink('/abcd');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'abcd');
+            Navigation.StateController.navigateLink('/ab/cd');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'ab');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'cd');
+            Navigation.StateController.navigateLink('/ab//cd');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 3);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'ab');
+            assert.strictEqual(Navigation.StateContext.data.x[1], null);
+            assert.strictEqual(Navigation.StateContext.data.x[2], 'cd');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['abcd'] }), '/abcd');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', 'cd'] }), '/ab/cd');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', null, 'cd'] }), '/ab//cd');
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2206,7 +2206,7 @@ describe('MatchTest', function () {
         });
     });
 
-    describe('Without Types Conflicing Default And Default Type', function () {
+    describe('Without Types Conflicting Default And Default Type', function () {
         beforeEach(function () {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's', states: [
@@ -2340,7 +2340,7 @@ describe('MatchTest', function () {
         });
     });
 
-    describe('Without Types Query String Conflicing Default And Default Type', function () {
+    describe('Without Types Query String Conflicting Default And Default Type', function () {
         beforeEach(function () {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's', states: [
@@ -4068,8 +4068,8 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: true }), '/true2_1/ab');
         });
     });
-    
-    describe('Without Types Splat Conflicing Default And Default Type', function () {
+
+    describe('Without Types Splat Conflicting Default And Default Type', function () {
         beforeEach(function () {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's', states: [

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -4326,4 +4326,60 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['a b', 'c de'] }), '/a+b/c+de');
         });
     });
+
+    describe('One Splat Param One Segment Default Type Number Array', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{*x}', defaultTypes: { x: 'numberarray' }, trackCrumbTrail: false }]}
+                ]);
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/123');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 123);
+            Navigation.StateController.navigateLink('/12/345/67');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 3);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 12);
+            assert.strictEqual(Navigation.StateContext.data.x[1], 345);
+            assert.strictEqual(Navigation.StateContext.data.x[2], 67);
+            Navigation.StateController.navigateLink('/ab2_0');
+            assert.strictEqual(Navigation.StateContext.data.x, 'ab');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [123] }), '/123');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [12, 345, 67] }), '/12/345/67');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/ab2_0');
+        });
+    });
+
+    describe('One Splat Param One Segment Default Type Booelan Array', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{*x}', defaultTypes: { x: 'booleanarray' }, trackCrumbTrail: false }]}
+                ]);
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/true');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x[0], true);
+            Navigation.StateController.navigateLink('/true/false/true');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 3);
+            assert.strictEqual(Navigation.StateContext.data.x[0], true);
+            assert.strictEqual(Navigation.StateContext.data.x[1], false);
+            assert.strictEqual(Navigation.StateContext.data.x[2], true);
+            Navigation.StateController.navigateLink('/ab2_0');
+            assert.strictEqual(Navigation.StateContext.data.x, 'ab');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [true] }), '/true');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [true, false, true] }), '/true/false/true');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/ab2_0');
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -4020,4 +4020,43 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd', 'efg'], y: 'hi' }), '/b/cd1-efg/hi');
         });
     })
+
+    describe('One Splat Param Two Segment Default', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{*x}/ab', defaults: { x: ['cde', 'fg'] }, trackCrumbTrail: false }]}
+                ]);
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/cd/ab');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'cd');
+            Navigation.StateController.navigateLink('/cd/efg/ab');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'efg');
+            Navigation.StateController.navigateLink('/cde/fg/ab');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'cde');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'fg');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/ab'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/cd'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/cde/fg/ab');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd'] }), '/cd/ab');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd', 'efg'] }), '/cd/efg/ab');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cde', 'fg'] }), '/cde/fg/ab');
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3676,4 +3676,53 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', null, 'cd'] }), '/ab//cd');
         });
     });
+
+    describe('One Splat Param Two Segment Default Type', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'ab/{*x}', defaultTypes: { x: 'stringarray' }, trackCrumbTrail: false }]}
+                ]);
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('ab/cd');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'cd');
+            Navigation.StateController.navigateLink('/ab/cd/efg');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'efg');
+            Navigation.StateController.navigateLink('/ab/cd/efg?y=hi');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'efg');
+            assert.strictEqual(Navigation.StateContext.data.y, 'hi');
+            Navigation.StateController.navigateLink('/ab/cd//efg');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 3);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.x[1], null);
+            assert.strictEqual(Navigation.StateContext.data.x[2], 'efg');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/ab'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd'] }), '/ab/cd');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd', 'efg'] }), '/ab/cd/efg');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd', 'efg'], y: 'hi' }), '/ab/cd/efg?y=hi');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd', null, 'efg'] }), '/ab/cd//efg');
+        });
+
+        it('should not build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3585,4 +3585,45 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
         });
     });
+
+    describe('One Splat Param One Segment Default Type', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{*x}', defaultTypes: { x: 'stringarray' }, trackCrumbTrail: false }]}
+                ]);
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/abcd');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'abcd');
+            Navigation.StateController.navigateLink('/ab/cd');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'ab');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'cd');
+            Navigation.StateController.navigateLink('/ab//cd');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 3);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'ab');
+            assert.strictEqual(Navigation.StateContext.data.x[1], null);
+            assert.strictEqual(Navigation.StateContext.data.x[2], 'cd');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['abcd'] }), '/abcd');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', 'cd'] }), '/ab/cd');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', null, 'cd'] }), '/ab//cd');
+        });
+
+        it('should not build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -4473,4 +4473,34 @@ describe('MatchTest', function () {
             assert.throws(() => Navigation.StateController.navigateLink('/cd/ef/gh'), /Url is invalid/, '');
         });
     });
+
+    describe('One Splat Param One Segment', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{*x}', trackCrumbTrail: false }]}
+                ]);
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/abcd');
+            assert.strictEqual(Navigation.StateContext.data.x, 'abcd');
+            Navigation.StateController.navigateLink('/1232_2');
+            assert.strictEqual(Navigation.StateContext.data.x, 123);
+        });
+
+        it('should not match', function() {
+            assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/ab/cd'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'abcd' }), '/abcd');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 123 }), '/1232_2');
+        });
+
+        it('should not build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -4141,6 +4141,45 @@ describe('MatchTest', function () {
         });
     });
 
+    describe('One Splat Param One Mixed Segment Default', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'ab{*x}', defaults: { x: ['cde', 'fg'] }, trackCrumbTrail: false }]}
+                ]);
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/abcde/fg');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'cde');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'fg');
+            Navigation.StateController.navigateLink('/abcd');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'cd');
+            Navigation.StateController.navigateLink('/abcd/efg');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'efg');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/ab'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/acd'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/abcde/fg');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cde', 'fg'] }), '/abcde/fg');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd'] }), '/abcd');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd', 'efg'] }), '/abcd/efg');
+        });
+    });
+
     describe('Without Types Splat Conflicting Default And Default Type', function () {
         beforeEach(function () {
             Navigation.StateInfoConfig.build([

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1456,29 +1456,29 @@ describe('MatchTest', function () {
         it('should match', function() {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's', states: [
-                    { key: 's', route: 'a/{*="()\'-_+~@:?><.;[],!£$%^#&}', defaults: { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' }, trackCrumbTrail: false }]}
+                    { key: 's', route: 'a/{=*"()\'-_+~@:?><.;[],!£$%^#&}', defaults: { '=*"()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' }, trackCrumbTrail: false }]}
                 ]);
             Navigation.StateController.navigateLink('/a/*%3D%22()\'-0__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
             assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
-            assert.strictEqual(Navigation.StateContext.data['*="()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
+            assert.strictEqual(Navigation.StateContext.data['=*"()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
             Navigation.StateController.navigateLink('/a/*%3D%22()\'-0__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
             assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
-            assert.strictEqual(Navigation.StateContext.data['*="()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
+            assert.strictEqual(Navigation.StateContext.data['=*"()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
             assert.strictEqual(Navigation.StateContext.data['*="()\'-__+~@:?><.;[],!£$%^#&'], '*="()\'-_+~@:?><.;[],!£$%^#&');
             Navigation.StateController.navigateLink('/a');
             assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
-            assert.strictEqual(Navigation.StateContext.data['*="()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
+            assert.strictEqual(Navigation.StateContext.data['=*"()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
             Navigation.StateController.navigateLink('/a?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
             assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
-            assert.strictEqual(Navigation.StateContext.data['*="()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
+            assert.strictEqual(Navigation.StateContext.data['=*"()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
             assert.strictEqual(Navigation.StateContext.data['*="()\'-__+~@:?><.;[],!£$%^#&'], '*="()\'-_+~@:?><.;[],!£$%^#&');
         });
 
         it('should build', function() {
-            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&' }), '/a/*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
-            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&', '*="()\'-__+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&'}), '/a/*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
-            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' }), '/a');
-            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { '*="()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&', '*="()\'-__+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&'}), '/a?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { '=*"()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&' }), '/a/*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { '=*"()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&', '*="()\'-__+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&'}), '/a/*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { '=*"()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' }), '/a');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { '=*"()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&', '*="()\'-__+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&'}), '/a?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/a');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { '*="()\'-__+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&' }), '/a?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
         });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -4048,6 +4048,9 @@ describe('MatchTest', function () {
             assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
             assert.strictEqual(Navigation.StateContext.data.x.length, 1);
             assert.strictEqual(Navigation.StateContext.data.x[0], 'cde1-fg');
+            Navigation.StateController.navigateLink('/true2_1/ab');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x, true);
         });
 
         it('should not match', function() {
@@ -4062,6 +4065,7 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd', 'efg'] }), '/cd/efg/ab');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cde', 'fg'] }), '/cde/fg/ab');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cde1-fg'] }), '/cde1-fg/ab');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: true }), '/true2_1/ab');
         });
     });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3750,6 +3750,7 @@ describe('MatchTest', function () {
 
         it('should build', function() {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [''] }), '/');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['abcd'] }), '/abcd');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', 'cd'] }), '/ab/cd');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', 'cd'], y: 'efg' }), '/ab/cd?y=efg');

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3681,26 +3681,6 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ghi', 'ef'] }), '/ghi/ef');
         });
     });
-
-    describe('One Splat Param One Segment Single Match Array Default', function () {
-        beforeEach(function () {
-            Navigation.StateInfoConfig.build([
-                { key: 'd', initial: 's', states: [
-                    { key: 's', route: '{*x}', defaults: { x: ['a', 'b'] }, trackCrumbTrail: false }]}
-                ]);
-        });
-
-        it('should match', function() {
-            Navigation.StateController.navigateLink('/ab');
-            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
-            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
-            assert.strictEqual(Navigation.StateContext.data.x[0], 'ab');
-        });
-
-        it('should build', function() {
-            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab'] }), '/ab');
-        });
-    });
     
     describe('One Optional Splat Param One Segment Default Type', function () {
         beforeEach(function () {
@@ -4151,6 +4131,26 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['a', 'bc'] }), '/');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3 }), '/3');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '3' }), '/3');
+        });
+    });
+
+    describe('One Splat Param One Segment Single Match Array Default', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{*x}', defaults: { x: ['a', 'b'] }, trackCrumbTrail: false }]}
+                ]);
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/ab');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'ab');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab'] }), '/ab');
         });
     });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3604,6 +3604,12 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateContext.data.x.length, 2);
             assert.strictEqual(Navigation.StateContext.data.x[0], 'ab');
             assert.strictEqual(Navigation.StateContext.data.x[1], 'cd');
+            Navigation.StateController.navigateLink('/ab/cd?y=efg');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'ab');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.y, 'efg');
             Navigation.StateController.navigateLink('/ab//cd');
             assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
             assert.strictEqual(Navigation.StateContext.data.x.length, 3);
@@ -3619,6 +3625,7 @@ describe('MatchTest', function () {
         it('should build', function() {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['abcd'] }), '/abcd');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', 'cd'] }), '/ab/cd');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', 'cd'], y: 'efg' }), '/ab/cd?y=efg');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', null, 'cd'] }), '/ab//cd');
         });
 
@@ -3647,6 +3654,12 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateContext.data.x.length, 2);
             assert.strictEqual(Navigation.StateContext.data.x[0], 'ab');
             assert.strictEqual(Navigation.StateContext.data.x[1], 'cd');
+            Navigation.StateController.navigateLink('/ab/cd?y=efg');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'ab');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.y, 'efg');
             Navigation.StateController.navigateLink('/ab//cd');
             assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
             assert.strictEqual(Navigation.StateContext.data.x.length, 3);
@@ -3659,6 +3672,7 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['abcd'] }), '/abcd');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', 'cd'] }), '/ab/cd');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', 'cd'], y: 'efg' }), '/ab/cd?y=efg');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', null, 'cd'] }), '/ab//cd');
         });
     });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3992,6 +3992,27 @@ describe('MatchTest', function () {
                 ]);
         });
         
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/a/cd/efg');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'efg');
+            Navigation.StateController.navigateLink('/a/cd2_0');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x, 'cd');
+            Navigation.StateController.navigateLink('/b/cd2_0/efg');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x, 'cd');
+            assert.strictEqual(Navigation.StateContext.data.y, 'efg');
+            Navigation.StateController.navigateLink('/b/cd1-efg/hi');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'efg');
+            assert.strictEqual(Navigation.StateContext.data.y, 'hi');
+        });
+
         it('should build', function() {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd', 'efg'] }), '/a/cd/efg');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cd' }), '/a/cd2_0');

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -4068,4 +4068,34 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: true }), '/true2_1/ab');
         });
     });
+    
+    describe('Without Types Splat Conflicing Default And Default Type', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{*x}', trackTypes: false, defaults: { x: ['a', 'bc'] }, defaultTypes: { x: 'number' }, trackCrumbTrail: false }]}
+                ]);
+        });
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'a');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'bc');
+            Navigation.StateController.navigateLink('/a/bc');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'a');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'bc');
+        });
+        
+        it('should not match', function() {
+            assert.throws(() => Navigation.StateController.navigateLink('/b/cd'), /not a valid number/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['a', 'bc'] }), '/');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3 }), '/3');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '3' }), '/3');
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3648,6 +3648,40 @@ describe('MatchTest', function () {
         });
     });
 
+
+    describe('One Splat Param One Segment Default', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{*x}', defaults: { x: ['ef', 'ghi'] }, trackCrumbTrail: false }]}
+                ]);
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'ef');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'ghi');
+            Navigation.StateController.navigateLink('/abcd');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'abcd');
+            Navigation.StateController.navigateLink('/ab/cd');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'ab');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'cd');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['abcd'] }), '/abcd');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', 'cd'] }), '/ab/cd');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ef', 'ghi'] }), '/');
+        });
+    });
+    
     describe('One Optional Splat Param One Segment Default Type', function () {
         beforeEach(function () {
             Navigation.StateInfoConfig.build([

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3803,6 +3803,43 @@ describe('MatchTest', function () {
         });
     });
 
+    describe('One Splat Param Two Segment Default', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'ab/{*x}', defaults: { x: ['ef', 'ghi'] }, trackCrumbTrail: false }]}
+                ]);
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/ab');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'ef');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'ghi');
+            Navigation.StateController.navigateLink('/ab/cd');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'cd');
+            Navigation.StateController.navigateLink('/ab/cd/efg');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'efg');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/ab');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd'] }), '/ab/cd');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd', 'efg'] }), '/ab/cd/efg');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ef', 'ghi'] }), '/ab');
+        });
+    });
+
     describe('Two Param One Splat Two Segment Default Type', function () {
         beforeEach(function () {
             Navigation.StateInfoConfig.build([

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -4262,4 +4262,45 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab'] }), '/ab');
         });
     });
+    
+    describe('Combine Array One Splat Param One Segment Default Type', function () {
+        beforeEach(function () {
+            Navigation.settings.combineArray = true;
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{*x}', defaultTypes: { x: 'stringarray' }, trackCrumbTrail: false }]}
+                ]);
+        });
+        afterEach(function() {
+            Navigation.settings.combineArray = false;
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/abcd');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'abcd');
+            Navigation.StateController.navigateLink('/ab1-cd');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'ab');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'cd');
+            Navigation.StateController.navigateLink('/a12-b1-c22-d');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'a1-b');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'c2-d');
+            Navigation.StateController.navigateLink('/a12-b');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'a1-b');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['abcd'] }), '/abcd');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', 'cd'] }), '/ab1-cd');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['a1-b', 'c2-d'] }), '/a12-b1-c22-d');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['a1-b'] }), '/a12-b');
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3616,6 +3616,18 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateContext.data.x[0], 'ab');
             assert.strictEqual(Navigation.StateContext.data.x[1], null);
             assert.strictEqual(Navigation.StateContext.data.x[2], 'cd');
+            Navigation.StateController.navigateLink('//ab/cd');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 3);
+            assert.strictEqual(Navigation.StateContext.data.x[0], null);
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'ab');
+            assert.strictEqual(Navigation.StateContext.data.x[2], 'cd');
+            Navigation.StateController.navigateLink('/ab/cd//');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 3);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'ab');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.x[2], null);
         });
 
         it('should not match', function() {
@@ -3627,6 +3639,8 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', 'cd'] }), '/ab/cd');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', 'cd'], y: 'efg' }), '/ab/cd?y=efg');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', null, 'cd'] }), '/ab//cd');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [null, 'ab', 'cd'] }), '//ab/cd');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', 'cd', null] }), '/ab/cd//');
         });
 
         it('should not build', function() {
@@ -3666,6 +3680,18 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateContext.data.x[0], 'ab');
             assert.strictEqual(Navigation.StateContext.data.x[1], null);
             assert.strictEqual(Navigation.StateContext.data.x[2], 'cd');
+            Navigation.StateController.navigateLink('//ab/cd');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 3);
+            assert.strictEqual(Navigation.StateContext.data.x[0], null);
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'ab');
+            assert.strictEqual(Navigation.StateContext.data.x[2], 'cd');
+            Navigation.StateController.navigateLink('/ab/cd//');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 3);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'ab');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.x[2], null);
         });
 
         it('should build', function() {
@@ -3674,6 +3700,8 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', 'cd'] }), '/ab/cd');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', 'cd'], y: 'efg' }), '/ab/cd?y=efg');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', null, 'cd'] }), '/ab//cd');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [null, 'ab', 'cd'] }), '//ab/cd');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', 'cd', null] }), '/ab/cd//');
         });
     });
 
@@ -3707,6 +3735,18 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateContext.data.x[0], 'cd');
             assert.strictEqual(Navigation.StateContext.data.x[1], null);
             assert.strictEqual(Navigation.StateContext.data.x[2], 'efg');
+            Navigation.StateController.navigateLink('/ab//cd/efg');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 3);
+            assert.strictEqual(Navigation.StateContext.data.x[0], null);
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.x[2], 'efg');
+            Navigation.StateController.navigateLink('/ab/cd/efg//');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 3);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'efg');
+            assert.strictEqual(Navigation.StateContext.data.x[2], null);
         });
 
         it('should not match', function() {
@@ -3719,6 +3759,8 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd', 'efg'] }), '/ab/cd/efg');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd', 'efg'], y: 'hi' }), '/ab/cd/efg?y=hi');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd', null, 'efg'] }), '/ab/cd//efg');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [null, 'cd', 'efg'] }), '/ab//cd/efg');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd', 'efg', null] }), '/ab/cd/efg//');
         });
 
         it('should not build', function() {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3777,7 +3777,7 @@ describe('MatchTest', function () {
         });
 
         it('should match', function() {
-            Navigation.StateController.navigateLink('ab/cd');
+            Navigation.StateController.navigateLink('/ab/cd');
             assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
             assert.strictEqual(Navigation.StateContext.data.x, 'ab');
             assert.strictEqual(Navigation.StateContext.data.y.length, 1);
@@ -3835,6 +3835,80 @@ describe('MatchTest', function () {
         it('should not build', function() {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), null);
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: ['cd'] }), null);
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: ['cd', 'efg'] }), null);
+        });
+    });
+
+    describe('Two Param One Optional Splat Two Segment Default Type', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{x}/{*y?}', defaultTypes: { y: 'stringarray' }, trackCrumbTrail: false }]}
+                ]);
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/ab');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x, 'ab');
+            Navigation.StateController.navigateLink('/ab/cd');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x, 'ab');
+            assert.strictEqual(Navigation.StateContext.data.y.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.y[0], 'cd');
+            Navigation.StateController.navigateLink('/ab/cd/efg');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x, 'ab');
+            assert.strictEqual(Navigation.StateContext.data.y.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.y[0], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.y[1], 'efg');
+            Navigation.StateController.navigateLink('/ab/cd/efg?z=hi');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+            assert.strictEqual(Navigation.StateContext.data.x, 'ab');
+            assert.strictEqual(Navigation.StateContext.data.y.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.y[0], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.y[1], 'efg');
+            assert.strictEqual(Navigation.StateContext.data.z, 'hi');
+            Navigation.StateController.navigateLink('/ab/cd//efg');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x, 'ab');
+            assert.strictEqual(Navigation.StateContext.data.y.length, 3);
+            assert.strictEqual(Navigation.StateContext.data.y[0], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.y[1], null);
+            assert.strictEqual(Navigation.StateContext.data.y[2], 'efg');
+            Navigation.StateController.navigateLink('/ab//cd/efg');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x, 'ab');
+            assert.strictEqual(Navigation.StateContext.data.y.length, 3);
+            assert.strictEqual(Navigation.StateContext.data.y[0], null);
+            assert.strictEqual(Navigation.StateContext.data.y[1], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.y[2], 'efg');
+            Navigation.StateController.navigateLink('/ab/cd/efg//');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x, 'ab');
+            assert.strictEqual(Navigation.StateContext.data.y.length, 3);
+            assert.strictEqual(Navigation.StateContext.data.y[0], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.y[1], 'efg');
+            assert.strictEqual(Navigation.StateContext.data.y[2], null);
+        });
+
+        it('should not match', function() {
+            assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/ab');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab', y: ['cd'] }), '/ab/cd');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab', y: ['cd', 'efg'] }), '/ab/cd/efg');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab', y: ['cd', 'efg'], z: 'hi' }), '/ab/cd/efg?z=hi');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab', y: ['cd', null, 'efg'] }), '/ab/cd//efg');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab', y: [null, 'cd', 'efg'] }), '/ab//cd/efg');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab', y: ['cd', 'efg', null] }), '/ab/cd/efg//');
+        });
+
+        it('should not build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: ['cd'] }), null);
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: ['cd', 'efg'] }), null);
         });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -4303,4 +4303,27 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['a1-b'] }), '/a12-b');
         });
     });
+
+    describe('Splat Param Array Encode', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{*x}', defaultTypes: { x: 'stringarray' }, trackCrumbTrail: false }]}
+                ]);
+            var state = Navigation.StateInfoConfig.dialogs['d'].states['s'];
+            state.stateHandler.urlEncode = (state, key, val) => val.replace(' ', '+')
+            state.stateHandler.urlDecode = (state, key, val) => val.replace('+', ' ')
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/a+b/c+de');
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'a b');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'c de');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['a b', 'c de'] }), '/a+b/c+de');
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -4382,4 +4382,58 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/ab2_0');
         });
     });
+
+    describe('One Splat Param One Segment Default Type Date Array', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{*x}', defaultTypes: { x: 'datearray' }, trackCrumbTrail: false }]}
+                ]);
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/2010-04-07');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            assert.strictEqual(+Navigation.StateContext.data.x[0], +new Date(2010, 3, 7));
+            Navigation.StateController.navigateLink('/2010-04-07/2011-08-03');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(+Navigation.StateContext.data.x[0], +new Date(2010, 3, 7));
+            assert.strictEqual(+Navigation.StateContext.data.x[1], +new Date(2011, 7, 3));
+            Navigation.StateController.navigateLink('/ab2_0');
+            assert.strictEqual(Navigation.StateContext.data.x, 'ab');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [new Date(2010, 3, 7)] }), '/2010-04-07');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [new Date(2010, 3, 7), new Date(2011, 7, 3)] }), '/2010-04-07/2011-08-03');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/ab2_0');
+        });
+    });
+
+    describe('One Splat Param One Segment Default Date Array', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{*x}', defaults: { x: [new Date(2010, 3, 7), new Date(2011, 7, 3)] }, trackCrumbTrail: false }]}
+                ]);
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/2010-04-07');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            assert.strictEqual(+Navigation.StateContext.data.x[0], +new Date(2010, 3, 7));
+            Navigation.StateController.navigateLink('/');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(+Navigation.StateContext.data.x[0], +new Date(2010, 3, 7));
+            assert.strictEqual(+Navigation.StateContext.data.x[1], +new Date(2011, 7, 3));
+            Navigation.StateController.navigateLink('/ab2_0');
+            assert.strictEqual(Navigation.StateContext.data.x, 'ab');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [new Date(2010, 3, 7)] }), '/2010-04-07');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [new Date(2010, 3, 7), new Date(2011, 7, 3)] }), '/');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/ab2_0');
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -4414,15 +4414,19 @@ describe('MatchTest', function () {
         beforeEach(function () {
             Navigation.StateInfoConfig.build([
                 { key: 'd', initial: 's', states: [
-                    { key: 's', route: '{*x}', defaults: { x: [new Date(2010, 3, 7), new Date(2011, 7, 3)] }, trackCrumbTrail: false }]}
+                    { key: 's', route: '{*x}', defaults: { x: [new Date(2011, 7, 3), new Date(2010, 3, 7)] }, trackCrumbTrail: false }]}
                 ]);
         });
 
         it('should match', function() {
+            Navigation.StateController.navigateLink('/');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(+Navigation.StateContext.data.x[0], +new Date(2011, 7, 3));
+            assert.strictEqual(+Navigation.StateContext.data.x[1], +new Date(2010, 3, 7));
             Navigation.StateController.navigateLink('/2010-04-07');
             assert.strictEqual(Navigation.StateContext.data.x.length, 1);
             assert.strictEqual(+Navigation.StateContext.data.x[0], +new Date(2010, 3, 7));
-            Navigation.StateController.navigateLink('/');
+            Navigation.StateController.navigateLink('/2010-04-07/2011-08-03');
             assert.strictEqual(Navigation.StateContext.data.x.length, 2);
             assert.strictEqual(+Navigation.StateContext.data.x[0], +new Date(2010, 3, 7));
             assert.strictEqual(+Navigation.StateContext.data.x[1], +new Date(2011, 7, 3));
@@ -4431,8 +4435,9 @@ describe('MatchTest', function () {
         });
 
         it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [new Date(2011, 7, 3), new Date(2010, 3, 7)] }), '/');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [new Date(2010, 3, 7)] }), '/2010-04-07');
-            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [new Date(2010, 3, 7), new Date(2011, 7, 3)] }), '/');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [new Date(2010, 3, 7), new Date(2011, 7, 3)] }), '/2010-04-07/2011-08-03');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/ab2_0');
         });
     });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3648,7 +3648,6 @@ describe('MatchTest', function () {
         });
     });
 
-
     describe('One Splat Param One Segment Default', function () {
         beforeEach(function () {
             Navigation.StateInfoConfig.build([

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -4503,4 +4503,47 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
         });
     });
+
+    describe('One Splat Param One Query String Default Type', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{*x}', defaultTypes: { x: 'stringarray', y: 'stringarray' }, trackCrumbTrail: false }]}
+                ]);
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/ab/cde?y=fgh&y=ij');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'ab');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'cde');
+            assert.strictEqual(Navigation.StateContext.data.y.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.y[0], 'fgh');
+            assert.strictEqual(Navigation.StateContext.data.y[1], 'ij');
+            Navigation.StateController.navigateLink('/ab?y=fgh&y=ij');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'ab');
+            assert.strictEqual(Navigation.StateContext.data.y.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.y[0], 'fgh');
+            assert.strictEqual(Navigation.StateContext.data.y[1], 'ij');
+            Navigation.StateController.navigateLink('/ab/cde?y=fgh');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'ab');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'cde');
+            assert.strictEqual(Navigation.StateContext.data.y.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.y[0], 'fgh');
+            Navigation.StateController.navigateLink('/ab?y=fgh');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'ab');
+            assert.strictEqual(Navigation.StateContext.data.y.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.y[0], 'fgh');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', 'cde'], y: ['fgh', 'ij'] }), '/ab/cde?y=fgh&y=ij');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab'], y: ['fgh', 'ij'] }), '/ab?y=fgh&y=ij');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', 'cde'], y: ['fgh'] }), '/ab/cde?y=fgh');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab'], y: ['fgh'] }), '/ab?y=fgh');
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3714,7 +3714,7 @@ describe('MatchTest', function () {
         });
 
         it('should match', function() {
-            Navigation.StateController.navigateLink('ab/cd');
+            Navigation.StateController.navigateLink('/ab/cd');
             assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
             assert.strictEqual(Navigation.StateContext.data.x.length, 1);
             assert.strictEqual(Navigation.StateContext.data.x[0], 'cd');
@@ -3923,7 +3923,7 @@ describe('MatchTest', function () {
         });
 
         it('should match', function() {
-            Navigation.StateController.navigateLink('cd/ab/efg');
+            Navigation.StateController.navigateLink('/cd/ab/efg');
             assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
             assert.strictEqual(Navigation.StateContext.data.x.length, 1);
             assert.strictEqual(Navigation.StateContext.data.x[0], 'cd');
@@ -3983,4 +3983,20 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: ['cd'] }), null);
         });
     });
+    
+    describe('Two Route Param Splat and Not Splat', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: ['a/{*x}', 'b/{x}/{y}'], defaultTypes: { x: 'stringarray' }, trackCrumbTrail: false }]}
+                ]);
+        });
+        
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd', 'efg'] }), '/a/cd/efg');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cd' }), '/a/cd2_0');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'cd', y: 'efg' }), '/b/cd2_0/efg');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd', 'efg'], y: 'hi' }), '/b/cd1-efg/hi');
+        });
+    })
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3913,4 +3913,74 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: ['cd', 'efg'] }), null);
         });
     });
+
+    describe('Two Splat Param Three Segment Default Type', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{*x}/ab/{*y}', defaultTypes: { x: 'stringarray', y: 'stringarray' }, trackCrumbTrail: false }]}
+                ]);
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('cd/ab/efg');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.y.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.y[0], 'efg');
+            Navigation.StateController.navigateLink('/cd/efg/ab/hi');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'efg');
+            assert.strictEqual(Navigation.StateContext.data.y.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.y[0], 'hi');
+            Navigation.StateController.navigateLink('/cd/ab/efg/hi');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.y.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.y[0], 'efg');
+            assert.strictEqual(Navigation.StateContext.data.y[1], 'hi');
+            Navigation.StateController.navigateLink('/cd/efg/ab/hij/kl');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'efg');
+            assert.strictEqual(Navigation.StateContext.data.y.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.y[0], 'hij');
+            assert.strictEqual(Navigation.StateContext.data.y[1], 'kl');
+            Navigation.StateController.navigateLink('//cd/ab/efg//');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], null);
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.y.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.y[0], 'efg');
+            assert.strictEqual(Navigation.StateContext.data.y[1], null);
+        });
+
+        it('should not match', function() {
+            assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/ab'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/cd/ab'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/ab/cd'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/cd/efg/'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd'], y: ['efg'] }), '/cd/ab/efg');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd', 'efg'], y: ['hi'] }), '/cd/efg/ab/hi');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd'], y: ['efg', 'hi'] }), '/cd/ab/efg/hi');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd', 'efg'], y: ['hij', 'kl'] }), '/cd/efg/ab/hij/kl');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: [null, 'cd'], y: ['efg', null] }), '//cd/ab/efg//');
+        });
+
+        it('should not build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd'] }), null);
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: ['cd'] }), null);
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3767,4 +3767,76 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
         });
     });
+
+    describe('Two Param One Splat Two Segment Default Type', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{x}/{*y}', defaultTypes: { y: 'stringarray' }, trackCrumbTrail: false }]}
+                ]);
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('ab/cd');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x, 'ab');
+            assert.strictEqual(Navigation.StateContext.data.y.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.y[0], 'cd');
+            Navigation.StateController.navigateLink('/ab/cd/efg');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x, 'ab');
+            assert.strictEqual(Navigation.StateContext.data.y.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.y[0], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.y[1], 'efg');
+            Navigation.StateController.navigateLink('/ab/cd/efg?z=hi');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 3);
+            assert.strictEqual(Navigation.StateContext.data.x, 'ab');
+            assert.strictEqual(Navigation.StateContext.data.y.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.y[0], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.y[1], 'efg');
+            assert.strictEqual(Navigation.StateContext.data.z, 'hi');
+            Navigation.StateController.navigateLink('/ab/cd//efg');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x, 'ab');
+            assert.strictEqual(Navigation.StateContext.data.y.length, 3);
+            assert.strictEqual(Navigation.StateContext.data.y[0], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.y[1], null);
+            assert.strictEqual(Navigation.StateContext.data.y[2], 'efg');
+            Navigation.StateController.navigateLink('/ab//cd/efg');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x, 'ab');
+            assert.strictEqual(Navigation.StateContext.data.y.length, 3);
+            assert.strictEqual(Navigation.StateContext.data.y[0], null);
+            assert.strictEqual(Navigation.StateContext.data.y[1], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.y[2], 'efg');
+            Navigation.StateController.navigateLink('/ab/cd/efg//');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x, 'ab');
+            assert.strictEqual(Navigation.StateContext.data.y.length, 3);
+            assert.strictEqual(Navigation.StateContext.data.y[0], 'cd');
+            assert.strictEqual(Navigation.StateContext.data.y[1], 'efg');
+            assert.strictEqual(Navigation.StateContext.data.y[2], null);
+        });
+
+        it('should not match', function() {
+            assert.throws(() => Navigation.StateController.navigateLink('/'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/ab'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab', y: ['cd'] }), '/ab/cd');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab', y: ['cd', 'efg'] }), '/ab/cd/efg');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab', y: ['cd', 'efg'], z: 'hi' }), '/ab/cd/efg?z=hi');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab', y: ['cd', null, 'efg'] }), '/ab/cd//efg');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab', y: [null, 'cd', 'efg'] }), '/ab//cd/efg');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab', y: ['cd', 'efg', null] }), '/ab/cd/efg//');
+        });
+
+        it('should not build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d'), null);
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), null);
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: ['cd'] }), null);
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { y: ['cd', 'efg'] }), null);
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -4044,6 +4044,10 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateContext.data.x.length, 2);
             assert.strictEqual(Navigation.StateContext.data.x[0], 'cde');
             assert.strictEqual(Navigation.StateContext.data.x[1], 'fg');
+            Navigation.StateController.navigateLink('/cde1-fg/ab');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'cde1-fg');
         });
 
         it('should not match', function() {
@@ -4057,6 +4061,7 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd'] }), '/cd/ab');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cd', 'efg'] }), '/cd/efg/ab');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cde', 'fg'] }), '/cde/fg/ab');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['cde1-fg'] }), '/cde1-fg/ab');
         });
     });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -4441,4 +4441,36 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 'ab' }), '/ab2_0');
         });
     });
+
+    describe('Multiple Routes Splat and Not Splat', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: 'ab/{*x}', defaultTypes: { x: 'stringarray' }, trackCrumbTrail: false },
+                    { key: 's1', route: 'cd/{x}', trackCrumbTrail: false }]}
+                ]);
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/ab/ef');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'ef');
+            Navigation.StateController.navigateLink('/ab/ef/gh');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 2);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'ef');
+            assert.strictEqual(Navigation.StateContext.data.x[1], 'gh');
+            Navigation.StateController.navigateLink('/cd/ef');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x, 'ef');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => Navigation.StateController.navigateLink('/aa/bbb'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/ab'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/cd'), /Url is invalid/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/cd/ef/gh'), /Url is invalid/, '');
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3681,6 +3681,26 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ghi', 'ef'] }), '/ghi/ef');
         });
     });
+
+    describe('One Splat Param One Segment Single Match Array Default', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{*x}', defaults: { x: ['a', 'b'] }, trackCrumbTrail: false }]}
+                ]);
+        });
+
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/ab');
+            assert.strictEqual(Object.keys(Navigation.StateContext.data).length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'ab');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab'] }), '/ab');
+        });
+    });
     
     describe('One Optional Splat Param One Segment Default Type', function () {
         beforeEach(function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3678,6 +3678,7 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['abcd'] }), '/abcd');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ab', 'cd'] }), '/ab/cd');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ef', 'ghi'] }), '/');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['ghi', 'ef'] }), '/ghi/ef');
         });
     });
     

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -4157,15 +4157,48 @@ describe('MatchTest', function () {
             assert.strictEqual(Navigation.StateContext.data.x.length, 2);
             assert.strictEqual(Navigation.StateContext.data.x[0], 'a');
             assert.strictEqual(Navigation.StateContext.data.x[1], 'bc');
+            Navigation.StateController.navigateLink('/3');
+            assert.strictEqual(Navigation.StateContext.data.x, 3);
         });
         
         it('should not match', function() {
-            assert.throws(() => Navigation.StateController.navigateLink('/b/cd'), /not a valid number/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/1/2'), /not a valid number/, '');
         });
 
         it('should build', function() {
             assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['a', 'bc'] }), '/');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3 }), '/3');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '3' }), '/3');
+        });
+    });
+
+    describe('Without Types Splat Conflicting Single Array Default And Default Type', function () {
+        beforeEach(function () {
+            Navigation.StateInfoConfig.build([
+                { key: 'd', initial: 's', states: [
+                    { key: 's', route: '{*x}', trackTypes: false, defaults: { x: ['a'] }, defaultTypes: { x: 'number' }, trackCrumbTrail: false }]}
+                ]);
+        });
+        it('should match', function() {
+            Navigation.StateController.navigateLink('/');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'a');
+            Navigation.StateController.navigateLink('/a');
+            assert.strictEqual(Navigation.StateContext.data.x.length, 1);
+            assert.strictEqual(Navigation.StateContext.data.x[0], 'a');
+            Navigation.StateController.navigateLink('/3');
+            assert.strictEqual(Navigation.StateContext.data.x, 3);
+        });
+        
+        it('should not match', function() {
+            assert.throws(() => Navigation.StateController.navigateLink('/b'), /not a valid number/, '');
+            assert.throws(() => Navigation.StateController.navigateLink('/1/2'), /not a valid number/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d'), '/');
+            assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: ['a'] }), '/');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: 3 }), '/3');
             assert.strictEqual(Navigation.StateController.getNavigationLink('d', { x: '3' }), '/3');
         });

--- a/NavigationJS/test/navigation-tests.ts
+++ b/NavigationJS/test/navigation-tests.ts
@@ -26,7 +26,7 @@ module NavigationTests {
 	class LogStateRouter extends Navigation.StateRouter {
 	    getData(route: string): { state: Navigation.State; data: any } {
 			console.log('get data');
-			return super.getData(route);
+			return super.getData(route, {});
 	    }
 	}
 	

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,10 @@ var typescript = require('gulp-tsc');
 var uglify = require('gulp-uglify');
 
 var tests = [
-	{ name: 'NavigationRouting', to: 'navigationRouting.test.js' }
+	{ name: 'NavigationRouting', to: 'navigationRouting.test.js' },
+	{ name: 'StateInfo', to: 'stateInfo.test.js' },
+	{ name: 'Navigation', to: 'navigation.test.js' },
+	{ name: 'NavigationData', to: 'navigationData.test.js' }
 ];
 var testTasks = [];
 function testTask(file, to) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,10 +12,7 @@ var typescript = require('gulp-tsc');
 var uglify = require('gulp-uglify');
 
 var tests = [
-	{ name: 'NavigationRouting', to: 'navigationRouting.test.js' },
-	{ name: 'StateInfo', to: 'stateInfo.test.js' },
-	{ name: 'Navigation', to: 'navigation.test.js' },
-	{ name: 'NavigationData', to: 'navigationData.test.js' }
+	{ name: 'NavigationRouting', to: 'navigationRouting.test.js' }
 ];
 var testTasks = [];
 function testTask(file, to) {


### PR DESCRIPTION
Specify a splat parameter using {\*x}. A splat parameter is a Route parameter that spans across /. So, {\*x} matches /foo and /foo/bar. Chose to put \* at the beginnning to match other routing libraries, e.g., C# and because it doesn't conflict with the ? for optionality. To specify an optional splat use {\*x?}.

Only Navigation data arrays mapped to splat parameters will span across /. Passing a string of 'foo/bar' in Navigation data produces the URL /foo%2Fbar, i.e., the / has been escaped. Instead, passing an array of ['foo', 'bar'] produces the URL /foo/bar (assumes the default type of x is 'stringarray', otherwise the foo will be encoded with the type).