### PR TITLE
Added Fluent Navigation

### DIFF
--- a/Navigation/src/FluentNavigator.ts
+++ b/Navigation/src/FluentNavigator.ts
@@ -1,6 +1,7 @@
 import Crumb from './config/Crumb';
 import State from './config/State';
 import StateContext from './StateContext';
+import StateHandler from './StateHandler';
 
 class FluentNavigator {
     private state: State = null;
@@ -9,12 +10,11 @@ class FluentNavigator {
     private crumbs: Crumb[] = [];
     private nextCrumb: Crumb = null;
     private states: { [index: string]: State } = {};
-    private getLink;
-    private parseLink;
+    private stateHandler: StateHandler;
 
-    constructor(states, getLink, parseLink, stateContext?: StateContext) {
+    constructor(states, stateHandler, stateContext?: StateContext) {
         this.states = states;
-        this.getLink = getLink;
+        this.stateHandler = stateHandler;
         if (stateContext) {
             this.state = stateContext.state;
             this.data = stateContext.data;
@@ -30,14 +30,14 @@ class FluentNavigator {
         this.crumbs = data[state.crumbTrailKey];
         delete data[state.crumbTrailKey];
         this.data = data;
-        this.nextCrumb = new Crumb(data, state, url, this.getLink(state, data), false);
+        this.nextCrumb = new Crumb(data, state, url, this.stateHandler.getLink(state, data), false);
     }
 
     public navigate(stateKey: string, navigationData?: any): this {
         if (!this.states[stateKey])
             throw new Error(stateKey + ' is not a valid State');
-        var url = this.getLink(this.states[stateKey], navigationData, this.crumbs, this.nextCrumb);
-        var { state, data } = this.parseLink(url);
+        var url = this.stateHandler.getLink(this.states[stateKey], navigationData, this.crumbs, this.nextCrumb);
+        var { state, data } = this.stateHandler.parseNavigationLink(url);
         this.setFluentContext(state, data, url);
         return this;
     }

--- a/Navigation/src/FluentNavigator.ts
+++ b/Navigation/src/FluentNavigator.ts
@@ -12,7 +12,7 @@ class FluentNavigator {
     private states: { [index: string]: State } = {};
     private stateHandler: StateHandler;
 
-    constructor(states, stateHandler, stateContext?: StateContext) {
+    constructor(states: { [index: string]: State }, stateHandler: StateHandler, stateContext?: StateContext) {
         this.states = states;
         this.stateHandler = stateHandler;
         if (stateContext) {

--- a/Navigation/src/FluentNavigator.ts
+++ b/Navigation/src/FluentNavigator.ts
@@ -6,8 +6,8 @@ import StateHandler from './StateHandler';
 interface FluentNavigator {
     url: string,
     navigate(stateKey: string, navigationData?: any): FluentNavigator;
-    refresh(navigationData?: any): FluentNavigator;
     navigateBack(distance: number): FluentNavigator;
+    refresh(navigationData?: any): FluentNavigator;
 }
 
 function createFluentNavigator(states: { [index: string]: State }, stateHandler: StateHandler, stateContext = new StateContext()): FluentNavigator {

--- a/Navigation/src/FluentNavigator.ts
+++ b/Navigation/src/FluentNavigator.ts
@@ -37,7 +37,7 @@ class FluentNavigator {
         if (!this.states[stateKey])
             throw new Error(stateKey + ' is not a valid State');
         var url = this.stateHandler.getLink(this.states[stateKey], navigationData, this.crumbs, this.nextCrumb);
-        var { state, data } = this.stateHandler.parseNavigationLink(url);
+        var { state, data } = this.stateHandler.parseLink(url);
         this.setFluentContext(state, data, url);
         return this;
     }

--- a/Navigation/src/FluentNavigator.ts
+++ b/Navigation/src/FluentNavigator.ts
@@ -25,9 +25,8 @@ function createFluentNavigator(states: { [index: string]: State }, stateHandler:
         navigate: function(stateKey: string, navigationData?: any): FluentNavigator {
             if (!states[stateKey])
                 throw new Error(stateKey + ' is not a valid State');
-            if (typeof navigationData === 'function'){
+            if (typeof navigationData === 'function')
                 navigationData = navigationData(stateContext.data);
-            }
             var url = stateHandler.getLink(states[stateKey], navigationData, stateContext.crumbs, stateContext.nextCrumb);
             var { state, data } = stateHandler.parseLink(url);
             return createFluentNavigator(states, stateHandler, getFluentContext(state, data, url));

--- a/Navigation/src/FluentNavigator.ts
+++ b/Navigation/src/FluentNavigator.ts
@@ -38,6 +38,7 @@ class FluentNavigator {
             throw new Error(stateKey + ' is not a valid State');
         var url = this.getLink(this.states[stateKey], navigationData, this.crumbs, this.nextCrumb);
         var { state, data } = this.parseLink(url);
+        this.setContext(state, data, url);
         return this;
     }
 }

--- a/Navigation/src/FluentNavigator.ts
+++ b/Navigation/src/FluentNavigator.ts
@@ -24,7 +24,7 @@ class FluentNavigator {
         }
     }
 
-    private setContext(state: State, data: any, url: string) {
+    private setFluentContext(state: State, data: any, url: string) {
         this.state = state;
         this.url = url;
         this.crumbs = data[state.crumbTrailKey];
@@ -38,7 +38,7 @@ class FluentNavigator {
             throw new Error(stateKey + ' is not a valid State');
         var url = this.getLink(this.states[stateKey], navigationData, this.crumbs, this.nextCrumb);
         var { state, data } = this.parseLink(url);
-        this.setContext(state, data, url);
+        this.setFluentContext(state, data, url);
         return this;
     }
 }

--- a/Navigation/src/FluentNavigator.ts
+++ b/Navigation/src/FluentNavigator.ts
@@ -31,6 +31,8 @@ function createFluentNavigator(states: { [index: string]: State }, stateHandler:
             if (typeof navigationData === 'function')
                 navigationData = navigationData(stateContext.data);
             var url = stateHandler.getLink(states[stateKey], navigationData, stateContext.crumbs, stateContext.nextCrumb);
+            if (url == null)
+                throw new Error('Invalid route data, a mandatory route parameter has not been supplied a value');
             return navigateLink(url);
         },
         refresh: function(navigationData?: any): FluentNavigator {

--- a/Navigation/src/FluentNavigator.ts
+++ b/Navigation/src/FluentNavigator.ts
@@ -3,46 +3,35 @@ import State from './config/State';
 import StateContext from './StateContext';
 import StateHandler from './StateHandler';
 
-class FluentNavigator {
-    private state: State = null;
-    private data: any = {};
-    url: string = null;
-    private crumbs: Crumb[] = [];
-    private nextCrumb: Crumb = null;
-    private states: { [index: string]: State } = {};
-    private stateHandler: StateHandler;
+interface FluentNavigator {
+    url: string,
+    navigate(stateKey: string, navigationData?: any): FluentNavigator;
+}
 
-    constructor(states: { [index: string]: State }, stateHandler: StateHandler, stateContext?: StateContext) {
-        this.states = states;
-        this.stateHandler = stateHandler;
-        if (stateContext) {
-            this.state = stateContext.state;
-            this.data = stateContext.data;
-            this.url = stateContext.url;
-            this.crumbs = stateContext.crumbs;
-            this.nextCrumb = stateContext.nextCrumb;
-        }
-    }
-
-    private setFluentContext(state: State, data: any, url: string) {
-        this.state = state;
-        this.url = url;
-        this.crumbs = data[state.crumbTrailKey];
+function createFluentNavigator(states: { [index: string]: State }, stateHandler: StateHandler, stateContext = new StateContext()): FluentNavigator {
+    var getFluentContext = function(state: State, data: any, url: string): StateContext {
+        var fluentContext = new StateContext();
+        fluentContext.state = state;
+        fluentContext.url = url;
+        fluentContext.crumbs = data[state.crumbTrailKey];
         delete data[state.crumbTrailKey];
-        this.data = data;
-        this.nextCrumb = new Crumb(data, state, url, this.stateHandler.getLink(state, data), false);
+        fluentContext.data = data;
+        fluentContext.nextCrumb = new Crumb(data, state, url, stateHandler.getLink(state, data), false);
+        return fluentContext;
     }
 
-    public navigate(stateKey: string, navigationData?: any): this {
-        if (!this.states[stateKey])
-            throw new Error(stateKey + ' is not a valid State');
-        if (typeof navigationData === 'function'){
-            navigationData = navigationData(this.data);
+    return {
+        url: stateContext.url,
+        navigate: function(stateKey: string, navigationData?: any): FluentNavigator {
+            if (!states[stateKey])
+                throw new Error(stateKey + ' is not a valid State');
+            if (typeof navigationData === 'function'){
+                navigationData = navigationData(stateContext.data);
+            }
+            var url = stateHandler.getLink(states[stateKey], navigationData, stateContext.crumbs, stateContext.nextCrumb);
+            var { state, data } = stateHandler.parseLink(url);
+            return createFluentNavigator(states, stateHandler, getFluentContext(state, data, url));
         }
-        var url = this.stateHandler.getLink(this.states[stateKey], navigationData, this.crumbs, this.nextCrumb);
-        var { state, data } = this.stateHandler.parseLink(url);
-        this.setFluentContext(state, data, url);
-        return this;
     }
 }
-export default FluentNavigator;
+export { FluentNavigator, createFluentNavigator };

--- a/Navigation/src/FluentNavigator.ts
+++ b/Navigation/src/FluentNavigator.ts
@@ -35,18 +35,18 @@ function createFluentNavigator(states: { [index: string]: State }, stateHandler:
                 throw new Error('Invalid route data, a mandatory route parameter has not been supplied a value');
             return navigateLink(url);
         },
+        navigateBack: function(distance: number): FluentNavigator {
+            if (!(distance <= stateContext.crumbs.length && distance > 0))
+                throw new Error('The distance parameter must be greater than zero and less than or equal to the number of Crumbs (' + stateContext.crumbs.length + ')');
+            var url = stateContext.crumbs[stateContext.crumbs.length - distance].url;
+            return navigateLink(url);
+        },
         refresh: function(navigationData?: any): FluentNavigator {
             if (typeof navigationData === 'function')
                 navigationData = navigationData(stateContext.data);
             var url = stateHandler.getLink(stateContext.state, navigationData, stateContext.crumbs, stateContext.nextCrumb);
             if (url == null)
                 throw new Error('Invalid route data, a mandatory route parameter has not been supplied a value');
-            return navigateLink(url);
-        },
-        navigateBack: function(distance: number): FluentNavigator {
-            if (!(distance <= stateContext.crumbs.length && distance > 0))
-                throw new Error('The distance parameter must be greater than zero and less than or equal to the number of Crumbs (' + stateContext.crumbs.length + ')');
-            var url = stateContext.crumbs[stateContext.crumbs.length - distance].url;
             return navigateLink(url);
         }
     }

--- a/Navigation/src/FluentNavigator.ts
+++ b/Navigation/src/FluentNavigator.ts
@@ -7,6 +7,7 @@ interface FluentNavigator {
     url: string,
     navigate(stateKey: string, navigationData?: any): FluentNavigator;
     refresh(navigationData?: any): FluentNavigator;
+    navigateBack(distance: number): FluentNavigator;
 }
 
 function createFluentNavigator(states: { [index: string]: State }, stateHandler: StateHandler, stateContext = new StateContext()): FluentNavigator {
@@ -42,6 +43,12 @@ function createFluentNavigator(states: { [index: string]: State }, stateHandler:
             var url = stateHandler.getLink(stateContext.state, navigationData, stateContext.crumbs, stateContext.nextCrumb);
             if (url == null)
                 throw new Error('Invalid route data, a mandatory route parameter has not been supplied a value');
+            return navigateLink(url);
+        },
+        navigateBack: function(distance: number): FluentNavigator {
+            if (!(distance <= stateContext.crumbs.length && distance > 0))
+                throw new Error('The distance parameter must be greater than zero and less than or equal to the number of Crumbs (' + this.stateContext.crumbs.length + ')');
+            var url = stateContext.crumbs[stateContext.crumbs.length - distance].url;
             return navigateLink(url);
         }
     }

--- a/Navigation/src/FluentNavigator.ts
+++ b/Navigation/src/FluentNavigator.ts
@@ -47,7 +47,7 @@ function createFluentNavigator(states: { [index: string]: State }, stateHandler:
         },
         navigateBack: function(distance: number): FluentNavigator {
             if (!(distance <= stateContext.crumbs.length && distance > 0))
-                throw new Error('The distance parameter must be greater than zero and less than or equal to the number of Crumbs (' + this.stateContext.crumbs.length + ')');
+                throw new Error('The distance parameter must be greater than zero and less than or equal to the number of Crumbs (' + stateContext.crumbs.length + ')');
             var url = stateContext.crumbs[stateContext.crumbs.length - distance].url;
             return navigateLink(url);
         }

--- a/Navigation/src/FluentNavigator.ts
+++ b/Navigation/src/FluentNavigator.ts
@@ -9,7 +9,7 @@ interface FluentNavigator {
 }
 
 function createFluentNavigator(states: { [index: string]: State }, stateHandler: StateHandler, stateContext = new StateContext()): FluentNavigator {
-    var getFluentContext = function(state: State, data: any, url: string): StateContext {
+    function getFluentContext(state: State, data: any, url: string): StateContext {
         var fluentContext = new StateContext();
         fluentContext.state = state;
         fluentContext.url = url;

--- a/Navigation/src/FluentNavigator.ts
+++ b/Navigation/src/FluentNavigator.ts
@@ -36,6 +36,9 @@ class FluentNavigator {
     public navigate(stateKey: string, navigationData?: any): this {
         if (!this.states[stateKey])
             throw new Error(stateKey + ' is not a valid State');
+        if (typeof navigationData === 'function'){
+            navigationData = navigationData(this.data);
+        }
         var url = this.stateHandler.getLink(this.states[stateKey], navigationData, this.crumbs, this.nextCrumb);
         var { state, data } = this.stateHandler.parseLink(url);
         this.setFluentContext(state, data, url);

--- a/Navigation/src/FluentNavigator.ts
+++ b/Navigation/src/FluentNavigator.ts
@@ -42,3 +42,4 @@ class FluentNavigator {
         return this;
     }
 }
+export default FluentNavigator;

--- a/Navigation/src/FluentNavigator.ts
+++ b/Navigation/src/FluentNavigator.ts
@@ -1,0 +1,43 @@
+import Crumb from './config/Crumb';
+import State from './config/State';
+import StateContext from './StateContext';
+
+class FluentNavigator {
+    private state: State = null;
+    private data: any = {};
+    url: string = null;
+    private crumbs: Crumb[] = [];
+    private nextCrumb: Crumb = null;
+    private states: { [index: string]: State } = {};
+    private getLink;
+    private parseLink;
+
+    constructor(states, getLink, parseLink, stateContext?: StateContext) {
+        this.states = states;
+        this.getLink = getLink;
+        if (stateContext) {
+            this.state = stateContext.state;
+            this.data = stateContext.data;
+            this.url = stateContext.url;
+            this.crumbs = stateContext.crumbs;
+            this.nextCrumb = stateContext.nextCrumb;
+        }
+    }
+
+    private setContext(state: State, data: any, url: string) {
+        this.state = state;
+        this.url = url;
+        this.crumbs = data[state.crumbTrailKey];
+        delete data[state.crumbTrailKey];
+        this.data = data;
+        this.nextCrumb = new Crumb(data, state, url, this.getLink(state, data), false);
+    }
+
+    public navigate(stateKey: string, navigationData?: any): this {
+        if (!this.states[stateKey])
+            throw new Error(stateKey + ' is not a valid State');
+        var url = this.getLink(this.states[stateKey], navigationData, this.crumbs, this.nextCrumb);
+        var { state, data } = this.parseLink(url);
+        return this;
+    }
+}

--- a/Navigation/src/FluentNavigator.ts
+++ b/Navigation/src/FluentNavigator.ts
@@ -11,7 +11,8 @@ interface FluentNavigator {
 }
 
 function createFluentNavigator(states: { [index: string]: State }, stateHandler: StateHandler, stateContext = new StateContext()): FluentNavigator {
-    function getFluentContext(state: State, data: any, url: string): StateContext {
+    function navigateLink(url): FluentNavigator {
+        var { state, data } = stateHandler.parseLink(url);
         var fluentContext = new StateContext();
         fluentContext.state = state;
         fluentContext.url = url;
@@ -19,12 +20,7 @@ function createFluentNavigator(states: { [index: string]: State }, stateHandler:
         delete data[state.crumbTrailKey];
         fluentContext.data = data;
         fluentContext.nextCrumb = new Crumb(data, state, url, stateHandler.getLink(state, data), false);
-        return fluentContext;
-    }
-
-    function navigateLink(url): FluentNavigator {
-        var { state, data } = stateHandler.parseLink(url);
-        return createFluentNavigator(states, stateHandler, getFluentContext(state, data, url));
+        return createFluentNavigator(states, stateHandler, fluentContext);
     }
 
     return {

--- a/Navigation/src/NavigationDataManager.ts
+++ b/Navigation/src/NavigationDataManager.ts
@@ -1,5 +1,6 @@
 ﻿import ConverterFactory from './converter/ConverterFactory';
 import State from './config/State';
+import TypeConverter from './converter/TypeConverter';
 
 class NavigationDataManager {
     private static SEPARATOR = '1_';
@@ -106,7 +107,7 @@ class NavigationDataManager {
         return this.converterFactory.getConverterFromKey(converterKey).convertFrom(val, separable);
     }
 
-    getConverter(obj: any) {
+    getConverter(obj: any): TypeConverter {
         var fullName = NavigationDataManager.getTypeName(obj);
         if (fullName === 'array') {
             var arr: any[] = obj;

--- a/Navigation/src/StateHandler.ts
+++ b/Navigation/src/StateHandler.ts
@@ -46,7 +46,20 @@ class StateHandler {
         return builtStates;
     }
 
-    getNavigationLink(state: State, navigationData: any, crumbTrail: string[]): string {
+    getLink(state: State, navigationData: any, crumbs?: Crumb[], nextCrumb?: Crumb): string {
+        var crumbTrail = [];
+        if (crumbs) {
+            crumbs = crumbs.slice();
+            if (nextCrumb)
+                crumbs.push(nextCrumb);
+            crumbs = state.truncateCrumbTrail(state, crumbs);
+            for(var i = 0; i < crumbs.length; i++)
+                crumbTrail.push(crumbs[i].crumblessUrl)
+        }
+        return this.getNavigationLink(state, navigationData, crumbTrail);
+    }
+
+    private getNavigationLink(state: State, navigationData: any, crumbTrail: string[]): string {
         var { data, arrayData } = this.navigationDataManager.formatData(state, navigationData, crumbTrail);
         var routeInfo = this.router.getRoute(state, data, arrayData);
         if (routeInfo.route == null)

--- a/Navigation/src/StateHandler.ts
+++ b/Navigation/src/StateHandler.ts
@@ -82,7 +82,7 @@ class StateHandler {
         return routeInfo.route;
     }
 
-    parseNavigationLink(url: string, fromRoute?: Route, err = ''): { state: State, data: any } {
+    parseLink(url: string, fromRoute?: Route, err = ''): { state: State, data: any } {
         var queryIndex = url.indexOf('?');
         var path = queryIndex < 0 ? url : url.substring(0, queryIndex);
         var query = queryIndex >= 0 ? url.substring(queryIndex + 1) : null;
@@ -95,7 +95,7 @@ class StateHandler {
         } catch(e) {
             err += '\n' + e.message;
         }
-        return navigationData || this.parseNavigationLink(url, route, err);        
+        return navigationData || this.parseLink(url, route, err);        
     }
 
     private getNavigationData(query: string, state: State, data: any, separableData: any): { state: State, data: any } {
@@ -134,7 +134,7 @@ class StateHandler {
             var crumblessUrl = crumbTrail[i];
             if (!crumblessUrl || crumblessUrl.substring(0, 1) !== '/')
                 throw new Error(crumblessUrl + ' is not a valid crumb');
-            var { state, data } = this.parseNavigationLink(crumblessUrl);
+            var { state, data } = this.parseLink(crumblessUrl);
             delete data[state.crumbTrailKey];
             var url = this.getNavigationLink(state, data, crumbTrail.slice(0, i));
             crumbs.push(new Crumb(data, state, url, crumblessUrl, i + 1 === len));

--- a/Navigation/src/StateNavigator.ts
+++ b/Navigation/src/StateNavigator.ts
@@ -45,7 +45,7 @@ class StateNavigator {
         this.stateContext.crumbs = data[state.crumbTrailKey];
         delete data[state.crumbTrailKey];
         this.stateContext.data = data;
-        this.stateContext.nextCrumb = new Crumb(data, state, url, this.getLink(state, data), false);
+        this.stateContext.nextCrumb = new Crumb(data, state, url, this.stateHandler.getLink(state, data), false);
         this.stateContext.previousState = null;
         this.stateContext.previousData = {};
         if (this.stateContext.crumbs.length > 0) {
@@ -81,20 +81,7 @@ class StateNavigator {
         if (!this.states[stateKey])
             throw new Error(stateKey + ' is not a valid State');
         var { crumbs, nextCrumb } = this.stateContext;
-        return this.getLink(this.states[stateKey], navigationData, crumbs, nextCrumb);
-    }
-
-    private getLink(state: State, navigationData: any, crumbs?: Crumb[], nextCrumb?: Crumb): string {
-        var crumbTrail = [];
-        if (crumbs) {
-            crumbs = crumbs.slice();
-            if (nextCrumb)
-                crumbs.push(nextCrumb);
-            crumbs = state.truncateCrumbTrail(state, crumbs);
-            for(var i = 0; i < crumbs.length; i++)
-                crumbTrail.push(crumbs[i].crumblessUrl)
-        }
-        return this.stateHandler.getNavigationLink(state, navigationData, crumbTrail);
+        return this.stateHandler.getLink(this.states[stateKey], navigationData, crumbs, nextCrumb);
     }
 
     canNavigateBack(distance: number) {
@@ -121,7 +108,7 @@ class StateNavigator {
 
     getRefreshLink(navigationData?: any): string {
         var { crumbs, nextCrumb } = this.stateContext;
-        return this.getLink(this.stateContext.state, navigationData, crumbs, nextCrumb);
+        return this.stateHandler.getLink(this.stateContext.state, navigationData, crumbs, nextCrumb);
     }
 
     navigateLink(url: string, historyAction: 'add' | 'replace' | 'none' = 'add', history = false) {
@@ -167,7 +154,7 @@ class StateNavigator {
 
     fluent(withContext = false): FluentNavigator {
         var stateContext = !withContext ? null : this.stateContext;
-        return new FluentNavigator(this.states, this.getLink, this.stateHandler.parseNavigationLink, stateContext);
+        return new FluentNavigator(this.states, this.stateHandler, stateContext);
     }
     
     start(url?: string) {

--- a/Navigation/src/StateNavigator.ts
+++ b/Navigation/src/StateNavigator.ts
@@ -1,5 +1,5 @@
 ﻿import Crumb from './config/Crumb';
-import FluentNavigator from './FluentNavigator';
+import { FluentNavigator, createFluentNavigator } from './FluentNavigator';
 import HashHistoryManager from './history/HashHistoryManager';
 import HistoryManager from './history/HistoryManager';
 import State from './config/State';
@@ -153,8 +153,8 @@ class StateNavigator {
     }
 
     fluent(withContext = false): FluentNavigator {
-        var stateContext = !withContext ? null : this.stateContext;
-        return new FluentNavigator(this.states, this.stateHandler, stateContext);
+        var stateContext = !withContext ? undefined : this.stateContext;
+        return createFluentNavigator(this.states, this.stateHandler, stateContext);
     }
     
     start(url?: string) {

--- a/Navigation/src/StateNavigator.ts
+++ b/Navigation/src/StateNavigator.ts
@@ -1,4 +1,5 @@
 ﻿import Crumb from './config/Crumb';
+import FluentNavigator from './FluentNavigator';
 import HashHistoryManager from './history/HashHistoryManager';
 import HistoryManager from './history/HistoryManager';
 import State from './config/State';
@@ -162,6 +163,11 @@ class StateNavigator {
         var { state, data } = this.stateHandler.parseNavigationLink(url);
         delete data[state.crumbTrailKey];
         return { state, data };
+    }
+
+    fluent(withContext = false): FluentNavigator {
+        var stateContext = !withContext ? null : this.stateContext;
+        return new FluentNavigator(this.states, this.getLink, this.stateHandler.parseNavigationLink, stateContext);
     }
     
     start(url?: string) {

--- a/Navigation/src/StateNavigator.ts
+++ b/Navigation/src/StateNavigator.ts
@@ -44,7 +44,7 @@ class StateNavigator {
         this.stateContext.crumbs = data[state.crumbTrailKey];
         delete data[state.crumbTrailKey];
         this.stateContext.data = data;
-        this.stateContext.nextCrumb = new Crumb(data, state, url, this.getLink(state, data, []), false);
+        this.stateContext.nextCrumb = new Crumb(data, state, url, this.getLink(state, data), false);
         this.stateContext.previousState = null;
         this.stateContext.previousData = {};
         if (this.stateContext.crumbs.length > 0) {
@@ -79,15 +79,16 @@ class StateNavigator {
     getNavigationLink(stateKey: string, navigationData?: any): string {
         if (!this.states[stateKey])
             throw new Error(stateKey + ' is not a valid State');
-        return this.getLink(this.states[stateKey], navigationData);
+        var { crumbs, nextCrumb } = this.stateContext;
+        return this.getLink(this.states[stateKey], navigationData, crumbs, nextCrumb);
     }
 
-    private getLink(state: State, navigationData: any, crumbTrail?: string[]): string {
-        if (!crumbTrail) {
-            crumbTrail = [];
-            var crumbs = this.stateContext.crumbs.slice();
-            if (this.stateContext.nextCrumb)
-                crumbs.push(this.stateContext.nextCrumb);
+    private getLink(state: State, navigationData: any, crumbs?: Crumb[], nextCrumb?: Crumb): string {
+        var crumbTrail = [];
+        if (crumbs) {
+            crumbs = crumbs.slice();
+            if (nextCrumb)
+                crumbs.push(nextCrumb);
             crumbs = state.truncateCrumbTrail(state, crumbs);
             for(var i = 0; i < crumbs.length; i++)
                 crumbTrail.push(crumbs[i].crumblessUrl)
@@ -118,7 +119,8 @@ class StateNavigator {
     }
 
     getRefreshLink(navigationData?: any): string {
-        return this.getLink(this.stateContext.state, navigationData);
+        var { crumbs, nextCrumb } = this.stateContext;
+        return this.getLink(this.stateContext.state, navigationData, crumbs, nextCrumb);
     }
 
     navigateLink(url: string, historyAction: 'add' | 'replace' | 'none' = 'add', history = false) {

--- a/Navigation/src/StateNavigator.ts
+++ b/Navigation/src/StateNavigator.ts
@@ -113,7 +113,7 @@ class StateNavigator {
 
     navigateLink(url: string, historyAction: 'add' | 'replace' | 'none' = 'add', history = false) {
         var oldUrl = this.stateContext.url;
-        var { state, data } = this.stateHandler.parseNavigationLink(url);
+        var { state, data } = this.stateHandler.parseLink(url);
         var navigateContinuation =  this.getNavigateContinuation(oldUrl, state, data, url, historyAction);
         var unloadContinuation = () => {
             if (oldUrl === this.stateContext.url)
@@ -147,7 +147,7 @@ class StateNavigator {
     }
     
     parseLink(url: string): { state: State, data: any } {
-        var { state, data } = this.stateHandler.parseNavigationLink(url);
+        var { state, data } = this.stateHandler.parseLink(url);
         delete data[state.crumbTrailKey];
         return { state, data };
     }

--- a/Navigation/src/navigation.d.ts
+++ b/Navigation/src/navigation.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for Navigation 2.0.0
+﻿// Type definitions for Navigation 3.1.0
 // Project: http://grahammendick.github.io/navigation/
 // Definitions by: Graham Mendick <https://github.com/grahammendick>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -410,6 +410,56 @@ declare namespace Navigation {
     }
 
     /**
+     * Fluently manages all navigation. These can be forward, backward or
+     * refreshing the current State
+     */
+    interface FluentNavigator {
+        /**
+         * Gets the current Url
+         */
+        url: string;
+        /**
+         * Navigates to a State
+         * @param stateKey The key of a State
+         * @throws state does not match the key of a State or there is 
+         * NavigationData that cannot be converted to a String
+         * @throws A mandatory route parameter has not been supplied a value
+         */
+        navigate(stateKey: string): FluentNavigator;
+        /**
+         * Navigates to a State
+         * @param stateKey The key of a State
+         * @param navigationData The NavigationData to be passed to the next
+         * State and stored in the StateContext
+         * @throws state does not match the key of a State or there is 
+         * NavigationData that cannot be converted to a String
+         * @throws A mandatory route parameter has not been supplied a value
+         */
+        navigate(stateKey: string, navigationData: any): FluentNavigator;
+        /**
+         * Navigates back along the crumb trail
+         * @param distance Starting at 1, the number of Crumb steps to go back
+         * @throws canNavigateBack returns false for this distance
+         * @throws A mandatory route parameter has not been supplied a value
+         */
+        navigateBack(distance: number): FluentNavigator;
+        /**
+         * Navigates to the current State passing no NavigationData
+         * @throws A mandatory route parameter has not been supplied a value
+         */
+        refresh(): FluentNavigator;
+        /**
+         * Navigates to the current State
+         * @param navigationData The NavigationData to be passed to the current
+         * State and stored in the StateContext
+         * @param A value determining the effect on browser history
+         * @throws There is NavigationData that cannot be converted to a String
+         * @throws A mandatory route parameter has not been supplied a value
+         */
+        refresh(navigationData: any): FluentNavigator;
+    }
+
+    /**
      * Manages all navigation. These can be forward, backward or refreshing the
      * current State
      */
@@ -592,6 +642,18 @@ declare namespace Navigation {
          * @param url The url to parse
          */
         parseLink(url: string): { state: State; data: any; };
+        /**
+         * Creates a clean FluentNavigator
+         * @returns A FluentNavigator 
+         */
+        fluent(): FluentNavigator;
+        /**
+         * Creates a FluentNavigator
+         * @param withContext a value indicating whether to inherit the current
+         * context
+         * @returns A FluentNavigator
+         */
+        fluent(withContext: boolean): FluentNavigator;
         /**
          * Navigates to the current location 
          */

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -384,4 +384,84 @@ describe('Fluent', function () {
             assert.throws(() => fluent.navigateBack(1));
         });
     });
+
+    describe('Back Refresh With Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2')
+                .navigateBack(1)
+                .refresh()
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Back Refresh', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2')
+                .navigateBack(1)
+                .refresh()
+                .url;
+            assert.strictEqual(url, '/r1');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Back Refresh Transition With Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true },
+                { key: 's3', route: 'r3', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2')
+                .navigateBack(1)
+                .refresh()
+                .navigate('s3')
+                .url;
+            assert.strictEqual(url, '/r3?crumb=%2Fr0&crumb=%2Fr1');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Back Refresh Transition With Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' },
+                { key: 's2', route: 'r2', trackCrumbTrail: true },
+                { key: 's3', route: 'r3', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2')
+                .navigateBack(1)
+                .refresh()
+                .navigate('s3')
+                .url;
+            assert.strictEqual(url, '/r3?crumb=%2Fr1');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
 });

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -628,6 +628,87 @@ describe('Fluent', function () {
         });
     });
 
+    describe('Reload Dialog', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r' }
+            ]);
+            stateNavigator.navigate('s0');
+            stateNavigator.configure([
+                { key: 's1', route: 'r' }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s1')
+                .url;
+            assert.strictEqual(url, '/r');
+            assert.strictEqual(stateNavigator.stateContext.state.key, 's0');
+        });
+    });
+
+    describe('Reload Transition', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r' }
+            ]);
+            stateNavigator.navigate('s0');
+            stateNavigator.stateContext.clear();
+            stateNavigator.configure([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Reload Refresh', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r' }
+            ]);
+            stateNavigator.navigate('s0');
+            stateNavigator.stateContext.clear();
+            stateNavigator.configure([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .refresh()
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Reload Back', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r' }
+            ]);
+            stateNavigator.navigate('s0');
+            stateNavigator.stateContext.clear();
+            stateNavigator.configure([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2')
+                .navigateBack(1)
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
     describe('Invalid Context', function () {
         it('should throw error', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -68,11 +68,11 @@ describe('Fluent', function () {
         });
     });
 
-    /*describe('Fluent Transition With Trail', function () {
+    describe('Transition With Trail', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
-                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
             var url = stateNavigator.fluent()
                 .navigate('s0')
@@ -81,5 +81,33 @@ describe('Fluent', function () {
             assert.strictEqual(url, '/r1?crumb=%2Fr0');
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
-    });*/
+    });
+
+    describe('State State', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r' }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s')
+                .navigate('s')
+                .url;
+            assert.strictEqual(url, '/r');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('State State With Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s')
+                .navigate('s')
+                .url;
+            assert.strictEqual(url, '/r');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
 });

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -843,6 +843,130 @@ describe('Fluent', function () {
         });
     });
 
+    describe('Two Controllers Refresh', function () {
+        it('should navigate', function() {
+            var stateNavigator0 = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var stateNavigator1 = new StateNavigator([
+                { key: 's2', route: 'r2' },
+                { key: 's3', route: 'r3', trackCrumbTrail: true }
+            ]);
+            var fluent0 = stateNavigator0.fluent()
+                .navigate('s0');
+            var fluent1 = stateNavigator1.fluent()
+                .navigate('s2');
+            fluent0 = fluent0
+                .navigate('s1');
+            fluent1 = fluent1
+                .navigate('s3');
+            var url0 = fluent0
+                .refresh()
+                .url;
+            var url1 = fluent1
+                .refresh()
+                .url;
+            assert.strictEqual(url0, '/r1?crumb=%2Fr0');
+            assert.strictEqual(url1, '/r3?crumb=%2Fr2');
+            assert.strictEqual(stateNavigator0.stateContext.url, null);
+            assert.strictEqual(stateNavigator1.stateContext.url, null);
+        });
+    });
+
+    describe('Two Controllers Back', function () {
+        it('should navigate', function() {
+            var stateNavigator0 = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+            var stateNavigator1 = new StateNavigator([
+                { key: 's3', route: 'r3' },
+                { key: 's4', route: 'r4', trackCrumbTrail: true },
+                { key: 's5', route: 'r5', trackCrumbTrail: true }
+            ]);
+            var fluent0 = stateNavigator0.fluent()
+                .navigate('s0');
+            var fluent1 = stateNavigator1.fluent()
+                .navigate('s3');
+            fluent0 = fluent0
+                .navigate('s1');
+            fluent1 = fluent1
+                .navigate('s4');
+            fluent0 = fluent0
+                .navigate('s2');
+            fluent1 = fluent1
+                .navigate('s5');
+            var url0 = fluent0
+                .navigateBack(1)
+                .url;
+            var url1 = fluent1
+                .navigateBack(1)
+                .url;
+            assert.strictEqual(url0, '/r1?crumb=%2Fr0');
+            assert.strictEqual(url1, '/r4?crumb=%2Fr3');
+            assert.strictEqual(stateNavigator0.stateContext.url, null);
+            assert.strictEqual(stateNavigator1.stateContext.url, null);
+        });
+    });
+
+    describe('Crumb Trail Route Param', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1/{crumb?}', trackCrumbTrail: true },
+                { key: 's2', route: 'r2/{crumb?}', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2')
+                .url;
+            assert.strictEqual(url, '/r2/%2Fr01-%2Fr1');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Crumb Trail Route Splat Param', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1/{*crumb?}', trackCrumbTrail: true },
+                { key: 's2', route: 'r2/{*crumb?}', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2')
+                .url;
+            assert.strictEqual(url, '/r2/%2Fr0/%2Fr1');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Crumb Trail Mixed Param', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2/{*crumb?}', trackCrumbTrail: true },
+                { key: 's3', route: 'r3/{crumb?}', trackCrumbTrail: true }
+            ]);
+            var fluent = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2');
+            var url1 = fluent.url;
+            var url2 = fluent
+                .navigate('s3')
+                .url;
+            assert.strictEqual(url1, '/r2/%2Fr0/%2Fr1');
+            assert.strictEqual(url2, '/r3/%2Fr01-%2Fr11-%2Fr2');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
     describe('Invalid Context', function () {
         it('should throw error', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -280,4 +280,108 @@ describe('Fluent', function () {
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
+
+    describe('Back One By One With Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true },
+                { key: 's3', route: 'r3', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2')
+                .navigate('s3')
+                .navigateBack(1)
+                .navigateBack(1)
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Back One By One', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' },
+                { key: 's2', route: 'r2', trackCrumbTrail: true },
+                { key: 's3', route: 'r3', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2')
+                .navigate('s3')
+                .navigateBack(1)
+                .navigateBack(1)
+                .url;
+            assert.strictEqual(url, '/r1');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Invalid Back With Trail', function () {
+        it('should throw error', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+            var fluent = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2');
+            assert.throws(() => fluent.navigateBack(3));
+        });
+    });
+
+    describe('Invalid Back', function () {
+        it('should throw error', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2' }
+            ]);
+            var fluent = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2');
+            assert.throws(() => fluent.navigateBack(1));
+        });
+    });
+
+    describe('Back Invalid Back With Trail', function () {
+        it('should throw error', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+            var fluent = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2')
+                .navigateBack(1);
+            assert.throws(() => fluent.navigateBack(2));
+        });
+    });
+
+    describe('Back Invalid Back', function () {
+        it('should throw error', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+            var fluent = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2')
+                .navigateBack(1);
+            assert.throws(() => fluent.navigateBack(1));
+        });
+    });
 });

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -520,4 +520,87 @@ describe('Fluent', function () {
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
+
+    describe('Transition State State Custom Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, crumbs) => {
+                return crumbs;
+            };
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s1')
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0&crumb=%2Fr1');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('State State Back Custom Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r', trackCrumbTrail: true }
+            ]);
+            var state = stateNavigator.states['s'];
+            state.truncateCrumbTrail = (state, crumbs) => {
+                return crumbs;
+            };
+            var url = stateNavigator.fluent()
+                .navigate('s')
+                .navigate('s')
+                .navigateBack(1)
+                .url;
+            assert.strictEqual(url, '/r');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('State State Back Custom Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, crumbs) => {
+                return crumbs;
+            };
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s1')
+                .navigateBack(1)
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('State State Back Two Custom Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, crumbs) => {
+                return crumbs;
+            };
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s1')
+                .navigate('s2')
+                .navigateBack(2)
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
 });

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -709,6 +709,140 @@ describe('Fluent', function () {
         });
     });
 
+    describe('Reload Error State', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r' }
+            ]);
+            try {
+                stateNavigator.configure([<any>
+                    { key: '' }
+                ]);
+            } catch(e) {
+            }
+            var url = stateNavigator.fluent()
+                .navigate('s')
+                .url;
+            assert.strictEqual(url, '/r');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Reload Error Transition', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            try {
+                stateNavigator.configure([<any>
+                    { key: '' }
+                ]);
+            } catch(e) {
+            }
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Reload Error Refresh', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            try {
+                stateNavigator.configure([<any>
+                    { key: '' }
+                ]);
+            } catch(e) {
+            }
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .refresh()
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Reload Error Back', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+            try {
+                stateNavigator.configure([<any>
+                    { key: '' }
+                ]);
+            } catch(e) {
+            }
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2')
+                .navigateBack(1)
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Two Controllers Dialog', function () {
+        it('should navigate', function() {
+            var stateNavigator0 = new StateNavigator([
+                { key: 's0', route: 'r0' }
+            ]);
+            var stateNavigator1 = new StateNavigator([
+                { key: 's1', route: 'r1' }
+            ]);
+            var url0 = stateNavigator0.fluent()
+                .navigate('s0')
+                .url;
+            var url1 = stateNavigator1.fluent()
+                .navigate('s1')
+                .url;
+            assert.strictEqual(url0, '/r0');
+            assert.strictEqual(url1, '/r1');
+            assert.strictEqual(stateNavigator0.stateContext.url, null);
+            assert.strictEqual(stateNavigator1.stateContext.url, null);
+        });
+    });
+
+    describe('Two Controllers Transition', function () {
+        it('should navigate', function() {
+            var stateNavigator0 = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var stateNavigator1 = new StateNavigator([
+                { key: 's2', route: 'r2' },
+                { key: 's3', route: 'r3', trackCrumbTrail: true }
+            ]);
+            var fluent0 = stateNavigator0.fluent()
+                .navigate('s0');
+            var fluent1 = stateNavigator1.fluent()
+                .navigate('s2');
+            var url0 = fluent0
+                .navigate('s1')
+                .url;
+            var url1 = fluent1
+                .navigate('s3')
+                .url;
+            assert.strictEqual(url0, '/r1?crumb=%2Fr0');
+            assert.strictEqual(url1, '/r3?crumb=%2Fr2');
+            assert.strictEqual(stateNavigator0.stateContext.url, null);
+            assert.strictEqual(stateNavigator1.stateContext.url, null);
+        });
+    });
+
     describe('Invalid Context', function () {
         it('should throw error', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -957,12 +957,73 @@ describe('Fluent', function () {
                 .navigate('s0')
                 .navigate('s1')
                 .navigate('s2');
-            var url1 = fluent.url;
-            var url2 = fluent
+            var s2Url = fluent.url;
+            var s3Url = fluent
                 .navigate('s3')
                 .url;
-            assert.strictEqual(url1, '/r2/%2Fr0/%2Fr1');
-            assert.strictEqual(url2, '/r3/%2Fr01-%2Fr11-%2Fr2');
+            assert.strictEqual(s2Url, '/r2/%2Fr0/%2Fr1');
+            assert.strictEqual(s3Url, '/r3/%2Fr01-%2Fr11-%2Fr2');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Crumb Trail Key', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: 'trail' }
+            ]);
+            var fluent = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2');
+            var s2Url = fluent.url;
+            var s1Url = fluent
+                .navigateBack(1)
+                .url;
+            assert.strictEqual(s1Url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(s2Url, '/r2?trail=%2Fr0&trail=%2Fr1');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Refresh Back Custom Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, crumbs) => {
+                return crumbs;
+            };
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .refresh()
+                .navigateBack(1)
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Crumb Trail Encode', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var state = stateNavigator.states['s1'];
+            state.urlEncode = (state, key, val) => {
+                return encodeURIComponent(val).replace('%2F', '/');
+            }
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .url;
+            assert.strictEqual(url, '/r1?crumb=/r0');
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -1,0 +1,63 @@
+/// <reference path="assert.d.ts" />
+/// <reference path="mocha.d.ts" />
+import * as assert from 'assert';
+import { StateNavigator } from '../src/Navigation';
+
+describe('Navigation', function () {
+    describe('Fluent State', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r' }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s')
+                .url;
+            assert.strictEqual(url, '/r');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Fluent Second State', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's', route: 'r' }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s')
+                .url;
+            assert.strictEqual(url, '/r');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    /*describe('Fluent Transition', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' },
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .url;
+            assert.strictEqual(url, '/r1');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Fluent Transition With Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });*/
+});

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -1028,6 +1028,26 @@ describe('Fluent', function () {
         });
     });
 
+    describe('Repeated States With Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true },
+                { key: 's3', route: 'r3', trackCrumbTrail: true },
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2')
+                .navigate('s3')
+                .navigate('s1')
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
     describe('Invalid Context', function () {
         it('should throw error', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -3,8 +3,8 @@
 import * as assert from 'assert';
 import { StateNavigator } from '../src/Navigation';
 
-describe('Navigation', function () {
-    describe('Fluent State', function () {
+describe('Fluent', function () {
+    describe('State', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([
                 { key: 's', route: 'r' }
@@ -17,7 +17,7 @@ describe('Navigation', function () {
         });
     });
 
-    describe('Fluent Second State', function () {
+    describe('Second State', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
@@ -31,11 +31,33 @@ describe('Navigation', function () {
         });
     });
 
-    /*describe('Fluent Transition', function () {
+    describe('State With Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s')
+                .url;
+            assert.strictEqual(url, '/r');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Invalid State', function () {
+        it('should throw error', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r' }
+            ]);
+            assert.throws(() =>  stateNavigator.fluent().navigate('s0'), /is not a valid State/);
+        });
+    });
+
+    describe('Transition', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
-                { key: 's1', route: 'r1' },
+                { key: 's1', route: 'r1' }
             ]);
             var url = stateNavigator.fluent()
                 .navigate('s0')
@@ -46,7 +68,7 @@ describe('Navigation', function () {
         });
     });
 
-    describe('Fluent Transition With Trail', function () {
+    /*describe('Fluent Transition With Trail', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -184,4 +184,38 @@ describe('Fluent', function () {
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
+
+    describe('Refresh', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .refresh()
+                .url;
+            assert.strictEqual(url, '/r1');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Back With Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2')
+                .navigateBack(1)
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
 });

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -464,4 +464,60 @@ describe('Fluent', function () {
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
+
+    describe('Transition Transition With Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2')
+                .url;
+            assert.strictEqual(url, '/r2?crumb=%2Fr1');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Crumb Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true },
+                { key: 's3', route: 'r3', trackCrumbTrail: true },
+                { key: 's4', route: 'r4', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2')
+                .navigate('s3')
+                .navigate('s4')
+                .url;
+            assert.strictEqual(url, '/r4?crumb=%2Fr0&crumb=%2Fr1&crumb=%2Fr2&crumb=%2Fr3');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('State State Custom Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r', trackCrumbTrail: true },
+            ]);
+            var state = stateNavigator.states['s'];
+            state.truncateCrumbTrail = (state, crumbs) => {
+                return crumbs;
+            };
+            var url = stateNavigator.fluent()
+                .navigate('s')
+                .navigate('s')
+                .url;
+            assert.strictEqual(url, '/r?crumb=%2Fr');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
 });

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -218,4 +218,66 @@ describe('Fluent', function () {
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
+
+    describe('Back', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2')
+                .navigateBack(1)
+                .url;
+            assert.strictEqual(url, '/r1');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Back Two With Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true },
+                { key: 's3', route: 'r3', trackCrumbTrail: true },
+                { key: 's4', route: 'r4', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2')
+                .navigate('s3')
+                .navigate('s4')
+                .navigateBack(2)
+                .url;
+            assert.strictEqual(url, '/r2?crumb=%2Fr0&crumb=%2Fr1');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Back Two', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' },
+                { key: 's2', route: 'r2' },
+                { key: 's3', route: 'r3', trackCrumbTrail: true },
+                { key: 's4', route: 'r4', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2')
+                .navigate('s3')
+                .navigate('s4')
+                .navigateBack(2)
+                .url;
+            assert.strictEqual(url, '/r2');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
 });

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -110,4 +110,45 @@ describe('Fluent', function () {
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
+
+    describe('Null State', function () {
+        it('should throw error', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r' }
+            ]);
+            assert.throws(() =>  stateNavigator.fluent().navigate(null), /is not a valid State/);
+        });
+    });
+
+    describe('Transition From Without Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0', trackCrumbTrail: false },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Transition With Trail Transition With Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2')
+                .url;
+            assert.strictEqual(url, '/r2?crumb=%2Fr0&crumb=%2Fr1');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
 });

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -603,4 +603,28 @@ describe('Fluent', function () {
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
+
+    describe('State State Back One By One Custom Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, crumbs) => {
+                return crumbs;
+            };
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s1')
+                .navigate('s2')
+                .navigateBack(1)
+                .navigateBack(1)
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
 });

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -627,4 +627,17 @@ describe('Fluent', function () {
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
+
+    describe('Invalid Context', function () {
+        it('should throw error', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var fluent = stateNavigator.fluent()
+                .navigate('s0');
+            fluent.navigate('s1');
+            assert.throws(() => fluent.navigateBack(1));
+        });
+    });
 });

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -151,4 +151,37 @@ describe('Fluent', function () {
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
+
+    describe('Transition Transition', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' },
+                { key: 's2', route: 'r2' }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s2')
+                .url;
+            assert.strictEqual(url, '/r2');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('Refresh With Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .refresh()
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
 });

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -4881,59 +4881,132 @@ describe('Navigation Data', function () {
     });
 
     describe('Crumb Link Defaults Navigate', function() {
-        it('should not include defaults in link', function() {
-            var stateNavigator = new StateNavigator([
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r', trackCrumbTrail: true, defaults: { 'string': 'Hello', _bool: true, 'number': 1 } },
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
-            var data = {};
-            data['number'] = 1;
-            data['_bool'] = '';
-            data['string'] = 4;
-            stateNavigator.navigate('s0');
-            stateNavigator.navigate('s1', data);
-            stateNavigator.refresh(stateNavigator.stateContext.includeCurrentData({}))
-            stateNavigator.navigate('s2');
-            var link = stateNavigator.stateContext.crumbs[1].url;
-            assert.equal(link.indexOf('_bool'), -1);
-            assert.equal(link.indexOf('number'), -1);
-            assert.notEqual(link.indexOf('string'), -1);
         });
+        var data = {};
+        data['number'] = 1;
+        data['_bool'] = '';
+        data['string'] = 4;
+        var link;
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                stateNavigator.navigate('s0');
+                stateNavigator.navigate('s1', data);
+                stateNavigator.refresh(stateNavigator.stateContext.includeCurrentData({}))
+                stateNavigator.navigate('s2');
+                link = stateNavigator.stateContext.crumbs[1].url;
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .refresh((currentData) => currentData)
+                    .navigate('s2')
+                    .url;
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.stateContext.crumbs[1].url;
+            });
+            test();
+        });
+
+        function test() {
+            it('should not include defaults in link', function() {
+                assert.equal(link.indexOf('_bool'), -1);
+                assert.equal(link.indexOf('number'), -1);
+                assert.notEqual(link.indexOf('string'), -1);
+            });
+        }
     });
 
     describe('Link Navigate With Trail', function() {
-        it('should include data in link', function() {
-            var stateNavigator = new StateNavigator([
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
             stateNavigator.navigate('s0');
-            var data = {};
-            data['_number'] = 1;
-            data['string'] = 'Hello';
-            stateNavigator.refresh(data);
-            var link = stateNavigator.getNavigationLink('s1');
-            assert.notEqual(link.indexOf('_number'), -1);
-            assert.notEqual(link.indexOf('string'), -1);
         });
+        var data = {};
+        data['_number'] = 1;
+        data['string'] = 'Hello';
+        var link;
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                stateNavigator.refresh(data);
+                link = stateNavigator.getNavigationLink('s1');
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                link = stateNavigator.fluent(true)
+                    .refresh(data)
+                    .navigate('s1')
+                    .url;
+            });
+            test();
+        });
+
+        function test() {
+            it('should include data in link', function() {
+                assert.notEqual(link.indexOf('_number'), -1);
+                assert.notEqual(link.indexOf('string'), -1);
+            });
+        }
     });
 
     describe('Link Navigate', function() {
-        it('should not include data in link', function() {
-            var stateNavigator = new StateNavigator([
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1' }
             ]);
             stateNavigator.navigate('s0');
-            var data = {};
-            data['_number'] = 1;
-            data['string'] = 'Hello';
-            stateNavigator.refresh(data);
-            var link = stateNavigator.getNavigationLink('s1');
-            assert.equal(link.indexOf('_number'), -1);
-            assert.equal(link.indexOf('string'), -1);
         });
+        var data = {};
+        data['_number'] = 1;
+        data['string'] = 'Hello';
+        var link;
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                stateNavigator.refresh(data);
+                link = stateNavigator.getNavigationLink('s1');
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                link = stateNavigator.fluent(true)
+                    .refresh(data)
+                    .navigate('s1')
+                    .url;
+            });
+            test();
+        });
+
+        function test() {
+            it('should not include data in link', function() {
+                assert.equal(link.indexOf('_number'), -1);
+                assert.equal(link.indexOf('string'), -1);
+            });
+        }
     });
 
     describe('Link Default Types Navigate', function() {

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -1242,6 +1242,24 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data)
+                    .url;
+                stateNavigator.navigateLink(link);
+                stateNavigator.stateContext.data['s'] = 'World';
+                stateNavigator.stateContext.data['i'] = 2;
+                link = stateNavigator.fluent(true)
+                    .refresh((currentData) => currentData)
+                    .navigate('s1')
+                    .navigateBack(1)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['s'], 'World');
@@ -1289,6 +1307,24 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data)
+                    .url;
+                stateNavigator.navigateLink(link);
+                stateNavigator.stateContext.data['s'] = null;
+                stateNavigator.stateContext.data['i'] = 2;
+                link = stateNavigator.fluent(true)
+                    .refresh((currentData) => currentData)
+                    .navigate('s1')
+                    .navigateBack(1)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['s'], undefined);
@@ -1324,6 +1360,18 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s1', data);
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getRefreshLink(stateNavigator.stateContext.includeCurrentData(null));
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .refresh((currentData) => currentData)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -1371,6 +1419,18 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1')
+                    .refresh(data)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['string'], 'Hello');
@@ -1413,6 +1473,18 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s1');
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getRefreshLink(data);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1')
+                    .refresh(data)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -1478,6 +1550,18 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data1)
+                    .refresh(data2)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['s'], 'World');
@@ -1512,6 +1596,18 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s1', data);
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getRefreshLink();
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .refresh()
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -1560,6 +1656,18 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data1)
+                    .refresh(data2)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['s'], 'World');
@@ -1599,6 +1707,21 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s1', data);
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationLink('s2', stateNavigator.stateContext.includeCurrentData(null));
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .url;
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.fluent(true)
+                    .navigate('s2', (currentData) => currentData)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -2275,6 +2275,19 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1')
+                    .navigate('s2')
+                    .navigateBack(1)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['string'], 'Hello');
@@ -2313,6 +2326,19 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s2');
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationBackLink(1);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1')
+                    .navigate('s2')
+                    .navigateBack(1)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -2357,6 +2383,19 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s2');
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationBackLink(1);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .navigate('s2')
+                    .navigateBack(1)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -2408,6 +2447,19 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .navigate('s2')
+                    .navigateBack(1)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['emptyString'], '');
@@ -2449,6 +2501,19 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s2');
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationBackLink(1);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .navigate('s2')
+                    .navigateBack(1)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -2498,6 +2563,19 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .navigate('s2')
+                    .navigateBack(1)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['emptyString'], 'World');
@@ -2537,6 +2615,19 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s2');
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationLink('s3');
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1')
+                    .navigate('s2')
+                    .navigate('s3')
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -2594,6 +2685,19 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1')
+                    .navigate('s2')
+                    .navigate('s3')
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.previousData['emptyString'], '');
@@ -2643,6 +2747,18 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .navigate('s2')
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.previousData['number'], 1);
@@ -2686,6 +2802,18 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s1', data);
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationLink('s2');
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .navigate('s2')
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -2743,6 +2871,18 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .navigate('s2')
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.previousData['string'], 'World');
@@ -2784,6 +2924,18 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s1', data);
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationLink('s2');
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .navigate('s2')
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -2846,6 +2998,21 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1')
+                    .navigate('s2')
+                    .navigate('s2')
+                    .navigate('s3')
+                    .navigateBack(3)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['string'], 'Hello');
@@ -2895,6 +3062,21 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s3');
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationBackLink(3);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1')
+                    .navigate('s2')
+                    .navigate('s2')
+                    .navigate('s3')
+                    .navigateBack(3)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -2951,6 +3133,20 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .navigate('s2')
+                    .navigate('s2')
+                    .navigateBack(2)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['emptyString'], '');
@@ -2999,6 +3195,20 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s2');
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationBackLink(2);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .navigate('s2')
+                    .navigate('s2')
+                    .navigateBack(2)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -3060,6 +3270,21 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .navigate('s2')
+                    .navigate('s2')
+                    .navigateBack(1)
+                    .navigateBack(1)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['emptyString'], 'World');
@@ -3109,6 +3334,21 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationBackLink(1);
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationBackLink(1);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .navigate('s2')
+                    .navigate('s2')
+                    .navigateBack(1)
+                    .navigateBack(1)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -5019,14 +5019,10 @@ describe('Navigation Data', function () {
             individualNavigationData['boolean'] = true;
             individualNavigationData['number'] = 0;
             stateNavigator.navigate('s', individualNavigationData);
-            var i = 0;
-            for (var key in stateNavigator.stateContext.data) {
-                i++;
-            }
             assert.strictEqual(stateNavigator.stateContext.data['string'], 'Hello');
             assert.strictEqual(stateNavigator.stateContext.data['boolean'], true);
             assert.strictEqual(stateNavigator.stateContext.data['number'], 0);
-            assert.equal(i, 3);
+            assert.equal(Object.keys(stateNavigator.stateContext.data).length, 3);
         });
     });
 
@@ -5043,47 +5039,114 @@ describe('Navigation Data', function () {
     });
 
     describe('Link Default Types Bool Navigate', function() {
-        it('should not include default types in link', function() {
-            var stateNavigator = new StateNavigator([
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
                 { key: 's', route: 'r', defaultTypes: { b1: 'boolean' } }
             ]);
-            var data = { b1: true, b2: false };
-            var url = stateNavigator.getNavigationLink('s', data);
-            assert.notEqual(url.indexOf('b1=true&'), -1);
-            assert.notEqual(url.indexOf('b2=false1_'), -1);
         });
+        var data = { b1: true, b2: false };
+        var link;
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                link = stateNavigator.getNavigationLink('s', data);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                link = stateNavigator.fluent()
+                    .navigate('s', data)
+                    .url;
+            });
+            test();
+        });
+
+        function test() {
+            it('should not include default types in link', function() {
+                assert.notEqual(link.indexOf('b1=true&'), -1);
+                assert.notEqual(link.indexOf('b2=false1_'), -1);
+            });
+        }
     });
 
     describe('Link Default Types Number Navigate', function() {
-        it('should not include default types in link', function() {
-            var stateNavigator = new StateNavigator([
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
                 { key: 's', route: 'r', defaultTypes: { n1: 'number' } }
             ]);
-            var data = { n1: 0, n2: 1 };
-            var url = stateNavigator.getNavigationLink('s', data);
-            assert.notEqual(url.indexOf('n1=0&'), -1);
-            assert.notEqual(url.indexOf('n2=11_'), -1);
         });
+        var data = { n1: 0, n2: 1 };
+        var link;
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                link = stateNavigator.getNavigationLink('s', data);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                link = stateNavigator.fluent()
+                    .navigate('s', data)
+                    .url;
+            });
+            test();
+        });
+
+        function test() {
+            it('should not include default types in link', function() {
+                assert.notEqual(link.indexOf('n1=0&'), -1);
+                assert.notEqual(link.indexOf('n2=11_'), -1);
+            });
+        }
     });
 
     describe('Link Default Types Refresh Navigate', function() {
-        it('should not include default types in link', function() {
-            var stateNavigator = new StateNavigator([
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
                 { key: 's', route: 'r', defaultTypes: { s1: 'string', s2: 'number', n1: 'number' } }
             ]);
-            var data = {
-                s1: 'hello',
-                s2: 'world',
-                n1: 0,
-                n2: 1
-            };
-            stateNavigator.navigate('s', data);
-            var url = stateNavigator.getRefreshLink(stateNavigator.stateContext.includeCurrentData(null));
-            assert.notEqual(url.indexOf('s1=hello&'), -1);
-            assert.notEqual(url.indexOf('s2=world1_'), -1);
-            assert.notEqual(url.indexOf('n1=0&'), -1);
-            assert.notEqual(url.indexOf('n2=11_'), -1);
         });
+        var data = {
+            s1: 'hello',
+            s2: 'world',
+            n1: 0,
+            n2: 1
+        };
+        var link;
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                stateNavigator.navigate('s', data);
+                link = stateNavigator.getRefreshLink(stateNavigator.stateContext.includeCurrentData(null));
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                link = stateNavigator.fluent()
+                    .navigate('s', data)
+                    .refresh((currentData) => currentData)
+                    .url;
+            });
+            test();
+        });
+
+        function test() {
+            it('should not include default types in link', function() {
+                assert.notEqual(link.indexOf('s1=hello&'), -1);
+                assert.notEqual(link.indexOf('s2=world1_'), -1);
+                assert.notEqual(link.indexOf('n1=0&'), -1);
+                assert.notEqual(link.indexOf('n2=11_'), -1);
+            });
+        }
     });
 
     describe('Override Default Types', function() {

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -6052,6 +6052,18 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data)
+                    .navigate('s1')
+                    .navigateBack(1)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['string'], 'Hello');
@@ -6097,6 +6109,19 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s2');
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationBackLink(1);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .navigate('s2')
+                    .navigateBack(1)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -6155,6 +6180,19 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .refresh()
+                    .navigateBack(1)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['string'], 'Hello');
@@ -6205,6 +6243,12 @@ describe('Navigation Data', function () {
                 assert.throws(() => stateNavigator.navigateLink(link), /The Url .+ is invalid/);
             });
         });
+
+        describe('Fluent Navigate', function() {
+            it('should throw error', function() {
+                assert.throws(() => stateNavigator.fluent().navigate('s', individualNavigationData), /The Url .+ is invalid/);
+            });
+        });
     });
 
     describe('Array Data Constraint', function() {
@@ -6239,6 +6283,12 @@ describe('Navigation Data', function () {
             it('should throw error', function() {
                 var link = stateNavigator.getNavigationLink('s', arrayNavigationData);
                 assert.throws(() => stateNavigator.navigateLink(link), /The Url .+ is invalid/);
+            });
+        });
+
+        describe('Fluent Navigate', function() {
+            it('should throw error', function() {
+                assert.throws(() => stateNavigator.fluent().navigate('s', arrayNavigationData), /The Url .+ is invalid/);
             });
         });
     });

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -5592,8 +5592,9 @@ describe('Navigation Data', function () {
     });
 
     describe('Without Types Back Navigate', function () {
-        it('should not track types', function() {
-            var stateNavigator = new StateNavigator([
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
                 { key: 's0', route: 's0', trackTypes: false },
                 { key: 's1', route: 's1', trackCrumbTrail: true },
                 { key: 's2', route: 's2', trackCrumbTrail: true }
@@ -5601,16 +5602,38 @@ describe('Navigation Data', function () {
             stateNavigator.navigate('s0', { x: '0_1_2_' });
             stateNavigator.navigate('s1');
             stateNavigator.navigate('s2');
-            var link = stateNavigator.getNavigationBackLink(2);
-            stateNavigator.navigateBack(2);
-            assert.strictEqual ('/s0?x=0_1_2_', link);
-            assert.strictEqual(stateNavigator.stateContext.data.x, '0_1_2_');
-        })
+        });
+        var link;
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                link = stateNavigator.getNavigationBackLink(2);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                link = stateNavigator.fluent(true)
+                    .navigateBack(2)
+                    .url;
+            });
+            test();
+        });
+
+        function test() {
+            it('should not track types', function() {
+                stateNavigator.navigateBack(2);
+                assert.strictEqual ('/s0?x=0_1_2_', link);
+                assert.strictEqual(stateNavigator.stateContext.data.x, '0_1_2_');
+            })
+        }
     });
 
     describe('Without Types Default Back Navigate', function () {
-        it('should not track types', function() {
-            var stateNavigator = new StateNavigator([
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
                 { key: 's0', route: 's0', trackTypes: false, defaults: { x: 2 }, defaultTypes: { y: 'boolean' } },
                 { key: 's1', route: 's1', trackCrumbTrail: true },
                 { key: 's2', route: 's2', trackCrumbTrail: true }
@@ -5618,11 +5641,32 @@ describe('Navigation Data', function () {
             stateNavigator.navigate('s0', { x: '3', y: 'true' });
             stateNavigator.navigate('s1');
             stateNavigator.navigate('s2');
-            var link = stateNavigator.getNavigationBackLink(2);
-            stateNavigator.navigateLink(link);
-            assert.strictEqual(stateNavigator.stateContext.data.x, 3);
-            assert.strictEqual(stateNavigator.stateContext.data.y, true);
         });
+        var link;
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                link = stateNavigator.getNavigationBackLink(2);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                link = stateNavigator.fluent(true)
+                    .navigateBack(2)
+                    .url;
+            });
+            test();
+        });
+
+        function test() {
+            it('should not track types', function() {
+                stateNavigator.navigateLink(link);
+                assert.strictEqual(stateNavigator.stateContext.data.x, 3);
+                assert.strictEqual(stateNavigator.stateContext.data.y, true);
+            });
+        }
     });
 
     describe('Without Types Array Type', function () {
@@ -5665,6 +5709,17 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getRefreshLink(data);
                 stateNavigator.navigateLink(link);
             });            
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s', data)
+                    .refresh(data)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
             test();
         });
         
@@ -5718,6 +5773,18 @@ describe('Navigation Data', function () {
             });            
             test();
         });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data)
+                    .navigate('s1')
+                    .navigateBack(1)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
         
         function test(){
             it('should populate data', function() {
@@ -5757,6 +5824,20 @@ describe('Navigation Data', function () {
                 var link = stateNavigator0.getNavigationLink('s0', data0);
                 stateNavigator0.navigateLink(link);
                 link = stateNavigator1.getNavigationLink('s1', data1);
+                stateNavigator1.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator0.fluent()
+                    .navigate('s0', data0)
+                    .url;
+                stateNavigator0.navigateLink(link);
+                link = stateNavigator1.fluent()
+                    .navigate('s1', data1)
+                    .url;
                 stateNavigator1.navigateLink(link);
             });
             test();
@@ -5824,6 +5905,26 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var fluent0 = stateNavigator0.fluent()
+                    .navigate('s0', data0);
+                var fluent1 = stateNavigator1.fluent()
+                    .navigate('s2', data1);
+                fluent0 = fluent0.navigate('s1');
+                fluent1 = fluent1.navigate('s3');
+                var link = fluent0
+                    .navigateBack(1)
+                    .url;
+                stateNavigator0.navigateLink(link);
+                link = fluent1
+                    .navigateBack(1)
+                    .url;
+                stateNavigator1.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator0.stateContext.data['string'], 'Hello');
@@ -5881,6 +5982,24 @@ describe('Navigation Data', function () {
                 link = stateNavigator1.getNavigationLink('s3');
                 stateNavigator1.navigateLink(link);
                 link = stateNavigator1.getRefreshLink(data1);
+                stateNavigator1.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator0.fluent()
+                    .navigate('s0')
+                    .navigate('s1')
+                    .refresh(data0)
+                    .url;
+                stateNavigator0.navigateLink(link);
+                link = stateNavigator1.fluent()
+                    .navigate('s2')
+                    .navigate('s3')
+                    .refresh(data1)
+                    .url;
                 stateNavigator1.navigateLink(link);
             });
             test();

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -5529,6 +5529,12 @@ describe('Navigation Data', function () {
                 assert.equal(stateNavigator.getNavigationLink('s'), null);
             });
         });
+
+        describe('Fluent Navigate', function() {
+            it('should throw error', function () {
+                assert.throws(() => stateNavigator.fluent().navigate('s'), /Invalid route data/);
+            });
+        });
     });
 
     describe('Missing Route Data Refresh', function() {
@@ -5551,6 +5557,14 @@ describe('Navigation Data', function () {
                 var link = stateNavigator.getNavigationLink('s', { s1: 1, s2: 2 });
                 stateNavigator.navigateLink(link);
                 assert.equal(stateNavigator.getRefreshLink(), null);
+            });
+        });
+
+        describe('Fluent Navigate Link', function() {
+            it('should throw error', function() {
+                var fluent = stateNavigator.fluent()
+                    .navigate('s', { s1: 1, s2: 2 });
+                assert.throws(() => fluent.refresh(), /Invalid route data/);
             });
         });
     });

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -4475,6 +4475,21 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .url;
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.fluent(true)
+                    .refresh()
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate old and previous data', function () {
                 assert.strictEqual(stateNavigator.stateContext.oldData['s'], 'Hello');
@@ -4524,6 +4539,21 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .url;
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.fluent(true)
+                    .refresh()
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate old but not previous data', function () {
                 assert.strictEqual(stateNavigator.stateContext.oldData['s'], 'Hello');
@@ -4565,6 +4595,21 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s1', data);
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationLink('s2');
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .url;
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.fluent(true)
+                    .navigate('s2')
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -1780,6 +1780,21 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data1)
+                    .navigate('s1', data2)
+                    .url;
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.fluent(true)
+                    .navigate('s2', data3)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.oldData['s'], 2);
@@ -1832,6 +1847,21 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s1', data2);
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationLink('s2', data3);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data1)
+                    .navigate('s1', data2)
+                    .url;
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.fluent(true)
+                    .navigate('s2', data3)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -1892,6 +1922,21 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data1)
+                    .navigate('s1', data2)
+                    .url;
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.fluent(true)
+                    .navigate('s2', data3)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.oldData.s, '2');
@@ -1926,6 +1971,17 @@ describe('Navigation Data', function () {
                 var link = stateNavigator.getNavigationLink('s0');
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationLink('s1');
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1')
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -1968,6 +2024,17 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1')
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['string'], 'Hello');
@@ -2001,6 +2068,17 @@ describe('Navigation Data', function () {
                 var link = stateNavigator.getNavigationLink('s0');
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationLink('s1', data);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -2045,6 +2123,17 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['emptyString'], '');
@@ -2084,6 +2173,17 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['emptyString'], 2);
@@ -2116,6 +2216,17 @@ describe('Navigation Data', function () {
                 var link = stateNavigator.getNavigationLink('s0');
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationLink('s1', data);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -5327,37 +5327,81 @@ describe('Navigation Data', function () {
     });
 
     describe('Reserved Url Character Default Types', function () {
-        it('should not include default types in link', function() {
-            var stateNavigator = new StateNavigator([
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
                 { key: 's', route: 'r', defaultTypes: { '*/()-_+~@:?><.;[]{}!£$%^#&': 'number' } }
             ]);
             var data = {};
             data['*/()-_+~@:?><.;[]{}!£$%^#&'] = 0;
             data['**=/()-_+~@:?><.;[]{}!£$%^#&&'] = 1;
             stateNavigator.navigate('s', data);
-            var url = stateNavigator.getRefreshLink(stateNavigator.stateContext.includeCurrentData({}));
-            assert.notEqual(url.indexOf('=0&'), -1);
-            assert.notEqual(url.indexOf('=11_'), -1);
-            assert.strictEqual(stateNavigator.stateContext.data['*/()-_+~@:?><.;[]{}!£$%^#&'], 0);
-            assert.strictEqual(stateNavigator.stateContext.data['**=/()-_+~@:?><.;[]{}!£$%^#&&'], 1);
         });
+        var link;
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                link = stateNavigator.getRefreshLink(stateNavigator.stateContext.includeCurrentData({}));
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                link = stateNavigator.fluent(true)
+                    .refresh((currentData) => currentData)
+                    .url;
+            });
+            test();
+        });
+
+        function test() {
+            it('should not include default types in link', function() {
+                assert.notEqual(link.indexOf('=0&'), -1);
+                assert.notEqual(link.indexOf('=11_'), -1);
+                assert.strictEqual(stateNavigator.stateContext.data['*/()-_+~@:?><.;[]{}!£$%^#&'], 0);
+                assert.strictEqual(stateNavigator.stateContext.data['**=/()-_+~@:?><.;[]{}!£$%^#&&'], 1);
+            });
+        }
     });
 
     describe('Separator Url Character Default Types', function () {
-        it('should not include default types in link', function() {
-            var stateNavigator = new StateNavigator([
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
                 { key: 's', route: 'r', defaultTypes: { _0_1_2_3_4_5_: 'number' } }
             ]);
             var data = {};
             data['_0_1_2_3_4_5_'] = 10;
             data['__0_1_2_3_4_5_'] = 20;
             stateNavigator.navigate('s', data);
-            var url = stateNavigator.getRefreshLink(stateNavigator.stateContext.includeCurrentData(null));
-            assert.notEqual(url.indexOf('=10&'), -1);
-            assert.notEqual(url.indexOf('=201_'), -1);
-            assert.strictEqual(stateNavigator.stateContext.data['_0_1_2_3_4_5_'], 10);
-            assert.strictEqual(stateNavigator.stateContext.data['__0_1_2_3_4_5_'], 20);
         });
+        var link;
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                link = stateNavigator.getRefreshLink(stateNavigator.stateContext.includeCurrentData(null));
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                link = stateNavigator.fluent(true)
+                    .refresh((currentData) => currentData)
+                    .url;
+            });
+            test();
+        });
+
+        function test() {
+            it('should not include default types in link', function() {
+                assert.notEqual(link.indexOf('=10&'), -1);
+                assert.notEqual(link.indexOf('=201_'), -1);
+                assert.strictEqual(stateNavigator.stateContext.data['_0_1_2_3_4_5_'], 10);
+                assert.strictEqual(stateNavigator.stateContext.data['__0_1_2_3_4_5_'], 20);
+            });
+        }
     });
 
     describe('Refresh Current Data', function() {
@@ -5389,6 +5433,18 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s1', data);
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getRefreshLink(stateNavigator.stateContext.includeCurrentData(null, ['s', 'c']));
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .refresh(({s, c}) => ({s, c}))
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -5429,6 +5485,17 @@ describe('Navigation Data', function () {
                 var link = stateNavigator.getNavigationLink('s0', data);
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationLink('s1', stateNavigator.stateContext.includeCurrentData({}, ['number', 'char']));
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data)
+                    .navigate('s1', ({number, char}) => ({number, char}))
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -33,6 +33,16 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s', individualNavigationData)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['string'], 'Hello');
@@ -67,6 +77,16 @@ describe('Navigation Data', function () {
         describe('Navigate Link', function() {
             beforeEach(function() {
                 var link = stateNavigator.getNavigationLink('s', individualNavigationData);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s', individualNavigationData)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -111,6 +131,16 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s', individualNavigationData)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['string'], 'Hello');
@@ -146,6 +176,16 @@ describe('Navigation Data', function () {
         describe('Navigate Link', function() {
             beforeEach(function() {
                 var link = stateNavigator.getNavigationLink('s', arrayNavigationData);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s', arrayNavigationData)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -206,6 +246,16 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s', arrayNavigationData)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['array_string'][0], 'He-llo');
@@ -256,6 +306,16 @@ describe('Navigation Data', function () {
         describe('Navigate Link', function() {
             beforeEach(function() {
                 var link = stateNavigator.getNavigationLink('s', arrayNavigationData);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s', arrayNavigationData)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -4706,82 +4706,178 @@ describe('Navigation Data', function () {
     });
 
     describe('Link Defaults Navigate', function() {
-        it('should not include defaults in link', function() {
-            var stateNavigator = new StateNavigator([
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r', trackCrumbTrail: true, defaults: { 'string': 'Hello', _bool: true, 'number': 1 } }
             ]);
-            var data = {};
-            data['_bool'] = null;
-            data['string'] = 'Hello';
-            data['number'] = 1;
-            stateNavigator.navigate('s0');
-            var link = stateNavigator.getNavigationLink('s1', data);
-            assert.equal(link.indexOf('string'), -1);
-            assert.equal(link.indexOf('_bool'), -1);
-            assert.equal(link.indexOf('number'), -1);
-            assert.notEqual(link.indexOf('r?'), -1);
         });
+        var data = {};
+        data['_bool'] = null;
+        data['string'] = 'Hello';
+        data['number'] = 1;
+        var link;
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                stateNavigator.navigate('s0');
+                link = stateNavigator.getNavigationLink('s1', data);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .url;
+            });
+            test();
+        });
+
+        function test() {
+            it('should not include defaults in link', function() {
+                assert.equal(link.indexOf('string'), -1);
+                assert.equal(link.indexOf('_bool'), -1);
+                assert.equal(link.indexOf('number'), -1);
+                assert.notEqual(link.indexOf('r?'), -1);
+            });
+        }
     });
 
     describe('Link Defaults Route Navigate', function() {
-        it('should not include defaults in link', function() {
-            var stateNavigator = new StateNavigator([
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r/{string?}/{number?}', trackCrumbTrail: true, defaults: { 'string': 'Hello', _bool: true, 'number': 1 } }
             ]);
-            var data = {};
-            data['_bool'] = null;
-            data['string'] = 'Hello';
-            data['number'] = 1;
-            stateNavigator.navigate('s0');
-            var link = stateNavigator.getNavigationLink('s1', data);
-            assert.equal(link.indexOf('string'), -1);
-            assert.equal(link.indexOf('_bool'), -1);
-            assert.equal(link.indexOf('number'), -1);
-            assert.notEqual(link.indexOf('r?'), -1);
         });
+        var data = {};
+        data['_bool'] = null;
+        data['string'] = 'Hello';
+        data['number'] = 1;
+        var link;
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                stateNavigator.navigate('s0');
+                link = stateNavigator.getNavigationLink('s1', data);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .url;
+            });
+            test();
+        });
+
+        function test() {
+            it('should not include defaults in link', function() {
+                assert.equal(link.indexOf('string'), -1);
+                assert.equal(link.indexOf('_bool'), -1);
+                assert.equal(link.indexOf('number'), -1);
+                assert.notEqual(link.indexOf('r?'), -1);
+            });
+        }
     });
 
     describe('Refresh Link Defaults Navigate', function() {
-        it('should not include defaults in link', function() {
-        var stateNavigator = new StateNavigator([
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r', defaults: { 'string': 'Hello', _bool: true, 'number': 1 } }
             ]);
-            var data = {};
-            data['_bool'] = null;
-            data['string'] = 'Hello';
-            data['number'] = 0;
-            stateNavigator.navigate('s0');
-            stateNavigator.navigate('s1', data);
-            var link = stateNavigator.getRefreshLink(stateNavigator.stateContext.includeCurrentData({}));
-            assert.equal(link.indexOf('string'), -1);
-            assert.equal(link.indexOf('_bool'), -1);
-            assert.notEqual(link.indexOf('number'), -1);
         });
+        var data = {};
+        data['_bool'] = null;
+        data['string'] = 'Hello';
+        data['number'] = 0;
+        var link;
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                stateNavigator.navigate('s0');
+                stateNavigator.navigate('s1', data);
+                link = stateNavigator.getRefreshLink(stateNavigator.stateContext.includeCurrentData({}));
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .refresh((currentData) => currentData)
+                    .url;
+            });
+            test();
+        });
+
+        function test() {
+            it('should not include defaults in link', function() {
+                assert.equal(link.indexOf('string'), -1);
+                assert.equal(link.indexOf('_bool'), -1);
+                assert.notEqual(link.indexOf('number'), -1);
+            });
+        }
     });
 
     describe('Back Link Defaults Navigate', function() {
-        it('should not include defaults in link', function() {
-            var stateNavigator = new StateNavigator([
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r', trackCrumbTrail: true, defaults: { 'string': 'Hello', _bool: true, 'number': 1 } },
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
-            var data = {};
-            data['_bool'] = null;
-            data['string'] = 'Hello';
-            data['number'] = 0;
-            stateNavigator.navigate('s0');
-            stateNavigator.navigate('s1', data);
-            stateNavigator.refresh(stateNavigator.stateContext.includeCurrentData({}))
-            stateNavigator.navigate('s2');
-            var link = stateNavigator.getNavigationBackLink(1);
-            assert.equal(link.indexOf('string'), -1);
-            assert.equal(link.indexOf('_bool'), -1);
-            assert.notEqual(link.indexOf('number'), -1);
         });
+        var data = {};
+        data['_bool'] = null;
+        data['string'] = 'Hello';
+        data['number'] = 0;
+        var link;
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                stateNavigator.navigate('s0');
+                stateNavigator.navigate('s1', data);
+                stateNavigator.refresh(stateNavigator.stateContext.includeCurrentData({}))
+                stateNavigator.navigate('s2');
+                link = stateNavigator.getNavigationBackLink(1);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .refresh((currentData) => currentData)
+                    .navigate('s2')
+                    .navigateBack(1)
+                    .url;
+            });
+            test();
+        });
+
+        function test() {
+            it('should not include defaults in link', function() {
+                assert.equal(link.indexOf('string'), -1);
+                assert.equal(link.indexOf('_bool'), -1);
+                assert.notEqual(link.indexOf('number'), -1);
+            });
+        }
     });
 
     describe('Crumb Link Defaults Navigate', function() {

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -368,6 +368,12 @@ describe('Navigation Data', function () {
                 assert.throws(() => stateNavigator.getNavigationLink('s', data));
             });
         });
+
+        describe('Fluent Navigate', function() {
+            it('should throw error', function () {
+                assert.throws(() => stateNavigator.fluent().navigate('s', data));
+            });
+        });
     });
 
     describe('Invalid Array Data', function () {
@@ -404,6 +410,12 @@ describe('Navigation Data', function () {
                 assert.throws(() => stateNavigator.getRefreshLink(stateNavigator.stateContext.includeCurrentData(null)));
             });
         });
+
+        describe('Fluent Navigate', function() {
+            it('should throw error', function () {
+                assert.throws(() => stateNavigator.fluent(true).refresh((currentData) => currentData));
+            });
+        });
     });
 
     describe('Individual Refresh Data', function() {
@@ -424,6 +436,12 @@ describe('Navigation Data', function () {
         describe('Navigate Link', function() {
             it('should throw error', function () {
                 assert.throws(() => stateNavigator.getRefreshLink({ item: {} }));
+            });
+        });
+
+        describe('Fluent Navigate', function() {
+            it('should throw error', function () {
+                assert.throws(() => stateNavigator.fluent(true).refresh({ item: {} }));
             });
         });
     });
@@ -454,6 +472,16 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s', data)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['item0'][0], '0');
@@ -476,13 +504,19 @@ describe('Navigation Data', function () {
         
         describe('Navigate', function() {
             it('should throw error', function () {
-                assert.throws(() => stateNavigator.getNavigationLink('s', data));
+                assert.throws(() => stateNavigator.navigate('s', data));
             });
         });
 
         describe('Navigate Link', function() {
             it('should throw error', function () {
                 assert.throws(() => stateNavigator.getNavigationLink('s', data));
+            });
+        });
+
+        describe('Fluent Navigate', function() {
+            it('should throw error', function () {
+                assert.throws(() => stateNavigator.fluent().navigate('s', data));
             });
         });
     });
@@ -519,6 +553,18 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data)
+                    .navigate('s1')
+                    .navigateBack(1)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['*="/()\'-_+~@:?><.;[],{}!£$%^#&'], '!#="/£$%^&*()\'-_+~@:?><.;[],{}');
@@ -549,6 +595,16 @@ describe('Navigation Data', function () {
         describe('Navigate Link', function() {
             beforeEach(function() {
                 var link = stateNavigator.getNavigationLink('s', data);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s', data)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -596,6 +652,18 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data)
+                    .navigate('s1')
+                    .navigateBack(1)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['_0_1_2_3_4_5_'], '__00__11__22__33__44__55__');
@@ -624,6 +692,16 @@ describe('Navigation Data', function () {
         describe('Navigate Link', function() {
             beforeEach(function() {
                 var link = stateNavigator.getNavigationLink('s', data);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s', data)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -658,6 +736,16 @@ describe('Navigation Data', function () {
         describe('Navigate Link', function() {
             beforeEach(function() {
                 var link = stateNavigator.getNavigationLink('s', data);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s', data)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -701,6 +789,18 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s1');
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationBackLink(1);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data)
+                    .navigate('s1')
+                    .navigateBack(1)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -752,6 +852,18 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data)
+                    .navigate('s1')
+                    .navigateBack(1)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['string'], 'Hello');
@@ -794,6 +906,18 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s1');
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationBackLink(1);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data)
+                    .navigate('s1')
+                    .navigateBack(1)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -861,6 +985,18 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data)
+                    .navigate('s1')
+                    .navigateBack(1)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['array_string'][0], 'He-llo');
@@ -918,6 +1054,18 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s1');
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationBackLink(1);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data)
+                    .navigate('s1')
+                    .navigateBack(1)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -982,6 +1130,18 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data)
+                    .navigate('s1')
+                    .navigateBack(1)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['s'], undefined);
@@ -1018,6 +1178,18 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s1');
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationBackLink(1);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data)
+                    .navigate('s1')
+                    .navigateBack(1)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -3405,6 +3405,20 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1')
+                    .navigate('s2')
+                    .navigate('s3')
+                    .navigate('s3')
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['string'], undefined);
@@ -3461,6 +3475,20 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1')
+                    .navigate('s2')
+                    .navigate('s3')
+                    .navigate('s3')
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['string'], undefined);
@@ -3511,6 +3539,18 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s', data)
+                    .navigate('s')
+                    .navigateBack(1)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['s'], 'Hello');
@@ -3550,6 +3590,18 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s');
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationBackLink(1);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s', data)
+                    .navigate('s')
+                    .navigateBack(1)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -3602,6 +3654,19 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .navigate('s2')
+                    .navigate('s2')
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['string'], undefined);
@@ -3649,6 +3714,19 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s2');
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationLink('s2');
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .navigate('s2')
+                    .navigate('s2')
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -3708,6 +3786,19 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .navigate('s2')
+                    .navigate('s2')
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['string'], 'World');
@@ -3758,6 +3849,19 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .navigate('s2')
+                    .navigate('s2')
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['string'], 'World');
@@ -3792,6 +3896,20 @@ describe('Navigation Data', function () {
                 var link = stateNavigator.getNavigationLink('s0', data);
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationLink('s1');
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data)
+                    .url;
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.fluent(true)
+                    .navigate('s1')
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -3839,6 +3957,20 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data)
+                    .url;
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.fluent(true)
+                    .navigate('s1')
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate old but not previous data', function () {
                 assert.strictEqual(stateNavigator.stateContext.oldData['s'], 'Hello');
@@ -3879,6 +4011,21 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s1', data);
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationBackLink(1);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .url;
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.fluent(true)
+                    .navigateBack(1)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -5421,6 +5421,117 @@ describe('Navigation Data', function () {
             beforeEach(function() {
                 stateNavigator.navigate('s0');
                 stateNavigator.navigate('s1', data);
+                stateNavigator.refresh(stateNavigator.stateContext.includeCurrentData({}));
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = stateNavigator.getNavigationLink('s0');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s1', data);
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getRefreshLink(stateNavigator.stateContext.includeCurrentData({}));
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .refresh((currentData) => currentData)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate data', function () {
+                assert.strictEqual(stateNavigator.stateContext.data['s'], 'Hello');
+                assert.strictEqual(stateNavigator.stateContext.data['c'], '1');
+                assert.strictEqual(stateNavigator.stateContext.data['n'], 1);
+            });
+        }
+    });
+
+    describe('Refresh New And Current Data', function() {
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' }
+            ]);
+        });
+        var data = {};
+        data['s'] = 'Hello';
+        data['n'] = 1;
+        data['c'] = '1';
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                stateNavigator.navigate('s0');
+                stateNavigator.navigate('s1', data);
+                stateNavigator.refresh(stateNavigator.stateContext.includeCurrentData({b: true}));
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = stateNavigator.getNavigationLink('s0');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s1', data);
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getRefreshLink(stateNavigator.stateContext.includeCurrentData({b: true}));
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .refresh(({s, n, c}) => ({b: true, s, n, c}))
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate data', function () {
+                assert.strictEqual(stateNavigator.stateContext.data['b'], true);
+                assert.strictEqual(stateNavigator.stateContext.data['s'], 'Hello');
+                assert.strictEqual(stateNavigator.stateContext.data['c'], '1');
+                assert.strictEqual(stateNavigator.stateContext.data['n'], 1);
+            });
+        }
+    });
+
+    describe('Refresh Current Data Keys', function() {
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' }
+            ]);
+        });
+        var data = {};
+        data['s'] = 'Hello';
+        data['n'] = 1;
+        data['c'] = '1';
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                stateNavigator.navigate('s0');
+                stateNavigator.navigate('s1', data);
                 stateNavigator.refresh(stateNavigator.stateContext.includeCurrentData(null, ['s', 'c']));
             });
             test();
@@ -5452,6 +5563,62 @@ describe('Navigation Data', function () {
 
         function test() {
             it('should populate data', function () {
+                assert.strictEqual(stateNavigator.stateContext.data['s'], 'Hello');
+                assert.strictEqual(stateNavigator.stateContext.data['c'], '1');
+                assert.strictEqual(stateNavigator.stateContext.data['n'], undefined);
+            });
+        }
+    });
+
+    describe('Refresh New And Current Data Keys', function() {
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' }
+            ]);
+        });
+        var data = {};
+        data['s'] = 'Hello';
+        data['n'] = 1;
+        data['c'] = '1';
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                stateNavigator.navigate('s0');
+                stateNavigator.navigate('s1', data);
+                stateNavigator.refresh(stateNavigator.stateContext.includeCurrentData({b: true}, ['s', 'c']));
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = stateNavigator.getNavigationLink('s0');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s1', data);
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getRefreshLink(stateNavigator.stateContext.includeCurrentData({b: true}, ['s', 'c']));
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .refresh(({s, c}) => ({b: true, s, c}))
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate data', function () {
+                assert.strictEqual(stateNavigator.stateContext.data['b'], true);
                 assert.strictEqual(stateNavigator.stateContext.data['s'], 'Hello');
                 assert.strictEqual(stateNavigator.stateContext.data['c'], '1');
                 assert.strictEqual(stateNavigator.stateContext.data['n'], undefined);

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -4087,6 +4087,23 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data1)
+                    .navigate('s1')
+                    .navigate('s2')
+                    .navigate('s3', data2)
+                    .url;
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.fluent(true)
+                    .navigateBack(2)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate old and previous data', function () {
                 assert.strictEqual(stateNavigator.stateContext.oldData['s'], 'World');
@@ -4141,6 +4158,23 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s3', data2);
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationBackLink(2);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data1)
+                    .navigate('s1')
+                    .navigate('s2')
+                    .navigate('s3', data2)
+                    .url;
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.fluent(true)
+                    .navigateBack(2)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -4208,6 +4242,24 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data1)
+                    .navigate('s1')
+                    .navigate('s2', data2)
+                    .navigate('s3')
+                    .navigateBack(1)
+                    .url;
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.fluent(true)
+                    .navigateBack(1)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate old and previous data', function () {
                 assert.strictEqual(stateNavigator.stateContext.oldData['s'], 'World');
