### PR TITLE
Catered for Date and Array in Active Link Check

### DIFF
--- a/NavigationAngular/src/LinkUtility.ts
+++ b/NavigationAngular/src/LinkUtility.ts
@@ -22,24 +22,34 @@ class LinkUtility {
         return navigationData;
     }
 
-    static isActive(stateNavigator: Navigation.StateNavigator, key: string, val: any): boolean {
-        if (!stateNavigator.stateContext.state)
-            return false;
-        if (val != null) {
-            var trackTypes = stateNavigator.stateContext.state.trackTypes;
-            var currentVal = stateNavigator.stateContext.data[key];
-            if (currentVal != null)
-                return trackTypes ? val === currentVal : val.toString() == currentVal.toString();
-            else
-                return val === '';
+    static setActive(element: ng.IAugmentedJQuery, stateNavigator: Navigation.StateNavigator, attrs: ng.IAttributes, navigationData, activeCssClass, disableActive) {
+        if (!activeCssClass && !disableActive)
+            return;
+        var active = !!attrs['href'];
+        for (var key in navigationData) {
+            var val = navigationData[key];
+            active = active && (val == null || this.areEqual(val, stateNavigator.stateContext.data[key]));
         }
-        return true;
-    }
-
-    static setActive(element: ng.IAugmentedJQuery, attrs: ng.IAttributes, active: boolean, activeCssClass: string, disableActive: boolean) {
         element.toggleClass(activeCssClass, active);
         if (active && disableActive)
             attrs.$set('href', null);
+    }
+
+    private static areEqual(val: any, currentVal: any): boolean {
+        if (currentVal == null)
+            return val == null || val === '';
+        var valType = Object.prototype.toString.call(val);
+        if (valType !== Object.prototype.toString.call(currentVal))
+            return false;
+        if (valType === '[object Array]') {
+            var active = val.length === currentVal.length;
+            for(var i = 0; active && i < val.length; i++) {
+                active = this.areEqual(val[i], currentVal[i]);
+            }
+            return active;
+        } else {
+            return isNaN(val) ? val === currentVal : +val === +currentVal;
+        }
     }
 
     static addListeners(element: ng.IAugmentedJQuery, setLink: () => void, $parse: ng.IParseService, attrs: ng.IAttributes, scope: ng.IScope) {

--- a/NavigationAngular/src/NavigationLink.ts
+++ b/NavigationAngular/src/NavigationLink.ts
@@ -27,14 +27,10 @@ var NavigationLink = ($parse: ng.IParseService) => {
 
 function setNavigationLink(element: ng.IAugmentedJQuery, attrs: ng.IAttributes, stateNavigator: Navigation.StateNavigator,
     stateKey: string, navigationData: any, includeCurrentData: boolean, currentDataKeys: string, activeCssClass: string, disableActive: boolean) {
-    var active = true;
-    for (var key in navigationData) {
-        active = active && LinkUtility.isActive(stateNavigator, key, navigationData[key]);
-    }
     LinkUtility.setLink(stateNavigator, element, attrs, () => stateNavigator.getNavigationLink(stateKey,
         LinkUtility.getData(stateNavigator, navigationData, includeCurrentData, currentDataKeys))
     );
-    active = active && !!attrs['href'] && stateNavigator.stateContext.state && stateNavigator.stateContext.state.key === stateKey;
-    LinkUtility.setActive(element, attrs, active, activeCssClass, disableActive);
+    if (stateNavigator.stateContext.state && stateNavigator.stateContext.state.key === stateKey)
+        LinkUtility.setActive(element, stateNavigator, attrs, navigationData, activeCssClass, disableActive);
 }
 export = NavigationLink;

--- a/NavigationAngular/src/RefreshLink.ts
+++ b/NavigationAngular/src/RefreshLink.ts
@@ -26,14 +26,9 @@ var RefreshLink = ($parse: ng.IParseService) => {
 
 function setRefreshLink(element: ng.IAugmentedJQuery, attrs: ng.IAttributes, stateNavigator: Navigation.StateNavigator,
     navigationData: any, includeCurrentData: boolean, currentDataKeys: string, activeCssClass: string, disableActive: boolean) {
-    var active = true;
-    for (var key in navigationData) {
-        active = active && LinkUtility.isActive(stateNavigator, key, navigationData[key]);
-    }
     LinkUtility.setLink(stateNavigator, element, attrs, () => stateNavigator.getRefreshLink(
         LinkUtility.getData(stateNavigator, navigationData, includeCurrentData, currentDataKeys))
     );
-    active = active && !!attrs['href'];
-    LinkUtility.setActive(element, attrs, active, activeCssClass, disableActive);
+    LinkUtility.setActive(element, stateNavigator, attrs, navigationData, activeCssClass, disableActive);
 }
 export = RefreshLink;

--- a/NavigationCycle/src/LinkUtility.ts
+++ b/NavigationCycle/src/LinkUtility.ts
@@ -24,25 +24,36 @@ class LinkUtility {
         return navigationData;
     }
     
-    static isActive(stateNavigator: Navigation.StateNavigator, key: string, val: any): boolean {
-        if (!stateNavigator.stateContext.state)
-            return false;
-        if (val != null) {
-            var trackTypes = stateNavigator.stateContext.state.trackTypes;
-            var currentVal = stateNavigator.stateContext.data[key];
-            if (currentVal != null)
-                return trackTypes ? val === currentVal : val.toString() == currentVal.toString();
-            else
-                return val === '';
+
+    static setActive(stateNavigator: Navigation.StateNavigator, properties: any, newProperties: any) {
+        if (!properties.activeCssClass && !properties.disableActive)
+            return;
+        var active = !!newProperties.href;
+        for (var key in properties.navigationData) {
+            var val = properties.navigationData[key];
+            active = active && (val == null || this.areEqual(val, stateNavigator.stateContext.data[key]));
         }
-        return true;
+        if (active && properties.activeCssClass)
+            newProperties.className = !newProperties.className ? properties.activeCssClass : newProperties.className + ' ' + properties.activeCssClass;
+        if (active && properties.disableActive)
+            newProperties.href = null;
     }
 
-    static setActive(properties: any, active: boolean, activeCssClass: string, disableActive: boolean) {
-        if (active && activeCssClass)
-            properties.className = !properties.className ? activeCssClass : properties.className + ' ' + activeCssClass;
-        if (active && disableActive)
-            properties.href = null;        
+    private static areEqual(val: any, currentVal: any): boolean {
+        if (currentVal == null)
+            return val == null || val === '';
+        var valType = Object.prototype.toString.call(val);
+        if (valType !== Object.prototype.toString.call(currentVal))
+            return false;
+        if (valType === '[object Array]') {
+            var active = val.length === currentVal.length;
+            for(var i = 0; active && i < val.length; i++) {
+                active = this.areEqual(val[i], currentVal[i]);
+            }
+            return active;
+        } else {
+            return isNaN(val) ? val === currentVal : +val === +currentVal;
+        }
     }
     
     static setHistoryAction(properties: any, historyAction) {

--- a/NavigationCycle/src/NavigationLink.ts
+++ b/NavigationCycle/src/NavigationLink.ts
@@ -6,18 +6,14 @@ var NavigationLink = (stateNavigator: Navigation.StateNavigator, properties: any
     var newProperties: any = {};
     for(var key in properties)
         newProperties[key] = properties[key];
-    var active = true;
-    for (var key in properties.navigationData) {
-        active = active && LinkUtility.isActive(stateNavigator, key, properties.navigationData[key]);
-    }
     var navigationData = LinkUtility.getData(stateNavigator, properties.navigationData, properties.includeCurrentData, properties.currentDataKeys);
     try {
         var link = stateNavigator.getNavigationLink(properties.stateKey, navigationData);
         newProperties.href = stateNavigator.historyManager.getHref(link);
     } catch(e) {
     }
-    active = active && !!newProperties.href && stateNavigator.stateContext.state && stateNavigator.stateContext.state.key === properties.stateKey;
-    LinkUtility.setActive(newProperties, active, properties.activeCssClass, properties.disableActive);
+    if (stateNavigator.stateContext.state && stateNavigator.stateContext.state.key === properties.stateKey)
+        LinkUtility.setActive(stateNavigator, properties, newProperties);
     LinkUtility.setHistoryAction(newProperties, properties.historyAction);
     return CycleDOM.h(newProperties.href ? 'a' : 'span', newProperties, children);
 }

--- a/NavigationCycle/src/RefreshLink.ts
+++ b/NavigationCycle/src/RefreshLink.ts
@@ -6,18 +6,13 @@ var RefreshLink = (stateNavigator: Navigation.StateNavigator, properties: any, c
     var newProperties: any = {};
     for(var key in properties)
         newProperties[key] = properties[key];
-    var active = true;
-    for (var key in properties.navigationData) {
-        active = active && LinkUtility.isActive(stateNavigator, key, properties.navigationData[key]);
-    }
     var navigationData = LinkUtility.getData(stateNavigator, properties.navigationData, properties.includeCurrentData, properties.currentDataKeys);
     try {
         var link = stateNavigator.getRefreshLink(navigationData);
         newProperties.href = stateNavigator.historyManager.getHref(link);
     } catch(e) {
     }
-    active = active && !!newProperties.href;
-    LinkUtility.setActive(newProperties, active, properties.activeCssClass, properties.disableActive);
+    LinkUtility.setActive(stateNavigator, properties, newProperties);
     LinkUtility.setHistoryAction(newProperties, properties.historyAction);
     return CycleDOM.h(newProperties.href ? 'a' : 'span', newProperties, children);
 }

--- a/NavigationInferno/src/LinkUtility.ts
+++ b/NavigationInferno/src/LinkUtility.ts
@@ -21,25 +21,35 @@ class LinkUtility {
         return navigationData;
     }
 
-    static isActive(stateNavigator: Navigation.StateNavigator, key: string, val: any): boolean {
-        if (!stateNavigator.stateContext.state)
-            return false;
-        if (val != null) {
-            var trackTypes = stateNavigator.stateContext.state.trackTypes;
-            var currentVal = stateNavigator.stateContext.data[key];
-            if (currentVal != null)
-                return trackTypes ? val === currentVal : val.toString() == currentVal.toString();
-            else
-                return val === '';
+    static setActive(stateNavigator: Navigation.StateNavigator, props: any, toProps: any) {
+        if (!props.activeCssClass && !props.disableActive)
+            return;
+        var active = !!toProps.href;
+        for (var key in props.navigationData) {
+            var val = props.navigationData[key];
+            active = active && (val == null || this.areEqual(val, stateNavigator.stateContext.data[key]));
         }
-        return true;
+        if (active && props.activeCssClass)
+            toProps.className = !toProps.className ? props.activeCssClass : toProps.className + ' ' + props.activeCssClass;
+        if (active && props.disableActive)
+            toProps.href = null;        
     }
 
-    static setActive(props: any, active: boolean, activeCssClass: string, disableActive: boolean) {
-        if (active && activeCssClass)
-            props.className = !props.className ? activeCssClass : props.className + ' ' + activeCssClass;
-        if (active && disableActive)
-            props.href = null;        
+    private static areEqual(val: any, currentVal: any): boolean {
+        if (currentVal == null)
+            return val == null || val === '';
+        var valType = Object.prototype.toString.call(val);
+        if (valType !== Object.prototype.toString.call(currentVal))
+            return false;
+        if (valType === '[object Array]') {
+            var active = val.length === currentVal.length;
+            for(var i = 0; active && i < val.length; i++) {
+                active = this.areEqual(val[i], currentVal[i]);
+            }
+            return active;
+        } else {
+            return isNaN(val) ? val === currentVal : +val === +currentVal;
+        }
     }
 
     static isValidAttribute(attr: string): boolean {

--- a/NavigationInferno/src/NavigationLink.ts
+++ b/NavigationInferno/src/NavigationLink.ts
@@ -31,14 +31,10 @@ class NavigationLink extends InfernoComponent {
             if (LinkUtility.isValidAttribute(key))
                 props[key] = this.props[key];
         }
-        var active = true;
-        for (var key in this.props.navigationData) {
-            active = active && LinkUtility.isActive(this.getStateNavigator(), key, this.props.navigationData[key]);
-        }
         props.href = this.getNavigationLink();
         LinkUtility.addListeners(this, this.getStateNavigator(), this.props, props, () => this.getNavigationLink());
-        active = active && !!props.href && this.getStateNavigator().stateContext.state && this.getStateNavigator().stateContext.state.key === this.props.stateKey;
-        LinkUtility.setActive(props, active, this.props.activeCssClass, this.props.disableActive);
+        if (this.getStateNavigator().stateContext.state && this.getStateNavigator().stateContext.state.key === this.props.stateKey)
+            LinkUtility.setActive(this.getStateNavigator(), this.props, props);
         return createElement('a', props, this.props.children);
     }
 };

--- a/NavigationInferno/src/RefreshLink.ts
+++ b/NavigationInferno/src/RefreshLink.ts
@@ -31,14 +31,9 @@ class RefreshLink extends InfernoComponent {
             if (LinkUtility.isValidAttribute(key))
                 props[key] = this.props[key];
         }
-        var active = true;
-        for (var key in this.props.navigationData) {
-            active = active && LinkUtility.isActive(this.getStateNavigator(), key, this.props.navigationData[key]);
-        }
         props.href = this.getRefreshLink();
         LinkUtility.addListeners(this, this.getStateNavigator(), this.props, props, () => this.getRefreshLink());
-        active = active && !!props.href;
-        LinkUtility.setActive(props, active, this.props.activeCssClass, this.props.disableActive);
+        LinkUtility.setActive(this.getStateNavigator(), this.props, props);
         return createElement('a', props, this.props.children);
     }
 };

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -20,9 +20,7 @@ class LinkUtility {
         return navigationData;
     }
 
-    static setActive(element: HTMLAnchorElement, stateNavigator: Navigation.StateNavigator, navigationData: any, allBindings: KnockoutAllBindingsAccessor) {
-        var activeCssClass = ko.unwrap(allBindings.get('activeCssClass'));
-        var disableActive = ko.unwrap(allBindings.get('disableActive'));
+    static setActive(element: HTMLAnchorElement, stateNavigator: Navigation.StateNavigator, navigationData: any, activeCssClass, disableActive) {
         if (!activeCssClass && !disableActive)
             return;
         var active = !!element.href;

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -20,24 +20,36 @@ class LinkUtility {
         return navigationData;
     }
 
-    static isActive(stateNavigator: Navigation.StateNavigator, key: string, val: any): boolean {
-        if (!stateNavigator.stateContext.state)
-            return false;
-        if (val != null) {
-            var trackTypes = stateNavigator.stateContext.state.trackTypes;
-            var currentVal = stateNavigator.stateContext.data[key];
-            if (currentVal != null)
-                return trackTypes ? val === currentVal : val.toString() == currentVal.toString();
-            else
-                return val === '';
+    static setActive(element: HTMLAnchorElement, stateNavigator: Navigation.StateNavigator, navigationData: any, allBindings: KnockoutAllBindingsAccessor) {
+        var activeCssClass = ko.unwrap(allBindings.get('activeCssClass'));
+        var disableActive = ko.unwrap(allBindings.get('disableActive'));
+        if (!activeCssClass && !disableActive)
+            return;
+        var active = !!element.href;
+        for (var key in navigationData) {
+            var val = navigationData[key];
+            active = active && (val == null || this.areEqual(val, stateNavigator.stateContext.data[key]));
         }
-        return true;
-    }
-
-    static setActive(element: HTMLAnchorElement, active: boolean, activeCssClass: string, disableActive: boolean) {
         ko.utils.toggleDomNodeCssClass(element, activeCssClass, active)
         if (active && disableActive)
             element.removeAttribute('href');        
+    }
+
+    private static areEqual(val: any, currentVal: any): boolean {
+        if (currentVal == null)
+            return val == null || val === '';
+        var valType = Object.prototype.toString.call(val);
+        if (valType !== Object.prototype.toString.call(currentVal))
+            return false;
+        if (valType === '[object Array]') {
+            var active = val.length === currentVal.length;
+            for(var i = 0; active && i < val.length; i++) {
+                active = this.areEqual(val[i], currentVal[i]);
+            }
+            return active;
+        } else {
+            return isNaN(val) ? val === currentVal : +val === +currentVal;
+        }
     }
 
     static addListeners(element: HTMLAnchorElement, setLink: () => void, allBindings: KnockoutAllBindingsAccessor, viewModel: any) {

--- a/NavigationKnockout/src/LinkUtility.ts
+++ b/NavigationKnockout/src/LinkUtility.ts
@@ -20,7 +20,7 @@ class LinkUtility {
         return navigationData;
     }
 
-    static setActive(element: HTMLAnchorElement, stateNavigator: Navigation.StateNavigator, navigationData: any, activeCssClass, disableActive) {
+    static setActive(element: HTMLAnchorElement, stateNavigator: Navigation.StateNavigator, navigationData, activeCssClass, disableActive) {
         if (!activeCssClass && !disableActive)
             return;
         var active = !!element.href;

--- a/NavigationKnockout/src/NavigationLink.ts
+++ b/NavigationKnockout/src/NavigationLink.ts
@@ -15,17 +15,14 @@ function setNavigationLink(element: HTMLAnchorElement, valueAccessor: () => any,
     var stateKey = ko.unwrap(valueAccessor());
     var data = {};
     var navigationData = ko.unwrap(allBindings.get('navigationData'));
-    var active = true;
     var stateNavigator: Navigation.StateNavigator = allBindings.get('stateNavigator');
     for (var key in navigationData) {
-        var val = ko.unwrap(navigationData[key]);
-        data[key] = val;
-        active = active && LinkUtility.isActive(stateNavigator, key, val);
+        data[key] = ko.unwrap(navigationData[key]);
     }
     LinkUtility.setLink(stateNavigator, element, () => stateNavigator.getNavigationLink(stateKey,
         LinkUtility.getData(stateNavigator, data, ko.unwrap(allBindings.get('includeCurrentData')), ko.unwrap(allBindings.get('currentDataKeys'))))
     );
-    active = active && !!element.href && stateNavigator.stateContext.state && stateNavigator.stateContext.state.key === stateKey;
-    LinkUtility.setActive(element, active, ko.unwrap(allBindings.get('activeCssClass')), ko.unwrap(allBindings.get('disableActive')));
+    if (stateNavigator.stateContext.state && stateNavigator.stateContext.state.key === stateKey)
+        LinkUtility.setActive(element, stateNavigator, data, allBindings);
 }
 export = NavigationLink;

--- a/NavigationKnockout/src/NavigationLink.ts
+++ b/NavigationKnockout/src/NavigationLink.ts
@@ -23,6 +23,6 @@ function setNavigationLink(element: HTMLAnchorElement, valueAccessor: () => any,
         LinkUtility.getData(stateNavigator, data, ko.unwrap(allBindings.get('includeCurrentData')), ko.unwrap(allBindings.get('currentDataKeys'))))
     );
     if (stateNavigator.stateContext.state && stateNavigator.stateContext.state.key === stateKey)
-        LinkUtility.setActive(element, stateNavigator, data, allBindings);
+        LinkUtility.setActive(element, stateNavigator, data, ko.unwrap(allBindings.get('activeCssClass')), ko.unwrap(allBindings.get('disableActive')));
 }
 export = NavigationLink;

--- a/NavigationKnockout/src/RefreshLink.ts
+++ b/NavigationKnockout/src/RefreshLink.ts
@@ -21,6 +21,6 @@ function setRefreshLink(element: HTMLAnchorElement, valueAccessor: () => any, al
     LinkUtility.setLink(stateNavigator, element, () => stateNavigator.getRefreshLink(
         LinkUtility.getData(stateNavigator, data, ko.unwrap(allBindings.get('includeCurrentData')), ko.unwrap(allBindings.get('currentDataKeys'))))
     );
-    LinkUtility.setActive(element, stateNavigator, data, allBindings);
+    LinkUtility.setActive(element, stateNavigator, data, ko.unwrap(allBindings.get('activeCssClass')), ko.unwrap(allBindings.get('disableActive')));
 }
 export = RefreshLink;

--- a/NavigationKnockout/src/RefreshLink.ts
+++ b/NavigationKnockout/src/RefreshLink.ts
@@ -14,17 +14,13 @@ var RefreshLink = ko.bindingHandlers['refreshLink'] = {
 function setRefreshLink(element: HTMLAnchorElement, valueAccessor: () => any, allBindings: KnockoutAllBindingsAccessor) {
     var data = {};
     var navigationData = ko.unwrap(valueAccessor());
-    var active = true;
     var stateNavigator: Navigation.StateNavigator = allBindings.get('stateNavigator');
     for (var key in navigationData) {
-        var val = ko.unwrap(navigationData[key]);
-        data[key] = val;
-        active = active && LinkUtility.isActive(stateNavigator, key, val);
+        data[key] = ko.unwrap(navigationData[key]);
     }
     LinkUtility.setLink(stateNavigator, element, () => stateNavigator.getRefreshLink(
         LinkUtility.getData(stateNavigator, data, ko.unwrap(allBindings.get('includeCurrentData')), ko.unwrap(allBindings.get('currentDataKeys'))))
     );
-    active = active && !!element.href;
-    LinkUtility.setActive(element, active, ko.unwrap(allBindings.get('activeCssClass')), ko.unwrap(allBindings.get('disableActive')));
+    LinkUtility.setActive(element, stateNavigator, data, allBindings);
 }
 export = RefreshLink;

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -23,7 +23,7 @@ class LinkUtility {
     static setActive(stateNavigator: Navigation.StateNavigator, props: any, toProps: any) {
         if (!props.activeCssClass && !props.disableActive)
             return;
-        var active = !!toProps.href && !!stateNavigator.stateContext.state;
+        var active = !!toProps.href;
         for (var key in props.navigationData) {
             var val = props.navigationData[key];
             active = active && (val == null || this.areEqual(val, stateNavigator.stateContext.data[key]));

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -41,7 +41,7 @@ class LinkUtility {
         if (valType !== Object.prototype.toString.call(currentVal))
             return false;
         if (valType === '[object Array]') {
-            var active = val.length !== currentVal.length;
+            var active = val.length === currentVal.length;
             for(var i = 0; active && i < val.length; i++) {
                 active = this.areEqual(val[i], currentVal[i]);
             }

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -23,15 +23,24 @@ class LinkUtility {
     static isActive(stateNavigator: Navigation.StateNavigator, key: string, val: any): boolean {
         if (!stateNavigator.stateContext.state)
             return false;
-        if (val != null) {
-            var trackTypes = stateNavigator.stateContext.state.trackTypes;
-            var currentVal = stateNavigator.stateContext.data[key];
-            if (currentVal != null)
-                return trackTypes ? val === currentVal : val.toString() == currentVal.toString();
-            else
-                return val === '';
+        return val == null || this.areEqual(val, stateNavigator.stateContext.data[key]);
+    }
+
+    private static areEqual(val: any, currentVal: any): boolean {
+        if (currentVal == null)
+            return val == null || val === '';
+        var valType = Object.prototype.toString.call(val);
+        if (valType !== Object.prototype.toString.call(currentVal))
+            return false;
+        if (valType === '[object Array]') {
+            var active = val.length !== currentVal.length;
+            for(var i = 0; active && i < val.length; i++) {
+                active = this.areEqual(val[i], currentVal[i]);
+            }
+            return active;
+        } else {
+            return isNaN(val) ? val === currentVal : +val === +currentVal;
         }
-        return true;
     }
 
     static setActive(props: any, active: boolean, activeCssClass: string, disableActive: boolean) {

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -20,10 +20,18 @@ class LinkUtility {
         return navigationData;
     }
 
-    static isActive(stateNavigator: Navigation.StateNavigator, key: string, val: any): boolean {
-        if (!stateNavigator.stateContext.state)
-            return false;
-        return val == null || this.areEqual(val, stateNavigator.stateContext.data[key]);
+    static setActive(stateNavigator: Navigation.StateNavigator, props: any, toProps: any) {
+        if (!props.activeCssClass && !props.disableActive)
+            return;
+        var active = !!toProps.href && !!stateNavigator.stateContext.state;
+        for (var key in props.navigationData) {
+            var val = props.navigationData[key];
+            active = active && (val == null || this.areEqual(val, stateNavigator.stateContext.data[key]));
+        }
+        if (active && props.activeCssClass)
+            toProps.className = !toProps.className ? props.activeCssClass : toProps.className + ' ' + props.activeCssClass;
+        if (active && props.disableActive)
+            toProps.href = null;        
     }
 
     private static areEqual(val: any, currentVal: any): boolean {
@@ -41,13 +49,6 @@ class LinkUtility {
         } else {
             return isNaN(val) ? val === currentVal : +val === +currentVal;
         }
-    }
-
-    static setActive(props: any, active: boolean, activeCssClass: string, disableActive: boolean) {
-        if (active && activeCssClass)
-            props.className = !props.className ? activeCssClass : props.className + ' ' + activeCssClass;
-        if (active && disableActive)
-            props.href = null;        
     }
 
     static isValidAttribute(attr: string): boolean {

--- a/NavigationReact/src/NavigationLink.ts
+++ b/NavigationReact/src/NavigationLink.ts
@@ -34,14 +34,10 @@ class NavigationLink extends React.Component<any, any> {
             if (LinkUtility.isValidAttribute(key))
                 props[key] = this.props[key];
         }
-        var active = true;
-        for (var key in this.props.navigationData) {
-            active = active && LinkUtility.isActive(this.getStateNavigator(), key, this.props.navigationData[key]);
-        }
         props.href = this.getNavigationLink();
         LinkUtility.addListeners(this, this.getStateNavigator(), this.props, props, () => this.getNavigationLink());
-        active = active && !!props.href && this.getStateNavigator().stateContext.state && this.getStateNavigator().stateContext.state.key === this.props.stateKey;
-        LinkUtility.setActive(props, active, this.props.activeCssClass, this.props.disableActive);
+        if (this.getStateNavigator().stateContext.state && this.getStateNavigator().stateContext.state.key === this.props.stateKey)
+            LinkUtility.setActive(this.getStateNavigator(), this.props, props);
         return React.createElement('a', props, this.props.children);
     }
 };

--- a/NavigationReact/src/RefreshLink.ts
+++ b/NavigationReact/src/RefreshLink.ts
@@ -34,14 +34,9 @@ class RefreshLink extends React.Component<any, any> {
             if (LinkUtility.isValidAttribute(key))
                 props[key] = this.props[key];
         }
-        var active = true;
-        for (var key in this.props.navigationData) {
-            active = active && LinkUtility.isActive(this.getStateNavigator(), key, this.props.navigationData[key]);
-        }
         props.href = this.getRefreshLink();
         LinkUtility.addListeners(this, this.getStateNavigator(), this.props, props, () => this.getRefreshLink());
-        active = active && !!props.href;
-        LinkUtility.setActive(props, active, this.props.activeCssClass, this.props.disableActive);
+        LinkUtility.setActive(this.getStateNavigator(), this.props, props);
         return React.createElement('a', props, this.props.children);
     }
 };


### PR DESCRIPTION
Removed trackTypes check in favour of triple-equals: '1' no longer considered active if current value is 1. Matching on value and type makes more sense for the data-first approach. 