### PR TITLE
Enhanced Route Specification

### DIFF
--- a/NavigationAngular/sample/app.js
+++ b/NavigationAngular/sample/app.js
@@ -2,7 +2,7 @@
 
 app.controller('PersonController', function ($scope) {
     var stateNavigator = new Navigation.StateNavigator([
-        { key: 'people', route: '{startRowIndex}/{maximumRows}/{sortExpression}', defaults: { startRowIndex: 0, maximumRows: 10, sortExpression: 'Name'}, trackTypes: false, title: 'Person Search' },
+        { key: 'people', route: '{startRowIndex?}/{maximumRows?}/{sortExpression?}', defaults: { startRowIndex: 0, maximumRows: 10, sortExpression: 'Name'}, trackTypes: false, title: 'Person Search' },
         { key: 'person', route: 'person', defaultTypes: { id: 'number' }, trackTypes: false, trackCrumbTrail: true, title: 'Person Details', }
     ]);
     $scope.stateNavigator = stateNavigator;

--- a/NavigationCycle/sample/app.js
+++ b/NavigationCycle/sample/app.js
@@ -123,7 +123,7 @@ function createStateComponents(stateNavigator) {
 
 function main(sources) {
     var stateNavigator = new Navigation.StateNavigator([
-        { key: 'people', route: '{startRowIndex}/{maximumRows}/{sortExpression}', defaults: { startRowIndex: 0, maximumRows: 10, sortExpression: 'Name'}, trackTypes: false, title: 'Person Search' },
+        { key: 'people', route: '{startRowIndex?}/{maximumRows?}/{sortExpression?}', defaults: { startRowIndex: 0, maximumRows: 10, sortExpression: 'Name'}, trackTypes: false, title: 'Person Search' },
         { key: 'person', route: 'person', defaultTypes: { id: 'number' }, trackTypes: false, trackCrumbTrail: true, title: 'Person Details', }
     ]);
     createStateComponents(stateNavigator);

--- a/NavigationJS/src/StateRouter.ts
+++ b/NavigationJS/src/StateRouter.ts
@@ -47,6 +47,7 @@ class StateRouter {
     private static findBestMatch(routes: Route[], data: any, arrayData: { [index: string]: string[] }): MatchInfo {
         var bestMatch: MatchInfo;
         var bestMatchCount = -1;
+        var bestMatchParamCount = -1;
         for(var i = 0; i < routes.length; i++) {
             var route = routes[i];
             var combinedData = StateRouter.getCombinedData(route, data, arrayData);
@@ -60,9 +61,10 @@ class StateRouter {
                         count++;
                     }
                 }
-                if (count > bestMatchCount) {
+                if (count > bestMatchCount || (count == bestMatchCount && route.params.length < bestMatchParamCount)) {
                     bestMatch = { route: route, data: routeData, routePath: routePath };
                     bestMatchCount = count;
+                    bestMatchParamCount = route.params.length;
                 }
             }
         }

--- a/NavigationJS/src/StateRouter.ts
+++ b/NavigationJS/src/StateRouter.ts
@@ -139,11 +139,22 @@ class StateRouter {
         var routes: string[] = [];
         var route = state.route;
         if (typeof route === 'string') {
-            routes.push(route);
+            routes = routes.concat(StateRouter.expandRoute(route));
         } else {
             for(var i = 0; i < route.length; i++) {
-                routes.push(route[i]);
+                routes = routes.concat(StateRouter.expandRoute(route[i]));
             }
+        }
+        return routes;
+    }
+    
+    private static expandRoute(route: string): string[] {
+        var routes: string[] = [];
+        var subRoutes = route.split('+');
+        var expandedRoute = '';
+        for(var i =0; i < subRoutes.length; i++) {
+            expandedRoute += subRoutes[i];
+            routes.push(expandedRoute);
         }
         return routes;
     }

--- a/NavigationJS/src/routing/Route.ts
+++ b/NavigationJS/src/routing/Route.ts
@@ -18,7 +18,7 @@ class Route {
         var segment: Segment;
         var pattern: string = '';
         for (var i = 0; i < subPaths.length; i++) {
-            segment = new Segment(subPaths[i], segment ? segment.optional : true, this.defaults);
+            segment = new Segment(subPaths[i], this.defaults);
             this.segments.unshift(segment);
             pattern = segment.pattern + pattern;
             var params: { name: string; optional: boolean; splat: boolean }[] = [];

--- a/NavigationJS/src/routing/Route.ts
+++ b/NavigationJS/src/routing/Route.ts
@@ -18,7 +18,7 @@ class Route {
         var segment: Segment;
         var pattern: string = '';
         for (var i = 0; i < subPaths.length; i++) {
-            segment = new Segment(subPaths[i], this.defaults);
+            segment = new Segment(subPaths[i], segment ? segment.optional : true,this.defaults);
             this.segments.unshift(segment);
             pattern = segment.pattern + pattern;
             var params: { name: string; optional: boolean; splat: boolean }[] = [];

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -1,14 +1,15 @@
 ﻿class Segment {
     path: string;
-    optional: boolean = false;
+    optional: boolean;
     pattern: string = '';
     params: { name: string; splat: boolean }[] = [];
     private subSegments: { name: string; param: boolean; splat: boolean, optional: boolean }[] = [];
     private subSegmentPattern: RegExp = /[{]{0,1}[^{}]+[}]{0,1}/g;
     private escapePattern: RegExp = /[\.+*\^$\[\](){}']/g;
 
-    constructor(path: string, defaults: any) {
+    constructor(path: string, optional: boolean, defaults: any) {
         this.path = path;
+        this.optional = optional;
         this.parse(defaults);
     }
 
@@ -20,13 +21,15 @@
             var subSegment = matches[i];
             if (subSegment.charAt(0) == '{') {
                 var param = subSegment.substring(1, subSegment.length - 1);
-                var optional = param.slice(-1) === '?'; 
+                var optional = param.slice(-1) === '?';
                 var splat = param.slice(0, 1) === '*';
                 var name = optional ? param.slice(0, -1) : param;
                 name = splat ? name.slice(1) : name;
                 this.params.push({ name: name, splat: splat });
+                this.optional = this.optional && optional && this.path.length === subSegment.length;
+                if (this.path.length === subSegment.length)
+                    optional = this.optional;
                 this.subSegments.push({ name: name, param: true, splat: splat, optional: optional });
-                this.optional = optional && this.path.length === subSegment.length;
                 var subPattern = !splat ? '[^/]+' : '.+';
                 this.pattern += !this.optional ? `(${subPattern})` : `(\/${subPattern})`;
                 this.pattern += optional ? '?' : '';

--- a/NavigationJS/src/routing/Segment.ts
+++ b/NavigationJS/src/routing/Segment.ts
@@ -19,7 +19,7 @@
         var matches = this.path.match(this.subSegmentPattern);
         for (var i = 0; i < matches.length; i++) {
             var subSegment = matches[i];
-            if (subSegment.charAt(0) == '{') {
+            if (subSegment.slice(0, 1) === '{' && subSegment.slice(-1) === '}') {
                 var param = subSegment.substring(1, subSegment.length - 1);
                 var optional = param.slice(-1) === '?';
                 var splat = param.slice(0, 1) === '*';

--- a/NavigationJS/test/NavigationDataTest.ts
+++ b/NavigationJS/test/NavigationDataTest.ts
@@ -3639,7 +3639,7 @@ describe('Navigation Data', function () {
         it('should not include defaults in link', function() {
             var stateNavigator = new Navigation.StateNavigator([
                 { key: 's0', route: 'r0' },
-                { key: 's1', route: 'r/{string}/{number}', trackCrumbTrail: true, defaults: { 'string': 'Hello', _bool: true, 'number': 1 } }
+                { key: 's1', route: 'r/{string?}/{number?}', trackCrumbTrail: true, defaults: { 'string': 'Hello', _bool: true, 'number': 1 } }
             ]);
             var data = {};
             data['_bool'] = null;

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -4878,6 +4878,44 @@ describe('MatchTest', function () {
             assert.strictEqual(stateNavigator.getNavigationLink('s', { x: ['cd', 'efg'], y: 'hi' }), '/b/cd1-efg/hi');
         });
     })
+    
+    describe('Expand Param Splat and Not Splat', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: 'a/{x}+/b/{*y}', defaultTypes: { y: 'stringarray' } }
+            ]);
+        });
+        
+        it('should match', function() {
+            var { data } = stateNavigator.parseLink('/a/cd');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 'cd');
+            var { data } = stateNavigator.parseLink('/a/cd/b/ef');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'cd');
+            assert.strictEqual(data.y.length, 1);
+            assert.strictEqual(data.y[0], 'ef');
+            var { data } = stateNavigator.parseLink('/a/cd/b/ef/ghi');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'cd');
+            assert.strictEqual(data.y.length, 2);
+            assert.strictEqual(data.y[0], 'ef');
+            assert.strictEqual(data.y[1], 'ghi');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/a'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/a/cd/b'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'cd' }), '/a/cd');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'cd', y: ['ef'] }), '/a/cd/b/ef');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'cd', y: ['ef', 'ghi'] }), '/a/cd/b/ef/ghi');
+        });
+    })
 
     describe('One Splat Param Two Segment Default', function () {
         var stateNavigator: Navigation.StateNavigator;

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2312,7 +2312,7 @@ describe('MatchTest', function () {
         });
     });
 