@@ -4265,6 +4317,24 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationBackLink(1);
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationBackLink(1);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data1)
+                    .navigate('s1')
+                    .navigate('s2', data2)
+                    .navigate('s3')
+                    .navigateBack(1)
+                    .url;
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.fluent(true)
+                    .navigateBack(1)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -4330,6 +4400,24 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationBackLink(1);
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationBackLink(1);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data1)
+                    .navigate('s1')
+                    .navigate('s2', data2)
+                    .navigate('s2')
+                    .navigateBack(1)
+                    .url;
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.fluent(true)
+                    .navigateBack(1)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -5476,7 +5476,7 @@ describe('Navigation Data', function () {
             beforeEach(function() {
                 stateNavigator.navigate('s0');
                 stateNavigator.navigate('s1', data);
-                stateNavigator.refresh(stateNavigator.stateContext.includeCurrentData({b: true}));
+                stateNavigator.refresh(stateNavigator.stateContext.includeCurrentData({b: true, 'n': 2}));
             });
             test();
         });
@@ -5487,7 +5487,7 @@ describe('Navigation Data', function () {
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationLink('s1', data);
                 stateNavigator.navigateLink(link);
-                link = stateNavigator.getRefreshLink(stateNavigator.stateContext.includeCurrentData({b: true}));
+                link = stateNavigator.getRefreshLink(stateNavigator.stateContext.includeCurrentData({b: true, 'n': 2}));
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -5498,7 +5498,7 @@ describe('Navigation Data', function () {
                 var link = stateNavigator.fluent()
                     .navigate('s0')
                     .navigate('s1', data)
-                    .refresh(({s, n, c}) => ({b: true, s, n, c}))
+                    .refresh(({s, n, c}) => ({b: true, 'n': 2, s, c}))
                     .url;
                 stateNavigator.navigateLink(link);
             });
@@ -5510,7 +5510,7 @@ describe('Navigation Data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['b'], true);
                 assert.strictEqual(stateNavigator.stateContext.data['s'], 'Hello');
                 assert.strictEqual(stateNavigator.stateContext.data['c'], '1');
-                assert.strictEqual(stateNavigator.stateContext.data['n'], 1);
+                assert.strictEqual(stateNavigator.stateContext.data['n'], 2);
             });
         }
     });
