### PR TITLE
Removed History Action enum

### DIFF
--- a/NavigationAngular/src/LinkUtility.ts
+++ b/NavigationAngular/src/LinkUtility.ts
@@ -55,10 +55,7 @@ class LinkUtility {
                     var navigating = this.getNavigating($parse, attrs, scope);
                     if (navigating(e, link)) {
                         e.preventDefault();
-                        var historyAction = scope.$eval(attrs['historyAction']);
-                        if (typeof historyAction === 'string')
-                            historyAction = Navigation.HistoryAction[historyAction];
-                        stateController.navigateLink(link, historyAction);
+                        stateController.navigateLink(link, scope.$eval(attrs['historyAction']));
                     }
                 }
             }

--- a/NavigationCycle/src/LinkUtility.ts
+++ b/NavigationCycle/src/LinkUtility.ts
@@ -49,13 +49,6 @@ class LinkUtility {
         if (historyAction)
             properties.historyAction = new HistoryActionHook(historyAction);
     }
-    
-    static getHistoryAction(properties: any) {
-        var historyAction = properties.historyAction;
-        if (typeof historyAction === 'string')
-            historyAction = Navigation.HistoryAction[historyAction];
-        return historyAction;
-    }
 }
 export = LinkUtility;
 

--- a/NavigationCycle/src/NavigationDriver.ts
+++ b/NavigationCycle/src/NavigationDriver.ts
@@ -6,16 +6,15 @@ import RefreshLink = require('./RefreshLink');
 import Rx = require('rx');
 
 function navigate(e, stateController: Navigation.StateController) {
-    var historyAction = LinkUtility.getHistoryAction(e);
     var toData = LinkUtility.getData(stateController, e.toData, e.includeCurrentData, e.currentDataKeys);
     if (e.action)
-        stateController.navigate(e.state, toData, historyAction);
+        stateController.navigate(e.state, toData, e.historyAction);
     if (!e.action && e.toData)
-        stateController.refresh(toData, historyAction);
+        stateController.refresh(toData, e.historyAction);
     if (e.distance)
-        stateController.navigateBack(e.distance, historyAction);
+        stateController.navigateBack(e.distance, e.historyAction);
     if (e.url)
-        stateController.navigateLink(e.url, historyAction);
+        stateController.navigateLink(e.url, e.historyAction);
 }
 
 var NavigationDriver = function(url) {
@@ -40,7 +39,7 @@ var NavigationDriver = function(url) {
                 if (!e.ctrlKey && !e.shiftKey && !e.metaKey && !e.altKey && !e.button) {
                     e.preventDefault();
                     var link = stateController.historyManager.getUrl(e.target);
-                    stateController.navigateLink(link, LinkUtility.getHistoryAction(e.target));
+                    stateController.navigateLink(link, e.target.historyAction);
                 }
             } else {
                 navigate(e, stateController);

--- a/NavigationJS/src/Navigation.ts
+++ b/NavigationJS/src/Navigation.ts
@@ -1,7 +1,6 @@
 ﻿import StateContext = require('./StateContext');
 import StateController = require('./StateController');
 import State = require('./config/State');
-import HistoryAction = require('./history/HistoryAction');
 import HashHistoryManager = require('./history/HashHistoryManager');
 import HTML5HistoryManager = require('./history/HTML5HistoryManager');
 import Crumb = require('./config/Crumb');
@@ -9,7 +8,6 @@ import StateHandler = require('./config/StateHandler');
 
 class Navigation {
     static State = State;
-    static HistoryAction = HistoryAction;
     static HashHistoryManager = HashHistoryManager;
     static HTML5HistoryManager = HTML5HistoryManager;
     static Crumb = Crumb;

--- a/NavigationJS/src/StateController.ts
+++ b/NavigationJS/src/StateController.ts
@@ -1,7 +1,6 @@
 ﻿import ConverterFactory = require('./converter/ConverterFactory');
 import Crumb = require('./config/Crumb');
 import HashHistoryManager = require('./history/HashHistoryManager');
-import HistoryAction = require('./history/HistoryAction');
 import IHistoryManager = require('./history/IHistoryManager');
 import NavigationDataManager = require('./NavigationDataManager');
 import State = require('./config/State');
@@ -100,7 +99,7 @@ class StateController {
         delete handler[this.NAVIGATE_HANDLER_ID];
     }
 
-    navigate(state: string, toData?: any, historyAction?: HistoryAction) {
+    navigate(state: string, toData?: any, historyAction?: string) {
         var url = this.getNavigationLink(state, toData);
         if (url == null)
             throw new Error('Invalid route data, a mandatory route parameter has not been supplied a value');
@@ -131,7 +130,7 @@ class StateController {
         return distance <= this.stateContext.crumbs.length && distance > 0;
     }
 
-    navigateBack(distance: number, historyAction?: HistoryAction) {
+    navigateBack(distance: number, historyAction?: string) {
         var url = this.getNavigationBackLink(distance);
         if (url == null)
             throw new Error('Invalid route data, a mandatory route parameter has not been supplied a value');
@@ -144,7 +143,7 @@ class StateController {
         return this.stateContext.crumbs[this.stateContext.crumbs.length - distance].navigationLink;
     }
 
-    refresh(toData?: any, historyAction?: HistoryAction) {
+    refresh(toData?: any, historyAction?: string) {
         var url = this.getRefreshLink(toData);
         if (url == null)
             throw new Error('Invalid route data, a mandatory route parameter has not been supplied a value');
@@ -155,7 +154,7 @@ class StateController {
         return this.getLink(this.stateContext.state, toData);
     }
 
-    navigateLink(url: string, historyAction = HistoryAction.Add, history = false) {
+    navigateLink(url: string, historyAction = 'add', history = false) {
         var oldUrl = this.stateContext.url;
         var { state, data } = this.parseLink(url);
         var navigateContinuation =  this.getNavigateContinuation(oldUrl, state, data, url, historyAction);
@@ -169,7 +168,7 @@ class StateController {
             state.navigating(data, url, navigateContinuation, history);
     }
     
-    private getNavigateContinuation(oldUrl: string, state: State, data: any, url: string, historyAction: HistoryAction): () => void {
+    private getNavigateContinuation(oldUrl: string, state: State, data: any, url: string, historyAction: string): () => void {
         return (asyncData?: any) => {
             if (oldUrl === this.stateContext.url) {
                 state.stateHandler.navigateLink(this.stateContext.state, state, url);
@@ -182,8 +181,8 @@ class StateController {
                         this.navigateHandlers[id](this.stateContext.oldState, state, this.stateContext.data);
                 }
                 if (url === this.stateContext.url) {
-                    if (historyAction !== HistoryAction.None)
-                        this.historyManager.addHistory(url, historyAction === HistoryAction.Replace);
+                    if (historyAction !== 'none')
+                        this.historyManager.addHistory(url, historyAction === 'replace');
                     if (this.stateContext.title && (typeof document !== 'undefined'))
                         document.title = this.stateContext.title;
                 }

--- a/NavigationJS/src/history/HistoryAction.ts
+++ b/NavigationJS/src/history/HistoryAction.ts
@@ -1,6 +1,0 @@
-enum HistoryAction {
-	Add,
-	Replace,
-	None
-}
-export = HistoryAction;

--- a/NavigationJS/src/navigation.d.ts
+++ b/NavigationJS/src/navigation.d.ts
@@ -126,24 +126,6 @@ declare module Navigation {
     }
 
     /**
-     * Determines the effect on browser history after a successful navigation
-     */
-    enum HistoryAction {
-        /**
-         * Creates a new browser history entry
-         */
-        Add = 0,
-        /**
-         * Changes the current browser history entry
-         */
-        Replace = 1,
-        /**
-         * Leaves browser history unchanged
-         */
-        None = 2,
-    }    
-
-    /**
      * Defines a contract a class must implement in order to manage the browser
      * Url
      */
@@ -483,7 +465,7 @@ declare module Navigation {
          * NavigationData that cannot be converted to a String
          * @throws A mandatory route parameter has not been supplied a value
          */
-        navigate(state: string, toData: any, historyAction: HistoryAction): void;
+        navigate(state: string, toData: any, historyAction: string): void;
         /**
          * Gets a Url to navigate to a State passing no NavigationData
          * @param state The key of a State
@@ -523,7 +505,7 @@ declare module Navigation {
          * @throws canNavigateBack returns false for this distance
          * @throws A mandatory route parameter has not been supplied a value
          */
-        navigateBack(distance: number, historyAction: HistoryAction): void;
+        navigateBack(distance: number, historyAction: string): void;
         /**
          * Gets a Url to navigate to a Crumb contained in the crumb trail, 
          * represented by the Crumbs collection, as specified by the distance.
@@ -552,7 +534,7 @@ declare module Navigation {
          * @throws There is NavigationData that cannot be converted to a String
          * @throws A mandatory route parameter has not been supplied a value
          */
-        refresh(toData: any, historyAction: HistoryAction): void;
+        refresh(toData: any, historyAction: string): void;
         /**
          * Gets a Url to navigate to the current State passing no 
          * NavigationData
@@ -576,14 +558,14 @@ declare module Navigation {
          * @param url The target location
          * @param A value determining the effect on browser history
          */
-        navigateLink(url: string, historyAction: HistoryAction): void;
+        navigateLink(url: string, historyAction: string): void;
         /**
          * Navigates to the url
          * @param url The target location
          * @param A value determining the effect on browser history
          * @param history A value indicating whether browser history was used
          */
-        navigateLink(url: string, historyAction: HistoryAction, history: boolean): void;
+        navigateLink(url: string, historyAction: string, history: boolean): void;
         /**
          * Parses the url out into State and Navigation Data
          * @param url The url to parse

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -1,12 +1,12 @@
 ﻿/// <reference path="assert.d.ts" />
 /// <reference path="mocha.d.ts" />
+/// <reference path="../src/navigation.d.ts" />
 import assert = require('assert');
 import Navigation = require('../src/Navigation');
-import StateController = require('../src/StateController');
 
 describe('Navigation Data', function () {
     describe('Individual Data', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r' }
@@ -45,7 +45,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Individual Data Route', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r/{string}/{boolean}/{number}/{date}' }
@@ -84,7 +84,7 @@ describe('Navigation Data', function () {
     });
     
     describe('Individual Data Without Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r', trackCrumbTrail: false }
@@ -123,7 +123,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Array Data', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r' }
@@ -178,7 +178,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Array Data Route', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r0/{array_string}/{array_boolean}/{array_number}/{array_date}/{array_blank}' }
@@ -233,7 +233,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Array Data Splat', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r0/{*array_string}/a/{*array_boolean}/b/{*array_number}/c/{*array_date}/d/{*array_blank}' }
@@ -288,7 +288,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Invalid Data', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r' }
@@ -324,7 +324,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Individual Data Refresh', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r' }
@@ -347,7 +347,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Individual Refresh Data', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r' }
@@ -369,7 +369,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Invalid Types Array Data', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r' }
@@ -405,7 +405,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Invalid Data With Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r', trackCrumbTrail: true }
@@ -428,7 +428,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Reserved Url Character Data', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -467,7 +467,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Reserved Url Character Route Data', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r/{string}/{number}' }
@@ -505,7 +505,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Separator Url Character Data', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -544,7 +544,7 @@ describe('Navigation Data', function () {
     });
     
     describe('Empty String Data', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r' }
@@ -578,7 +578,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Empty Array Data', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r' }
@@ -612,7 +612,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Navigate Data Back', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -658,7 +658,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Navigate Array Data Back', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -720,7 +720,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Navigate Array Data Route Back', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0/{array_string}/{array_boolean}/{array_number}/{array_date}/{array_blank}' },
@@ -782,7 +782,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Navigate Array Data Splat Back', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0/{*array_string}/a/{*array_boolean}/b/{*array_number}/c/{*array_date}/d/{*array_blank}' },
@@ -844,7 +844,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Navigate Empty String Data Back', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -885,7 +885,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Navigate Empty Array Data Back', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -926,7 +926,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Change Data Back', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -973,7 +973,7 @@ describe('Navigation Data', function () {
     });
     
     describe('Blank Data Back', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1020,7 +1020,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Data Refresh', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1059,7 +1059,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Refresh Data', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1105,7 +1105,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Refresh Array Data', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1167,7 +1167,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Refresh Data Override', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1208,7 +1208,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Refresh Data Blank', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1247,7 +1247,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Change Refresh Data', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1292,7 +1292,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Wizard Data', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1341,7 +1341,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Transition Transition', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1398,7 +1398,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Dynamic Data Transition Transition', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1447,7 +1447,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Defaults', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1484,7 +1484,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Defaults Route', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1521,7 +1521,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Data And Defaults', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1560,7 +1560,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Data And Defaults Route', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1599,7 +1599,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Override Defaults', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1636,7 +1636,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Override Defaults Route', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1673,7 +1673,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Back Defaults', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1716,7 +1716,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Back Defaults Route', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1759,7 +1759,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Back Data And Defaults', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1805,7 +1805,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Back Data And Defaults Route', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1851,7 +1851,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Back Override Defaults', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1895,7 +1895,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Back Override Defaults Route', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1939,7 +1939,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Crumb Defaults', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1991,7 +1991,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Crumb Defaults Route', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -2043,7 +2043,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Crumb Data And Defaults', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -2091,7 +2091,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Crumb Data And Defaults Route', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -2141,7 +2141,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Crumb Data Override Defaults', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -2187,7 +2187,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Crumb Data Override Defaults Route', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -2233,7 +2233,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Back Defaults Custom Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -2287,7 +2287,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Back Defaults Custom Trail Route', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                     { key: 's0', route: 'r0' },
@@ -2341,7 +2341,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Back Data And Defaults Custom Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -2394,7 +2394,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Back Data And Defaults Custom Trail Route', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -2447,7 +2447,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Back Override Defaults Custom Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -2501,7 +2501,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Back Override Defaults Custom Trail Route', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -2555,7 +2555,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Crumb Defaults Custom Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                     { key: 's0', route: 'r0' },
@@ -2611,7 +2611,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Crumb Defaults Custom Trail Route', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                     { key: 's0', route: 'r0' },
@@ -2667,7 +2667,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Back Custom Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r', trackCrumbTrail: true }
@@ -2711,7 +2711,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Back Custom Trail Route', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r/{s?}', trackCrumbTrail: true }
@@ -2755,7 +2755,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Crumb Data And Defaults Custom Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -2807,7 +2807,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Crumb Data And Defaults Custom Trail Route', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -2859,7 +2859,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Override Crumb Defaults Custom Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                     { key: 's0', route: 'r0' },
@@ -2909,7 +2909,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Override Crumb Defaults Custom Trail Route', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                     { key: 's0', route: 'r0' },
@@ -2959,7 +2959,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Navigate Previous Data With Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0'},
@@ -3001,7 +3001,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Navigate Previous Data', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -3043,7 +3043,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Navigate Previous Data Back With Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -3088,7 +3088,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Navigate Previous Data Back Two With Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -3147,7 +3147,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Navigate Previous Data Back Two', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -3206,7 +3206,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Navigate Previous Data One By One With Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -3268,7 +3268,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Navigate Previous Data One By One', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -3330,7 +3330,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Navigate Previous Data One By One Custom Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -3395,7 +3395,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Navigate Previous Data Refresh With Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0'},
@@ -3444,7 +3444,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Navigate Previous Data Refresh', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -3493,7 +3493,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Navigate Previous Data Defaults', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -3829,7 +3829,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Override Default Types', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -3869,7 +3869,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Override Default Types Refresh', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -3912,7 +3912,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Override Default Types Back', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -4002,7 +4002,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Refresh Current Data', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -4045,7 +4045,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Current Data Defaults', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -4085,7 +4085,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Missing Route Data', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r/{s1}/{s2}' }
@@ -4106,7 +4106,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Missing Route Data Refresh', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r/{s1}/{s2}' }
@@ -4201,7 +4201,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Clear State Context', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r' }
@@ -4239,7 +4239,7 @@ describe('Navigation Data', function () {
     });
 
     describe('Url Encode Data Back', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'a/{s}' },
@@ -4287,8 +4287,8 @@ describe('Navigation Data', function () {
     });
 
     describe('Two Controllers Data', function() {
-        var stateController0: StateController;
-        var stateController1: StateController;
+        var stateController0: Navigation.StateController;
+        var stateController1: Navigation.StateController;
         beforeEach(function() {
             stateController0 = new Navigation.StateController([
                 { key: 's0', route: 'r' }
@@ -4335,8 +4335,8 @@ describe('Navigation Data', function () {
     });
 
     describe('Two Controllers Data Back', function() {
-        var stateController0: StateController;
-        var stateController1: StateController;
+        var stateController0: Navigation.StateController;
+        var stateController1: Navigation.StateController;
         beforeEach(function() {
             stateController0 = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -4397,8 +4397,8 @@ describe('Navigation Data', function () {
     });
 
     describe('Two Controllers Refresh Data', function() {
-        var stateController0: StateController;
-        var stateController1: StateController;
+        var stateController0: Navigation.StateController;
+        var stateController1: Navigation.StateController;
         beforeEach(function() {
             stateController0 = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -4459,7 +4459,7 @@ describe('Navigation Data', function () {
     });
     
     describe('Crumb Trail Route Param', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -4505,7 +4505,7 @@ describe('Navigation Data', function () {
     });
     
     describe('Crumb Trail Route Splat Param', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -4555,7 +4555,7 @@ describe('Navigation Data', function () {
     });
     
     describe('Refresh Data Back Custom Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1,12 +1,12 @@
 ﻿/// <reference path="assert.d.ts" />
 /// <reference path="mocha.d.ts" />
+/// <reference path="../src/navigation.d.ts" />
 import assert = require('assert');
 import Navigation = require('../src/Navigation');
-import StateController = require('../src/StateController');
 
 describe('MatchTest', function () {
     describe('Root', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '' }
@@ -35,7 +35,7 @@ describe('MatchTest', function () {
     });
 
     describe('No Param One Segment', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'abc' }
@@ -69,7 +69,7 @@ describe('MatchTest', function () {
     });
 
     describe('No Param Two Segment', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'ab/c' }
@@ -103,7 +103,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Param One Segment', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}' }
@@ -138,7 +138,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Param Two Segment', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'ab/{x}' }
@@ -178,7 +178,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Param Two Segment', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}/{y}' }
@@ -218,7 +218,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Param Three Segment', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'ab/{x}/{y}' }
@@ -262,7 +262,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Param Four Segment', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'ab/{x}/c/{y}' }
@@ -305,7 +305,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Optional Param One Segment', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x?}' }
@@ -341,7 +341,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Optional Param Two Segment', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'ab/{x?}' }
@@ -382,7 +382,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Optional Param Two Segment', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x?}/{y?}' }
@@ -433,7 +433,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Optional Param Three Segment', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'ab/{x?}/{y?}' }
@@ -487,7 +487,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Param One Optional Two Segment', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}/{y?}' }
@@ -532,7 +532,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Param One Optional Three Segment', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'ab/{x}/{y?}' }
@@ -581,7 +581,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Param One Optional Four Segment', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'ab/{x}/c/{y?}' }
@@ -630,7 +630,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Param One Mixed Segment', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'ab{x}' }
@@ -665,7 +665,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Param One Mixed Segment', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'ab{x}e{y}' }
@@ -707,7 +707,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Param One Optional Two Segment One Mixed', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}ab/{y?}' }
@@ -755,7 +755,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Param One Segment Default', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}', defaults: { x: 'cde' } }
@@ -795,7 +795,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Param One Segment Default Number', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}', defaults: { x: 345 } }
@@ -838,7 +838,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Param One Segment Default Boolean', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}', defaults: { x: true } }
@@ -881,7 +881,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Param One Segment Default Date', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}', defaults: { x: new Date(2010, 3, 7) } }
@@ -934,7 +934,7 @@ describe('MatchTest', function () {
     });
 
     describe('No Param One Segment Default Type Number', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'abc', defaultTypes: { x: 'number' } }
@@ -971,7 +971,7 @@ describe('MatchTest', function () {
     });
 
     describe('No Param One Segment Default Type Boolean', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'abc', defaultTypes: { x: 'boolean' } }
@@ -1008,7 +1008,7 @@ describe('MatchTest', function () {
     });
 
     describe('No Param One Segment Default Type Date', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'abc', defaultTypes: { x: 'date' } }
@@ -1051,7 +1051,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Param Two Segment Default', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'ab/{x}', defaults: { x: 'ccdd' } }
@@ -1096,7 +1096,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Param Two Segment Two Default', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}/{y}', defaults: { x: 'ab', y: 'c' } }
@@ -1159,7 +1159,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Param Two Segment Default', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}/{y}', defaults: { y: 'ab' } }
@@ -1209,7 +1209,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Param One Optional Two Segment Default', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}/{y?}', defaults: { x: 'abc' } }
@@ -1264,7 +1264,7 @@ describe('MatchTest', function () {
     });
 
     describe('Four Param Two Optional Five Segment Default', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'ab/{w}/{x}/{y?}/{z?}', defaults: { w: 'abc', x: 'de' } }
@@ -1400,7 +1400,7 @@ describe('MatchTest', function () {
     });
 
     describe('Spaces', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}' }
@@ -1423,7 +1423,7 @@ describe('MatchTest', function () {
     });
 
     describe('Multi Char Param', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'a/{someVar}' }
@@ -1457,7 +1457,7 @@ describe('MatchTest', function () {
     });
 
     describe('Reserved Url Character', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'a/{=*"()\'-_+~@:?><.;[],!£$%^#&}', defaults: { '=*"()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' } }
@@ -1492,7 +1492,7 @@ describe('MatchTest', function () {
     });
 
     describe('Reserved Regex Character', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '.+*\^$\[\]()\'/{x}' }
@@ -1516,7 +1516,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Param Optional Mandatory One Mixed Segment', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'ab{x?}' }
@@ -1551,7 +1551,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Param One Optional Mandatory Three Segment', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'ab/{x?}/{y}' }
@@ -1593,7 +1593,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Param Two Segment Default Mandatory', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}/{y}', defaults: { x: 'ab' } }
@@ -1633,7 +1633,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Param One Optional Mandatory Four Segment Default Mandatory', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'ab/{x?}/{y}/c', defaults: { y: 'ee' } }
@@ -1711,7 +1711,7 @@ describe('MatchTest', function () {
     });
 
     describe('Multiple Routes', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'ab/{x}' },
@@ -1744,7 +1744,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Route One With Param', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: ['', 'abc/{x}'] }
@@ -1782,7 +1782,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Route Param', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: ['abc/{x}', 'def/{y}'] }
@@ -1842,7 +1842,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Route Parent Child', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: ['abc/{x}', 'abc/{x}/def/{y}'] }
@@ -1893,7 +1893,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Route Default', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: ['abc/{x}', 'def/{y}'], defaults: { x: 's' } }
@@ -1960,7 +1960,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Route Optional', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: ['abc/{x?}', 'abc/{x}/def/{y}'] }
@@ -2012,7 +2012,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Route Default Number', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: ['def/{y}', 'abc/{x}'], defaults: { x: 2 } }
@@ -2069,7 +2069,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Route Default Type Number', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: ['def/{y}', 'abc/{x}'], defaultTypes: { x: 'number' } }
@@ -2113,7 +2113,7 @@ describe('MatchTest', function () {
     });
 
     describe('Without Types', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}', trackTypes: false }
@@ -2140,7 +2140,7 @@ describe('MatchTest', function () {
     });
 
     describe('Without Types Default', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}', trackTypes: false, defaults: { x: 2 } }
@@ -2169,7 +2169,7 @@ describe('MatchTest', function () {
     });
 
     describe('Without Types Default Type', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}', trackTypes: false, defaultTypes: { x: 'boolean' } }
@@ -2195,7 +2195,7 @@ describe('MatchTest', function () {
     });
 
     describe('Without Types Default And Default Type', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}', trackTypes: false, defaults: { x: '2' }, defaultTypes: { x: 'number' } }
@@ -2224,7 +2224,7 @@ describe('MatchTest', function () {
     });
 
     describe('Without Types Conflicting Default And Default Type', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}', trackTypes: false, defaults: { x: 'a' }, defaultTypes: { x: 'number' } }
@@ -2250,7 +2250,7 @@ describe('MatchTest', function () {
     });
 
     describe('Without Types Query String', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '', trackTypes: false }
@@ -2277,7 +2277,7 @@ describe('MatchTest', function () {
     });
 
     describe('Without Types Query String Default', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '', trackTypes: false, defaults: { x: 2 } }
@@ -2306,7 +2306,7 @@ describe('MatchTest', function () {
     });
 
     describe('Without Types Query String Default Type', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '', trackTypes: false, defaultTypes: { x: 'boolean' } }
@@ -2332,7 +2332,7 @@ describe('MatchTest', function () {
     });
 
     describe('Without Types Query String Default And Default Type', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '', trackTypes: false, defaults: { x: '2' }, defaultTypes: { x: 'number' } }
@@ -2361,7 +2361,7 @@ describe('MatchTest', function () {
     });
 
     describe('Without Types Query String Conflicting Default And Default Type', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '', trackTypes: false, defaults: { x: 'a' }, defaultTypes: { x: 'number' } }
@@ -2414,7 +2414,7 @@ describe('MatchTest', function () {
     });
 
     describe('Array Query String Default Type', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '', defaultTypes: { x: 'stringarray' } }
@@ -2447,7 +2447,7 @@ describe('MatchTest', function () {
     });
 
     describe('Array Param Default Type', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}', defaultTypes: { x: 'stringarray' } }
@@ -2480,7 +2480,7 @@ describe('MatchTest', function () {
     });
 
     describe('Array Query String Default Type Number', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '', defaultTypes: { x: 'numberarray' } }
@@ -2501,7 +2501,7 @@ describe('MatchTest', function () {
     });
 
     describe('Array Query String Default Type Boolean', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '', defaultTypes: { x: 'booleanarray' } }
@@ -2521,7 +2521,7 @@ describe('MatchTest', function () {
     });
 
     describe('Without Types Array Query String Default Type', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '', trackTypes: false, defaultTypes: { x: 'stringarray' } }
@@ -2547,7 +2547,7 @@ describe('MatchTest', function () {
     });
 
     describe('Array Query String Default', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '', defaults: { x: ['Hello', 'World'] } }
@@ -2572,7 +2572,7 @@ describe('MatchTest', function () {
     });
 
     describe('Array Query String Default Number', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '', defaults: { x: [1, 2, 4] } }
@@ -2598,7 +2598,7 @@ describe('MatchTest', function () {
     });
 
     describe('Array Query String Default Boolean', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '', defaults: { x: [true, false] } }
@@ -2623,7 +2623,7 @@ describe('MatchTest', function () {
     });
 
     describe('Array Query String Default Date', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '', defaults: { x: [new Date(2010, 3, 7), new Date(2011, 7, 3)] } }
@@ -2648,7 +2648,7 @@ describe('MatchTest', function () {
     });
 
     describe('String Query String Default Type Number', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '', defaultTypes: { x: 'number' } }
@@ -2666,7 +2666,7 @@ describe('MatchTest', function () {
     });
 
     describe('String Param Default Type Number', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}', defaultTypes: { x: 'number' } }
@@ -2684,7 +2684,7 @@ describe('MatchTest', function () {
     });
 
     describe('Number Query String Default Type Boolean', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '', defaultTypes: { x: 'boolean' } }
@@ -2702,7 +2702,7 @@ describe('MatchTest', function () {
     });
 
     describe('Number Param Default Type Boolean', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}', defaultTypes: { x: 'boolean' } }
@@ -2720,7 +2720,7 @@ describe('MatchTest', function () {
     });
 
     describe('Boolean Query String Default Type Date', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '', defaultTypes: { x: 'date' } }
@@ -2738,7 +2738,7 @@ describe('MatchTest', function () {
     });
 
     describe('Boolean Param Default Type Date', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}', defaultTypes: { x: 'date' } }
@@ -2756,7 +2756,7 @@ describe('MatchTest', function () {
     });
 
     describe('Date Query String Default Type String', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '', defaultTypes: { x: 'string' } }
@@ -2774,7 +2774,7 @@ describe('MatchTest', function () {
     });
 
     describe('Date Param Default Type String', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}', defaultTypes: { x: 'string' } }
@@ -2792,7 +2792,7 @@ describe('MatchTest', function () {
     });
 
     describe('String Array Query String Default Type Number Array', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '', defaultTypes: { x: 'numberarray' } }
@@ -2812,7 +2812,7 @@ describe('MatchTest', function () {
     });
 
     describe('String Array Param Default Type Number Array', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}', defaultTypes: { x: 'numberarray' } }
@@ -2832,7 +2832,7 @@ describe('MatchTest', function () {
     });
 
     describe('Number Array Query String Default Type Boolean Array', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '', defaultTypes: { x: 'booleanarray' } }
@@ -2852,7 +2852,7 @@ describe('MatchTest', function () {
     });
 
     describe('Number Array Param Default Type Boolean Array', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}', defaultTypes: { x: 'booleanarray' } }
@@ -2872,7 +2872,7 @@ describe('MatchTest', function () {
     });
 
     describe('Boolean Array Query String Default Type Date Array', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '', defaultTypes: { x: 'datearray' } }
@@ -2892,7 +2892,7 @@ describe('MatchTest', function () {
     });
 
     describe('Boolean Array Param Default Type Date Array', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}', defaultTypes: { x: 'datearray' } }
@@ -2912,7 +2912,7 @@ describe('MatchTest', function () {
     });
 
     describe('Date Array Query String Default Type String Array', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '', defaultTypes: { x: 'stringarray' } }
@@ -2932,7 +2932,7 @@ describe('MatchTest', function () {
     });
 
     describe('Date Array Param Default Type String Array', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}', defaultTypes: { x: 'stringarray' } }
@@ -2952,7 +2952,7 @@ describe('MatchTest', function () {
     });
 
     describe('No Param One Segment Encode', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'abc' }
@@ -2973,7 +2973,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Param Encode', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}' }
@@ -2994,7 +2994,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Param Query String Encode', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}' }
@@ -3020,7 +3020,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Param Route Encode', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}' }
@@ -3046,7 +3046,7 @@ describe('MatchTest', function () {
     });
 
     describe('No Param One Segment State Encode', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'a' },
@@ -3077,7 +3077,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Param State Encode', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'a/{x}' },
@@ -3108,7 +3108,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Param Query String Key Encode', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}' }
@@ -3134,7 +3134,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Param Route Key Encode', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}' }
@@ -3160,7 +3160,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Param Route Key Encode', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}/{y}' }
@@ -3186,7 +3186,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Optional Param Route Key Encode', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x?}' }
@@ -3212,7 +3212,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Mixed Param Route Key Encode', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'ab{x}' }
@@ -3238,7 +3238,7 @@ describe('MatchTest', function () {
     });
 
     describe('No Param Two Query String Key Encode', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '' }
@@ -3264,7 +3264,7 @@ describe('MatchTest', function () {
     });
 
     describe('No Param Key Encode', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '' }
@@ -3289,7 +3289,7 @@ describe('MatchTest', function () {
     });
 
     describe('No Param Two Key Encode', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '' }
@@ -3315,7 +3315,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Param Empty Encode', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}' }
@@ -3337,7 +3337,7 @@ describe('MatchTest', function () {
     });
 
     describe('No Param Array Encode', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '', defaultTypes: { x: 'stringarray' } }
@@ -3360,7 +3360,7 @@ describe('MatchTest', function () {
     });
 
     describe('No Param Array Query String Encode', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '', defaultTypes: { x: 'stringarray' } }
@@ -3387,7 +3387,7 @@ describe('MatchTest', function () {
     });
 
     describe('No Param Array Key Encode', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '', defaultTypes: { x: 'stringarray', y: 'stringarray' } }
@@ -3416,7 +3416,7 @@ describe('MatchTest', function () {
     });
 
     describe('No Param One Segment Array State Encode', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'a', defaultTypes: { x: 'stringarray' } },
@@ -3451,7 +3451,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Optional Empty Param Route Encode', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x?}' }
@@ -3472,7 +3472,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Empty Param Route Encode', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}' }
@@ -3492,7 +3492,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Empty Mixed Param Route Encode', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'ab{x}' }
@@ -3512,7 +3512,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Splat Param One Segment Default Type', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{*x}', defaultTypes: { x: 'stringarray' } }
@@ -3574,7 +3574,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Splat Param One Segment Default', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{*x}', defaults: { x: ['ef', 'ghi'] } }
@@ -3608,7 +3608,7 @@ describe('MatchTest', function () {
     });
     
     describe('One Optional Splat Param One Segment Default Type', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{*x?}', defaultTypes: { x: 'stringarray' } }
@@ -3666,7 +3666,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Splat Param Two Segment Default Type', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'ab/{*x}', defaultTypes: { x: 'stringarray' } }
@@ -3729,7 +3729,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Splat Param Two Segment Default', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'ab/{*x}', defaults: { x: ['ef', 'ghi'] } }
@@ -3766,7 +3766,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Param One Splat Two Segment Default Type', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}/{*y}', defaultTypes: { y: 'stringarray' } }
@@ -3838,7 +3838,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Param One Optional Splat Two Segment Default Type', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{x}/{*y?}', defaultTypes: { y: 'stringarray' } }
@@ -3912,7 +3912,7 @@ describe('MatchTest', function () {
     });
 
     describe('Two Splat Param Three Segment Default Type', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{*x}/ab/{*y}', defaultTypes: { x: 'stringarray', y: 'stringarray' } }
@@ -3982,7 +3982,7 @@ describe('MatchTest', function () {
     });
     
     describe('Two Route Param Splat and Not Splat', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: ['a/{*x}', 'b/{x}/{y}'], defaultTypes: { x: 'stringarray' } }
@@ -4019,7 +4019,7 @@ describe('MatchTest', function () {
     })
 
     describe('One Splat Param Two Segment Default', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{*x}/ab', defaults: { x: ['cde', 'fg'] } }
@@ -4067,7 +4067,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Splat Param One Mixed Segment Default', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'ab{*x}', defaults: { x: ['cde', 'fg'] } }
@@ -4106,7 +4106,7 @@ describe('MatchTest', function () {
     });
 
     describe('Without Types Splat Conflicting Default And Default Type', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{*x}', trackTypes: false, defaults: { x: ['a', 'bc'] }, defaultTypes: { x: 'number' } }
@@ -4138,7 +4138,7 @@ describe('MatchTest', function () {
     });
 
     describe('Without Types Splat Conflicting Single Array Default And Default Type', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{*x}', trackTypes: false, defaults: { x: ['a'] }, defaultTypes: { x: 'number' } }
@@ -4169,7 +4169,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Splat Param One Segment Single Match Array Default', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{*x}', defaults: { x: ['a', 'b'] } }
@@ -4189,7 +4189,7 @@ describe('MatchTest', function () {
     });
 
     describe('Splat Param Array Encode', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{*x}', defaultTypes: { x: 'stringarray' } }
@@ -4212,7 +4212,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Splat Param One Segment Default Type Number Array', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{*x}', defaultTypes: { x: 'numberarray' } }
@@ -4240,7 +4240,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Splat Param One Segment Default Type Booelan Array', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{*x}', defaultTypes: { x: 'booleanarray' } }
@@ -4268,7 +4268,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Splat Param One Segment Default Type Date Array', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{*x}', defaultTypes: { x: 'datearray' } }
@@ -4295,7 +4295,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Splat Param One Segment Default Date Array', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{*x}', defaults: { x: [new Date(2011, 7, 3), new Date(2010, 3, 7)] } }
@@ -4327,7 +4327,7 @@ describe('MatchTest', function () {
     });
 
     describe('Multiple Routes Splat and Not Splat', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'ab/{*x}', defaultTypes: { x: 'stringarray' } },
@@ -4359,7 +4359,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Splat Param One Segment', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{*x}' }
@@ -4389,7 +4389,7 @@ describe('MatchTest', function () {
     });
 
     describe('One Splat Param One Query String Default Type', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: '{*x}', defaultTypes: { x: 'stringarray', y: 'stringarray' } }
@@ -4432,7 +4432,7 @@ describe('MatchTest', function () {
     });
 
     describe('Reload Param', function () {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function () {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'ab/{x}' }
@@ -4458,8 +4458,8 @@ describe('MatchTest', function () {
     });
 
     describe('Two Controllers Param', function () {
-        var stateController0: StateController;
-        var stateController1: StateController;
+        var stateController0: Navigation.StateController;
+        var stateController1: Navigation.StateController;
         beforeEach(function () {
             stateController0 = new Navigation.StateController([
                 { key: 's', route: 'ab/{x}' }
@@ -4490,8 +4490,8 @@ describe('MatchTest', function () {
     });
 
     describe('Two Controllers Param Default', function () {
-        var stateController0: StateController;
-        var stateController1: StateController;
+        var stateController0: Navigation.StateController;
+        var stateController1: Navigation.StateController;
         beforeEach(function () {
             stateController0 = new Navigation.StateController([
                 { key: 's', route: 'ab/{x}', defaults: { x: 'cd' } }
@@ -4530,8 +4530,8 @@ describe('MatchTest', function () {
     });
 
     describe('Two Controllers Param Default Type', function () {
-        var stateController0: StateController;
-        var stateController1: StateController;
+        var stateController0: Navigation.StateController;
+        var stateController1: Navigation.StateController;
         beforeEach(function () {
             stateController0 = new Navigation.StateController([
                 { key: 's', route: 'ab/{x}' }
@@ -4562,8 +4562,8 @@ describe('MatchTest', function () {
     });
 
     describe('Two Controllers Param Encode', function () {
-        var stateController0: StateController;
-        var stateController1: StateController;
+        var stateController0: Navigation.StateController;
+        var stateController1: Navigation.StateController;
         beforeEach(function () {
             stateController0 = new Navigation.StateController([
                 { key: 's', route: '0/{x}' }

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -1,12 +1,12 @@
 ﻿/// <reference path="assert.d.ts" />
 /// <reference path="mocha.d.ts" />
+/// <reference path="../src/navigation.d.ts" />
 import assert = require('assert');
 import Navigation = require('../src/Navigation');
-import StateController = require('../src/StateController');
 
 describe('Navigation', function () {
     describe('State', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r' }
@@ -39,7 +39,7 @@ describe('Navigation', function () {
     });
 
     describe('Second State', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -73,7 +73,7 @@ describe('Navigation', function () {
     });
 
     describe('State With Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r', trackCrumbTrail: true }
@@ -106,7 +106,7 @@ describe('Navigation', function () {
     });
 
     describe('Invalid State', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r' }
@@ -127,7 +127,7 @@ describe('Navigation', function () {
     });
 
     describe('Transition', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -170,7 +170,7 @@ describe('Navigation', function () {
     });
 
     describe('Transition With Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -213,7 +213,7 @@ describe('Navigation', function () {
     });
 
     describe('State State', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r' }
@@ -255,7 +255,7 @@ describe('Navigation', function () {
     });
 
     describe('State State With Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r', trackCrumbTrail: true }
@@ -298,7 +298,7 @@ describe('Navigation', function () {
     
 
     describe('Null State', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r' }
@@ -319,7 +319,7 @@ describe('Navigation', function () {
     });
     
     describe('Transition From Without Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0', trackCrumbTrail: false },
@@ -364,7 +364,7 @@ describe('Navigation', function () {
     });
 
     describe('Transition With Trail Transition With Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -414,7 +414,7 @@ describe('Navigation', function () {
     });
     
     describe('Transition Transition', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -462,7 +462,7 @@ describe('Navigation', function () {
     
     
     describe('Refresh With Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -510,7 +510,7 @@ describe('Navigation', function () {
     });
 
     describe('Refresh', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -556,7 +556,7 @@ describe('Navigation', function () {
     });
     
     describe('Back With Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -608,7 +608,7 @@ describe('Navigation', function () {
     });
 
     describe('Back', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -658,7 +658,7 @@ describe('Navigation', function () {
     });
 
     describe('Back Two With Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -720,7 +720,7 @@ describe('Navigation', function () {
     });
 
     describe('Back Two', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -778,7 +778,7 @@ describe('Navigation', function () {
     });
 
     describe('Back One By One With Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -835,7 +835,7 @@ describe('Navigation', function () {
     });
 
     describe('Back One By One', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -892,7 +892,7 @@ describe('Navigation', function () {
     });
 
     describe('Can Navigate Back With Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -939,7 +939,7 @@ describe('Navigation', function () {
     });
 
     describe('Can Navigate Back', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -980,7 +980,7 @@ describe('Navigation', function () {
     });
 
     describe('Invalid Back With Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1016,7 +1016,7 @@ describe('Navigation', function () {
     });
 
     describe('Invalid Back', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1052,7 +1052,7 @@ describe('Navigation', function () {
     });
 
     describe('Back Invalid Back With Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1091,7 +1091,7 @@ describe('Navigation', function () {
     });
 
     describe('Back Invalid Back', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1130,7 +1130,7 @@ describe('Navigation', function () {
     });
 
     describe('Back Refresh With Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1183,7 +1183,7 @@ describe('Navigation', function () {
     });
 
     describe('Back Refresh', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1236,7 +1236,7 @@ describe('Navigation', function () {
     });
 
     describe('Back Refresh Transition With Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1297,7 +1297,7 @@ describe('Navigation', function () {
     });
 
     describe('Back Refresh Transition', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1356,7 +1356,7 @@ describe('Navigation', function () {
     });
 
     describe('Transition Transition With Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1405,7 +1405,7 @@ describe('Navigation', function () {
     });
 
     describe('Crumb Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1464,7 +1464,7 @@ describe('Navigation', function () {
     });
 
     describe('State State Custom Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                     { key: 's', route: 'r', trackCrumbTrail: true },
@@ -1502,7 +1502,7 @@ describe('Navigation', function () {
     });
 
     describe('Transition State State Custom Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1545,7 +1545,7 @@ describe('Navigation', function () {
     });
 
     describe('State State Back Custom Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r', trackCrumbTrail: true }
@@ -1588,7 +1588,7 @@ describe('Navigation', function () {
     });
 
     describe('Transition State State Back Custom Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1635,7 +1635,7 @@ describe('Navigation', function () {
     });
 
     describe('State State Back Two Custom Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -1686,7 +1686,7 @@ describe('Navigation', function () {
     });
 
     describe('State State Back One By One Custom Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -3108,7 +3108,7 @@ describe('Navigation', function () {
     });
 
     describe('Clear State Context', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r' }
@@ -3150,7 +3150,7 @@ describe('Navigation', function () {
 
     describe('History Null', function () {
         var replaceHistory;
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             var historyManager = new Navigation.HashHistoryManager();
             replaceHistory = undefined;
@@ -3188,7 +3188,7 @@ describe('Navigation', function () {
 
     describe('History Add', function () {
         var replaceHistory;
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             var historyManager = new Navigation.HashHistoryManager();
             replaceHistory = undefined;
@@ -3226,7 +3226,7 @@ describe('Navigation', function () {
 
     describe('History Replace', function () {
         var replaceHistory;
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             var historyManager = new Navigation.HashHistoryManager();
             replaceHistory = undefined;
@@ -3264,7 +3264,7 @@ describe('Navigation', function () {
 
     describe('History None', function () {
         var replaceHistory;
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             var historyManager = new Navigation.HashHistoryManager();
             replaceHistory = undefined;
@@ -3474,7 +3474,7 @@ describe('Navigation', function () {
     });
 
     describe('Reload Dialog', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r' }
@@ -3511,7 +3511,7 @@ describe('Navigation', function () {
     });
 
     describe('Reload Transition', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r' }
@@ -3561,7 +3561,7 @@ describe('Navigation', function () {
     });
     
     describe('Reload Refresh', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r' }
@@ -3614,7 +3614,7 @@ describe('Navigation', function () {
     });
     
     describe('Reload Back', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r' }
@@ -3671,7 +3671,7 @@ describe('Navigation', function () {
     });
     
     describe('Reload Error Dialog', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's', route: 'r' }
@@ -3710,7 +3710,7 @@ describe('Navigation', function () {
     });
 
     describe('Reload Error Transition', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -3761,7 +3761,7 @@ describe('Navigation', function () {
     });
     
     describe('Reload Error Refresh', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -3815,7 +3815,7 @@ describe('Navigation', function () {
     });
     
     describe('Reload Error Back', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -3873,8 +3873,8 @@ describe('Navigation', function () {
     });
 
     describe('Two Controllers Dialog', function() {
-        var stateController0: StateController;
-        var stateController1: StateController;
+        var stateController0: Navigation.StateController;
+        var stateController1: Navigation.StateController;
         beforeEach(function() {
             stateController0 = new Navigation.StateController([
                 { key: 's0', route: 'r' }
@@ -3915,8 +3915,8 @@ describe('Navigation', function () {
     });
 
     describe('Two Controllers Transition', function() {
-        var stateController0: StateController;
-        var stateController1: StateController;
+        var stateController0: Navigation.StateController;
+        var stateController1: Navigation.StateController;
         beforeEach(function() {
             stateController0 = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -3977,8 +3977,8 @@ describe('Navigation', function () {
     });
     
     describe('Two Controllers Refresh', function() {
-        var stateController0: StateController;
-        var stateController1: StateController;
+        var stateController0: Navigation.StateController;
+        var stateController1: Navigation.StateController;
         beforeEach(function() {
             stateController0 = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -4045,8 +4045,8 @@ describe('Navigation', function () {
     });
     
     describe('Two Controllers Back', function() {
-        var stateController0: StateController;
-        var stateController1: StateController;
+        var stateController0: Navigation.StateController;
+        var stateController1: Navigation.StateController;
         beforeEach(function() {
             stateController0 = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -4152,7 +4152,7 @@ describe('Navigation', function () {
     });
     
     describe('Crumb Trail Route Param', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         var s2Link: string; 
         beforeEach(function() {
             stateController = new Navigation.StateController([
@@ -4212,7 +4212,7 @@ describe('Navigation', function () {
     });
     
     describe('Crumb Trail Route Splat Param', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         var s2Link: string; 
         beforeEach(function() {
             stateController = new Navigation.StateController([
@@ -4272,7 +4272,7 @@ describe('Navigation', function () {
     });
     
     describe('Crumb Trail Mixed Param', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         var s2Link: string; 
         var s3Link: string; 
         beforeEach(function() {
@@ -4352,7 +4352,7 @@ describe('Navigation', function () {
     });
     
     describe('Crumb Trail Key', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         var s1Link: string, s2Link: string;
         beforeEach(function() {
             stateController = new Navigation.StateController([
@@ -4417,7 +4417,7 @@ describe('Navigation', function () {
     });
     
     describe('Refresh Back Custom Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },
@@ -4513,7 +4513,7 @@ describe('Navigation', function () {
     });
     
     describe('Repeated States With Trail', function() {
-        var stateController: StateController;
+        var stateController: Navigation.StateController;
         beforeEach(function() {
             stateController = new Navigation.StateController([
                 { key: 's0', route: 'r0' },

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -3204,7 +3204,7 @@ describe('Navigation', function () {
         
         describe('Navigate', function() {
             beforeEach(function() {
-                stateController.navigate('s', null, Navigation.HistoryAction.Add);
+                stateController.navigate('s', null, 'add');
             });
             test();
         });
@@ -3212,7 +3212,7 @@ describe('Navigation', function () {
         describe('Navigate Link', function() {
             beforeEach(function() {
                 var link = stateController.getNavigationLink('s');
-                stateController.navigateLink(link, Navigation.HistoryAction.Add);
+                stateController.navigateLink(link, 'add');
             });
             test();
         });
@@ -3242,7 +3242,7 @@ describe('Navigation', function () {
         
         describe('Navigate', function() {
             beforeEach(function() {
-                stateController.navigate('s', null, Navigation.HistoryAction.Replace);
+                stateController.navigate('s', null, 'replace');
             });
             test();
         });
@@ -3250,7 +3250,7 @@ describe('Navigation', function () {
         describe('Navigate Link', function() {
             beforeEach(function() {
                 var link = stateController.getNavigationLink('s');
-                stateController.navigateLink(link, Navigation.HistoryAction.Replace);
+                stateController.navigateLink(link, 'replace');
             });
             test();
         });
@@ -3280,7 +3280,7 @@ describe('Navigation', function () {
         
         describe('Navigate', function() {
             beforeEach(function() {
-                stateController.navigate('s', null, Navigation.HistoryAction.None);
+                stateController.navigate('s', null, 'none');
             });
             test();
         });
@@ -3288,7 +3288,7 @@ describe('Navigation', function () {
         describe('Navigate Link', function() {
             beforeEach(function() {
                 var link = stateController.getNavigationLink('s');
-                stateController.navigateLink(link, Navigation.HistoryAction.None);
+                stateController.navigateLink(link, 'none');
             });
             test();
         });
@@ -3331,7 +3331,7 @@ describe('Navigation', function () {
                 replaceHistory = replace;
             }
             stateController.configure(dialogs, historyManager);
-            stateController.refresh(null, Navigation.HistoryAction.Add);
+            stateController.refresh(null, 'add');
             assert.strictEqual(replaceHistory, false);
         });
     });
@@ -3349,7 +3349,7 @@ describe('Navigation', function () {
                 replaceHistory = replace;
             }
             stateController.configure(dialogs, historyManager);
-            stateController.refresh(null, Navigation.HistoryAction.Replace);
+            stateController.refresh(null, 'replace');
             assert.strictEqual(replaceHistory, true);
         });
     });
@@ -3367,7 +3367,7 @@ describe('Navigation', function () {
                 replaceHistory = replace;
             }
             stateController.configure(dialogs, historyManager);
-            stateController.refresh(null, Navigation.HistoryAction.None);
+            stateController.refresh(null, 'none');
             assert.strictEqual(replaceHistory, undefined);
         });
     });
@@ -3407,7 +3407,7 @@ describe('Navigation', function () {
                 replaceHistory = replace;
             }
             stateController.configure(dialogs, historyManager);
-            stateController.navigateBack(1, Navigation.HistoryAction.Add);
+            stateController.navigateBack(1, 'add');
             assert.strictEqual(replaceHistory, false);
         });
     });
@@ -3427,7 +3427,7 @@ describe('Navigation', function () {
                 replaceHistory = replace;
             }
             stateController.configure(dialogs, historyManager);
-            stateController.navigateBack(1, Navigation.HistoryAction.Replace);
+            stateController.navigateBack(1, 'replace');
             assert.strictEqual(replaceHistory, true);
         });
     });
@@ -3447,7 +3447,7 @@ describe('Navigation', function () {
                 replaceHistory = replace;
             }
             stateController.configure(dialogs, historyManager);
-            stateController.navigateBack(1, Navigation.HistoryAction.None);
+            stateController.navigateBack(1, 'none');
             assert.strictEqual(replaceHistory, undefined);
         });
     });
@@ -3466,7 +3466,7 @@ describe('Navigation', function () {
                 historyManager
             );
             stateController.states['s0'].navigated = () => {
-                stateController.navigate('s1', null, Navigation.HistoryAction.None);
+                stateController.navigate('s1', null, 'none');
             }
             stateController.navigate('s0');
             assert.ok(!called);

--- a/NavigationJS/test/navigation-tests.ts
+++ b/NavigationJS/test/navigation-tests.ts
@@ -68,10 +68,10 @@ module NavigationTests {
 	// Navigation
 	stateController.start('home');
 	stateController.navigate('person');
-	stateController.navigate('person', null, Navigation.HistoryAction.Add);
+	stateController.navigate('person', null, 'add');
 	stateController.refresh();
 	stateController.refresh({ page: 3 });
-	stateController.refresh({ page: 2 }, Navigation.HistoryAction.Replace);
+	stateController.refresh({ page: 2 }, 'replace');
 	stateController.navigate('select', { id: 10 });
 	var canGoBack: boolean = stateController.canNavigateBack(1);
 	stateController.navigateBack(1);
@@ -83,11 +83,11 @@ module NavigationTests {
 	link = stateController.getRefreshLink({ page: 2 });
 	stateController.navigateLink(link);
 	link = stateController.getNavigationLink('select', { id: 10 });
-	stateController.navigateLink(link, Navigation.HistoryAction.Replace);
+	stateController.navigateLink(link, 'replace');
 	link = stateController.getNavigationBackLink(1);
 	var crumb = stateController.stateContext.crumbs[0];
 	link = crumb.navigationLink;
-	stateController.navigateLink(link, Navigation.HistoryAction.None, true);
+	stateController.navigateLink(link, 'none', true);
 	
 	// StateContext
 	stateController.navigate('home');

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -55,10 +55,7 @@ class LinkUtility {
                             e.preventDefault();
                         else
                             e['returnValue'] = false;
-                        var historyAction = ko.unwrap(allBindings.get('historyAction'));
-                        if (typeof historyAction === 'string')
-                            historyAction = Navigation.HistoryAction[historyAction];
-                        stateController.navigateLink(link, historyAction);
+                        stateController.navigateLink(link, ko.unwrap(allBindings.get('historyAction')));
                     }
                 }
             }

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -61,10 +61,7 @@ class LinkUtility {
                     var navigating = this.getNavigating(props);
                     if (navigating(e, domId, link)) {
                         e.preventDefault();
-                        var historyAction = props.historyAction;
-                        if (typeof historyAction === 'string')
-                            historyAction = Navigation.HistoryAction[historyAction];
-                        stateController.navigateLink(link, historyAction);
+                        stateController.navigateLink(link, props.historyAction);
                     }
                 }
             }


### PR DESCRIPTION
Changed history action to a string parameter. Doesn't make sense passing a number (enum value) as a parameter. Makes the plugin history action consistent with the Api history action.