-    describe('Expand Route Mixed Optional Parent Child', function () {
+    describe('Expand Route Optional Mixed Grand Parent Child', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
@@ -2490,6 +2490,60 @@ describe('MatchTest', function () {
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
                 { key: 's', route: ['abc/{x?}+/def/{y}'] }
+            ]);
+        });
+
+        it('should match', function() {
+            var { data } = stateNavigator.parseLink('/abc');
+            assert.strictEqual(Object.keys(data).length, 0);
+            var { data } = stateNavigator.parseLink('/abc?z=d');
+            assert.strictEqual(data.z, 'd');
+            assert.strictEqual(Object.keys(data).length, 1);
+            var { data } = stateNavigator.parseLink('/abc/de');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 'de');
+            var { data } = stateNavigator.parseLink('/abc/de?z=f');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.z, 'f');
+            var { data } = stateNavigator.parseLink('/abc/de/def/gh');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.y, 'gh');
+            var { data } = stateNavigator.parseLink('/abc/de/def/gh?z=i');
+            assert.strictEqual(Object.keys(data).length, 3);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.y, 'gh');
+            assert.strictEqual(data.z, 'i');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => stateNavigator.parseLink('/abc/de/def'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/de/def/gh/i'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abd/de'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/de/deg/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ abc/de'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ abc/de/def/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/def/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), '/abc');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { z: 'd' }), '/abc?z=d');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de' }), '/abc/de');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', z: 'f' }), '/abc/de?z=f');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 'gh' }), '/abc/de/def/gh');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 'gh', z: 'f' }), '/abc/de/def/gh?z=f');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'gh' }), '/abc?y=gh');
+        });
+    });
+
+    describe('Expand Route Optional Grand Parent Child', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: ['abc+/{x}+/def/{y}'] }
             ]);
         });
 

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2523,6 +2523,21 @@ describe('MatchTest', function () {
         });
     });
 
+    describe('Two Route Reverse Default', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: ['{x}/{y}', '{x}'], defaults: { y: 's' } }
+            ]);
+        });
+        
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'a' }), '/a');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'a', y: 'b' }), '/a/b');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'a', y: 's' }), '/a');
+        });
+    });
+
     describe('Two Route Optional Parent Child', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2406,24 +2406,19 @@ describe('MatchTest', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
-                { key: 's', route: 'abc/{x?}+/def/{y}', defaults: { x: 's' } }
+                { key: 's', route: 'abc/{x}+/def/{y?}', defaults: { y: 's' } }
             ]);
         });
 
         it('should match', function() {
-            var { data } = stateNavigator.parseLink('/abc');
-            assert.strictEqual(Object.keys(data).length, 1);
-            assert.strictEqual(data.x, 's');
-            var { data } = stateNavigator.parseLink('/abc?z=d');
-            assert.strictEqual(Object.keys(data).length, 2);
-            assert.strictEqual(data.x, 's');
-            assert.strictEqual(data.z, 'd');
             var { data } = stateNavigator.parseLink('/abc/de');
-            assert.strictEqual(Object.keys(data).length, 1);
-            assert.strictEqual(data.x, 'de');
-            var { data } = stateNavigator.parseLink('/abc/de?z=f');
             assert.strictEqual(Object.keys(data).length, 2);
             assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.y, 's');
+            var { data } = stateNavigator.parseLink('/abc/de?z=f');
+            assert.strictEqual(Object.keys(data).length, 3);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.y, 's');
             assert.strictEqual(data.z, 'f');
             var { data } = stateNavigator.parseLink('/abc/de/def/gh');
             assert.strictEqual(Object.keys(data).length, 2);
@@ -2434,33 +2429,33 @@ describe('MatchTest', function () {
             assert.strictEqual(data.x, 'de');
             assert.strictEqual(data.y, 'gh');
             assert.strictEqual(data.z, 'i');
-            var { data } = stateNavigator.parseLink('/abc/s/def/gh');
+            var { data } = stateNavigator.parseLink('/abc/de/def');
             assert.strictEqual(Object.keys(data).length, 2);
-            assert.strictEqual(data.x, 's');
-            assert.strictEqual(data.y, 'gh');
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.y, 's');
         });
 
         it('should not match', function() {
-            assert.throws(() => stateNavigator.parseLink('/abc/de/def'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/abc/de/def/gh/i'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/abd/de'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/abc/de/deg/gh'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/ abc/de'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/ abc/de/def/gh'), /Url is invalid/, '');
-            assert.throws(() => stateNavigator.parseLink('/abc/def/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
         });
 
         it('should build', function() {
-            assert.strictEqual(stateNavigator.getNavigationLink('s'), '/abc');
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { z: 'd' }), '/abc?z=d');
             assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de' }), '/abc/de');
             assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', z: 'f' }), '/abc/de?z=f');
             assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 'gh' }), '/abc/de/def/gh');
             assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 'gh', z: 'f' }), '/abc/de/def/gh?z=f');
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'gh' }), '/abc/s/def/gh');
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 's' }), '/abc');
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 's', z: 'd' }), '/abc?z=d');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 's' }), '/abc/de');
+        });
+        
+        it('should not build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), null);
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'gh' }), null);
         });
     });
 
@@ -2754,62 +2749,57 @@ describe('MatchTest', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
-                { key: 's', route: 'abc+/{x}+/def/{y}', defaults: { x: 2 } }
+                { key: 's', route: 'abc/{x}+/def/{y?}', defaults: { y: 2 } }
             ]);
         });
 
         it('should match', function() {
-            var { data } = stateNavigator.parseLink('/abc');
-            assert.strictEqual(Object.keys(data).length, 1);
-            assert.strictEqual(data.x, 2);
-            var { data } = stateNavigator.parseLink('/abc?z=d');
+            var { data } = stateNavigator.parseLink('/abc/de');
             assert.strictEqual(Object.keys(data).length, 2);
-            assert.strictEqual(data.x, 2);
-            assert.strictEqual(data.z, 'd');
-            var { data } = stateNavigator.parseLink('/abc/3');
-            assert.strictEqual(Object.keys(data).length, 1);
-            assert.strictEqual(data.x, 3);
-            var { data } = stateNavigator.parseLink('/abc/3?z=f');
-            assert.strictEqual(Object.keys(data).length, 2);
-            assert.strictEqual(data.x, 3);
-            assert.strictEqual(data.z, 'f');
-            var { data } = stateNavigator.parseLink('/abc/3/def/gh');
-            assert.strictEqual(Object.keys(data).length, 2);
-            assert.strictEqual(data.x, 3);
-            assert.strictEqual(data.y, 'gh');
-            var { data } = stateNavigator.parseLink('/abc/3/def/gh?z=i');
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.y, 2);
+            var { data } = stateNavigator.parseLink('/abc/de?z=f');
             assert.strictEqual(Object.keys(data).length, 3);
-            assert.strictEqual(data.x, 3);
-            assert.strictEqual(data.y, 'gh');
-            assert.strictEqual(data.z, 'i');
-            var { data } = stateNavigator.parseLink('/abc/2/def/gh');
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.y, 2);
+            assert.strictEqual(data.z, 'f');
+            var { data } = stateNavigator.parseLink('/abc/de/def/3');
             assert.strictEqual(Object.keys(data).length, 2);