@@ -5587,7 +5587,7 @@ describe('Navigation Data', function () {
             beforeEach(function() {
                 stateNavigator.navigate('s0');
                 stateNavigator.navigate('s1', data);
-                stateNavigator.refresh(stateNavigator.stateContext.includeCurrentData({b: true}, ['s', 'c']));
+                stateNavigator.refresh(stateNavigator.stateContext.includeCurrentData({b: true, c: '2'}, ['s', 'c']));
             });
             test();
         });
@@ -5598,7 +5598,7 @@ describe('Navigation Data', function () {
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationLink('s1', data);
                 stateNavigator.navigateLink(link);
-                link = stateNavigator.getRefreshLink(stateNavigator.stateContext.includeCurrentData({b: true}, ['s', 'c']));
+                link = stateNavigator.getRefreshLink(stateNavigator.stateContext.includeCurrentData({b: true, c: '2'}, ['s', 'c']));
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -5609,7 +5609,7 @@ describe('Navigation Data', function () {
                 var link = stateNavigator.fluent()
                     .navigate('s0')
                     .navigate('s1', data)
-                    .refresh(({s, c}) => ({b: true, s, c}))
+                    .refresh(({s, c}) => ({b: true, c: '2', s}))
                     .url;
                 stateNavigator.navigateLink(link);
             });
@@ -5620,7 +5620,7 @@ describe('Navigation Data', function () {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['b'], true);
                 assert.strictEqual(stateNavigator.stateContext.data['s'], 'Hello');
-                assert.strictEqual(stateNavigator.stateContext.data['c'], '1');
+                assert.strictEqual(stateNavigator.stateContext.data['c'], '2');
                 assert.strictEqual(stateNavigator.stateContext.data['n'], undefined);
             });
         }

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -5180,6 +5180,17 @@ describe('Navigation Data', function () {
             test();
         });
 
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
         function test() {
             it('should populate data', function () {
                 assert.strictEqual(stateNavigator.stateContext.data['s'], true);
@@ -5218,6 +5229,18 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationLink('s1', data);
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getRefreshLink(stateNavigator.stateContext.includeCurrentData(null));
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .refresh((currentData) => currentData)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -5274,6 +5297,21 @@ describe('Navigation Data', function () {
                 link = stateNavigator.getNavigationBackLink(2);
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getRefreshLink(stateNavigator.stateContext.includeCurrentData({}));
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .navigate('s2')
+                    .navigate('s3')
+                    .navigateBack(2)
+                    .refresh((currentData) => currentData)
+                    .url;
                 stateNavigator.navigateLink(link);
             });
             test();

--- a/Navigation/test/NavigationRoutingTest.ts
+++ b/Navigation/test/NavigationRoutingTest.ts
@@ -1723,34 +1723,34 @@ describe('MatchTest', function () {
         var stateNavigator: StateNavigator;
         beforeEach(function () {
             stateNavigator = new StateNavigator([
-                { key: 's', route: 'a/{=*"()\'-_~@:?><.;[],!£$%^#&?}', defaults: { '=*"()\'-_~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' } }
+                { key: 's', route: 'a/{=*"()\'-_~@:?><.;[],!£$%^#&?}', defaults: { '=*"()\'-_~@:?><.;[],!£$%^#&': 'x*="()\'-__+~@:?><.;[],!£$%^#&' } }
             ]);
         });
         
         it('should match', function() {
-            var { data } = stateNavigator.parseLink('/a/*%3D%22()\'-0__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+            var { data } = stateNavigator.parseLink('/a/x*%3D%22()\'-0__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
             assert.strictEqual(Object.keys(data).length, 1);
-            assert.strictEqual(data['=*"()\'-_~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
-            var { data } = stateNavigator.parseLink('/a/*%3D%22()\'-0__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+            assert.strictEqual(data['=*"()\'-_~@:?><.;[],!£$%^#&'], 'x*="()\'-__+~@:?><.;[],!£$%^#&');
+            var { data } = stateNavigator.parseLink('/a/x*%3D%22()\'-0__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26?x*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=x*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
             assert.strictEqual(Object.keys(data).length, 2);
-            assert.strictEqual(data['=*"()\'-_~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
-            assert.strictEqual(data['*="()\'-__+~@:?><.;[],!£$%^#&'], '*="()\'-_+~@:?><.;[],!£$%^#&');
+            assert.strictEqual(data['=*"()\'-_~@:?><.;[],!£$%^#&'], 'x*="()\'-__+~@:?><.;[],!£$%^#&');
+            assert.strictEqual(data['x*="()\'-__+~@:?><.;[],!£$%^#&'], 'x*="()\'-_+~@:?><.;[],!£$%^#&');
             var { data } = stateNavigator.parseLink('/a');
             assert.strictEqual(Object.keys(data).length, 1);
-            assert.strictEqual(data['=*"()\'-_~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
-            var { data } = stateNavigator.parseLink('/a?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+            assert.strictEqual(data['=*"()\'-_~@:?><.;[],!£$%^#&'], 'x*="()\'-__+~@:?><.;[],!£$%^#&');
+            var { data } = stateNavigator.parseLink('/a?x*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=x*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
             assert.strictEqual(Object.keys(data).length, 2);
-            assert.strictEqual(data['=*"()\'-_~@:?><.;[],!£$%^#&'], '*="()\'-__+~@:?><.;[],!£$%^#&');
-            assert.strictEqual(data['*="()\'-__+~@:?><.;[],!£$%^#&'], '*="()\'-_+~@:?><.;[],!£$%^#&');
+            assert.strictEqual(data['=*"()\'-_~@:?><.;[],!£$%^#&'], 'x*="()\'-__+~@:?><.;[],!£$%^#&');
+            assert.strictEqual(data['x*="()\'-__+~@:?><.;[],!£$%^#&'], 'x*="()\'-_+~@:?><.;[],!£$%^#&');
         });
 
         it('should build', function() {
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { '=*"()\'-_~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&' }), '/a/*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { '=*"()\'-_~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&', '*="()\'-__+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&'}), '/a/*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { '=*"()\'-_~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&' }), '/a');
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { '=*"()\'-_~@:?><.;[],!£$%^#&': '*="()\'-__+~@:?><.;[],!£$%^#&', '*="()\'-__+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&'}), '/a?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { '=*"()\'-_~@:?><.;[],!£$%^#&': 'x*="()\'-_+~@:?><.;[],!£$%^#&' }), '/a/x*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { '=*"()\'-_~@:?><.;[],!£$%^#&': 'x*="()\'-_+~@:?><.;[],!£$%^#&', 'x*="()\'-__+~@:?><.;[],!£$%^#&': 'x*="()\'-_+~@:?><.;[],!£$%^#&'}), '/a/x*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26?x*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=x*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { '=*"()\'-_~@:?><.;[],!£$%^#&': 'x*="()\'-__+~@:?><.;[],!£$%^#&' }), '/a');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { '=*"()\'-_~@:?><.;[],!£$%^#&': 'x*="()\'-__+~@:?><.;[],!£$%^#&', 'x*="()\'-__+~@:?><.;[],!£$%^#&': 'x*="()\'-_+~@:?><.;[],!£$%^#&'}), '/a?x*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=x*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
             assert.strictEqual(stateNavigator.getNavigationLink('s'), '/a');
-            assert.strictEqual(stateNavigator.getNavigationLink('s', { '*="()\'-__+~@:?><.;[],!£$%^#&': '*="()\'-_+~@:?><.;[],!£$%^#&' }), '/a?*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
+            assert.strictEqual(stateNavigator.getNavigationLink('s', { 'x*="()\'-__+~@:?><.;[],!£$%^#&': 'x*="()\'-_+~@:?><.;[],!£$%^#&' }), '/a?x*%3D%22()\'-__%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26=x*%3D%22()\'-0_%2B~%40%3A%3F%3E%3C.%3B%5B%5D%2C!%C2%A3%24%25%5E%23%26');
         });
     });
 

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -28,10 +28,8 @@ describe('Navigation', function () {
         });
         
         function test(){
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s']);
-            });
-            it('should have not populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 0);
             });
         }
