### PR TITLE
Renamed SceneNavigator to NavigationMotion

### DIFF
--- a/NavigationReactNative/sample/gesture/Gesture.js
+++ b/NavigationReactNative/sample/gesture/Gesture.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import {Dimensions, View} from 'react-native';
-import {SceneNavigator, spring} from 'navigation-react-native';
+import {NavigationMotion, spring} from 'navigation-react-native';
 
 export default ({stateNavigator}) => (
-  <SceneNavigator
+  <NavigationMotion
     startStateKey="scene"
     unmountedStyle={{translate: spring(1)}}
     mountedStyle={{translate: spring(0)}}
@@ -25,5 +25,5 @@ export default ({stateNavigator}) => (
         {scene}
       </View>
     )}
-  </SceneNavigator>
+  </NavigationMotion>
 );

--- a/NavigationReactNative/sample/twitter/Twitter.js
+++ b/NavigationReactNative/sample/twitter/Twitter.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Dimensions, View} from 'react-native';
-import {SceneNavigator, spring} from 'navigation-react-native';
+import {NavigationMotion, spring} from 'navigation-react-native';
 
 const getStyle = (translate, scale, opacity) => ({
   translate: spring(translate),
@@ -9,7 +9,7 @@ const getStyle = (translate, scale, opacity) => ({
 });
 
 export default ({stateNavigator, startStateKey, visible}) => (
-  <SceneNavigator
+  <NavigationMotion
     startStateKey={startStateKey}
     unmountedStyle={getStyle(1, 1, 1)}
     mountedStyle={getStyle(0, 1, 1)}
@@ -34,5 +34,5 @@ export default ({stateNavigator, startStateKey, visible}) => (
         {scene}
       </View>
     )}
-  </SceneNavigator>
+  </NavigationMotion>
 );

--- a/NavigationReactNative/src/NavigationMotion.tsx
+++ b/NavigationReactNative/src/NavigationMotion.tsx
@@ -4,7 +4,7 @@ import { Motion, TransitionMotion } from 'react-motion';
 import { View } from 'react-native';
 import spring from './spring.js'
 
-class SceneNavigator extends React.Component<any, any> {
+class NavigationMotion extends React.Component<any, any> {
     private onNavigate = (oldState, state, data, asyncData) => {
         this.setState((prevState) => {
             var {url, crumbs} = this.getStateNavigator().stateContext;
@@ -93,4 +93,4 @@ function getStyle(styleProp, state?, data?, transitioning?, strip?) {
     return newStyle;
 }
 
-export default SceneNavigator;
+export default NavigationMotion;

--- a/NavigationReactNative/src/NavigationReactNative.ts
+++ b/NavigationReactNative/src/NavigationReactNative.ts
@@ -1,7 +1,7 @@
 import NavigationBackAndroid_android from './NavigationBackAndroid.android';
 import NavigationBackAndroid_ios from './NavigationBackAndroid.ios';
 var NavigationBackAndroid = require('./NavigationBackAndroid').default;
-import SceneNavigator from './SceneNavigator';
+import NavigationMotion from './NavigationMotion';
 import spring from './spring';
 
-export { NavigationBackAndroid, SceneNavigator, spring };
+export { NavigationBackAndroid, NavigationMotion, spring };


### PR DESCRIPTION
The component is NavigationReact combined with ReactMotion, so NavigationMotion makes sense. Even if remove ReactMotion one day, the name still works