-            assert.strictEqual(data.x, 2);
-            assert.strictEqual(data.y, 'gh');
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.y, 3);
+            var { data } = stateNavigator.parseLink('/abc/de/def/3?z=i');
+            assert.strictEqual(Object.keys(data).length, 3);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.y, 3);
+            assert.strictEqual(data.z, 'i');
+            var { data } = stateNavigator.parseLink('/abc/de/def');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.y, 2);
         });
 
         it('should not match', function() {
-            assert.throws(() => stateNavigator.parseLink('/abc/de/def'), /Url is invalid/, '');
-            assert.throws(() => stateNavigator.parseLink('/abc/de/def/gh/i'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/de/def/3/i'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/abd/de'), /Url is invalid/, '');
-            assert.throws(() => stateNavigator.parseLink('/abc/de/deg/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/de/deg/3'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/ abc/de'), /Url is invalid/, '');
-            assert.throws(() => stateNavigator.parseLink('/ abc/de/def/gh'), /Url is invalid/, '');
-            assert.throws(() => stateNavigator.parseLink('/abc/def/gh'), /Url is invalid/, '');
-            assert.throws(() => stateNavigator.parseLink('/abc/def'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ abc/de/def/3'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/de/def/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
         });
 
         it('should build', function() {
-            assert.strictEqual(stateNavigator.getNavigationLink('s'), '/abc');
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { z: 'd' }), '/abc?z=d');
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 3 }), '/abc/3');
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 3, z: 'f' }), '/abc/3?z=f');
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 3, y: 'gh' }), '/abc/3/def/gh');
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 3, y: 'gh', z: 'f' }), '/abc/3/def/gh?z=f');
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'gh' }), '/abc/2/def/gh');
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 2 }), '/abc');
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 2, z: 'd' }), '/abc?z=d');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de' }), '/abc/de');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', z: 'f' }), '/abc/de?z=f');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 3 }), '/abc/de/def/3');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 3, z: 'f' }), '/abc/de/def/3?z=f');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 2 }), '/abc/de');
+        });
+        
+        it('should not build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), null);
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 3 }), null);
         });
     });
 
@@ -3210,6 +3200,21 @@ describe('MatchTest', function () {
             assert.strictEqual(stateNavigator.getNavigationLink('s', { x: '2' }), '/');
             assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 1 }), '/a/1');
             assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 1, y: 2 }), '/1?y=2');
+        });
+    });
+
+    describe('Without Types Expand Route Default', function () {
+        it('should build', function() {
+            var stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: '+a/{x}+/b/{y}', trackTypes: false, defaults: { y: 2 } }
+            ]);
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), '/');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 1, y: 2 }), '/a/1');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 1, y: '2' }), '/a/1');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 1 }), '/a/1');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: '1' }), '/a/1');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 1, y: 3 }), '/a/1/b/3');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 1, y: '3' }), '/a/1/b/3');
         });
     });
 

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -5471,4 +5471,50 @@ describe('MatchTest', function () {
             assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'ab' }), '/x}?x=ab');
         });
     });
+
+    describe('Leading and Trailing Slash', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: '/a/{x}/' }
+            ]);
+        });
+
+        it('should match', function() {
+            var { data } = stateNavigator.parseLink('/a/b');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 'b');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'b' }), '/a/b');
+        });
+    });
+
+    describe('Expand Route Leading and Trailing Slash', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: '/abc/+{x}/+def/{y}/' }
+            ]);
+        });
+
+        it('should match', function() {
+            var { data } = stateNavigator.parseLink('/abc');
+            assert.strictEqual(Object.keys(data).length, 0);
+            var { data } = stateNavigator.parseLink('/abc/de');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 'de');
+            var { data } = stateNavigator.parseLink('/abc/de/def/gh');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.y, 'gh');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), '/abc');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de' }), '/abc/de');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 'gh' }), '/abc/de/def/gh');
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2406,7 +2406,7 @@ describe('MatchTest', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
-                { key: 's', route: 'abc/{x}+/def/{y?}', defaults: { y: 's' } }
+                { key: 's', route: 'abc/{x}+/def/{y}', defaults: { y: 's' } }
             ]);
         });
 
@@ -2429,10 +2429,6 @@ describe('MatchTest', function () {
             assert.strictEqual(data.x, 'de');
             assert.strictEqual(data.y, 'gh');
             assert.strictEqual(data.z, 'i');
-            var { data } = stateNavigator.parseLink('/abc/de/def');
-            assert.strictEqual(Object.keys(data).length, 2);
-            assert.strictEqual(data.x, 'de');
-            assert.strictEqual(data.y, 's');
         });
 
         it('should not match', function() {
@@ -2441,6 +2437,7 @@ describe('MatchTest', function () {
             assert.throws(() => stateNavigator.parseLink('/abc/de/deg/gh'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/ abc/de'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/ abc/de/def/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/de/def'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/abc'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
         });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -770,6 +770,47 @@ describe('MatchTest', function () {
             assert.strictEqual(Object.keys(data).length, 2);
             assert.strictEqual(data.x, 'ab');
             assert.strictEqual(data.z, 'cd');
+            var { data } = stateNavigator.parseLink('/cde');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 'cde');
+            var { data } = stateNavigator.parseLink('/cde?z=fg');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'cde');
+            assert.strictEqual(data.z, 'fg');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ab/cd'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ab//'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'ab' }), '/ab');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'ab', z: 'cd' }), '/ab?z=cd');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'cde' }), '/cde');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'cde', z: 'fg' }), '/cde?z=fg');
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), '/cde');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { z: 'fg' }), '/cde?z=fg');
+        });
+    });
+
+    describe('One Optional Param One Segment Default', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: '{x?}', defaults: { x: 'cde' } }
+            ]);
+        });
+
+        it('should match', function() {
+            var { data } = stateNavigator.parseLink('/ab');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 'ab');
+            var { data } = stateNavigator.parseLink('/ab?z=cd');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'ab');
+            assert.strictEqual(data.z, 'cd');
             var { data } = stateNavigator.parseLink('/');
             assert.strictEqual(Object.keys(data).length, 1);
             assert.strictEqual(data.x, 'cde');

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2310,6 +2310,7 @@ describe('MatchTest', function () {
             assert.throws(() => stateNavigator.parseLink('/abc/de/deg/gh'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/ abc/de'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/ abc/de/def/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/def/gh'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
         });
 
@@ -2320,6 +2321,7 @@ describe('MatchTest', function () {
             assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', z: 'f' }), '/abc/de?z=f');
             assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 'gh' }), '/abc/de/def/gh');
             assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 'gh', z: 'f' }), '/abc/de/def/gh?z=f');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'gh' }), '/abc?y=gh');
         });
     });
 
@@ -2362,6 +2364,7 @@ describe('MatchTest', function () {
             assert.throws(() => stateNavigator.parseLink('/abc/de/deg/gh'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/ abc/de'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/ abc/de/def/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/def/gh'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
         });
 
@@ -2372,6 +2375,7 @@ describe('MatchTest', function () {
             assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', z: 'f' }), '/abc/de?z=f');
             assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 'gh' }), '/abc/de/def/gh');
             assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 'gh', z: 'f' }), '/abc/de/def/gh?z=f');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'gh' }), '/abc?y=gh');
         });
     });
 

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2204,6 +2204,108 @@ describe('MatchTest', function () {
         });
     });
 
+    describe('Expand Route Mixed Parent Child', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: 'abc{x}+/def/{y}' }
+            ]);
+        });
+
+        it('should match', function() {
+            var { data } = stateNavigator.parseLink('/abcde');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 'de');
+            var { data } = stateNavigator.parseLink('/abcde?z=f');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.z, 'f');
+            var { data } = stateNavigator.parseLink('/abcde/def/gh');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.y, 'gh');
+            var { data } = stateNavigator.parseLink('/abcde/def/gh?z=i');
+            assert.strictEqual(Object.keys(data).length, 3);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.y, 'gh');
+            assert.strictEqual(data.z, 'i');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => stateNavigator.parseLink('/abc'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abcde/def'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abcde/def/gh/i'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abdde'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abcde/deg/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ abcde'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ abcde/def/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de' }), '/abcde');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', z: 'f' }), '/abcde?z=f');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 'gh' }), '/abcde/def/gh');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 'gh', z: 'f' }), '/abcde/def/gh?z=f');
+        });
+
+        it('should not build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), null);
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'gh' }), null);
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { z: 'g' }), null);
+        });
+    });
+
+    describe('Expand Route Mixed Optional Parent Child', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: 'abc+{x}+/def/{y}' }
+            ]);
+        });
+
+        it('should match', function() {
+            var { data } = stateNavigator.parseLink('/abc');
+            assert.strictEqual(Object.keys(data).length, 0);
+            var { data } = stateNavigator.parseLink('/abcde');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 'de');
+            var { data } = stateNavigator.parseLink('/abcde?z=f');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.z, 'f');
+            var { data } = stateNavigator.parseLink('/abcde/def/gh');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.y, 'gh');
+            var { data } = stateNavigator.parseLink('/abcde/def/gh?z=i');
+            assert.strictEqual(Object.keys(data).length, 3);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.y, 'gh');
+            assert.strictEqual(data.z, 'i');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => stateNavigator.parseLink('/abcde/def'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abcde/def/gh/i'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abdde'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abcde/deg/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ abcde'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ abcde/def/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), '/abc');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de' }), '/abcde');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', z: 'f' }), '/abcde?z=f');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 'gh' }), '/abcde/def/gh');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 'gh', z: 'f' }), '/abcde/def/gh?z=f');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { z: 'g' }), '/abc?z=g');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'gh' }), '/abc?y=gh');
+        });
+    });
+
     describe('Two Route Default', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2191,7 +2191,7 @@ describe('MatchTest', function () {
         });
     });
 
