### PR TITLE
Tidied Up Url Handling

### DIFF
--- a/Navigation/src/StateNavigator.ts
+++ b/Navigation/src/StateNavigator.ts
@@ -163,7 +163,7 @@ class StateNavigator {
     }
     
     start(url?: string) {
-        this.navigateLink(url ? url : this.historyManager.getCurrentUrl());
+        this.navigateLink(url != null ? url : this.historyManager.getCurrentUrl());
     };
 }
 export = StateNavigator;

--- a/Navigation/src/history/HTML5HistoryManager.ts
+++ b/Navigation/src/history/HTML5HistoryManager.ts
@@ -6,7 +6,7 @@ class HTML5HistoryManager implements HistoryManager {
     disabled: boolean = (typeof window === 'undefined') || !(window.history && window.history.pushState);
     
     constructor(applicationPath: string = '') {
-        this.applicationPath = applicationPath;
+        this.applicationPath = HTML5HistoryManager.prependSlash(applicationPath);
     }
 
     init(navigateHistory: () => void) {
@@ -32,7 +32,7 @@ class HTML5HistoryManager implements HistoryManager {
     getHref(url: string): string {
         if (url == null)
             throw new Error('The Url is invalid');
-        return this.applicationPath + url;
+        return this.applicationPath + HTML5HistoryManager.prependSlash(url);
     }
 
     getUrl(hrefElement: HTMLAnchorElement | Location) {
@@ -42,6 +42,10 @@ class HTML5HistoryManager implements HistoryManager {
     stop() {
         if (!this.disabled)
             window.removeEventListener('popstate', this.navigateHistory);
+    }
+
+    private static prependSlash(url: string): string {
+        return url && url.substring(0, 1) !== '/' ? '/' + url : url;
     }
 }
 export = HTML5HistoryManager;

--- a/Navigation/src/history/HTML5HistoryManager.ts
+++ b/Navigation/src/history/HTML5HistoryManager.ts
@@ -26,7 +26,7 @@ class HTML5HistoryManager implements HistoryManager {
     }
 
     getCurrentUrl(): string {
-        return location.pathname.substring(this.applicationPath.length) + location.search;
+        return this.getUrl(location);
     }
 
     getHref(url: string): string {
@@ -35,8 +35,8 @@ class HTML5HistoryManager implements HistoryManager {
         return this.applicationPath + url;
     }
 
-    getUrl(anchor: HTMLAnchorElement) {
-        return anchor.pathname.substring(this.applicationPath.length) + anchor.search;
+    getUrl(hrefElement: HTMLAnchorElement | Location) {
+        return hrefElement.pathname.substring(this.applicationPath.length) + hrefElement.search;
     }
     
     stop() {

--- a/Navigation/src/history/HTML5HistoryManager.ts
+++ b/Navigation/src/history/HTML5HistoryManager.ts
@@ -45,7 +45,7 @@ class HTML5HistoryManager implements HistoryManager {
     }
 
     private static prependSlash(url: string): string {
-        return url && url.substring(0, 1) !== '/' ? '/' + url : url;
+        return (url && url.substring(0, 1) !== '/') ? '/' + url : url;
     }
 }
 export = HTML5HistoryManager;

--- a/Navigation/src/history/HashHistoryManager.ts
+++ b/Navigation/src/history/HashHistoryManager.ts
@@ -30,7 +30,7 @@ class HashHistoryManager implements HistoryManager {
     }
 
     getCurrentUrl(): string {
-        return this.decode(location.hash.substring(1));
+        return this.getUrl(location);
     }
 
     getHref(url: string): string {
@@ -39,8 +39,8 @@ class HashHistoryManager implements HistoryManager {
         return '#' + this.encode(url);
     }
 
-    getUrl(anchor: HTMLAnchorElement) {
-        return this.decode(anchor.hash.substring(1));
+    getUrl(hrefElement: HTMLAnchorElement | Location) {
+        return this.decode(hrefElement.hash.substring(1));
     }
     
     stop() {

--- a/Navigation/src/history/HistoryManager.ts
+++ b/Navigation/src/history/HistoryManager.ts
@@ -4,7 +4,7 @@
     addHistory(url: string, replace: boolean): void;
     getCurrentUrl(): string;
     getHref(url: string): string;
-    getUrl(anchor: HTMLAnchorElement): string;
+    getUrl(hrefElement: HTMLAnchorElement | Location): string;
     stop(): void;
 }
 export = HistoryManager;

--- a/Navigation/src/navigation.d.ts
+++ b/Navigation/src/navigation.d.ts
@@ -184,9 +184,9 @@ declare namespace Navigation {
          */
         getHref(url: string): string;
         /**
-         * Gets a Url from the anchor 
+         * Gets a Url from the anchor or location
          */
-        getUrl(anchor: HTMLAnchorElement): string;
+        getUrl(hrefElement: HTMLAnchorElement | Location): string;
         /**
          * Removes browser history event listeners
          */
@@ -236,9 +236,9 @@ declare namespace Navigation {
          */
         getHref(url: string): string;
         /**
-         * Gets a Url from the anchor 
+         * Gets a Url from the anchor or location
          */
-        getUrl(anchor: HTMLAnchorElement): string;
+        getUrl(hrefElement: HTMLAnchorElement | Location): string;
         /**
          * Removes a listener for the hashchange event
          */
@@ -287,9 +287,9 @@ declare namespace Navigation {
          */
         getHref(url: string): string;
         /**
-         * Gets a Url from the anchor 
+         * Gets a Url from the anchor or location
          */
-        getUrl(anchor: HTMLAnchorElement): string;
+        getUrl(hrefElement: HTMLAnchorElement | Location): string;
         /**
          * Removes a listener for the popstate event
          */

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -4933,4 +4933,26 @@ describe('Navigation', function () {
             });
         }
     });
+
+    describe('Start Route', function () {
+        it('should navigate', function() {
+            var stateNavigator = new Navigation.StateNavigator([
+                { key: 's0', route: '' },
+                { key: 's1', route: 'ab' }
+            ]);
+            stateNavigator.start('/ab');
+            assert.strictEqual(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+        });
+    });
+
+    describe('Start Empty Route', function () {
+        it('should navigate', function() {
+            var stateNavigator = new Navigation.StateNavigator([
+                { key: 's0', route: '' },
+                { key: 's1', route: 'ab' }
+            ]);
+            stateNavigator.start('');
+            assert.strictEqual(stateNavigator.stateContext.state, stateNavigator.states['s0']);
+        });
+    });
 });

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -4955,4 +4955,18 @@ describe('Navigation', function () {
             assert.strictEqual(stateNavigator.stateContext.state, stateNavigator.states['s0']);
         });
     });
+
+    describe('HTML5 History', function () {
+        it('should prepend slash', function() {
+            var history = new Navigation.HTML5HistoryManager();
+            assert.strictEqual(history.getHref('a'), '/a');
+            assert.strictEqual(history.getHref('/a'), '/a');
+            history = new Navigation.HTML5HistoryManager('a');
+            assert.strictEqual(history.getHref('b'), '/a/b');
+            assert.strictEqual(history.getHref('/b'), '/a/b');
+            history = new Navigation.HTML5HistoryManager('/a');
+            assert.strictEqual(history.getHref('b'), '/a/b');
+            assert.strictEqual(history.getHref('/b'), '/a/b');
+        });
+    });
 });


### PR DESCRIPTION
- Changed History Managers so that the only function that builds Urls is getUrl. Makes it easier to override, e.g., add generic language route parameter for internationalization
- Accepted empty string as start Url. Protects against server side Url being empty
- Allowed applicationPath to omit leading slash and ensured HTML5 Urls always have leading slash
