### PR TITLE
Removed automatic Crumb Trail truncation

### DIFF
--- a/Navigation/src/StateHandler.ts
+++ b/Navigation/src/StateHandler.ts
@@ -52,7 +52,7 @@ class StateHandler {
             crumbs = crumbs.slice();
             if (nextCrumb)
                 crumbs.push(nextCrumb);
-            crumbs = state.truncateCrumbTrail(state, crumbs, { ...state.defaults, ...navigationData });
+            crumbs = state.truncateCrumbTrail(state, { ...state.defaults, ...navigationData }, crumbs);
             for(var i = 0; i < crumbs.length; i++)
                 crumbTrail.push(crumbs[i].crumblessUrl)
         }

--- a/Navigation/src/config/State.ts
+++ b/Navigation/src/config/State.ts
@@ -41,13 +41,7 @@ class State implements StateInfo {
     }
 
     truncateCrumbTrail(state: State, crumbs: Crumb[], data: any): Crumb[] {
-        var newCrumbs: Crumb[] = [];
-        for (var i = 0; i < crumbs.length; i++) {
-            if (crumbs[i].state === state)
-                break;
-            newCrumbs.push(crumbs[i]);
-        }
-        return newCrumbs;
+        return crumbs;
     }
 }
 export default State;

--- a/Navigation/src/config/State.ts
+++ b/Navigation/src/config/State.ts
@@ -40,7 +40,7 @@ class State implements StateInfo {
         return true;
     }
 
-    truncateCrumbTrail(state: State, crumbs: Crumb[], data: any): Crumb[] {
+    truncateCrumbTrail(state: State, data: any, crumbs: Crumb[]): Crumb[] {
         return crumbs;
     }
 }

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -1043,6 +1043,25 @@ describe('Fluent', function () {
         });
     });
 
