### PR TITLE
Improved getNavigationLink Performance

### DIFF
--- a/Navigation/src/NavigationDataManager.ts
+++ b/Navigation/src/NavigationDataManager.ts
@@ -2,7 +2,6 @@
 import State = require('./config/State');
 
 class NavigationDataManager {
-    private static SEPARATOR = '_';
     private static SEPARATOR1 = '1_';
     private converterFactory = new ConverterFactory();
 
@@ -29,11 +28,11 @@ class NavigationDataManager {
     }
 
     private static decodeUrlValue(urlValue: string): string {
-        return urlValue.replace(new RegExp('0' + this.SEPARATOR, 'g'), this.SEPARATOR);
+        return urlValue.replace(/0_/g, '_');
     }
 
     private static encodeUrlValue(urlValue: string): string {
-        return urlValue.replace(new RegExp(this.SEPARATOR, 'g'), '0' + this.SEPARATOR);
+        return urlValue.replace(/_/g, '0_');
     }
 
     formatURLObject(key: string, urlObject: any, state: State, encode = false): { val: string, arrayVal?: string[] } {

--- a/Navigation/src/NavigationDataManager.ts
+++ b/Navigation/src/NavigationDataManager.ts
@@ -89,7 +89,7 @@ class NavigationDataManager {
 
     private parseURLString(key: string, val: string | string[], state: State, decode = false, separable = false): any {
         decode = decode || state.trackTypes;
-        var defaultType: string = state.defaultTypes[key] ? state.defaultTypes[key] : 'string';
+        var defaultType: string = state.defaultTypes[key] || 'string';
         var urlValue = typeof val === 'string' ? val : val[0];
         var converterKey = this.converterFactory.getConverterFromName(defaultType).key;
         if (state.trackTypes && urlValue.indexOf(NavigationDataManager.SEPARATOR) > -1) {

--- a/Navigation/src/NavigationDataManager.ts
+++ b/Navigation/src/NavigationDataManager.ts
@@ -123,8 +123,12 @@ class NavigationDataManager {
     }
     
     private static getTypeName(obj: any): string {
-        var typeName: string = Object.prototype.toString.call(obj);
-        return typeName.substring(8, typeName.length - 1).toLowerCase();
+        var typeName: string = typeof obj;
+        if (typeName === 'object') {
+            typeName = Object.prototype.toString.call(obj);
+            typeName = typeName.substring(8, typeName.length - 1).toLowerCase();
+        }
+        return typeName;
     }
 }
 export = NavigationDataManager;

--- a/Navigation/src/NavigationDataManager.ts
+++ b/Navigation/src/NavigationDataManager.ts
@@ -2,7 +2,7 @@
 import State = require('./config/State');
 
 class NavigationDataManager {
-    private static SEPARATOR1 = '1_';
+    private static SEPARATOR = '1_';
     private converterFactory = new ConverterFactory();
 
     formatData(state: State, navigationData: any, crumbTrail: string[]): { data: any, arrayData: { [index: string]: string[] }} {
@@ -48,9 +48,9 @@ class NavigationDataManager {
                 formattedArray[0] = NavigationDataManager.encodeUrlValue(formattedArray[0]);
         }
         if (state.trackTypes && converter.name !== defaultType) {
-            formattedValue += NavigationDataManager.SEPARATOR1 + converter.key;
+            formattedValue += NavigationDataManager.SEPARATOR + converter.key;
             if (formattedArray)
-                formattedArray[0] = formattedArray[0] + NavigationDataManager.SEPARATOR1 + converter.key;
+                formattedArray[0] = formattedArray[0] + NavigationDataManager.SEPARATOR + converter.key;
         }
         return { val: formattedValue, arrayVal: formattedArray };
     }
@@ -92,8 +92,8 @@ class NavigationDataManager {
         var defaultType: string = state.defaultTypes[key] ? state.defaultTypes[key] : 'string';
         var urlValue = typeof val === 'string' ? val : val[0];
         var converterKey = this.converterFactory.getConverterFromName(defaultType).key;
-        if (state.trackTypes && urlValue.indexOf(NavigationDataManager.SEPARATOR1) > -1) {
-            var arr = urlValue.split(NavigationDataManager.SEPARATOR1);
+        if (state.trackTypes && urlValue.indexOf(NavigationDataManager.SEPARATOR) > -1) {
+            var arr = urlValue.split(NavigationDataManager.SEPARATOR);
             urlValue = arr[0];
             converterKey = arr[1];
         }

--- a/Navigation/src/StateRouter.ts
+++ b/Navigation/src/StateRouter.ts
@@ -91,18 +91,12 @@ class StateRouter {
 
     private static urlEncode(route: Route, name: string, val: string): string {
         var state: State = route['_state'];
-        if (state.urlEncode)
-            return state.urlEncode(state, name, val, false);
-        else
-            return encodeURIComponent(val);
+        return state.urlEncode(state, name, val, false);
     }
 
     private static urlDecode(route: Route, name: string, val: string): string {
         var state: State = route['_state'];
-        if (state.urlDecode)
-            return state.urlDecode(state, name, val, false);
-        else
-            return decodeURIComponent(val);
+        return state.urlDecode(state, name, val, false);
     }
 
     addRoutes(states: State[]) {

--- a/Navigation/src/converter/ArrayConverter.ts
+++ b/Navigation/src/converter/ArrayConverter.ts
@@ -2,7 +2,6 @@
 
 class ArrayConverter extends TypeConverter {
     private converter: TypeConverter;
-    private static SEPARATOR = '-';
     private static SEPARATOR1 = '1-';
 
     constructor(converter: TypeConverter, key: string) {
@@ -17,7 +16,7 @@ class ArrayConverter extends TypeConverter {
                 var vals = val.split(ArrayConverter.SEPARATOR1);
                 for (var i = 0; i < vals.length; i++) {
                     if (vals[i].length !== 0)
-                        arr.push(this.converter.convertFrom(vals[i].replace(new RegExp('0' + ArrayConverter.SEPARATOR, 'g'), ArrayConverter.SEPARATOR)));
+                        arr.push(this.converter.convertFrom(vals[i].replace(/0-/g, '-')));
                     else
                         arr.push(null);
                 }
@@ -42,7 +41,7 @@ class ArrayConverter extends TypeConverter {
             if (val[i] != null && val[i].toString()) {
                 var convertedValue = this.converter.convertTo(val[i]).val;
                 arr.push(convertedValue);
-                vals.push(convertedValue.replace(new RegExp(ArrayConverter.SEPARATOR, 'g'), '0' + ArrayConverter.SEPARATOR));
+                vals.push(convertedValue.replace(/-/g, '0-'));
             } else {
                 arr.push('');
                 vals.push('');

--- a/Navigation/src/converter/ArrayConverter.ts
+++ b/Navigation/src/converter/ArrayConverter.ts
@@ -2,7 +2,7 @@
 
 class ArrayConverter extends TypeConverter {
     private converter: TypeConverter;
-    private static SEPARATOR1 = '1-';
+    private static SEPARATOR = '1-';
 
     constructor(converter: TypeConverter, key: string) {
         super(key, converter.name + 'array');
@@ -13,7 +13,7 @@ class ArrayConverter extends TypeConverter {
         var arr = [];
         if (typeof val === 'string') {
             if (!separable) {
-                var vals = val.split(ArrayConverter.SEPARATOR1);
+                var vals = val.split(ArrayConverter.SEPARATOR);
                 for (var i = 0; i < vals.length; i++) {
                     if (vals[i].length !== 0)
                         arr.push(this.converter.convertFrom(vals[i].replace(/0-/g, '-')));
@@ -47,7 +47,7 @@ class ArrayConverter extends TypeConverter {
                 vals.push('');
             }
         }
-        return { val: vals.join(ArrayConverter.SEPARATOR1), arrayVal: arr };
+        return { val: vals.join(ArrayConverter.SEPARATOR), arrayVal: arr };
     }
 }
 export = ArrayConverter;

--- a/Navigation/src/routing/Route.ts
+++ b/Navigation/src/routing/Route.ts
@@ -57,9 +57,7 @@ class Route {
         return data;
     }
 
-    build(data?: any, urlEncode?: (route: Route, name: string, val: string) => string): string {
-        if (!urlEncode)
-            urlEncode = (route, name, val) => encodeURIComponent(val);
+    build(data: any, urlEncode: (route: Route, name: string, val: string) => string): string {
         data = data != null ? data : {};
         var route = '';
         var optional = true;

--- a/Navigation/src/routing/Route.ts
+++ b/Navigation/src/routing/Route.ts
@@ -58,7 +58,7 @@ class Route {
     }
 
     build(data: any, urlEncode: (route: Route, name: string, val: string) => string): string {
-        data = data != null ? data : {};
+        data = data || {};
         var route = '';
         var optional = true;
         for (var i = this.segments.length - 1; i >= 0; i--) {

--- a/Navigation/src/routing/Segment.ts
+++ b/Navigation/src/routing/Segment.ts
@@ -56,7 +56,7 @@
                 var defaultVal = defaults[subSegment.name];
                 optional = subSegment.optional && (!val || val === defaultVal);
                 if (this.optional || !optional) {
-                    val = val ? val : defaultVal;
+                    val = val || defaultVal;
                     blank = blank || !val;
                     if (val) {
                         if (!subSegment.splat || typeof val === 'string' ) {


### PR DESCRIPTION
Doubled the speed of `getNavigationLink`. Reduced the time to produce 10,000 links from 80ms to 40ms.

```js
var stateNavigator = new Navigation.StateNavigator([
    {key: 'ab', route: 'a/{a}/b/{b}', defaultTypes: {b: 'number'}}
]);

function run(){
  for(var i = 0; i < 10000; i++){
    stateNavigator.getNavigationLink('ab', { a: 'abc', b: 123 });
  }
}
```

Made two changes in `NavigationDataManager`, each responsible for a 30% speed increase:

* Replaced new `RegExp('_', 'g')` with `/_/g`
* Replaced `Object.prototype.toString.call` with `typeof`