@@ -62,10 +60,8 @@ describe('Navigation', function () {
         });
         
         function test(){
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s']);
-            });
-            it('should have not populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 0);
             });
         }
@@ -4966,49 +4962,6 @@ describe('Navigation', function () {
             history = new HTML5HistoryManager('/a');
             assert.strictEqual(history.getHref('b'), '/a/b');
             assert.strictEqual(history.getHref('/b'), '/a/b');
-        });
-    });
-
-    describe('Fluent State', function () {
-        it('should navigate', function() {
-            var stateNavigator = new StateNavigator([
-                { key: 's', route: 'r' }
-            ]);
-            var url = stateNavigator.fluent()
-                .navigate('s')
-                .url;
-            assert.strictEqual(url, '/r');
-            assert.strictEqual(stateNavigator.stateContext.url, null);
-        });
-    });
-
-    describe('Fluent Transition', function () {
-        it('should navigate', function() {
-            var stateNavigator = new StateNavigator([
-                { key: 's0', route: 'r0' },
-                { key: 's1', route: 'r1' },
-            ]);
-            var url = stateNavigator.fluent()
-                .navigate('s0')
-                .navigate('s1')
-                .url;
-            assert.strictEqual(url, '/r1');
-            assert.strictEqual(stateNavigator.stateContext.url, null);
-        });
-    });
-
-    describe('Fluent Transition With Trail', function () {
-        it('should navigate', function() {
-            var stateNavigator = new StateNavigator([
-                { key: 's0', route: 'r0' },
-                { key: 's1', route: 'r1', trackCrumbTrail: true },
-            ]);
-            var url = stateNavigator.fluent()
-                .navigate('s0')
-                .navigate('s1')
-                .url;
-            assert.strictEqual(url, '/r1?crumb=%2Fr0');
-            assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
 });

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -733,16 +733,10 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s2']);
-            });
-            it('should populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
             });
         }