+    describe('Refresh Back Custom Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, data, crumbs) => crumbs.slice(0, 1);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .refresh()
+                .navigateBack(1)
+                .url;
+            assert.strictEqual(url, '/r0');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
     describe('Crumb Trail Encode', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -508,7 +508,7 @@ describe('Fluent', function () {
                 { key: 's', route: 'r', trackCrumbTrail: true },
             ]);
             var state = stateNavigator.states['s'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
             var url = stateNavigator.fluent()
@@ -527,7 +527,7 @@ describe('Fluent', function () {
                 { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
             var url = stateNavigator.fluent()
@@ -546,7 +546,7 @@ describe('Fluent', function () {
                 { key: 's', route: 'r', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
             var url = stateNavigator.fluent()
@@ -566,7 +566,7 @@ describe('Fluent', function () {
                 { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
             var url = stateNavigator.fluent()
@@ -588,7 +588,7 @@ describe('Fluent', function () {
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
             var url = stateNavigator.fluent()
@@ -611,7 +611,7 @@ describe('Fluent', function () {
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
             var url = stateNavigator.fluent()
@@ -994,7 +994,7 @@ describe('Fluent', function () {
                 { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
             var url = stateNavigator.fluent()

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -105,7 +105,7 @@ describe('Fluent', function () {
                 .navigate('s')
                 .navigate('s')
                 .url;
-            assert.strictEqual(url, '/r');
+            assert.strictEqual(url, '/r?crumb=%2Fr');
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
@@ -179,7 +179,7 @@ describe('Fluent', function () {
                 .navigate('s1')
                 .refresh()
                 .url;
-            assert.strictEqual(url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(url, '/r1?crumb=%2Fr0&crumb=%2Fr1');
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
@@ -398,7 +398,7 @@ describe('Fluent', function () {
                 .navigateBack(1)
                 .refresh()
                 .url;
-            assert.strictEqual(url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(url, '/r1?crumb=%2Fr0&crumb=%2Fr1');
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
@@ -438,7 +438,7 @@ describe('Fluent', function () {
                 .refresh()
                 .navigate('s3')
                 .url;
-            assert.strictEqual(url, '/r3?crumb=%2Fr0&crumb=%2Fr1');
+            assert.strictEqual(url, '/r3?crumb=%2Fr0&crumb=%2Fr1&crumb=%2Fr1');
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
@@ -680,7 +680,7 @@ describe('Fluent', function () {
                 .navigate('s1')
                 .refresh()
                 .url;
-            assert.strictEqual(url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(url, '/r1?crumb=%2Fr0&crumb=%2Fr1');
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
@@ -765,7 +765,7 @@ describe('Fluent', function () {
                 .navigate('s1')
                 .refresh()
                 .url;
-            assert.strictEqual(url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(url, '/r1?crumb=%2Fr0&crumb=%2Fr1');
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
@@ -866,8 +866,8 @@ describe('Fluent', function () {
             var url1 = fluent1
                 .refresh()
                 .url;
-            assert.strictEqual(url0, '/r1?crumb=%2Fr0');
-            assert.strictEqual(url1, '/r3?crumb=%2Fr2');
+            assert.strictEqual(url0, '/r1?crumb=%2Fr0&crumb=%2Fr1');
+            assert.strictEqual(url1, '/r3?crumb=%2Fr2&crumb=%2Fr3');
             assert.strictEqual(stateNavigator0.stateContext.url, null);
             assert.strictEqual(stateNavigator1.stateContext.url, null);
         });
@@ -1042,7 +1042,7 @@ describe('Fluent', function () {
                 .navigate('s3')
                 .navigate('s1')
                 .url;
-            assert.strictEqual(url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(url, '/r1?crumb=%2Fr0&crumb=%2Fr1&crumb=%2Fr2&crumb=%2Fr3');
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -644,6 +644,28 @@ describe('Fluent', function () {
         });
     });
 
+    describe('State State Back One By One Custom Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, data, crumbs) => crumbs.slice(0, 1);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s1')
+                .navigate('s2')
+                .navigateBack(1)
+                .navigateBack(1)
+                .url;
+            assert.strictEqual(url, '/r0');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
     describe('Reload Dialog', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -603,6 +603,27 @@ describe('Fluent', function () {
         });
     });
 
+    describe('State State Back Two Custom Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, data, crumbs) => crumbs.slice(0, 1);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s1')
+                .navigate('s2')
+                .navigateBack(2)
+                .url;
+            assert.strictEqual(url, '/r0');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
     describe('State State Back One By One', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -502,15 +502,12 @@ describe('Fluent', function () {
         });
     });
 
-    describe('State State Custom Trail', function () {
+    describe('State State', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([
                 { key: 's', route: 'r', trackCrumbTrail: true },
             ]);
             var state = stateNavigator.states['s'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
             var url = stateNavigator.fluent()
                 .navigate('s')
                 .navigate('s')
@@ -520,16 +517,12 @@ describe('Fluent', function () {
         });
     });
 
-    describe('Transition State State Custom Trail', function () {
+    describe('Transition State State', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
-            var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
             var url = stateNavigator.fluent()
                 .navigate('s0')
                 .navigate('s1')
@@ -540,15 +533,11 @@ describe('Fluent', function () {
         });
     });
 
-    describe('State State Back Custom Trail', function () {
+    describe('State State Back', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([
                 { key: 's', route: 'r', trackCrumbTrail: true }
             ]);
-            var state = stateNavigator.states['s'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
             var url = stateNavigator.fluent()
                 .navigate('s')
                 .navigate('s')
@@ -559,16 +548,12 @@ describe('Fluent', function () {
         });
     });
 
-    describe('State State Back Custom Trail', function () {
+    describe('Transition State State Back', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
-            var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
             var url = stateNavigator.fluent()
                 .navigate('s0')
                 .navigate('s1')
@@ -580,17 +565,13 @@ describe('Fluent', function () {
         });
     });
 
-    describe('State State Back Two Custom Trail', function () {
+    describe('State State Back Two', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1', trackCrumbTrail: true },
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
-            var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
             var url = stateNavigator.fluent()
                 .navigate('s0')
                 .navigate('s1')
@@ -603,17 +584,13 @@ describe('Fluent', function () {
         });
     });
 
-    describe('State State Back One By One Custom Trail', function () {
+    describe('State State Back One By One', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1', trackCrumbTrail: true },
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
-            var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
             var url = stateNavigator.fluent()
                 .navigate('s0')
                 .navigate('s1')
@@ -987,16 +964,12 @@ describe('Fluent', function () {
         });
     });
 
-    describe('Refresh Back Custom Trail', function () {
+    describe('Refresh Back', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
-            var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
             var url = stateNavigator.fluent()
                 .navigate('s0')
                 .navigate('s1')

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -502,6 +502,21 @@ describe('Fluent', function () {
         });
     });
 
+    describe('State State', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r', trackCrumbTrail: true },
+            ]);
+            var state = stateNavigator.states['s'];
+            var url = stateNavigator.fluent()
+                .navigate('s')
+                .navigate('s')
+                .url;
+            assert.strictEqual(url, '/r?crumb=%2Fr');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
     describe('Transition State State', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -502,21 +502,6 @@ describe('Fluent', function () {
         });
     });
 
-    describe('State State', function () {
-        it('should navigate', function() {
-            var stateNavigator = new StateNavigator([
-                { key: 's', route: 'r', trackCrumbTrail: true },
-            ]);
-            var state = stateNavigator.states['s'];
-            var url = stateNavigator.fluent()
-                .navigate('s')
-                .navigate('s')
-                .url;
-            assert.strictEqual(url, '/r?crumb=%2Fr');
-            assert.strictEqual(stateNavigator.stateContext.url, null);
-        });
-    });
-
     describe('Transition State State', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -502,17 +502,18 @@ describe('Fluent', function () {
         });
     });
 
-    describe('State State', function () {
+    describe('State State Custom Trail', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([
                 { key: 's', route: 'r', trackCrumbTrail: true },
             ]);
             var state = stateNavigator.states['s'];
+            state.truncateCrumbTrail = (state, data, crumbs) => [];
             var url = stateNavigator.fluent()
                 .navigate('s')
                 .navigate('s')
                 .url;
-            assert.strictEqual(url, '/r?crumb=%2Fr');
+            assert.strictEqual(url, '/r');
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -534,6 +534,24 @@ describe('Fluent', function () {
         });
     });
 
+    describe('Transition State State Custom Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, data, crumbs) => crumbs.slice(-1);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .navigate('s1')
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr1');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
     describe('State State Back', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -3767,9 +3767,7 @@ describe('Navigation Data', function () {
                 { key: 's', route: 'r', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
+            state.truncateCrumbTrail = (state, data, crumbs) => crumbs.concat(crumbs);
         });
         var data = {};
         data['s'] = 'Hello';
@@ -3823,9 +3821,7 @@ describe('Navigation Data', function () {
                 { key: 's', route: 'r/{s?}', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
+            state.truncateCrumbTrail = (state, data, crumbs) => crumbs.concat(crumbs);
         });
         var data = {};
         data['s'] = 'Hello';
@@ -3880,10 +3876,8 @@ describe('Navigation Data', function () {
                 { key: 's1', route: 'r1', trackCrumbTrail: true, defaults: { 'string': 'Hello', _bool: true, 'number': 1 } },
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
-            var state = stateNavigator.states['s2'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, data, crumbs) => [];
         });
         var data = { s: 1, t: '2' };
         
@@ -3926,13 +3920,11 @@ describe('Navigation Data', function () {
 
         function test() {
             it('should populate data', function () {
-                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['string'], undefined);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['s'], undefined);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['string'], 'Hello');
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['_bool'], true);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['number'], 1);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['s'], 1);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['t'], '2');
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['string'], 'Hello');
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['_bool'], true);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['number'], 1);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['s'], 1);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['t'], '2');
             });
         }
     });
@@ -3945,10 +3937,8 @@ describe('Navigation Data', function () {
                 { key: 's1', route: 'r/{string}/{number}', trackCrumbTrail: true, defaults: { 'string': 'Hello', _bool: true, 'number': 1 } },
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
-            var state = stateNavigator.states['s2'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, data, crumbs) => [];
         });
         var data = { s: 1, t: '2' };
         
@@ -3991,13 +3981,11 @@ describe('Navigation Data', function () {
 
         function test() {
             it('should populate data', function () {
-                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['string'], undefined);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['s'], undefined);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['string'], 'Hello');
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['_bool'], true);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['number'], 1);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['s'], 1);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['t'], '2');
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['string'], 'Hello');
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['_bool'], true);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['number'], 1);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['s'], 1);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['t'], '2');
             });
         }
     });
@@ -4010,10 +3998,8 @@ describe('Navigation Data', function () {
                     { key: 's1', route: 'r1', trackCrumbTrail: true, defaults: { 'string': 'Hello', _bool: true, 'number': 1 } },
                     { key: 's2', route: 'r2', trackCrumbTrail: true }
                 ]);
-            var state = stateNavigator.states['s2'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, data, crumbs) => [];
         });
         var data = {};
         data['string'] = 'World';
@@ -4058,9 +4044,9 @@ describe('Navigation Data', function () {
 
         function test() {
             it('should populate data', function () {
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['string'], 'World');
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['_bool'], true);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['number'], 0);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['string'], 'World');
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['_bool'], true);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['number'], 0);
             });
         }
     });
@@ -4073,10 +4059,8 @@ describe('Navigation Data', function () {
                     { key: 's1', route: 'r/{string}/{number}', trackCrumbTrail: true, defaults: { 'string': 'Hello', _bool: true, 'number': 1 } },
                     { key: 's2', route: 'r2', trackCrumbTrail: true }
                 ]);
-            var state = stateNavigator.states['s2'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, data, crumbs) => [];
         });
         var data = {};
         data['string'] = 'World';
@@ -4121,9 +4105,9 @@ describe('Navigation Data', function () {
 
         function test() {
             it('should populate data', function () {
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['string'], 'World');
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['_bool'], true);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['number'], 0);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['string'], 'World');
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['_bool'], true);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['number'], 0);
             });
         }
     });

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -4605,9 +4605,7 @@ describe('Navigation Data', function () {
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s2'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
+            state.truncateCrumbTrail = (state, data, crumbs) => crumbs.slice(0, 1);
          });
         var data1 = {};
         data1['s'] = 'Hello';
@@ -4621,7 +4619,7 @@ describe('Navigation Data', function () {
                 stateNavigator.navigate('s0', data1);
                 stateNavigator.navigate('s1');
                 stateNavigator.navigate('s2', data2);
-                stateNavigator.navigate('s2');
+                stateNavigator.navigate('s1');
                 stateNavigator.navigateBack(1);
                 stateNavigator.navigateBack(1);
             });
@@ -4636,7 +4634,7 @@ describe('Navigation Data', function () {
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationLink('s2', data2);
                 stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationLink('s2');
+                link = stateNavigator.getNavigationLink('s1');
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationBackLink(1);
                 stateNavigator.navigateLink(link);
@@ -4652,7 +4650,7 @@ describe('Navigation Data', function () {
                     .navigate('s0', data1)
                     .navigate('s1')
                     .navigate('s2', data2)
-                    .navigate('s2')
+                    .navigate('s1')
                     .navigateBack(1)
                     .url;
                 stateNavigator.navigateLink(link);
@@ -4669,12 +4667,12 @@ describe('Navigation Data', function () {
                 assert.strictEqual(stateNavigator.stateContext.oldData['s'], 'World');
                 assert.strictEqual(stateNavigator.stateContext.oldData['t1'], undefined);
                 assert.strictEqual(stateNavigator.stateContext.oldData['t2'], 2);
-                assert.strictEqual(stateNavigator.stateContext.previousData['s'], 'Hello');
-                assert.strictEqual(stateNavigator.stateContext.previousData['t1'], 1);
-                assert.strictEqual(stateNavigator.stateContext.previousData['t2'], undefined);
-                assert.strictEqual(stateNavigator.stateContext.data['s'], undefined);
-                assert.strictEqual(stateNavigator.stateContext.data['t1'], undefined);
+                assert.strictEqual(stateNavigator.stateContext.data['s'], 'Hello');
+                assert.strictEqual(stateNavigator.stateContext.data['t1'], 1);
                 assert.strictEqual(stateNavigator.stateContext.data['t2'], undefined);
+                assert.strictEqual(stateNavigator.stateContext.previousData['s'], undefined);
+                assert.strictEqual(stateNavigator.stateContext.previousData['t1'], undefined);
+                assert.strictEqual(stateNavigator.stateContext.previousData['t2'], undefined);
             });
         }
     });
@@ -4687,9 +4685,7 @@ describe('Navigation Data', function () {
                 { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
+            state.truncateCrumbTrail = (state, data, crumbs) => crumbs.slice(-1);
          });
         var data = {};
         data['s'] = 'Hello';
@@ -4751,9 +4747,7 @@ describe('Navigation Data', function () {
                 { key: 's1', route: 'r1' }
             ]);
             var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
+            state.truncateCrumbTrail = (state, data, crumbs) => [];
          });
         var data = {};
         data['s'] = 'Hello';
@@ -6554,9 +6548,7 @@ describe('Navigation Data', function () {
                 { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
+            state.truncateCrumbTrail = (state, data, crumbs) => crumbs.slice(-1);
         });
         var data = {};
         data['string'] = 'Hello';

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -3637,10 +3637,8 @@ describe('Navigation Data', function () {
                     { key: 's2', route: 'r2', trackCrumbTrail: true, defaults: { emptyString: '', 'number': 4, char: 7 } },
                     { key: 's3', route: 'r3', trackCrumbTrail: true }
                 ]);
-            var state = stateNavigator.states['s3'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, data, crumbs) => [];
         });
         
         describe('Navigate', function() {
@@ -3686,14 +3684,12 @@ describe('Navigation Data', function () {
 
         function test() {
             it('should populate data', function () {
-                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['string'], undefined);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['number'], undefined);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['string'], 'Hello');
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['_bool'], true);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['number'], 1);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[2].data['emptyString'], '');
-                assert.strictEqual(stateNavigator.stateContext.crumbs[2].data['number'], 4);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[2].data['char'], 7);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['string'], 'Hello');
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['_bool'], true);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['number'], 1);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['emptyString'], '');
+                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['number'], 4);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['char'], 7);
             });
         }
     });