-    describe('Expand Route Parent Child', function () {
+    describe('Expand Route', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
@@ -2242,7 +2242,7 @@ describe('MatchTest', function () {
         });
     });
 
-    describe('Expand Route Mixed Parent Child', function () {
+    describe('Expand Route Mixed', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
@@ -2296,7 +2296,7 @@ describe('MatchTest', function () {
         });
     });
 
-    describe('Expand Route Optional Mixed Parent Child', function () {
+    describe('Expand Route Optional Mixed', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
@@ -2350,7 +2350,7 @@ describe('MatchTest', function () {
         });
     });
 
-    describe('Expand Route Optional Mixed Grand Parent Child', function () {
+    describe('Expand Route Expand Optional Mixed', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
@@ -2523,7 +2523,7 @@ describe('MatchTest', function () {
         });
     });
 
-    describe('Expand Route Optional Parent Child', function () {
+    describe('Expand Route Optional', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
@@ -2577,7 +2577,7 @@ describe('MatchTest', function () {
         });
     });
 
-    describe('Expand Route Optional Grand Parent Child', function () {
+    describe('Expand Route Expand Optional', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3669,6 +3669,44 @@ describe('MatchTest', function () {
         });
 
         it('should match', function() {
+            var { data } = stateNavigator.parseLink('/ef/ghi');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x.length, 2);
+            assert.strictEqual(data.x[0], 'ef');
+            assert.strictEqual(data.x[1], 'ghi');
+            var { data } = stateNavigator.parseLink('/abcd');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x.length, 1);
+            assert.strictEqual(data.x[0], 'abcd');
+            var { data } = stateNavigator.parseLink('/ab/cd');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x.length, 2);
+            assert.strictEqual(data.x[0], 'ab');
+            assert.strictEqual(data.x[1], 'cd');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), '/ef/ghi');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: ['abcd'] }), '/abcd');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: ['ab', 'cd'] }), '/ab/cd');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: ['ef', 'ghi'] }), '/ef/ghi');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: ['ghi', 'ef'] }), '/ghi/ef');
+        });
+    });
+
+    describe('One Optional Splat Param One Segment Default', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: '{*x?}', defaults: { x: ['ef', 'ghi'] } }
+            ]);
+        });
+
+        it('should match', function() {
             var { data } = stateNavigator.parseLink('/');
             assert.strictEqual(Object.keys(data).length, 1);
             assert.strictEqual(data.x.length, 2);
@@ -4581,10 +4619,10 @@ describe('MatchTest', function () {
         var stateNavigator1: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator0 = new Navigation.StateNavigator([
-                { key: 's', route: 'ab/{x}', defaults: { x: 'cd' } }
+                { key: 's', route: 'ab/{x?}', defaults: { x: 'cd' } }
             ]);
             stateNavigator1 = new Navigation.StateNavigator([
-                { key: 's', route: 'cd/{x}', defaults: { x: 12 } }
+                { key: 's', route: 'cd/{x?}', defaults: { x: 12 } }
             ]);
         });
 

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1824,7 +1824,7 @@ describe('MatchTest', function () {
     describe('Extra Defaults', function () {
         it('should match', function() {
             var stateNavigator = new Navigation.StateNavigator([
-                { key: 's', route: '{x}', defaults: { x: 'a', y: 'b' } }
+                { key: 's', route: '{x?}', defaults: { x: 'a', y: 'b' } }
             ]);
             var { data } = stateNavigator.parseLink('/');
             assert.strictEqual(Object.keys(data).length, 2);

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2402,6 +2402,68 @@ describe('MatchTest', function () {
         });
     });
 
+    describe('Expand Route Default', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: 'abc/{x?}+/def/{y}', defaults: { x: 's' } }
+            ]);
+        });
+
+        it('should match', function() {
+            var { data } = stateNavigator.parseLink('/abc');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 's');
+            var { data } = stateNavigator.parseLink('/abc?z=d');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 's');
+            assert.strictEqual(data.z, 'd');
+            var { data } = stateNavigator.parseLink('/abc/de');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 'de');
+            var { data } = stateNavigator.parseLink('/abc/de?z=f');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.z, 'f');
+            var { data } = stateNavigator.parseLink('/abc/de/def/gh');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.y, 'gh');
+            var { data } = stateNavigator.parseLink('/abc/de/def/gh?z=i');
+            assert.strictEqual(Object.keys(data).length, 3);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.y, 'gh');
+            assert.strictEqual(data.z, 'i');
+            var { data } = stateNavigator.parseLink('/abc/s/def/gh');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 's');
+            assert.strictEqual(data.y, 'gh');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => stateNavigator.parseLink('/abc/de/def'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/de/def/gh/i'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abd/de'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/de/deg/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ abc/de'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ abc/de/def/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/def/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), '/abc');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { z: 'd' }), '/abc?z=d');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de' }), '/abc/de');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', z: 'f' }), '/abc/de?z=f');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 'gh' }), '/abc/de/def/gh');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 'gh', z: 'f' }), '/abc/de/def/gh?z=f');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'gh' }), '/abc/s/def/gh');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 's' }), '/abc');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 's', z: 'd' }), '/abc?z=d');
+        });
+    });
+
     describe('Two Route Default', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -5633,4 +5633,42 @@ describe('MatchTest', function () {
             assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 'gh' }), '/abc/de/def/gh');
         });
     });
+
+    describe('Expand and Two Route', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: ['abc/{x}+/def/{y}', 'ghi/{y}'] }
+            ]);
+        });
+
+        it('should match', function() {
+            var { data } = stateNavigator.parseLink('/abc/ab');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 'ab');
+            var { data } = stateNavigator.parseLink('/abc/ab/def/de');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'ab');
+            assert.strictEqual(data.y, 'de');
+            var { data } = stateNavigator.parseLink('/ghi/gh');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.y, 'gh');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => stateNavigator.parseLink('/abc'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/ab/def'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ghi'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'ab' }), '/abc/ab');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'ab', y: 'de' }), '/abc/ab/def/de');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'gh' }), '/ghi/gh');
+        });
+
+        it('should not build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), null);
+        });
+    });
 });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -835,11 +835,11 @@ describe('MatchTest', function () {
         });
     });
 
-    describe('One Param One Segment Default Number', function () {
+    describe('One Optional Param One Segment Default Number', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
-                { key: 's', route: '{x}', defaults: { x: 345 } }
+                { key: 's', route: '{x?}', defaults: { x: 345 } }
             ]);
         });
 
@@ -878,11 +878,11 @@ describe('MatchTest', function () {
         });
     });
 
-    describe('One Param One Segment Default Boolean', function () {
+    describe('One Optional Param One Segment Default Boolean', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
-                { key: 's', route: '{x}', defaults: { x: true } }
+                { key: 's', route: '{x?}', defaults: { x: true } }
             ]);
         });
 
@@ -921,11 +921,11 @@ describe('MatchTest', function () {
         });
     });
 
-    describe('One Param One Segment Default Date', function () {
+    describe('One Optional Param One Segment Default Date', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
-                { key: 's', route: '{x}', defaults: { x: new Date(2010, 3, 7) } }
+                { key: 's', route: '{x?}', defaults: { x: new Date(2010, 3, 7) } }
             ]);
         });
 
@@ -1096,6 +1096,52 @@ describe('MatchTest', function () {
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
                 { key: 's', route: 'ab/{x}', defaults: { x: 'ccdd' } }
+            ]);
+        });
+
+        it('should match', function() {
+            var { data } = stateNavigator.parseLink('/ab/cde');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 'cde');
+            var { data } = stateNavigator.parseLink('/ab/cde?y=fg');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'cde');
+            assert.strictEqual(data.y, 'fg');
+            var { data } = stateNavigator.parseLink('/ab/ccdd');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 'ccdd');
+            var { data } = stateNavigator.parseLink('/ab/ccdd?y=ee');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'ccdd');
+            assert.strictEqual(data.y, 'ee');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => stateNavigator.parseLink('/ ab/cd'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/d'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ab/d/e'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/a/b/d'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abd'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/cab/d'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ab'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'cde' }), '/ab/cde');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'cde', y: 'fg' }), '/ab/cde?y=fg');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'ccdd' }), '/ab/ccdd');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'ccdd', y: 'ee' }), '/ab/ccdd?y=ee');
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), '/ab/ccdd');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'ee' }), '/ab/ccdd?y=ee');
+        });
+    });
+
+    describe('One Optional Param Two Segment Default', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: 'ab/{x?}', defaults: { x: 'ccdd' } }
             ]);
         });
 

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -801,6 +801,77 @@ describe('MatchTest', function () {
         });
     });
 