@@ -790,16 +784,10 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s2']);
-            });
-            it('should not populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, null);
-            });
-            it('should not populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 0);
             });
         }
@@ -837,16 +825,10 @@ describe('Navigation', function () {
         });
 
         function test() {
-            it('should return false for 0', function() {
+            it('should navigate back 2', function() {
                 assert.ok(!stateNavigator.canNavigateBack(0));
-            });
-            it('should return true for 1', function() {
                 assert.ok(stateNavigator.canNavigateBack(1));
-            });
-            it('should return true for 2', function() {
                 assert.ok(stateNavigator.canNavigateBack(2));
-            });
-            it('should return false for 3', function() {
                 assert.ok(!stateNavigator.canNavigateBack(3));
             });
         }
@@ -884,10 +866,8 @@ describe('Navigation', function () {
         });
 
         function test() {
-            it('should return false for 0', function() {
+            it('should not navigate back', function() {
                 assert.ok(!stateNavigator.canNavigateBack(0));
-            });
-            it('should return false for 1', function() {
                 assert.ok(!stateNavigator.canNavigateBack(1));
             });
         }

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -3863,7 +3863,7 @@ describe('Navigation', function () {
         }
     });
     
-    describe('Reload Error Dialog', function() {
+    describe('Reload Error State', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {
             stateNavigator = new StateNavigator([
@@ -3893,10 +3893,8 @@ describe('Navigation', function () {
         });
         
         function test(){
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s']);
-            });
-            it('should not populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 0);
             });
         }
@@ -3936,16 +3934,10 @@ describe('Navigation', function () {
         });
         
         function test() {            
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s0']);
-            });
-            it('should populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
                 assert.ok(stateNavigator.stateContext.crumbs[0].last);
@@ -3990,16 +3982,10 @@ describe('Navigation', function () {
         });
         
         function test() {            
-            it('should populate current State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
-            });
-            it('should populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-            });
-            it('should not populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
                 assert.ok(stateNavigator.stateContext.crumbs[0].last);
@@ -4048,16 +4034,10 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s2']);
-            });
-            it('should populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
                 assert.ok(stateNavigator.stateContext.crumbs[0].last);
@@ -4096,11 +4076,9 @@ describe('Navigation', function () {
         });
         
         function test(){
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator0.stateContext.state, stateNavigator0.states['s0']);
                 assert.equal(stateNavigator1.stateContext.state, stateNavigator1.states['s1']);
-            });
-            it('should not populate crumb trail', function() {
                 assert.equal(stateNavigator0.stateContext.crumbs.length, 0);
                 assert.equal(stateNavigator1.stateContext.crumbs.length, 0);
             });
@@ -4146,19 +4124,13 @@ describe('Navigation', function () {
         });
         
         function test() {            
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator0.stateContext.state, stateNavigator0.states['s1']);
                 assert.equal(stateNavigator1.stateContext.state, stateNavigator1.states['s3']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator0.stateContext.oldState, stateNavigator0.states['s0']);
                 assert.equal(stateNavigator1.stateContext.oldState, stateNavigator1.states['s2']);
-            });
-            it('should populate previous State', function() {
                 assert.equal(stateNavigator0.stateContext.previousState, stateNavigator0.states['s0']);
                 assert.equal(stateNavigator1.stateContext.previousState, stateNavigator1.states['s2']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator0.stateContext.crumbs.length, 1);
                 assert.equal(stateNavigator0.stateContext.crumbs[0].state, stateNavigator0.states['s0']);
                 assert.ok(stateNavigator0.stateContext.crumbs[0].last);

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -184,16 +184,10 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s0']);
-            });
-            it('should populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
             });
         }
@@ -226,16 +220,10 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s']);
-            });
-            it('should not populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, null);
-            });
-            it('should not populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 0);
             });
         }