@@ -3707,10 +3703,8 @@ describe('Navigation Data', function () {
                     { key: 's2', route: 'r2/{char}/{number?}', trackCrumbTrail: true, defaults: { emptyString: '', 'number': 4, char: 7 } },
                     { key: 's3', route: 'r3', trackCrumbTrail: true }
                 ]);
-            var state = stateNavigator.states['s3'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, data, crumbs) => [];
         });
         
         describe('Navigate', function() {
@@ -3756,14 +3750,12 @@ describe('Navigation Data', function () {
 
         function test() {
             it('should populate data', function () {
-                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['string'], undefined);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['number'], undefined);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['string'], 'Hello');
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['_bool'], true);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['number'], 1);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[2].data['emptyString'], '');
-                assert.strictEqual(stateNavigator.stateContext.crumbs[2].data['number'], 4);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[2].data['char'], 7);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['string'], 'Hello');
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['_bool'], true);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['number'], 1);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['emptyString'], '');
+                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['number'], 4);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['char'], 7);
             });
         }
     });

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -3239,10 +3239,8 @@ describe('Navigation Data', function () {
                 { key: 's2', route: 'r2', trackCrumbTrail: true },
                 { key: 's3', route: 'r3', trackCrumbTrail: true }
             ]);
-            var state = stateNavigator.states['s2'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, data, crumbs) => [];
         });
         
         describe('Navigate', function() {
@@ -3308,10 +3306,8 @@ describe('Navigation Data', function () {
                     { key: 's2', route: 'r2', trackCrumbTrail: true },
                     { key: 's3', route: 'r3', trackCrumbTrail: true },
                 ]);
-            var state = stateNavigator.states['s2'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, data, crumbs) => [];
         });
         
         describe('Navigate', function() {
@@ -3376,10 +3372,8 @@ describe('Navigation Data', function () {
                 { key: 's1', route: 'r1', trackCrumbTrail: true, defaults: { emptyString: '', 'number': 4, char: 7 } },
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
-            var state = stateNavigator.states['s2'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, data, crumbs) => [];
         });
         var data = { s: 1, t: '2' };
         
@@ -3443,10 +3437,8 @@ describe('Navigation Data', function () {
                 { key: 's1', route: 'r/{char}/{number?}', trackCrumbTrail: true, defaults: { emptyString: '', 'number': 4, char: 7 } },
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
-            var state = stateNavigator.states['s2'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, data, crumbs) => [];
         });
         var data = { s: 1, t: '2' };
         
@@ -3510,10 +3502,8 @@ describe('Navigation Data', function () {
                 { key: 's1', route: 'r1', trackCrumbTrail: true, defaults: { emptyString: '', 'number': 4, char: 7 } },
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
-            var state = stateNavigator.states['s2'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, data, crumbs) => [];
         });
         var data = { emptyString: 'World', 'number': 1, char: 5 };
         
@@ -3579,10 +3569,8 @@ describe('Navigation Data', function () {
                 { key: 's1', route: 'r/{char}/{number?}', trackCrumbTrail: true, defaults: { emptyString: '', 'number': 4, char: 7 } },
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
-            var state = stateNavigator.states['s2'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, data, crumbs) => [];
         });
         var data = { emptyString: 'World', 'number': 1, char: 5 };
         

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -1954,7 +1954,7 @@ describe('Navigation Data', function () {
                 { key: 's', route: 'r', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s'];
-            state.truncateCrumbTrail = (state, crumbs, data) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 var lastCrumb = crumbs[crumbs.length - 1];
                 return lastCrumb && lastCrumb.data.n === data.n ? crumbs.slice(0, -1) : crumbs;
             };
@@ -2016,7 +2016,7 @@ describe('Navigation Data', function () {
                 { key: 's', route: 'r', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s'];
-            state.truncateCrumbTrail = (state, crumbs, data) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 if (data['string'] === 'Hello' && data['boolean'] === true
                     && data['number'] === 0 && +data['date'] === +new Date(2010, 3, 7))
                     return crumbs;
@@ -2072,7 +2072,7 @@ describe('Navigation Data', function () {
                 { key: 's', route: 'r', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s'];
-            state.truncateCrumbTrail = (state, crumbs, data) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 if (data.array_string && data.array_string[0] === 'He-llo' && data.array_string[1] === 'World'
                     && data.array_boolean[0] === '' && data.array_boolean[1] === true && data.array_boolean[2] === false
                     && data.array_number[0] === 1 && data.array_number[1] === null && data.array_number[2] === undefined && data.array_number[3] === 2
@@ -3136,7 +3136,7 @@ describe('Navigation Data', function () {
                 { key: 's', route: 'r', trackCrumbTrail: true, defaults: { 'string': 'Hello', _bool: true, 'number': 1 } }
             ]);
             var state = stateNavigator.states['s'];
-            state.truncateCrumbTrail = (state, crumbs, data) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 if (data['string'] === 'Hello' && data._bool === true && data['number'] === 1)
                     return crumbs;
                 return [];
@@ -3186,7 +3186,7 @@ describe('Navigation Data', function () {
                 { key: 's', route: 'r', trackCrumbTrail: true, defaults: { 'string': 'Hello', _bool: true, 'number': 1 } }
             ]);
             var state = stateNavigator.states['s'];
-            state.truncateCrumbTrail = (state, crumbs, data) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 if (data.string === 'World' && data._bool === true && data.number === 2)
                     return crumbs;
                 return [];
@@ -3240,7 +3240,7 @@ describe('Navigation Data', function () {
                 { key: 's3', route: 'r3', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s2'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
         });
@@ -3309,7 +3309,7 @@ describe('Navigation Data', function () {
                     { key: 's3', route: 'r3', trackCrumbTrail: true },
                 ]);
             var state = stateNavigator.states['s2'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
         });
@@ -3377,7 +3377,7 @@ describe('Navigation Data', function () {
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s2'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
         });
@@ -3444,7 +3444,7 @@ describe('Navigation Data', function () {
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s2'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
         });
@@ -3511,7 +3511,7 @@ describe('Navigation Data', function () {
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s2'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
         });
@@ -3580,7 +3580,7 @@ describe('Navigation Data', function () {
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s2'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
         });
@@ -3650,7 +3650,7 @@ describe('Navigation Data', function () {
                     { key: 's3', route: 'r3', trackCrumbTrail: true }
                 ]);
             var state = stateNavigator.states['s3'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
         });
@@ -3720,7 +3720,7 @@ describe('Navigation Data', function () {
                     { key: 's3', route: 'r3', trackCrumbTrail: true }
                 ]);
             var state = stateNavigator.states['s3'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
         });
@@ -3787,7 +3787,7 @@ describe('Navigation Data', function () {
                 { key: 's', route: 'r', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
         });
@@ -3843,7 +3843,7 @@ describe('Navigation Data', function () {
                 { key: 's', route: 'r/{s?}', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
         });
@@ -3901,7 +3901,7 @@ describe('Navigation Data', function () {
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s2'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
         });
@@ -3966,7 +3966,7 @@ describe('Navigation Data', function () {
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s2'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
         });
@@ -4031,7 +4031,7 @@ describe('Navigation Data', function () {
                     { key: 's2', route: 'r2', trackCrumbTrail: true }
                 ]);
             var state = stateNavigator.states['s2'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
         });
@@ -4094,7 +4094,7 @@ describe('Navigation Data', function () {
                     { key: 's2', route: 'r2', trackCrumbTrail: true }
                 ]);
             var state = stateNavigator.states['s2'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
         });
@@ -4641,7 +4641,7 @@ describe('Navigation Data', function () {
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s2'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
          });
@@ -4723,7 +4723,7 @@ describe('Navigation Data', function () {
                 { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
          });
@@ -4787,7 +4787,7 @@ describe('Navigation Data', function () {
                 { key: 's1', route: 'r1' }
             ]);
             var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
          });
@@ -6590,7 +6590,7 @@ describe('Navigation Data', function () {
                 { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
         });

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -1332,6 +1332,40 @@ describe('Navigation', function () {
         }
     });
 
+    describe('State State', function() {
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
+                { key: 's', route: 'r', trackCrumbTrail: true },
+            ]);
+        });
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                stateNavigator.navigate('s');
+                stateNavigator.navigate('s');
+            });
+            test();
+        });
+        
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = stateNavigator.getNavigationLink('s');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s');
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+        
+        function test() {
+            it('should populate crumb trail', function() {
+                assert.equal(stateNavigator.stateContext.crumbs.length, 1);
+                assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s']);
+            });
+        }
+    });
+
     describe('Transition State State', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -1332,40 +1332,6 @@ describe('Navigation', function () {
         }
     });
 