+    describe('One Param Two Segment One Mixed', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: 'ab{x}/cd' }
+            ]);
+        });
+
+        it('should match', function() {
+            var { data } = stateNavigator.parseLink('/abcde/cd');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 'cde');
+            var { data } = stateNavigator.parseLink('/abcde/cd?y=f');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'cde');
+            assert.strictEqual(data.y, 'f');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => stateNavigator.parseLink('/ab/cd'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ab'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'cde' }), '/abcde/cd');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'cde', y: 'f' }), '/abcde/cd?y=f');
+        });
+
+        it('should not build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'de' }), null);
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), null);
+        });
+    });
+
+    describe('One Optional Param Two Segment One Mixed', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: 'ab{x?}/cd' }
+            ]);
+        });
+
+        it('should match', function() {
+            var { data } = stateNavigator.parseLink('/ab/cd');
+            assert.strictEqual(Object.keys(data).length, 0);
+            var { data } = stateNavigator.parseLink('/ab/cd?y=f');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.y, 'f');
+            var { data } = stateNavigator.parseLink('/abcde/cd');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 'cde');
+            var { data } = stateNavigator.parseLink('/abcde/cd?y=f');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'cde');
+            assert.strictEqual(data.y, 'f');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => stateNavigator.parseLink('/ab'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), '/ab/cd');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'f' }), '/ab/cd?y=f');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'cde' }), '/abcde/cd');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'cde', y: 'f' }), '/abcde/cd?y=f');
+        });
+    });
+
     describe('One Param One Segment Default', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2271,11 +2271,63 @@ describe('MatchTest', function () {
         });
     });
 
-    describe('Two Route Optional', function () {
+    describe('Two Route Optional Parent Child', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
                 { key: 's', route: ['abc/{x?}', 'abc/{x}/def/{y}'] }
+            ]);
+        });
+
+        it('should match', function() {
+            var { data } = stateNavigator.parseLink('/abc');
+            assert.strictEqual(Object.keys(data).length, 0);
+            var { data } = stateNavigator.parseLink('/abc?z=d');
+            assert.strictEqual(data.z, 'd');
+            assert.strictEqual(Object.keys(data).length, 1);
+            var { data } = stateNavigator.parseLink('/abc/de');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 'de');
+            var { data } = stateNavigator.parseLink('/abc/de?z=f');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.z, 'f');
+            var { data } = stateNavigator.parseLink('/abc/de/def/gh');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.y, 'gh');
+            var { data } = stateNavigator.parseLink('/abc/de/def/gh?z=i');
+            assert.strictEqual(Object.keys(data).length, 3);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.y, 'gh');
+            assert.strictEqual(data.z, 'i');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => stateNavigator.parseLink('/abc/de/def'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/de/def/gh/i'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abd/de'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/de/deg/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ abc/de'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ abc/de/def/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), '/abc');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { z: 'd' }), '/abc?z=d');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de' }), '/abc/de');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', z: 'f' }), '/abc/de?z=f');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 'gh' }), '/abc/de/def/gh');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 'gh', z: 'f' }), '/abc/de/def/gh?z=f');
+        });
+    });
+
+    describe('Expand Route Optional Parent Child', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: ['abc/{x?}+/def/{y}'] }
             ]);
         });
 

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2750,6 +2750,69 @@ describe('MatchTest', function () {
         });
     });
 
+    describe('Expand Route Default Number', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: 'abc+/{x}+/def/{y}', defaults: { x: 2 } }
+            ]);
+        });
+
+        it('should match', function() {
+            var { data } = stateNavigator.parseLink('/abc');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 2);
+            var { data } = stateNavigator.parseLink('/abc?z=d');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 2);
+            assert.strictEqual(data.z, 'd');
+            var { data } = stateNavigator.parseLink('/abc/3');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 3);
+            var { data } = stateNavigator.parseLink('/abc/3?z=f');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 3);
+            assert.strictEqual(data.z, 'f');
+            var { data } = stateNavigator.parseLink('/abc/3/def/gh');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 3);
+            assert.strictEqual(data.y, 'gh');
+            var { data } = stateNavigator.parseLink('/abc/3/def/gh?z=i');
+            assert.strictEqual(Object.keys(data).length, 3);
+            assert.strictEqual(data.x, 3);
+            assert.strictEqual(data.y, 'gh');
+            assert.strictEqual(data.z, 'i');
+            var { data } = stateNavigator.parseLink('/abc/2/def/gh');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 2);
+            assert.strictEqual(data.y, 'gh');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => stateNavigator.parseLink('/abc/de/def'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/de/def/gh/i'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abd/de'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/de/deg/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ abc/de'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ abc/de/def/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/def/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/def'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), '/abc');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { z: 'd' }), '/abc?z=d');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 3 }), '/abc/3');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 3, z: 'f' }), '/abc/3?z=f');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 3, y: 'gh' }), '/abc/3/def/gh');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 3, y: 'gh', z: 'f' }), '/abc/3/def/gh?z=f');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'gh' }), '/abc/2/def/gh');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 2 }), '/abc');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 2, z: 'd' }), '/abc?z=d');
+        });
+    });
+
     describe('Two Route Default Type Number', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2233,6 +2233,8 @@ describe('MatchTest', function () {
 
         it('should not match', function() {
             assert.throws(() => stateNavigator.parseLink('/abc'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/def/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/def'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/abcde/def'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/abcde/def/gh/i'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/abdde'), /Url is invalid/, '');
@@ -2253,6 +2255,60 @@ describe('MatchTest', function () {
             assert.strictEqual(stateNavigator.getNavigationLink('s'), null);
             assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'gh' }), null);
             assert.strictEqual(stateNavigator.getNavigationLink('s', { z: 'g' }), null);
+        });
+    });
+
+    describe('Expand Route Optional Mixed Parent Child', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: 'abc{x?}+/def/{y}' }
+            ]);
+        });
+
+        it('should match', function() {
+            var { data } = stateNavigator.parseLink('/abc');
+            assert.strictEqual(Object.keys(data).length, 0);
+            var { data } = stateNavigator.parseLink('/abcde');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 'de');
+            var { data } = stateNavigator.parseLink('/abc/def/gh');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.y, 'gh');
+            var { data } = stateNavigator.parseLink('/abcde?z=f');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.z, 'f');
+            var { data } = stateNavigator.parseLink('/abcde/def/gh');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.y, 'gh');
+            var { data } = stateNavigator.parseLink('/abcde/def/gh?z=i');
+            assert.strictEqual(Object.keys(data).length, 3);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.y, 'gh');
+            assert.strictEqual(data.z, 'i');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => stateNavigator.parseLink('/abc/def'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abcde/def'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abcde/def/gh/i'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abdde'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abcde/deg/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ abcde'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ abcde/def/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), '/abc');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de' }), '/abcde');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', z: 'f' }), '/abcde?z=f');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 'gh' }), '/abcde/def/gh');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 'gh', z: 'f' }), '/abcde/def/gh?z=f');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { z: 'g' }), '/abc?z=g');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'gh' }), '/abc/def/gh');
         });
     });
 
@@ -2286,6 +2342,8 @@ describe('MatchTest', function () {
         });
 
         it('should not match', function() {
+            assert.throws(() => stateNavigator.parseLink('/abc/def/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/def'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/abcde/def'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/abcde/def/gh/i'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/abdde'), /Url is invalid/, '');

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -3206,15 +3206,21 @@ describe('MatchTest', function () {
     describe('Without Types Expand Route Default', function () {
         it('should build', function() {
             var stateNavigator = new Navigation.StateNavigator([
-                { key: 's', route: '+a/{x}+/b/{y}', trackTypes: false, defaults: { y: 2 } }
+                { key: 's', route: '+a/{x}+/b/{y}', trackTypes: false, defaults: { x: '3', y: 2 } }
             ]);
             assert.strictEqual(stateNavigator.getNavigationLink('s'), '/');
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 1, y: 2 }), '/a/1');
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 1, y: '2' }), '/a/1');
             assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 1 }), '/a/1');
             assert.strictEqual(stateNavigator.getNavigationLink('s', { x: '1' }), '/a/1');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 3 }), '/');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: '3' }), '/');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 1, y: 2 }), '/a/1');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 1, y: '2' }), '/a/1');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 3, y: 2 }), '/');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: '3', y: '2' }), '/');
             assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 1, y: 3 }), '/a/1/b/3');
             assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 1, y: '3' }), '/a/1/b/3');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 3, y: 3 }), '/a/3/b/3');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: '3', y: '3' }), '/a/3/b/3');
         });
     });
 

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2042,6 +2042,44 @@ describe('MatchTest', function () {
         });
     });
 
