### PR TITLE
Prevented Link Double Render in React

### DIFF
--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -63,7 +63,7 @@ class LinkUtility {
             var element = <HTMLAnchorElement> component['el'];
             var href = element.href;
             if (lazy) {
-                component.setState({ stateContext: stateNavigator.stateContext.url });
+                component.forceUpdate();
                 href = getLink();
                 if (href)
                     element.href = href;
@@ -80,7 +80,7 @@ class LinkUtility {
             }
         };
         if (lazy)
-            toProps.onContextMenu = (e: MouseEvent) => component.setState({ stateContext: stateNavigator.stateContext.url });
+            toProps.onContextMenu = (e: MouseEvent) => component.forceUpdate();
     }
 
     static getNavigating(props: any): (e: MouseEvent, domId: string, link: string) => boolean {

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -63,7 +63,7 @@ class LinkUtility {
             var element = <HTMLAnchorElement> component['el'];
             var href = element.href;
             if (lazy) {
-                component.forceUpdate();
+                component.setState({ stateContext: stateNavigator.stateContext.url });
                 href = getLink();
                 if (href)
                     element.href = href;
@@ -80,7 +80,7 @@ class LinkUtility {
             }
         };
         if (lazy)
-            toProps.onContextMenu = (e: MouseEvent) => component.forceUpdate();
+            toProps.onContextMenu = (e: MouseEvent) => component.setState({ stateContext: stateNavigator.stateContext.url });
     }
 
     static getNavigating(props: any): (e: MouseEvent, domId: string, link: string) => boolean {

--- a/NavigationReact/src/NavigationBackLink.ts
+++ b/NavigationReact/src/NavigationBackLink.ts
@@ -3,8 +3,13 @@ import Navigation = require('navigation');
 import React = require('react');
 
 class NavigationBackLink extends React.Component<any, any> {
-    private onNavigate = () => this.forceUpdate();
-    
+    private onNavigate = () => this.setState({ stateContext: this.getStateNavigator().stateContext.url });
+
+    constructor(props, context) {
+        super(props, context);
+        this.state = { stateContext: this.getStateNavigator().stateContext.url };
+    }
+
     static contextTypes = {
         stateNavigator: React.PropTypes.object
     }

--- a/NavigationReact/src/NavigationBackLink.ts
+++ b/NavigationReact/src/NavigationBackLink.ts
@@ -3,11 +3,15 @@ import Navigation = require('navigation');
 import React = require('react');
 
 class NavigationBackLink extends React.Component<any, any> {
-    private onNavigate = () => this.setState({ stateContext: this.getStateNavigator().stateContext.url });
+    private onNavigate = () => {
+        if (this.state.stateContext !== this.getStateNavigator().stateContext.url
+            || this.state.crumb !== this.getNavigationBackLink())
+            this.setState(this.getNextState());
+    }
 
     constructor(props, context) {
         super(props, context);
-        this.state = { stateContext: this.getStateNavigator().stateContext.url };
+        this.state = this.getNextState();
     }
 
     static contextTypes = {
@@ -21,12 +25,22 @@ class NavigationBackLink extends React.Component<any, any> {
     private getNavigationBackLink(): string {
         return LinkUtility.getLink(this.getStateNavigator(), () => this.getStateNavigator().getNavigationBackLink(this.props.distance));
     }
+
+    private getNextState() {
+        return { 
+            stateContext: this.getStateNavigator().stateContext.url,
+            crumb: this.getNavigationBackLink()
+        };
+    }
     
     componentDidMount() {
         if (!this.props.lazy)
             this.getStateNavigator().onNavigate(this.onNavigate);
     }
     
+    componentWillReceiveProps() {
+        this.setState(this.getNextState());
+    }
     componentWillUnmount() {
         if (!this.props.lazy)
             this.getStateNavigator().offNavigate(this.onNavigate);

--- a/NavigationReact/src/NavigationBackLink.ts
+++ b/NavigationReact/src/NavigationBackLink.ts
@@ -32,7 +32,7 @@ class NavigationBackLink extends React.Component<any, any> {
             crumb: this.getNavigationBackLink()
         };
     }
-    
+
     componentDidMount() {
         if (!this.props.lazy)
             this.getStateNavigator().onNavigate(this.onNavigate);

--- a/NavigationReact/src/NavigationLink.ts
+++ b/NavigationReact/src/NavigationLink.ts
@@ -3,8 +3,16 @@ import Navigation = require('navigation');
 import React = require('react');
 
 class NavigationLink extends React.Component<any, any> {
-    private onNavigate = () => this.forceUpdate();
-    
+    private onNavigate = () => {
+        if (this.state.stateContext !== this.getStateNavigator().stateContext.url)
+            this.setState({ stateContext: this.getStateNavigator().stateContext.url });
+    }
+
+    constructor(props, context) {
+        super(props, context);
+        this.state = { stateContext: this.getStateNavigator().stateContext.url };
+    }
+
     static contextTypes = {
         stateNavigator: React.PropTypes.object
     }
@@ -22,7 +30,11 @@ class NavigationLink extends React.Component<any, any> {
         if (!this.props.lazy)
             this.getStateNavigator().onNavigate(this.onNavigate);
     }
-    
+
+    componentWillReceiveProps() {
+        this.setState({ stateContext: this.getStateNavigator().stateContext.url });
+    }
+
     componentWillUnmount() {
         if (!this.props.lazy)
             this.getStateNavigator().offNavigate(this.onNavigate);

--- a/NavigationReact/src/NavigationLink.ts
+++ b/NavigationReact/src/NavigationLink.ts
@@ -5,12 +5,12 @@ import React = require('react');
 class NavigationLink extends React.Component<any, any> {
     private onNavigate = () => {
         if (this.state.stateContext !== this.getStateNavigator().stateContext.url)
-            this.setState({ stateContext: this.getStateNavigator().stateContext.url });
+            this.setState(this.getNextState());
     }
 
     constructor(props, context) {
         super(props, context);
-        this.state = { stateContext: this.getStateNavigator().stateContext.url };
+        this.state = this.getNextState();
     }
 
     static contextTypes = {
@@ -26,13 +26,17 @@ class NavigationLink extends React.Component<any, any> {
         return LinkUtility.getLink(this.getStateNavigator(), () => this.getStateNavigator().getNavigationLink(this.props.stateKey, navigationData));
     }
     
+    private getNextState() {
+        return { stateContext: this.getStateNavigator().stateContext.url };
+    }
+
     componentDidMount() {
         if (!this.props.lazy)
             this.getStateNavigator().onNavigate(this.onNavigate);
     }
 
     componentWillReceiveProps() {
-        this.setState({ stateContext: this.getStateNavigator().stateContext.url });
+        this.setState(this.getNextState());
     }
 
     componentWillUnmount() {

--- a/NavigationReact/src/RefreshLink.ts
+++ b/NavigationReact/src/RefreshLink.ts
@@ -3,8 +3,16 @@ import Navigation = require('navigation');
 import React = require('react');
 
 class RefreshLink extends React.Component<any, any> {
-    private onNavigate = () => this.forceUpdate();
-    
+    private onNavigate = () => {
+        if (this.state.stateContext !== this.getStateNavigator().stateContext.url)
+            this.setState({ stateContext: this.getStateNavigator().stateContext.url });
+    }
+
+    constructor(props, context) {
+        super(props, context);
+        this.state = { stateContext: this.getStateNavigator().stateContext.url };
+    }
+
     static contextTypes = {
         stateNavigator: React.PropTypes.object
     }
@@ -22,7 +30,11 @@ class RefreshLink extends React.Component<any, any> {
         if (!this.props.lazy)
             this.getStateNavigator().onNavigate(this.onNavigate);
     }
-    
+
+    componentWillReceiveProps() {
+        this.setState({ stateContext: this.getStateNavigator().stateContext.url });
+    }
+
     componentWillUnmount() {
         if (!this.props.lazy)
             this.getStateNavigator().offNavigate(this.onNavigate);

--- a/NavigationReact/src/RefreshLink.ts
+++ b/NavigationReact/src/RefreshLink.ts
@@ -5,12 +5,12 @@ import React = require('react');
 class RefreshLink extends React.Component<any, any> {
     private onNavigate = () => {
         if (this.state.stateContext !== this.getStateNavigator().stateContext.url)
-            this.setState({ stateContext: this.getStateNavigator().stateContext.url });
+            this.setState(this.getNextState());
     }
 
     constructor(props, context) {
         super(props, context);
-        this.state = { stateContext: this.getStateNavigator().stateContext.url };
+        this.state = this.getNextState();
     }
 
     static contextTypes = {
@@ -21,18 +21,22 @@ class RefreshLink extends React.Component<any, any> {
         return this.props.stateNavigator || (<any> this.context).stateNavigator;
     }
     
-    getRefreshLink(): string {
+    private getRefreshLink(): string {
         var navigationData = LinkUtility.getData(this.getStateNavigator(), this.props.navigationData, this.props.includeCurrentData, this.props.currentDataKeys);
         return LinkUtility.getLink(this.getStateNavigator(), () => this.getStateNavigator().getRefreshLink(navigationData));
     }
     
+    private getNextState() {
+        return { stateContext: this.getStateNavigator().stateContext.url };
+    }
+
     componentDidMount() {
         if (!this.props.lazy)
             this.getStateNavigator().onNavigate(this.onNavigate);
     }
 
     componentWillReceiveProps() {
-        this.setState({ stateContext: this.getStateNavigator().stateContext.url });
+        this.setState(this.getNextState());
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
The forceUpdate in the onNavigate handler caused an unnecessary re-render. Immediately after a Link component renders the onNavigate handler fires which causes a re-render even though nothing's changed.

ReactDOM.render is synchronous only if mounting a brand new component. When ReactDOM.render is async then the unnecessary re-render doesn't happen because the onNavigate fires before the first render and so React squashes the two render requests into one.

Changed the Link components to store the state context url in React state each time they render. Then the onNavigate handler only re-renders if the the state context url has changed since previous render.

The Back Link stores the crumb as well as the url in state because the crumb can change even when the context url doesn't (with a custom truncate crumb trail). Accessing the crumb is cheap because it's not evaluated each time, it's just take from the cached crumbs.

Didn't implement this in knockout or angular because the Links update so often it didn't seem worth it.