-    describe('State State', function() {
-        var stateNavigator: StateNavigator;
-        beforeEach(function() {
-            stateNavigator = new StateNavigator([
-                { key: 's', route: 'r', trackCrumbTrail: true },
-            ]);
-        });
-        
-        describe('Navigate', function() {
-            beforeEach(function() {
-                stateNavigator.navigate('s');
-                stateNavigator.navigate('s');
-            });
-            test();
-        });
-        
-        describe('Navigate Link', function() {
-            beforeEach(function() {
-                var link = stateNavigator.getNavigationLink('s');
-                stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationLink('s');
-                stateNavigator.navigateLink(link);
-            });
-            test();
-        });
-        
-        function test() {
-            it('should populate crumb trail', function() {
-                assert.equal(stateNavigator.stateContext.crumbs.length, 1);
-                assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s']);
-            });
-        }
-    });
-
     describe('Transition State State', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -1406,6 +1406,46 @@ describe('Navigation', function () {
         }
     });
 
+    describe('Transition State State Custom Trail', function() {
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, data, crumbs) => crumbs.slice(-1);
+        });
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                stateNavigator.navigate('s0');
+                stateNavigator.navigate('s1');
+                stateNavigator.navigate('s1');
+            });
+            test();
+        });
+        
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = stateNavigator.getNavigationLink('s0');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s1');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s1');
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+        
+        function test() {
+            it('should populate crumb trail', function() {
+                assert.equal(stateNavigator.stateContext.crumbs.length, 1);
+                assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s1']);
+            });
+        }
+    });
+
     describe('State State Back', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -1332,16 +1332,12 @@ describe('Navigation', function () {
         }
     });
 