+    describe('Expand Route One With Param', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: '+abc/{x}' }
+            ]);
+        });
+
+        it('should match', function() {
+            var { data } = stateNavigator.parseLink('/');
+            assert.strictEqual(Object.keys(data).length, 0);
+            var { data } = stateNavigator.parseLink('/?y=d');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.y, 'd');
+            var { data } = stateNavigator.parseLink('/abc/de');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 'de');
+            var { data } = stateNavigator.parseLink('/abc/de?y=f');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.y, 'f');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => stateNavigator.parseLink('/abc'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ab/de'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ abc/de'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('//abc/de'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), '/');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'd' }), '/?y=d');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de' }), '/abc/de');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 'f' }), '/abc/de?y=f');
+        });
+    });
+
     describe('Two Route Param', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -4333,6 +4333,49 @@ describe('MatchTest', function () {
         });
     });
 
+    describe('One Optional Splat Param One Mixed Segment Default', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: 'ab{*x?}', defaults: { x: ['cde', 'fg'] } }
+            ]);
+        });
+
+        it('should match', function() {
+            var { data } = stateNavigator.parseLink('/ab');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x.length, 2);
+            assert.strictEqual(data.x[0], 'cde');
+            assert.strictEqual(data.x[1], 'fg');
+            var { data } = stateNavigator.parseLink('/abcde/fg');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x.length, 2);
+            assert.strictEqual(data.x[0], 'cde');
+            assert.strictEqual(data.x[1], 'fg');
+            var { data } = stateNavigator.parseLink('/abcd');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x.length, 1);
+            assert.strictEqual(data.x[0], 'cd');
+            var { data } = stateNavigator.parseLink('/abcd/efg');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x.length, 2);
+            assert.strictEqual(data.x[0], 'cd');
+            assert.strictEqual(data.x[1], 'efg');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/acd'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), '/ab');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: ['cde', 'fg'] }), '/ab');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: ['cd'] }), '/abcd');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: ['cd', 'efg'] }), '/abcd/efg');
+        });
+    });
+
     describe('Without Types Splat Conflicting Default And Default Type', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -2857,6 +2857,61 @@ describe('MatchTest', function () {
         });
     });
 
+    describe('Expand Route Default Type Number', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: 'abc+/{x}+/def/{y}', defaultTypes: { x: 'number' } }
+            ]);
+        });
+
+        it('should match', function() {
+            var { data } = stateNavigator.parseLink('/abc');
+            assert.strictEqual(Object.keys(data).length, 0);
+            var { data } = stateNavigator.parseLink('/abc?z=d');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.z, 'd');
+            var { data } = stateNavigator.parseLink('/abc/3');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 3);
+            var { data } = stateNavigator.parseLink('/abc/3?z=f');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 3);
+            assert.strictEqual(data.z, 'f');
+            var { data } = stateNavigator.parseLink('/abc/3/def/gh');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 3);
+            assert.strictEqual(data.y, 'gh');
+            var { data } = stateNavigator.parseLink('/abc/3/def/gh?z=i');
+            assert.strictEqual(Object.keys(data).length, 3);
+            assert.strictEqual(data.x, 3);
+            assert.strictEqual(data.y, 'gh');
+            assert.strictEqual(data.z, 'i');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => stateNavigator.parseLink('/abc/de/def'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/de/def/gh/i'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abd/de'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/de/deg/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ abc/de'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ abc/de/def/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/def/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/def'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), '/abc');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { z: 'd' }), '/abc?z=d');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 3 }), '/abc/3');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 3, z: 'f' }), '/abc/3?z=f');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 3, y: 'gh' }), '/abc/3/def/gh');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 3, y: 'gh', z: 'f' }), '/abc/3/def/gh?z=f');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'gh' }), '/abc?y=gh');
+        });
+    });
+
     describe('Without Types', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1412,7 +1412,7 @@ describe('MatchTest', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
-                { key: 's', route: 'ab/{w}/{x}/{y?}/{z?}', defaults: { w: 'abc', x: 'de' } }
+                { key: 's', route: 'ab/{w?}/{x?}/{y?}/{z?}', defaults: { w: 'abc', x: 'de' } }
             ]);
         });
 

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1547,7 +1547,7 @@ describe('MatchTest', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
-                { key: 's', route: 'a/{=*"()\'-_+~@:?><.;[],!£$%^#&}', defaults: { '=*"()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' } }
+                { key: 's', route: 'a/{=*"()\'-_+~@:?><.;[],!£$%^#&?}', defaults: { '=*"()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' } }
             ]);
         });
         

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1200,6 +1200,64 @@ describe('MatchTest', function () {
             assert.strictEqual(data.x, 'aa');
             assert.strictEqual(data.y, 'bbb');
             assert.strictEqual(data.z, 'cccc');
+            var { data } = stateNavigator.parseLink('/aa/c');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'aa');
+            assert.strictEqual(data.y, 'c');
+            var { data } = stateNavigator.parseLink('/ab/bbb');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'ab');
+            assert.strictEqual(data.y, 'bbb');
+            var { data } = stateNavigator.parseLink('/ab/c');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'ab');
+            assert.strictEqual(data.y, 'c');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => stateNavigator.parseLink('/aa/bbb/e'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/aa'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
+        });
+   
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'aa', y: 'bbb' }), '/aa/bbb');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'aa', y: 'bbb', z: 'cccc' }), '/aa/bbb?z=cccc');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'aa', y: 'c' }), '/aa/c');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'aa', y: 'c', z: 'd' }), '/aa/c?z=d');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'bbb' }), '/ab/bbb');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'bbb', z: 'cccc' }), '/ab/bbb?z=cccc');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'c' }), '/ab/c');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'c', z: 'd' }), '/ab/c?z=d');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'aa' }), '/aa/c');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'aa', z: 'd' }), '/aa/c?z=d');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'ab', y: 'c' }), '/ab/c');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'ab', y: 'c', z: 'd' }), '/ab/c?z=d');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'ab' }), '/ab/c');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'ab', z: 'd' }), '/ab/c?z=d');
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), '/ab/c');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { z: 'd' }), '/ab/c?z=d');
+        });
+    });
+
+    describe('Two Optional Param Two Segment Two Default', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: '{x?}/{y?}', defaults: { x: 'ab', y: 'c' } }
+            ]);
+        });
+
+        it('should match', function() {
+            var { data } = stateNavigator.parseLink('/aa/bbb');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'aa');
+            assert.strictEqual(data.y, 'bbb');
+            var { data } = stateNavigator.parseLink('/aa/bbb?z=cccc');
+            assert.strictEqual(Object.keys(data).length, 3);
+            assert.strictEqual(data.x, 'aa');
+            assert.strictEqual(data.y, 'bbb');
+            assert.strictEqual(data.z, 'cccc');
             var { data } = stateNavigator.parseLink('/aa');
             assert.strictEqual(Object.keys(data).length, 2);
             assert.strictEqual(data.x, 'aa');

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -689,6 +689,7 @@ describe('MatchTest', function () {
             assert.throws(() => stateNavigator.parseLink('/ab/cdefgh'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/abcdefgh//'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/abcde'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abe'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/abc'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/ab'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
@@ -701,7 +702,53 @@ describe('MatchTest', function () {
 
         it('should not build', function() {
             assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'cd' }), null);
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'fghh' }), null);
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'fgh' }), null);
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), null);
+        });
+    });
+
+    describe('Two Param One Optional One Mixed Segment', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: 'ab{x?}e{y}' }
+            ]);
+        });
+
+        it('should match', function() {
+            var { data } = stateNavigator.parseLink('/abcdefgh');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'cd');
+            assert.strictEqual(data.y, 'fgh');
+            var { data } = stateNavigator.parseLink('/abcdefgh?z=i');
+            assert.strictEqual(Object.keys(data).length, 3);
+            assert.strictEqual(data.x, 'cd');
+            assert.strictEqual(data.y, 'fgh');
+            assert.strictEqual(data.z, 'i');
+            var { data } = stateNavigator.parseLink('/abefgh');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.y, 'fgh');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => stateNavigator.parseLink('/ abcdefgh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ab/cdefgh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abcdefgh//'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abcde'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abe'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ab'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'cd', y: 'fgh' }), '/abcdefgh');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'cd', y: 'fgh', z: 'i' }), '/abcdefgh?z=i');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { y: 'fgh' }), '/abefgh');
+        });
+
+        it('should not build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'cd' }), null);
             assert.strictEqual(stateNavigator.getNavigationLink('s'), null);
         });
     });

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1307,7 +1307,7 @@ describe('MatchTest', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
-                { key: 's', route: '{x}/{y}', defaults: { y: 'ab' } }
+                { key: 's', route: '{x}/{y?}', defaults: { y: 'ab' } }
             ]);
         });
 