@@ -268,16 +256,10 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s']);
-            });
-            it('should not populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, null);
-            });
-            it('should not populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 0);
             });
         }

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -402,22 +402,15 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s2']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
-            });
-            it('should not populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, null);
-            });
-            it('should not populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 0);
             });
         }
     });
-    
-    
+
     describe('Refresh With Trail', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {
@@ -449,16 +442,10 @@ describe('Navigation', function () {
         });
         
         function test() {            
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
-            });
-            it('should populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
                 assert.ok(stateNavigator.stateContext.crumbs[0].last);

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -4968,4 +4968,16 @@ describe('Navigation', function () {
             assert.strictEqual(history.getHref('/b'), '/a/b');
         });
     });
+
+    describe('Fluent', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r' }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s')
+                .url;
+            assert.strictEqual(url, '/r');
+        });
+    });
 });

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -1257,16 +1257,10 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s2']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
-            });
-            it('should populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s1']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
                 assert.ok(stateNavigator.stateContext.crumbs[0].last);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s1']);
@@ -1314,17 +1308,13 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should match', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.url.match(/crumb/g).length, 4);
-            });
-            it('should populate crumb State', function() {
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
                 assert.equal(stateNavigator.stateContext.crumbs[1].state, stateNavigator.states['s1']);
                 assert.equal(stateNavigator.stateContext.crumbs[2].state, stateNavigator.states['s2']);
                 assert.equal(stateNavigator.stateContext.crumbs[3].state, stateNavigator.states['s3']);
                 assert.equal(stateNavigator.stateContext.crumbs.length, 4);
-            });
-            it('should populate crumb last', function() {
                 assert.ok(!stateNavigator.stateContext.crumbs[0].last);
                 assert.ok(!stateNavigator.stateContext.crumbs[1].last);
                 assert.ok(!stateNavigator.stateContext.crumbs[2].last);
@@ -1337,8 +1327,8 @@ describe('Navigation', function () {
         var stateNavigator: StateNavigator;
         beforeEach(function() {
             stateNavigator = new StateNavigator([
-                    { key: 's', route: 'r', trackCrumbTrail: true },
-                ]);
+                { key: 's', route: 'r', trackCrumbTrail: true },
+            ]);
             var state = stateNavigator.states['s'];
             state.truncateCrumbTrail = (state, crumbs) => {
                 return crumbs;

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -4679,16 +4679,10 @@ describe('Navigation', function () {
             it('should match', function() {
                 assert.equal(stateNavigator.stateContext.url.match(/crumb/g).length, 1);
             });
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s3']);
-            });
-            it('should not populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
                 assert.ok(stateNavigator.stateContext.crumbs[0].last);

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -4981,4 +4981,19 @@ describe('Navigation', function () {
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
+
+    describe('Fluent Transition', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' },
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .url;
+            assert.strictEqual(url, '/r1');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
 });

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -574,16 +574,10 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s2']);
-            });
-            it('should not populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, null);
-            });
-            it('should not populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 0);
             });
         }
@@ -632,16 +626,10 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s2']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s4']);
-            });
-            it('should populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s1']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 2);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
                 assert.equal(stateNavigator.stateContext.crumbs[1].state, stateNavigator.states['s1']);