-    describe('State State Custom Trail', function() {
+    describe('State State', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {
             stateNavigator = new StateNavigator([
                 { key: 's', route: 'r', trackCrumbTrail: true },
             ]);
-            var state = stateNavigator.states['s'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
         });
         
         describe('Navigate', function() {
@@ -1370,17 +1366,13 @@ describe('Navigation', function () {
         }
     });
 
-    describe('Transition State State Custom Trail', function() {
+    describe('Transition State State', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {
             stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
-            var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
         });
         
         describe('Navigate', function() {
@@ -1413,16 +1405,12 @@ describe('Navigation', function () {
         }
     });
 
-    describe('State State Back Custom Trail', function() {
+    describe('State State Back', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {
             stateNavigator = new StateNavigator([
                 { key: 's', route: 'r', trackCrumbTrail: true }
             ]);
-            var state = stateNavigator.states['s'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
         });
         
         describe('Navigate', function() {
@@ -1454,17 +1442,13 @@ describe('Navigation', function () {
         }
     });
 
-    describe('Transition State State Back Custom Trail', function() {
+    describe('Transition State State Back', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {
             stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
-            var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
         });
         
         describe('Navigate', function() {
@@ -1499,7 +1483,7 @@ describe('Navigation', function () {
         }
     });
 
-    describe('State State Back Two Custom Trail', function() {
+    describe('State State Back Two', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {
             stateNavigator = new StateNavigator([
@@ -1507,10 +1491,6 @@ describe('Navigation', function () {
                 { key: 's1', route: 'r1', trackCrumbTrail: true },
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
-            var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
         });
         
         describe('Navigate', function() {
@@ -1548,7 +1528,7 @@ describe('Navigation', function () {
         }
     });
 
-    describe('State State Back One By One Custom Trail', function() {
+    describe('State State Back One By One', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {
             stateNavigator = new StateNavigator([
@@ -1556,10 +1536,6 @@ describe('Navigation', function () {
                 { key: 's1', route: 'r1', trackCrumbTrail: true },
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
-            var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
         });
         
         describe('Navigate', function() {
@@ -4564,17 +4540,13 @@ describe('Navigation', function () {
         }
     });
     
-    describe('Refresh Back Custom Trail', function() {
+    describe('Refresh Back', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {
             stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
-            var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, data, crumbs) => {
-                return crumbs;
-            };
         });
 
         describe('Navigate', function() {

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -4722,7 +4722,52 @@ describe('Navigation', function () {
             });
         }
     });
-    
+
+    describe('Refresh Back Custom Trail', function() {
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, data, crumbs) => crumbs.slice(0, 1);
+        });
+
+        describe('Navigate', function() {
+            beforeEach(function() {
+                stateNavigator.navigate('s0');
+                stateNavigator.navigate('s1');
+                stateNavigator.refresh();
+                stateNavigator.navigateBack(1);
+            });
+            test();
+        });
+        
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = stateNavigator.getNavigationLink('s0');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s1');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getRefreshLink();
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationBackLink(1);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+        
+        function test() {
+            it('should populate context', function() {
+                assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s0']);
+                assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
+                assert.equal(stateNavigator.stateContext.previousState, null);
+                assert.equal(stateNavigator.stateContext.crumbs.length, 0);
+            });
+        }
+    });
+
     describe('Crumb Trail Malicious', function() {
         it ('should throw error', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -258,8 +258,10 @@ describe('Navigation', function () {
             it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s']);
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s']);
-                assert.equal(stateNavigator.stateContext.previousState, null);
-                assert.equal(stateNavigator.stateContext.crumbs.length, 0);
+                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s']);
+                assert.equal(stateNavigator.stateContext.crumbs.length, 1);
+                assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s']);
+                assert.ok(stateNavigator.stateContext.crumbs[0].last);
             });
         }
     });
@@ -444,10 +446,12 @@ describe('Navigation', function () {
             it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.crumbs.length, 1);
+                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s1']);
+                assert.equal(stateNavigator.stateContext.crumbs.length, 2);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
-                assert.ok(stateNavigator.stateContext.crumbs[0].last);
+                assert.equal(stateNavigator.stateContext.crumbs[1].state, stateNavigator.states['s1']);
+                assert.ok(!stateNavigator.stateContext.crumbs[0].last);
+                assert.ok(stateNavigator.stateContext.crumbs[1].last);
             });
         }
     });
@@ -1063,8 +1067,12 @@ describe('Navigation', function () {
             it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.crumbs.length, 1);
+                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s1']);
+                assert.equal(stateNavigator.stateContext.crumbs.length, 2);
+                assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
+                assert.equal(stateNavigator.stateContext.crumbs[1].state, stateNavigator.states['s1']);
+                assert.ok(!stateNavigator.stateContext.crumbs[0].last);
+                assert.ok(stateNavigator.stateContext.crumbs[1].last);
             });
         }
     });
@@ -1162,11 +1170,13 @@ describe('Navigation', function () {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s3']);
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.crumbs.length, 2);
+                assert.equal(stateNavigator.stateContext.crumbs.length, 3);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
                 assert.equal(stateNavigator.stateContext.crumbs[1].state, stateNavigator.states['s1']);
+                assert.equal(stateNavigator.stateContext.crumbs[2].state, stateNavigator.states['s1']);
                 assert.ok(!stateNavigator.stateContext.crumbs[0].last);
-                assert.ok(stateNavigator.stateContext.crumbs[1].last);
+                assert.ok(!stateNavigator.stateContext.crumbs[1].last);
+                assert.ok(stateNavigator.stateContext.crumbs[2].last);
             });
         }
     });
@@ -3803,10 +3813,12 @@ describe('Navigation', function () {
             it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.crumbs.length, 1);
+                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s1']);
+                assert.equal(stateNavigator.stateContext.crumbs.length, 2);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
-                assert.ok(stateNavigator.stateContext.crumbs[0].last);
+                assert.equal(stateNavigator.stateContext.crumbs[1].state, stateNavigator.states['s1']);
+                assert.ok(!stateNavigator.stateContext.crumbs[0].last);
+                assert.ok(stateNavigator.stateContext.crumbs[1].last);
             });
         }
     });
@@ -3984,10 +3996,12 @@ describe('Navigation', function () {
             it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.crumbs.length, 1);
+                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s1']);
+                assert.equal(stateNavigator.stateContext.crumbs.length, 2);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
-                assert.ok(stateNavigator.stateContext.crumbs[0].last);
+                assert.equal(stateNavigator.stateContext.crumbs[1].state, stateNavigator.states['s1']);
+                assert.ok(!stateNavigator.stateContext.crumbs[0].last);
+                assert.ok(stateNavigator.stateContext.crumbs[1].last);
             });
         }
     });
@@ -4190,14 +4204,18 @@ describe('Navigation', function () {
                 assert.equal(stateNavigator1.stateContext.state, stateNavigator1.states['s3']);
                 assert.equal(stateNavigator0.stateContext.oldState, stateNavigator0.states['s1']);
                 assert.equal(stateNavigator1.stateContext.oldState, stateNavigator1.states['s3']);
-                assert.equal(stateNavigator0.stateContext.previousState, stateNavigator0.states['s0']);
-                assert.equal(stateNavigator1.stateContext.previousState, stateNavigator1.states['s2']);
-                assert.equal(stateNavigator0.stateContext.crumbs.length, 1);
+                assert.equal(stateNavigator0.stateContext.previousState, stateNavigator0.states['s1']);
+                assert.equal(stateNavigator1.stateContext.previousState, stateNavigator1.states['s3']);
+                assert.equal(stateNavigator0.stateContext.crumbs.length, 2);
                 assert.equal(stateNavigator0.stateContext.crumbs[0].state, stateNavigator0.states['s0']);
-                assert.ok(stateNavigator0.stateContext.crumbs[0].last);
-                assert.equal(stateNavigator1.stateContext.crumbs.length, 1);
+                assert.equal(stateNavigator0.stateContext.crumbs[1].state, stateNavigator0.states['s1']);
+                assert.ok(!stateNavigator0.stateContext.crumbs[0].last);
+                assert.ok(stateNavigator0.stateContext.crumbs[1].last);
+                assert.equal(stateNavigator1.stateContext.crumbs.length, 2);
                 assert.equal(stateNavigator1.stateContext.crumbs[0].state, stateNavigator1.states['s2']);
-                assert.ok(stateNavigator1.stateContext.crumbs[0].last);
+                assert.equal(stateNavigator1.stateContext.crumbs[1].state, stateNavigator1.states['s3']);
+                assert.ok(!stateNavigator1.stateContext.crumbs[0].last);
+                assert.ok(stateNavigator1.stateContext.crumbs[1].last);
             });
         }
     });
@@ -4676,15 +4694,21 @@ describe('Navigation', function () {
         
         function test() {
             it('should match', function() {
-                assert.equal(stateNavigator.stateContext.url.match(/crumb/g).length, 1);
+                assert.equal(stateNavigator.stateContext.url.match(/crumb/g).length, 4);
             });
             it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s3']);
-                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.crumbs.length, 1);
+                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s3']);
+                assert.equal(stateNavigator.stateContext.crumbs.length, 4);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
-                assert.ok(stateNavigator.stateContext.crumbs[0].last);
+                assert.equal(stateNavigator.stateContext.crumbs[1].state, stateNavigator.states['s1']);
+                assert.equal(stateNavigator.stateContext.crumbs[2].state, stateNavigator.states['s2']);
+                assert.equal(stateNavigator.stateContext.crumbs[3].state, stateNavigator.states['s3']);
+                assert.ok(!stateNavigator.stateContext.crumbs[0].last);
+                assert.ok(!stateNavigator.stateContext.crumbs[1].last);
+                assert.ok(!stateNavigator.stateContext.crumbs[2].last);
+                assert.ok(stateNavigator.stateContext.crumbs[3].last);
             });
         }
     });

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -1569,6 +1569,53 @@ describe('Navigation', function () {
         }
     });
 
+    describe('State State Back Two Custom Trail', function() {
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, data, crumbs) => crumbs.slice(0, 1);
+        });
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                stateNavigator.navigate('s0');
+                stateNavigator.navigate('s1');
+                stateNavigator.navigate('s1');
+                stateNavigator.navigate('s2');
+                stateNavigator.navigateBack(2);
+            });
+            test();
+        });
+        
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = stateNavigator.getNavigationLink('s0');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s1');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s1');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s2');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationBackLink(2);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+        
+        function test() {
+            it('should populate context', function() {
+                assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s0']);
+                assert.equal(stateNavigator.stateContext.crumbs.length, 0);
+            });
+        }
+    });
+
     describe('State State Back One By One', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -1332,12 +1332,14 @@ describe('Navigation', function () {
         }
     });
 