@@ -1357,7 +1357,7 @@ describe('MatchTest', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
-                { key: 's', route: '{x}/{y?}', defaults: { x: 'abc' } }
+                { key: 's', route: '{x?}/{y?}', defaults: { x: 'abc' } }
             ]);
         });
 
@@ -3913,7 +3913,7 @@ describe('MatchTest', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
-                { key: 's', route: 'ab/{*x}', defaults: { x: ['ef', 'ghi'] } }
+                { key: 's', route: 'ab/{*x?}', defaults: { x: ['ef', 'ghi'] } }
             ]);
         });
 

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1723,32 +1723,32 @@ describe('MatchTest', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
-                { key: 's', route: 'a/{=*"()\'-_+~@:?><.;[],!£$%^#&?}', defaults: { '=*"()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' } }
+                { key: 's', route: 'a/{=*"()\'-_~@:?><.;[],!£$%^#&?}', defaults: { '=*"()\'-_~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' } }
             ]);
         });
         
         it('should match', function() {
             var { data } = stateNavigator.parseLink('/a/*%3D%22()\'-0__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
             assert.strictEqual(Object.keys(data).length, 1);
-            assert.strictEqual(data['=*"()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
+            assert.strictEqual(data['=*"()\'-_~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
             var { data } = stateNavigator.parseLink('/a/*%3D%22()\'-0__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
             assert.strictEqual(Object.keys(data).length, 2);
-            assert.strictEqual(data['=*"()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
+            assert.strictEqual(data['=*"()\'-_~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
             assert.strictEqual(data['*="()\'-__+~@:?><.;[],!£$%^#&'], '*="()\'-_+~@:?><.;[],!£$%^#&');
             var { data } = stateNavigator.parseLink('/a');
             assert.strictEqual(Object.keys(data).length, 1);
-            assert.strictEqual(data['=*"()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
+            assert.strictEqual(data['=*"()\'-_~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
             var { data } = stateNavigator.parseLink('/a?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
             assert.strictEqual(Object.keys(data).length, 2);
-            assert.strictEqual(data['=*"()\'-_+~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
+            assert.strictEqual(data['=*"()\'-_~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
             assert.strictEqual(data['*="()\'-__+~@:?><.;[],!£$%^#&'], '*="()\'-_+~@:?><.;[],!£$%^#&');
         });
 
         it('should build', function() {
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { '=*"()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&' }), '/a/*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { '=*"()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&', '*="()\'-__+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&'}), '/a/*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { '=*"()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' }), '/a');
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { '=*"()\'-_+~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&', '*="()\'-__+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&'}), '/a?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { '=*"()\'-_~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&' }), '/a/*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { '=*"()\'-_~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&', '*="()\'-__+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&'}), '/a/*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { '=*"()\'-_~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' }), '/a');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { '=*"()\'-_~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&', '*="()\'-__+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&'}), '/a?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
             assert.strictEqual(stateNavigator.getNavigationLink('s'), '/a');
             assert.strictEqual(stateNavigator.getNavigationLink('s', { '*="()\'-__+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&' }), '/a?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
         });
@@ -1758,23 +1758,23 @@ describe('MatchTest', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
-                { key: 's', route: '.+*\^$\[\]()\'/{x}' }
+                { key: 's', route: '.*\^$\[\]()\'/{x}' }
             ]);
         });
         
         it('should match', function() {
-            var { data } = stateNavigator.parseLink('/.+*\^$\[\]()\'/abc');
+            var { data } = stateNavigator.parseLink('/.*\^$\[\]()\'/abc');
             assert.strictEqual(Object.keys(data).length, 1);
             assert.strictEqual(data.x, 'abc');
-            var { data } = stateNavigator.parseLink('/.+*\^$\[\]()\'/abc?y=de');
+            var { data } = stateNavigator.parseLink('/.*\^$\[\]()\'/abc?y=de');
             assert.strictEqual(Object.keys(data).length, 2);
             assert.strictEqual(data.x, 'abc');
             assert.strictEqual(data.y, 'de');
         });
 
         it('should build', function() {
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'abc' }), '/.+*\^$\[\]()\'/abc');
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'abc', y: 'de' }), '/.+*\^$\[\]()\'/abc?y=de');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'abc' }), '/.*\^$\[\]()\'/abc');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'abc', y: 'de' }), '/.*\^$\[\]()\'/abc?y=de');
         });
     });
 
@@ -2107,6 +2107,57 @@ describe('MatchTest', function () {
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
                 { key: 's', route: ['abc/{x}', 'abc/{x}/def/{y}'] }
+            ]);
+        });
+
+        it('should match', function() {
+            var { data } = stateNavigator.parseLink('/abc/de');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 'de');
+            var { data } = stateNavigator.parseLink('/abc/de?z=f');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.z, 'f');
+            var { data } = stateNavigator.parseLink('/abc/de/def/gh');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.y, 'gh');
+            var { data } = stateNavigator.parseLink('/abc/de/def/gh?z=i');
+            assert.strictEqual(Object.keys(data).length, 3);
+            assert.strictEqual(data.x, 'de');
+            assert.strictEqual(data.y, 'gh');
+            assert.strictEqual(data.z, 'i');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => stateNavigator.parseLink('/abc'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/de/def'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/de/def/gh/i'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abd/de'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/abc/de/deg/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ abc/de'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/ abc/de/def/gh'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de' }), '/abc/de');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', z: 'f' }), '/abc/de?z=f');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 'gh' }), '/abc/de/def/gh');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'de', y: 'gh', z: 'f' }), '/abc/de/def/gh?z=f');
+        });
+
+        it('should not build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), null);
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { z: 'g' }), null);
+        });
+    });
+
+    describe('Expand Route Parent Child', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: 'abc/{x}+/def/{y}' }
             ]);
         });
 

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1618,22 +1618,20 @@ describe('MatchTest', function () {
             assert.strictEqual(Object.keys(data).length, 2);
             assert.strictEqual(data.x, 'cde');
             assert.strictEqual(data.y, 'fg');
+            var { data } = stateNavigator.parseLink('/ab');
+            assert.strictEqual(Object.keys(data).length, 0);
         });
 
         it('should not match', function() {
             assert.throws(() => stateNavigator.parseLink('/ab/cde'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/abcd//'), /Url is invalid/, '');
-            assert.throws(() => stateNavigator.parseLink('/ab'), /Url is invalid/, '');
             assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
         });
 
         it('should build', function() {
             assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'cde' }), '/abcde');
             assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'cde', y: 'fg' }), '/abcde?y=fg');
-        });
-
-        it('should not build', function() {
-            assert.strictEqual(stateNavigator.getNavigationLink('s'), null);
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), '/ab');
         });
     });
 

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -1983,7 +1983,7 @@ describe('MatchTest', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
-                { key: 's', route: ['abc/{x}', 'def/{y}'], defaults: { x: 's' } }
+                { key: 's', route: ['abc/{x?}', 'def/{y}'], defaults: { x: 's' } }
             ]);
         });
 
@@ -2102,7 +2102,7 @@ describe('MatchTest', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
-                { key: 's', route: ['def/{y}', 'abc/{x}'], defaults: { x: 2 } }
+                { key: 's', route: ['def/{y}', 'abc/{x?}'], defaults: { x: 2 } }
             ]);
         });
 
@@ -2230,7 +2230,7 @@ describe('MatchTest', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
-                { key: 's', route: '{x}', trackTypes: false, defaults: { x: 2 } }
+                { key: 's', route: '{x?}', trackTypes: false, defaults: { x: 2 } }
             ]);
         });
 
@@ -2285,7 +2285,7 @@ describe('MatchTest', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
-                { key: 's', route: '{x}', trackTypes: false, defaults: { x: '2' }, defaultTypes: { x: 'number' } }
+                { key: 's', route: '{x?}', trackTypes: false, defaults: { x: '2' }, defaultTypes: { x: 'number' } }
             ]);
         });
 
