### PR TITLE
Changed History Action to use Hook

### DIFF
--- a/NavigationCycle/src/LinkUtility.ts
+++ b/NavigationCycle/src/LinkUtility.ts
@@ -3,6 +3,18 @@
 /// <reference path="rx.d.ts" />
 import Navigation = require('navigation');
 
+class HistoryActionHook {
+    private historyAction;
+    
+    constructor(historyAction) {
+        this.historyAction = historyAction;    
+    }
+    
+    hook(node) {
+        node['historyAction'] = this.historyAction;
+    }
+}
+
 class LinkUtility {
     static getData(toData, includeCurrentData, currentDataKeys) {
         if (currentDataKeys)
@@ -34,13 +46,8 @@ class LinkUtility {
     }
     
     static setHistory(properties: any, historyAction) {
-        if (typeof historyAction === 'string')
-            properties.historyAction = Navigation.HistoryAction[historyAction];
-        if (properties.historyAction && typeof properties.historyAction == 'number') {
-            if (!properties.attributes)
-                properties.attributes = {};
-            properties.attributes['data-history-action'] = properties.historyAction.toString();
-        }
+        if (historyAction)
+            properties.historyAction = new HistoryActionHook(historyAction);
     }
 }
 export = LinkUtility;

--- a/NavigationCycle/src/NavigationDriver.ts
+++ b/NavigationCycle/src/NavigationDriver.ts
@@ -32,7 +32,10 @@ var NavigationDriver = function(url) {
                 if (!e.ctrlKey && !e.shiftKey && !e.metaKey && !e.altKey && !e.button) {
                     e.preventDefault();
                     var link = Navigation.settings.historyManager.getUrl(e.target);
-                    Navigation.StateController.navigateLink(link, false, +e.target.getAttribute('data-history-action'));
+                    var historyAction = e.target.historyAction;
+                    if (typeof historyAction === 'string')
+                        historyAction = Navigation.HistoryAction[historyAction];
+                    Navigation.StateController.navigateLink(link, false, historyAction);
                 }
             } else {
                 navigate(e);


### PR DESCRIPTION
No need to use data-* attributes to track values across render. Use the virtual dom has Hooks are instead. Means no pollution of the html with data- attributes. The CycleDOM doesn't export SoftSetHook so wrote a dedicated HistoryActionHook.