-    describe('State State', function() {
+    describe('State State Custom Trail', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {
             stateNavigator = new StateNavigator([
                 { key: 's', route: 'r', trackCrumbTrail: true },
             ]);
+            var state = stateNavigator.states['s'];
+            state.truncateCrumbTrail = (state, data, crumbs) => [];
         });
         
         describe('Navigate', function() {
@@ -1360,8 +1362,7 @@ describe('Navigation', function () {
         
         function test() {
             it('should populate crumb trail', function() {
-                assert.equal(stateNavigator.stateContext.crumbs.length, 1);
-                assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s']);
+                assert.equal(stateNavigator.stateContext.crumbs.length, 0);
             });
         }
     });

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -1339,7 +1339,7 @@ describe('Navigation', function () {
                 { key: 's', route: 'r', trackCrumbTrail: true },
             ]);
             var state = stateNavigator.states['s'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
         });
@@ -1378,7 +1378,7 @@ describe('Navigation', function () {
                 { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
         });
@@ -1420,7 +1420,7 @@ describe('Navigation', function () {
                 { key: 's', route: 'r', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
         });
@@ -1462,7 +1462,7 @@ describe('Navigation', function () {
                 { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
         });
@@ -1508,7 +1508,7 @@ describe('Navigation', function () {
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
         });
@@ -1557,7 +1557,7 @@ describe('Navigation', function () {
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
         });
@@ -4572,7 +4572,7 @@ describe('Navigation', function () {
                 { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
             var state = stateNavigator.states['s1'];
-            state.truncateCrumbTrail = (state, crumbs) => {
+            state.truncateCrumbTrail = (state, data, crumbs) => {
                 return crumbs;
             };
         });

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -1664,6 +1664,56 @@ describe('Navigation', function () {
         }
     });
 
+    describe('State State Back One By One Custom Trail', function() {
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+            var state = stateNavigator.states['s1'];
+            state.truncateCrumbTrail = (state, data, crumbs) => crumbs.slice(0, 1);
+        });
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                stateNavigator.navigate('s0');
+                stateNavigator.navigate('s1');
+                stateNavigator.navigate('s1');
+                stateNavigator.navigate('s2');
+                stateNavigator.navigateBack(1);
+                stateNavigator.navigateBack(1);
+            });
+            test();
+        });
+        
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = stateNavigator.getNavigationLink('s0');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s1');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s1');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s2');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationBackLink(1);
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationBackLink(1);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+        
+        function test() {
+            it('should populate context', function() {
+                assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s0']);
+                assert.equal(stateNavigator.stateContext.crumbs.length, 0);
+            });
+        }
+    });
+
     describe('Bookmarked Link With Trail Navigate', function() {
         it ('should populate old and previous States', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/navigation-tests.ts
+++ b/Navigation/test/navigation-tests.ts
@@ -41,7 +41,7 @@ person.urlDecode = function urlDecode(state: State, key: string, val: string, qu
     return queryString ? val.replace(/\+/g, ' ') : decodeURIComponent(val);
 };
 person.validate = (data: any) => data.id > 0;
-person.truncateCrumbTrail = (state: State, crumbs: Crumb[], data: any) => crumbs;
+person.truncateCrumbTrail = (state: State, data: any, crumbs: Crumb[]) => crumbs;
 
 // Navigation Event
 var navigationListener = (oldState: State, state: State, data: any, asyncData: any) => {

--- a/Navigation/test/node_modules/@types/navigation.d.ts
+++ b/Navigation/test/node_modules/@types/navigation.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for Navigation 3.1
+﻿// Type definitions for Navigation 4.0
 // Project: http://grahammendick.github.io/navigation/
 // Definitions by: Graham Mendick <https://github.com/grahammendick>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/Navigation/test/node_modules/@types/navigation.d.ts
+++ b/Navigation/test/node_modules/@types/navigation.d.ts
@@ -146,11 +146,11 @@ declare namespace Navigation {
          * Truncates the crumb trail whenever a repeated or initial State is
          * encountered
          * @param The State navigated to
-         * @param The Crumb collection representing the crumb trail
          * @param The new NavigationData
+         * @param The Crumb collection representing the crumb trail
          * @returns Truncated crumb trail
          */
-        truncateCrumbTrail(state: State, crumbs: Crumb[], data: any): Crumb[];
+        truncateCrumbTrail(state: State, data: any, crumbs: Crumb[]): Crumb[];
     }
 
     /**

--- a/NavigationAngular/src/node_modules/@types/navigation.d.ts
+++ b/NavigationAngular/src/node_modules/@types/navigation.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for Navigation 3.1
+﻿// Type definitions for Navigation 4.0
 // Project: http://grahammendick.github.io/navigation/
 // Definitions by: Graham Mendick <https://github.com/grahammendick>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -146,10 +146,11 @@ declare namespace Navigation {
          * Truncates the crumb trail whenever a repeated or initial State is
          * encountered
          * @param The State navigated to
+         * @param The new NavigationData
          * @param The Crumb collection representing the crumb trail
          * @returns Truncated crumb trail
          */
-        truncateCrumbTrail(state: State, crumbs: Crumb[]): Crumb[];
+        truncateCrumbTrail(state: State, data: any, crumbs: Crumb[]): Crumb[];
     }
 
     /**

--- a/NavigationCycle/src/node_modules/@types/navigation.d.ts
+++ b/NavigationCycle/src/node_modules/@types/navigation.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for Navigation 3.1
+﻿// Type definitions for Navigation 4.0
 // Project: http://grahammendick.github.io/navigation/
 // Definitions by: Graham Mendick <https://github.com/grahammendick>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -146,10 +146,11 @@ declare namespace Navigation {
          * Truncates the crumb trail whenever a repeated or initial State is
          * encountered
          * @param The State navigated to
+         * @param The new NavigationData
          * @param The Crumb collection representing the crumb trail
          * @returns Truncated crumb trail
          */
-        truncateCrumbTrail(state: State, crumbs: Crumb[]): Crumb[];
+        truncateCrumbTrail(state: State, data: any, crumbs: Crumb[]): Crumb[];
     }
 
     /**

--- a/NavigationInferno/src/node_modules/@types/navigation.d.ts
+++ b/NavigationInferno/src/node_modules/@types/navigation.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for Navigation 3.1
+﻿// Type definitions for Navigation 4.0
 // Project: http://grahammendick.github.io/navigation/
 // Definitions by: Graham Mendick <https://github.com/grahammendick>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -146,10 +146,11 @@ declare namespace Navigation {
          * Truncates the crumb trail whenever a repeated or initial State is
          * encountered
          * @param The State navigated to
+         * @param The new NavigationData
          * @param The Crumb collection representing the crumb trail
          * @returns Truncated crumb trail
          */
-        truncateCrumbTrail(state: State, crumbs: Crumb[]): Crumb[];
+        truncateCrumbTrail(state: State, data: any, crumbs: Crumb[]): Crumb[];
     }
 
     /**

--- a/NavigationKnockout/src/node_modules/@types/navigation.d.ts
+++ b/NavigationKnockout/src/node_modules/@types/navigation.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for Navigation 3.1
+﻿// Type definitions for Navigation 4.0
 // Project: http://grahammendick.github.io/navigation/
 // Definitions by: Graham Mendick <https://github.com/grahammendick>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -146,10 +146,11 @@ declare namespace Navigation {
          * Truncates the crumb trail whenever a repeated or initial State is
          * encountered
          * @param The State navigated to
+         * @param The new NavigationData
          * @param The Crumb collection representing the crumb trail
          * @returns Truncated crumb trail
          */
-        truncateCrumbTrail(state: State, crumbs: Crumb[]): Crumb[];
+        truncateCrumbTrail(state: State, data: any, crumbs: Crumb[]): Crumb[];
     }
 
     /**

--- a/NavigationReact/src/node_modules/@types/navigation.d.ts
+++ b/NavigationReact/src/node_modules/@types/navigation.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for Navigation 3.1
+﻿// Type definitions for Navigation 4.0
 // Project: http://grahammendick.github.io/navigation/
 // Definitions by: Graham Mendick <https://github.com/grahammendick>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -146,10 +146,11 @@ declare namespace Navigation {
          * Truncates the crumb trail whenever a repeated or initial State is
          * encountered
          * @param The State navigated to
+         * @param The new NavigationData
          * @param The Crumb collection representing the crumb trail
          * @returns Truncated crumb trail
          */