@@ -694,16 +682,10 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s2']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s4']);
-            });
-            it('should not populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, null);
-            });
-            it('should not populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 0);
             });
         }

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -4186,19 +4186,13 @@ describe('Navigation', function () {
         });
         
         function test() {            
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator0.stateContext.state, stateNavigator0.states['s1']);
                 assert.equal(stateNavigator1.stateContext.state, stateNavigator1.states['s3']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator0.stateContext.oldState, stateNavigator0.states['s1']);
                 assert.equal(stateNavigator1.stateContext.oldState, stateNavigator1.states['s3']);
-            });
-            it('should populate previous State', function() {
                 assert.equal(stateNavigator0.stateContext.previousState, stateNavigator0.states['s0']);
                 assert.equal(stateNavigator1.stateContext.previousState, stateNavigator1.states['s2']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator0.stateContext.crumbs.length, 1);
                 assert.equal(stateNavigator0.stateContext.crumbs[0].state, stateNavigator0.states['s0']);
                 assert.ok(stateNavigator0.stateContext.crumbs[0].last);
@@ -4262,19 +4256,13 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator0.stateContext.state, stateNavigator0.states['s1']);
                 assert.equal(stateNavigator1.stateContext.state, stateNavigator1.states['s4']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator0.stateContext.oldState, stateNavigator0.states['s2']);
                 assert.equal(stateNavigator1.stateContext.oldState, stateNavigator1.states['s5']);
-            });
-            it('should populate previous State', function() {
                 assert.equal(stateNavigator0.stateContext.previousState, stateNavigator0.states['s0']);
                 assert.equal(stateNavigator1.stateContext.previousState, stateNavigator1.states['s3']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator0.stateContext.crumbs.length, 1);
                 assert.equal(stateNavigator0.stateContext.crumbs[0].state, stateNavigator0.states['s0']);
                 assert.ok(stateNavigator0.stateContext.crumbs[0].last);
@@ -4359,16 +4347,10 @@ describe('Navigation', function () {
                 assert.equal(s2Link.indexOf('?'), -1);
                 assert.equal(stateNavigator.stateContext.url.indexOf('?'), -1);
             })          
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s2']);
-            });
-            it('should populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
                 assert.ok(stateNavigator.stateContext.crumbs[0].last);
@@ -4419,16 +4401,10 @@ describe('Navigation', function () {
                 assert.equal(s2Link.indexOf('?'), -1);
                 assert.equal(stateNavigator.stateContext.url.indexOf('?'), -1);
             })          
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s2']);
-            });
-            it('should populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
                 assert.ok(stateNavigator.stateContext.crumbs[0].last);
@@ -4488,16 +4464,10 @@ describe('Navigation', function () {
                 assert.equal(s3Link.indexOf('?'), -1);
                 assert.notEqual(stateNavigator.stateContext.url.indexOf('?'), -1);
             })          
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s3']);
-            });
-            it('should populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
                 assert.ok(stateNavigator.stateContext.crumbs[0].last);

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -4538,16 +4538,10 @@ describe('Navigation', function () {
                 assert.equal(s2Link.indexOf('crumb'), -1);
                 assert.notEqual(s2Link.indexOf('trail'), -1);
             })          
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s0']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
-            });
-            it('should not populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, null);
-            });
-            it('should not populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 0);
             });
         }