@@ -2314,7 +2314,7 @@ describe('MatchTest', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
-                { key: 's', route: '{x}', trackTypes: false, defaults: { x: 'a' }, defaultTypes: { x: 'number' } }
+                { key: 's', route: '{x?}', trackTypes: false, defaults: { x: 'a' }, defaultTypes: { x: 'number' } }
             ]);
         });
         it('should match', function() {
@@ -2486,7 +2486,7 @@ describe('MatchTest', function () {
     describe('Without Types Two Route Default', function () {
         it('should build', function() {
             var stateNavigator = new Navigation.StateNavigator([
-                { key: 's', route: ['{x}', 'a/{y}'], trackTypes: false, defaults: { x: 2 } }
+                { key: 's', route: ['{x?}', 'a/{y}'], trackTypes: false, defaults: { x: 2 } }
             ]);
             assert.strictEqual(stateNavigator.getNavigationLink('s'), '/');
             assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 2, y: 1 }), '/a/1');
@@ -4234,7 +4234,7 @@ describe('MatchTest', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
-                { key: 's', route: '{*x}', trackTypes: false, defaults: { x: ['a', 'bc'] }, defaultTypes: { x: 'number' } }
+                { key: 's', route: '{*x?}', trackTypes: false, defaults: { x: ['a', 'bc'] }, defaultTypes: { x: 'number' } }
             ]);
         });
         it('should match', function() {
@@ -4266,7 +4266,7 @@ describe('MatchTest', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
-                { key: 's', route: '{*x}', trackTypes: false, defaults: { x: ['a'] }, defaultTypes: { x: 'number' } }
+                { key: 's', route: '{*x?}', trackTypes: false, defaults: { x: ['a'] }, defaultTypes: { x: 'number' } }
             ]);
         });
         it('should match', function() {
@@ -4423,7 +4423,7 @@ describe('MatchTest', function () {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function () {
             stateNavigator = new Navigation.StateNavigator([
-                { key: 's', route: '{*x}', defaults: { x: [new Date(2011, 7, 3), new Date(2010, 3, 7)] } }
+                { key: 's', route: '{*x?}', defaults: { x: [new Date(2011, 7, 3), new Date(2010, 3, 7)] } }
             ]);
         });
 

--- a/NavigationJS/test/NavigationRoutingTest.ts
+++ b/NavigationJS/test/NavigationRoutingTest.ts
@@ -4819,4 +4819,58 @@ describe('MatchTest', function () {
             assert.strictEqual(stateNavigator1.getNavigationLink('s', { x: 'a b' }), '/1/a1b');
         });
     });
+
+    describe('First Half Param', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: '{x' }
+            ]);
+        });
+
+        it('should match', function() {
+            var { data } = stateNavigator.parseLink('/{x');
+            assert.strictEqual(Object.keys(data).length, 0);
+            var { data } = stateNavigator.parseLink('/{x?x=ab');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 'ab');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => stateNavigator.parseLink('/a'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), '/{x');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'ab' }), '/{x?x=ab');
+        });
+    });
+
+    describe('Last Half Param', function () {
+        var stateNavigator: Navigation.StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new Navigation.StateNavigator([
+                { key: 's', route: 'x}' }
+            ]);
+        });
+
+        it('should match', function() {
+            var { data } = stateNavigator.parseLink('/x}');
+            assert.strictEqual(Object.keys(data).length, 0);
+            var { data } = stateNavigator.parseLink('/x}?x=ab');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 'ab');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => stateNavigator.parseLink('/a'), /Url is invalid/, '');
+            assert.throws(() => stateNavigator.parseLink('/'), /Url is invalid/, '');
+        });
+
+        it('should build', function() {
+            assert.strictEqual(stateNavigator.getNavigationLink('s'), '/x}');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { x: 'ab' }), '/x}?x=ab');
+        });
+    });
 });

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -3117,6 +3117,23 @@ describe('Navigation', function () {
         });
     });
 
+    describe('Expand And Two Route Navigate', function () {
+        it('should go to State', function() {
+            var stateNavigator = new Navigation.StateNavigator([
+                { key: 's0', route: 's' },
+                { key: 's1', route: ['abc/{x}+/def/{y}', 'ghi/{y}'] }
+            ]);
+            stateNavigator.navigateLink('/abc/de');
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+            stateNavigator.navigateLink('abc/de/def/gh');
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+            stateNavigator.navigateLink('/ghi/jk');
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+            stateNavigator.navigateLink('/s');
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s0']);
+        });
+    });
+
     describe('Clear State Context', function() {
         var stateNavigator: Navigation.StateNavigator;
         beforeEach(function() {

--- a/NavigationJS/test/NavigationTest.ts
+++ b/NavigationJS/test/NavigationTest.ts
@@ -3072,6 +3072,21 @@ describe('Navigation', function () {
         });
     });
 
+    describe('Expand Route Navigate', function () {
+        it('should go to State', function() {
+            var stateNavigator = new Navigation.StateNavigator([
+                { key: 's0', route: 's' },
+                { key: 's1', route: 'abc/{x}+/def/{y}' }
+            ]);
+            stateNavigator.navigateLink('/abc/de');
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+            stateNavigator.navigateLink('abc/de/def/gh');
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+            stateNavigator.navigateLink('/s');
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s0']);
+        });
+    });
+    
     describe('Two Route Root Navigate', function () {
         it('should go to State', function() {
             var stateNavigator = new Navigation.StateNavigator([
@@ -3081,6 +3096,21 @@ describe('Navigation', function () {
             stateNavigator.navigateLink('/abc/de');
             assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s0']);
             stateNavigator.navigateLink('/sa');
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s0']);
+            stateNavigator.navigateLink('/s');
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+        });
+    });
+    
+    describe('Expand Route Root Navigate', function () {
+        it('should go to State', function() {
+            var stateNavigator = new Navigation.StateNavigator([
+                { key: 's0', route: '+abc/{x}' },
+                { key: 's1', route: 's' }
+            ]);
+            stateNavigator.navigateLink('/abc/de');
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s0']);
+            stateNavigator.navigateLink('/');
             assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s0']);
             stateNavigator.navigateLink('/s');
             assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);

--- a/NavigationKnockout/sample/app.js
+++ b/NavigationKnockout/sample/app.js
@@ -44,7 +44,7 @@
 };
 
 var stateNavigator = new Navigation.StateNavigator([
-    { key: 'people', route: '{startRowIndex}/{maximumRows}/{sortExpression}', defaults: { startRowIndex: 0, maximumRows: 10, sortExpression: 'Name'}, trackTypes: false, title: 'Person Search' },
+    { key: 'people', route: '{startRowIndex?}/{maximumRows?}/{sortExpression?}', defaults: { startRowIndex: 0, maximumRows: 10, sortExpression: 'Name'}, trackTypes: false, title: 'Person Search' },
     { key: 'person', route: 'person', defaultTypes: { id: 'number' }, trackTypes: false, trackCrumbTrail: true, title: 'Person Details' }
 ]/*, new Navigation.HashHistoryManager(true)*/);
 ko.applyBindings(new PersonViewModel(stateNavigator));

--- a/NavigationReact/sample/app.html
+++ b/NavigationReact/sample/app.html
@@ -130,7 +130,7 @@
         });
 
         var stateNavigator = new Navigation.StateNavigator([
-            { key: 'people', route: '{startRowIndex}/{maximumRows}/{sortExpression}', defaults: { startRowIndex: 0, maximumRows: 10, sortExpression: 'Name'}, trackTypes: false, title: 'Person Search' },
+            { key: 'people', route: '{startRowIndex?}/{maximumRows?}/{sortExpression?}', defaults: { startRowIndex: 0, maximumRows: 10, sortExpression: 'Name'}, trackTypes: false, title: 'Person Search' },
             { key: 'person', route: 'person', defaultTypes: { id: 'number' }, trackTypes: false, trackCrumbTrail: true, title: 'Person Details' }
         ]);
 


### PR DESCRIPTION
* Introduced + shorthand for parent child: ab{x}+/ef{y} matches ab/cd and ab/cd/ef/gh
* Honoured Optional in Mixed Segment: ab{x?} matches /ab
* Differentiated Optional and Non-Optional with Defaults: default x = 'cd', ab/{x?} matches /ab but ab/{x} doesn't
* Ignored route array order: default y = 'b', ['{x}', '{x}/{y}'] and ['{x}/{y}','{x}'] with data {x: 'a', y: 'b'} both build /a