-        truncateCrumbTrail(state: State, crumbs: Crumb[]): Crumb[];
+        truncateCrumbTrail(state: State, data: any, crumbs: Crumb[]): Crumb[];
     }
 
     /**

--- a/NavigationReactNative/sample/twitter/Timeline.js
+++ b/NavigationReactNative/sample/twitter/Timeline.js
@@ -4,12 +4,12 @@ import {NavigationBackAndroid} from 'navigation-react-native';
 import Banner from './Banner';
 import Tweets from './Tweets';
 
-export default ({timeline: {name, username, logo, bio, 
+export default ({timeline: {id, name, username, logo, bio, 
   followers, following, tweets}, stateNavigator}) => (
   <View>
     <NavigationBackAndroid stateNavigator={stateNavigator} />
     <Banner title={name} stateNavigator={stateNavigator} />
-    <ScrollView style={styles.view}>
+    <ScrollView ref={el => {if (el) this.scrollView = el}} style={styles.view}>
       <View>
         <Image style={styles.logo} source={logo} />
         <Text style={styles.name}>{name}</Text>
@@ -22,7 +22,14 @@ export default ({timeline: {name, username, logo, bio,
         <Text style={styles.count}>{followers.toLocaleString()}</Text>
         <Text style={styles.interaction}>FOLLOWERS</Text>
       </View>
-      <Tweets tweets={tweets} stateNavigator={stateNavigator} />
+      <Tweets
+        tweets={tweets}
+        onTimeline={accountId => {
+          if (accountId === id)
+            this.scrollView.scrollTo({y: 0});
+          return accountId !== id;
+        }}
+        stateNavigator={stateNavigator} />
     </ScrollView>
   </View>
 );

--- a/NavigationReactNative/sample/twitter/Tweets.js
+++ b/NavigationReactNative/sample/twitter/Tweets.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {StyleSheet, Text, Image, View, ListView, TouchableHighlight} from 'react-native';
 
-export default ({tweets, stateNavigator}) => {
+export default ({tweets, onTimeline, stateNavigator}) => {
   const dataSource = new ListView
     .DataSource({rowHasChanged: (r1, r2) => r1 !== r2})
     .cloneWithRows(tweets);
@@ -18,7 +18,8 @@ export default ({tweets, stateNavigator}) => {
             <TouchableHighlight
               underlayColor="white"
               onPress={() => {
-                stateNavigator.navigate('timeline', {id: accountId});
+                if (!onTimeline || onTimeline(accountId))
+                  stateNavigator.navigate('timeline', {id: accountId});
             }}>
               <Image style={styles.logo} source={logo} />
             </TouchableHighlight>

--- a/NavigationReactNative/sample/twitter/createStateNavigator.js
+++ b/NavigationReactNative/sample/twitter/createStateNavigator.js
@@ -20,13 +20,5 @@ export default () => {
   tweet.renderScene = ({id}) => <Tweet tweet={getTweet(id)} stateNavigator={stateNavigator} />;
   timeline.renderScene = ({id}) => <Timeline timeline={getTimeline(id)} stateNavigator={stateNavigator} />;
 
-  tweet.truncateCrumbTrail = (state, crumbs) => crumbs;
-
-  timeline.truncateCrumbTrail = (state, crumbs, data) => {
-    const lastCrumb = crumbs[crumbs.length - 1];
-    if (lastCrumb.state === state && lastCrumb.data.id === data.id)
-      return crumbs.slice(0, -1);
-    return crumbs;
-  };
   return stateNavigator;
 }

--- a/NavigationReactNative/sample/twitter/data.js
+++ b/NavigationReactNative/sample/twitter/data.js
@@ -153,7 +153,7 @@ const getTweet = id => {
 };
 
 const getTimeline = id => {
-  const timeline = { ...accounts[id] };
+  const timeline = { ...accounts[id], id };
   timeline.tweets = timeline.tweets.map(tweetId => fetchTweet(tweetId));
   return timeline;
 };

--- a/NavigationReactNative/src/node_modules/@types/navigation.d.ts
+++ b/NavigationReactNative/src/node_modules/@types/navigation.d.ts
@@ -1,10 +1,8 @@
-﻿// Type definitions for Navigation 3.1.0
+﻿// Type definitions for Navigation 4.0
 // Project: http://grahammendick.github.io/navigation/
 // Definitions by: Graham Mendick <https://github.com/grahammendick>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-declare module 'navigation' {
-    export = Navigation;
-}
+export = Navigation;
 
 declare namespace Navigation {
     /**
@@ -148,10 +146,11 @@ declare namespace Navigation {
          * Truncates the crumb trail whenever a repeated or initial State is
          * encountered
          * @param The State navigated to
+         * @param The new NavigationData
          * @param The Crumb collection representing the crumb trail
          * @returns Truncated crumb trail
          */
-        truncateCrumbTrail(state: State, crumbs: Crumb[]): Crumb[];
+        truncateCrumbTrail(state: State, data: any, crumbs: Crumb[]): Crumb[];
     }
 
     /**
@@ -184,9 +183,13 @@ declare namespace Navigation {
          */
         getHref(url: string): string;
         /**
-         * Gets a Url from the anchor or location
+         * Gets a Url from the anchor
          */
-        getUrl(hrefElement: HTMLAnchorElement | Location): string;
+        getUrl(hrefElement: HTMLAnchorElement): string;
+        /**
+         * Gets a Url from the location
+         */
+        getUrl(hrefElement: Location): string;
         /**
          * Removes browser history event listeners
          */