@@ -4591,16 +4585,10 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
-            });
-            it('should not populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
                 assert.ok(stateNavigator.stateContext.crumbs[0].last);
@@ -4632,7 +4620,7 @@ describe('Navigation', function () {
     });
     
     describe('Crumb Trail Encode', function() {
-        it ('should throw error', function() {
+        it ('should populate context', function() {
             var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1', trackCrumbTrail: true }

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -484,16 +484,10 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
-            });
-            it('should not populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, null);
-            });
-            it('should not populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 0);
             });
         }
@@ -534,16 +528,10 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s2']);
-            });
-            it('should populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
                 assert.ok(stateNavigator.stateContext.crumbs[0].last);

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -91,10 +91,8 @@ describe('Navigation', function () {
         });
         
         function test(){
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s']);
-            });
-            it('should have not populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 0);
             });
         }
@@ -149,16 +147,10 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s0']);
-            });
-            it('should not populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, null);
-            });
-            it('should not populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 0);
             });
         }

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -3714,10 +3714,8 @@ describe('Navigation', function () {
         });
         
         function test(){
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should not populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 0);
             });
         }
@@ -3756,16 +3754,10 @@ describe('Navigation', function () {
         });
         
         function test() {            
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s0']);
-            });
-            it('should populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
                 assert.ok(stateNavigator.stateContext.crumbs[0].last);
@@ -3809,16 +3801,10 @@ describe('Navigation', function () {
         });
         
         function test() {            
-            it('should populate current State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
-            });
-            it('should populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
                 assert.ok(stateNavigator.stateContext.crumbs[0].last);
@@ -3866,16 +3852,10 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s2']);
-            });
-            it('should populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
                 assert.ok(stateNavigator.stateContext.crumbs[0].last);

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -315,16 +315,10 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s0']);
-            });
-            it('should populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
                 assert.ok(stateNavigator.stateContext.crumbs[0].last);
@@ -364,16 +358,10 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s2']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
-            });
-            it('should populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s1']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
                 assert.equal(stateNavigator.stateContext.crumbs[1].state, stateNavigator.states['s1']);
                 assert.ok(!stateNavigator.stateContext.crumbs[0].last);

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -1584,10 +1584,8 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
             });
         }

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -4978,6 +4978,7 @@ describe('Navigation', function () {
                 .navigate('s')
                 .url;
             assert.strictEqual(url, '/r');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
 });

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -4969,7 +4969,7 @@ describe('Navigation', function () {
         });
     });
 
-    describe('Fluent', function () {
+    describe('Fluent State', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([
                 { key: 's', route: 'r' }

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -1061,16 +1061,10 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
-            });
-            it('should populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
             });
         }
@@ -1114,16 +1108,10 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
-            });
-            it('should populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, null);
-            });
-            it('should not populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 0);
             });
         }
@@ -1171,16 +1159,10 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s3']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
-            });
-            it('should populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s1']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 2);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
                 assert.equal(stateNavigator.stateContext.crumbs[1].state, stateNavigator.states['s1']);
@@ -1232,16 +1214,10 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s3']);
-            });
-            it('should populate old State', function() {
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
-            });
-            it('should populate previous State', function() {
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s1']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
                 assert.ok(stateNavigator.stateContext.crumbs[0].last);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s1']);

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -1438,10 +1438,8 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s']);
-            });
-            it('should not populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 0);
             });
         }
@@ -1485,10 +1483,8 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
             });
         }
@@ -1536,10 +1532,8 @@ describe('Navigation', function () {
         });
         
         function test() {
-            it('should populate State', function() {
+            it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            });
-            it('should populate crumb trail', function() {
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
             });
         }

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -4996,4 +4996,19 @@ describe('Navigation', function () {
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
+
+    describe('Fluent Transition With Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
 });

--- a/Navigation/test/navigation-tests.ts
+++ b/Navigation/test/navigation-tests.ts
@@ -71,6 +71,15 @@ namespace NavigationTests {
 	var crumb = stateNavigator.stateContext.crumbs[0];
 	link = crumb.url;
 	stateNavigator.navigateLink(link, 'none', true);
+
+	// Fluent Navigation
+	var link = stateNavigator.fluent()
+		.navigate('people')
+		.refresh()
+		.refresh({ page: 3 })
+		.navigate('person', { id: 10 })
+		.navigateBack(1)
+		.url;
 	
 	// State Context
 	var state: Navigation.State = stateNavigator.stateContext.state;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,7 @@ var tests = [
     { name: 'StateConfig', to: 'stateConfig.test.js' },
     { name: 'Navigation', to: 'navigation.test.js' },
     { name: 'NavigationData', to: 'navigationData.test.js' },
+    { name: 'FluentNavigation', to: 'fluentNavigation.test.js' },
     { name: 'NavigationLink', to: 'navigationLink.test.js', folder: 'React', ext: 'tsx' },
     { name: 'NavigationBackLink', to: 'navigationBackLink.test.js', folder: 'React', ext: 'tsx' },
     { name: 'RefreshLink', to: 'refreshLink.test.js', folder: 'React', ext: 'tsx' }


### PR DESCRIPTION
Solves the problem of constructing links with pre-populated crumb trails. For example, how do you build a link to 'person' with the 'people' crumb populated so that back navigation works?
```js
var stateNavigator = new StateNavigator([
  {key: 'people', route: ''}
  {key: 'person', trackCrumbTrail: true}
]);
```
If the user navigates from 'people' to 'person' then the crumb is populated. Fluent navigation solves the problem of manually constructing this same link. Can't just call `getNavigationLink('person', {id: 10})` because that only works if the current `state` is 'person'. Don't want to have to navigate to 'person' `state` first because that changes the UI.

Fluent navigation allows navigation without changing the current `state` or UI. Can then access the url from the fluent context.
```js
var link = stateNavigator.fluent()
  .navigate('people')
  .navigate('person', {id: 10})
  .url;

// link: /person?id=10&crumb=%2F
stateNavigator.navigateLink(link);
```
Especially useful for Navigation React Native (not released yet) where need to pre-populate the crumb trail stack when coming to the app from a notification, for example.