@@ -207,14 +210,10 @@ declare namespace Navigation {
         disabled: boolean;
         /**
          * Initializes a new instance of the HashHistoryManager class
-         */
-        constructor();
-        /**
-         * Initializes a new instance of the HashHistoryManager class
          * @param replaceQueryIdentifier a value indicating whether to use '#'
          * in place of '?'. Set to true for Internet explorer 6 and 7 support
          */
-        constructor(replaceQueryIdentifier: boolean);
+        constructor(replaceQueryIdentifier?: boolean);
         /**
          * Registers a listener for the hashchange event
          * @param navigateHistory The history navigation event handler
@@ -236,9 +235,13 @@ declare namespace Navigation {
          */
         getHref(url: string): string;
         /**
-         * Gets a Url from the anchor or location
+         * Gets a Url from the anchor
          */
-        getUrl(hrefElement: HTMLAnchorElement | Location): string;
+        getUrl(hrefElement: HTMLAnchorElement): string;
+        /**
+         * Gets a Url from the location
+         */
+        getUrl(hrefElement: Location): string;
         /**
          * Removes a listener for the hashchange event
          */
@@ -259,13 +262,9 @@ declare namespace Navigation {
         disabled: boolean;
         /**
          * Initializes a new instance of the HTML5HistoryManager class
-         */
-        constructor();
-        /**
-         * Initializes a new instance of the HTML5HistoryManager class
          * @param applicationPath The application path
          */
-        constructor(applicationPath: string);
+        constructor(applicationPath?: string);
         /**
          * Registers a listener for the popstate event
          * @param navigateHistory The history navigation event handler
@@ -287,9 +286,13 @@ declare namespace Navigation {
          */
         getHref(url: string): string;
         /**
-         * Gets a Url from the anchor or location
+         * Gets a Url from the anchor
          */
-        getUrl(hrefElement: HTMLAnchorElement | Location): string;
+        getUrl(hrefElement: HTMLAnchorElement): string;
+        /**
+         * Gets a Url from the location
+         */
+        getUrl(hrefElement: Location): string;
         /**
          * Removes a listener for the popstate event
          */
@@ -396,17 +399,11 @@ declare namespace Navigation {
          */
         clear(): void;
         /** 
-         * Combines the data with all the current NavigationData
-         * @param The data to add to the current NavigationData
-         * @returns The combined data
-         */
-        includeCurrentData(data: any): any;
-        /** 
          * Combines the data with a subset of the current NavigationData
          * @param The data to add to the current NavigationData
          * @returns The combined data
          */
-        includeCurrentData(data: any, keys: string[]): any;
+        includeCurrentData(data: any, keys?: string[]): any;
     }
 
     /**
@@ -421,21 +418,13 @@ declare namespace Navigation {
         /**
          * Navigates to a State
          * @param stateKey The key of a State
-         * @throws state does not match the key of a State or there is 
-         * NavigationData that cannot be converted to a String
-         * @throws A mandatory route parameter has not been supplied a value
-         */
-        navigate(stateKey: string): FluentNavigator;
-        /**
-         * Navigates to a State
-         * @param stateKey The key of a State
          * @param navigationData The NavigationData to be passed to the next
          * State and stored in the StateContext
          * @throws state does not match the key of a State or there is 
          * NavigationData that cannot be converted to a String
          * @throws A mandatory route parameter has not been supplied a value
          */
-        navigate(stateKey: string, navigationData: any): FluentNavigator;
+        navigate(stateKey: string, navigationData?: any): FluentNavigator;
         /**
          * Navigates back along the crumb trail
          * @param distance Starting at 1, the number of Crumb steps to go back
@@ -444,11 +433,6 @@ declare namespace Navigation {
          */
         navigateBack(distance: number): FluentNavigator;
         /**
-         * Navigates to the current State passing no NavigationData
-         * @throws A mandatory route parameter has not been supplied a value
-         */
-        refresh(): FluentNavigator;
-        /**
          * Navigates to the current State
          * @param navigationData The NavigationData to be passed to the current
          * State and stored in the StateContext
@@ -456,7 +440,7 @@ declare namespace Navigation {
          * @throws There is NavigationData that cannot be converted to a String
          * @throws A mandatory route parameter has not been supplied a value
          */
-        refresh(navigationData: any): FluentNavigator;
+        refresh(navigationData?: any): FluentNavigator;
     }
 
     /**
@@ -478,30 +462,16 @@ declare namespace Navigation {
         states: { [index: string]: State; };
         /**
          * Initializes a new instance of the StateNavigator class
-         */
-        constructor();
-        /**
-         * Initializes a new instance of the StateNavigator class
-         * @param states A collection of States
-         */
-        constructor(states: StateInfo[]);
-        /**
-         * Initializes a new instance of the StateNavigator class
          * @param states A collection of States
          * @param historyManager The manager of the browser Url
          */
-        constructor(states: StateInfo[], historyManager: HistoryManager);
-        /**
-         * Configures the StateNavigator
-         * @param stateInfos A collection of State Infos
-         */
-        configure(stateInfos: StateInfo[]): void;
+        constructor(states?: StateInfo[], historyManager?: HistoryManager);
         /**
          * Configures the StateNavigator
          * @param stateInfos A collection of State Infos
          * @param historyManager The manager of the browser Url
          */
-        configure(stateInfos: StateInfo[], historyManager: HistoryManager): void;
+        configure(stateInfos: StateInfo[], historyManager?: HistoryManager): void;
         /**
          * Registers a navigate event listener
          * @param handler The navigate event listener
@@ -515,24 +485,6 @@ declare namespace Navigation {
         /**
          * Navigates to a State
          * @param stateKey The key of a State
-         * @throws state does not match the key of a State or there is 
-         * NavigationData that cannot be converted to a String
-         * @throws A mandatory route parameter has not been supplied a value
-         */
-        navigate(stateKey: string): void;
-        /**
-         * Navigates to a State
-         * @param stateKey The key of a State
-         * @param navigationData The NavigationData to be passed to the next
-         * State and stored in the StateContext
-         * @throws state does not match the key of a State or there is 
-         * NavigationData that cannot be converted to a String
-         * @throws A mandatory route parameter has not been supplied a value
-         */
-        navigate(stateKey: string, navigationData: any): void;
-        /**
-         * Navigates to a State
-         * @param stateKey The key of a State
          * @param navigationData The NavigationData to be passed to the next
          * State and stored in the StateContext
          * @param A value determining the effect on browser history
@@ -540,15 +492,7 @@ declare namespace Navigation {
          * NavigationData that cannot be converted to a String
          * @throws A mandatory route parameter has not been supplied a value
          */
-        navigate(stateKey: string, navigationData: any, historyAction: 'add' | 'replace' | 'none'): void;
-        /**
-         * Gets a Url to navigate to a State
-         * @param stateKey The key of a State
-         * @returns Url that will navigate to State specified in the action
-         * @throws state does not match the key of a State or there is 
-         * NavigationData that cannot be converted to a String
-         */
-        getNavigationLink(stateKey: string): string;
+        navigate(stateKey: string, navigationData?: any, historyAction?: 'add' | 'replace' | 'none'): void;
         /**
          * Gets a Url to navigate to a State
          * @param stateKey The key of a State
@@ -558,7 +502,7 @@ declare namespace Navigation {
          * @throws state does not match the key of a State or there is 
          * NavigationData that cannot be converted to a String
          */
-        getNavigationLink(stateKey: string, navigationData: any): string;
+        getNavigationLink(stateKey: string, navigationData?: any): string;
         /**
          * Determines if the distance specified is within the bounds of the
          * crumb trail represented by the Crumbs collection
@@ -567,18 +511,11 @@ declare namespace Navigation {
         /**
          * Navigates back along the crumb trail
          * @param distance Starting at 1, the number of Crumb steps to go back
-         * @throws canNavigateBack returns false for this distance
-         * @throws A mandatory route parameter has not been supplied a value
-         */
-        navigateBack(distance: number): void;
-        /**
-         * Navigates back along the crumb trail
-         * @param distance Starting at 1, the number of Crumb steps to go back
          * @param A value determining the effect on browser history
          * @throws canNavigateBack returns false for this distance
          * @throws A mandatory route parameter has not been supplied a value
          */
-        navigateBack(distance: number, historyAction: 'add' | 'replace' | 'none'): void;
+        navigateBack(distance: number, historyAction?: 'add' | 'replace' | 'none'): void;
         /**
          * Gets a Url to navigate back along the crumb trail
          * @param distance Starting at 1, the number of Crumb steps to go back
@@ -586,19 +523,6 @@ declare namespace Navigation {
          */
         getNavigationBackLink(distance: number): string;
         /**
-         * Navigates to the current State passing no NavigationData
-         * @throws A mandatory route parameter has not been supplied a value
-         */
-        refresh(): void;
-        /**
-         * Navigates to the current State
-         * @param navigationData The NavigationData to be passed to the current
-         * State and stored in the StateContext
-         * @throws There is NavigationData that cannot be converted to a String
-         * @throws A mandatory route parameter has not been supplied a value
-         */
-        refresh(navigationData: any): void;
-        /**
          * Navigates to the current State
          * @param navigationData The NavigationData to be passed to the current
          * State and stored in the StateContext
@@ -606,11 +530,7 @@ declare namespace Navigation {
          * @throws There is NavigationData that cannot be converted to a String
          * @throws A mandatory route parameter has not been supplied a value
          */
-        refresh(navigationData: any, historyAction: 'add' | 'replace' | 'none'): void;
-        /**
-         * Gets a Url to navigate to the current State
-         */
-        getRefreshLink(): string;
+        refresh(navigationData?: any, historyAction?: 'add' | 'replace' | 'none'): void;
         /**
          * Gets a Url to navigate to the current State
          * @param navigationData The NavigationData to be passed to the current
@@ -618,50 +538,30 @@ declare namespace Navigation {
          * @returns Url that will navigate to the current State
          * @throws There is NavigationData that cannot be converted to a String
          */
-        getRefreshLink(navigationData: any): string;
-        /**
-         * Navigates to the url
-         * @param url The target location
-         */
-        navigateLink(url: string): void;
-        /**
-         * Navigates to the url
-         * @param url The target location
-         * @param A value determining the effect on browser history
-         */
-        navigateLink(url: string, historyAction: 'add' | 'replace' | 'none'): void;
+        getRefreshLink(navigationData?: any): string;
         /**
          * Navigates to the url
          * @param url The target location
          * @param A value determining the effect on browser history
          * @param history A value indicating whether browser history was used
          */
-        navigateLink(url: string, historyAction: 'add' | 'replace' | 'none', history: boolean): void;
+        navigateLink(url: string, historyAction?: 'add' | 'replace' | 'none', history?: boolean): void;
         /**
          * Parses the url out into State and Navigation Data
          * @param url The url to parse
          */
         parseLink(url: string): { state: State; data: any; };
         /**
-         * Creates a clean FluentNavigator
-         * @returns A FluentNavigator 
-         */
-        fluent(): FluentNavigator;
-        /**
          * Creates a FluentNavigator
          * @param withContext a value indicating whether to inherit the current
          * context
          * @returns A FluentNavigator
          */
-        fluent(withContext: boolean): FluentNavigator;
-        /**
-         * Navigates to the current location 
-         */
-        start(): void;
+        fluent(withContext?: boolean): FluentNavigator;
         /**
          * Navigates to the passed in url
          * @param url The url to navigate to 
          */
-        start(url: string): void;
+        start(url?: string): void;
     }
 }


### PR DESCRIPTION
Originally, if the Crumb Trail didn’t truncate at repeated States then back navigation increased, rather than decreased, the Crumb Trail. But back navigation no longer relies on Crumb Trail truncation, so it’s safe to remove. 

If it wasn’t removed then, with the introduction of Navigation React Native, all States would need a custom truncateCrumbTrail function that removes it.