### PR TITLE
Moved Scene data instead of style

### DIFF
--- a/NavigationReactNative/sample/gesture/Gesture.js
+++ b/NavigationReactNative/sample/gesture/Gesture.js
@@ -6,7 +6,7 @@ export default ({stateNavigator}) => (
   <NavigationMotion
     startStateKey="scene"
     unmountedStyle={{translate: spring(1)}}
-    mountedStyle={{translate: spring(0)}}
+    mountedStyle={(state, {translate = 0}) => ({translate: spring(translate)})}
     crumbStyle={{translate: spring(0)}}
     style={{flex: 1}}
     stateNavigator={stateNavigator}>

--- a/NavigationReactNative/sample/gesture/Scene.js
+++ b/NavigationReactNative/sample/gesture/Scene.js
@@ -18,7 +18,7 @@ export default class Next extends React.Component {
   }
   handlePanResponderMove(e, gestureState) {
     var {moveScene} = this.props; 
-    moveScene({translate: spring(Math.max(0, gestureState.dx) / Dimensions.get('window').width)});
+    moveScene({translate: Math.max(0, gestureState.dx) / Dimensions.get('window').width});
   }
   handlePanResponderEnd(e, gestureState) {
     var {moveScene, stateNavigator} = this.props; 

--- a/NavigationReactNative/sample/medley/Scene.js
+++ b/NavigationReactNative/sample/medley/Scene.js
@@ -25,14 +25,14 @@ export default ({direction, color, stateNavigator}) => {
       }}>
         <Text style={styles.text}>{direction} {crumbs.length}</Text>
       </TouchableHighlight>
-      <TouchableHighlight
+      {stateNavigator.canNavigateBack(1) && <TouchableHighlight
         underlayColor={color}
         onPress={() => {
-          if (url === stateNavigator.stateContext.url && stateNavigator.canNavigateBack(1))
+          if (url === stateNavigator.stateContext.url)
             stateNavigator.navigateBack(1);
       }}>
         <Text style={styles.text}>Back</Text>
-      </TouchableHighlight>
+      </TouchableHighlight>}
     </View>
   )
 };

--- a/NavigationReactNative/sample/web/NavigationMotion.js
+++ b/NavigationReactNative/sample/web/NavigationMotion.js
@@ -8,12 +8,8 @@ class NavigationMotion extends React.Component {
         this.setState((prevState) => {
             var {url, crumbs} = this.getStateNavigator().stateContext;
             var scenes = {[url]: {element: state.renderScene(data, this.moveScene(url), asyncData)}};
-            for(var i = 0; i < crumbs.length; i++) {
-                scenes[crumbs[i].url] = {
-                    ...prevState.scenes[crumbs[i].url],
-                    style: null
-                };
-            }
+            for(var i = 0; i < crumbs.length; i++)
+                scenes[crumbs[i].url] = prevState.scenes[crumbs[i].url];
             return {scenes};
         });
     }
@@ -36,36 +32,38 @@ class NavigationMotion extends React.Component {
         this.getStateNavigator().offNavigate(this.onNavigate);
     }
     moveScene(url) {
-        return style => {
+        return data => {
             this.setState((prevState) => {
                 var scenes = {...prevState.scenes};
                 if (scenes[url])
-                    scenes[url].style = style; 
+                    scenes[url].data = data; 
                 return {scenes};
             }
         )};
     }
-    transitionStyle(scene, url) {
-        var {mountedStyle, crumbStyle} = this.props;
-        var mount = url === this.getStateNavigator().stateContext.nextCrumb.url;
-        return (scene && scene.style) || (mount ? mountedStyle : crumbStyle);
+    getScenes(){
+        var {crumbs, nextCrumb} = this.getStateNavigator().stateContext;
+        return crumbs.concat(nextCrumb).map(({state, data, url}) => {
+            var scene = this.state.scenes[url] || {};
+            return {state, data, url, scene, sceneData: scene.data, mount: url === nextCrumb.url};
+        });
     }
     render() {
         var {state, crumbs, nextCrumb} = this.getStateNavigator().stateContext;
-        var {unmountedStyle, style, children} = this.props;
+        var {unmountedStyle, mountedStyle, crumbStyle, style, children} = this.props;
         return (state &&
             <TransitionMotion
-                willEnter={({data: {state, data}}) => getStyle(unmountedStyle, state, data, true)}
-                willLeave={({data: {state, data}}) => getStyle(unmountedStyle, state, data)}
-                styles={crumbs.concat(nextCrumb).map(({state, data, url}) => ({
+                willEnter={({data: sceneContext}) => getStyle(unmountedStyle, sceneContext, true)}
+                willLeave={({data: sceneContext}) => getStyle(unmountedStyle, sceneContext)}
+                styles={this.getScenes().map(({url, mount, ...sceneContext}) => ({
                     key: url,
-                    data: {scene: this.state.scenes[url], state, data},
-                    style: getStyle(this.transitionStyle(this.state.scenes[url], url), state, data)
+                    data: sceneContext,
+                    style: getStyle(mount ? mountedStyle : crumbStyle, sceneContext)
                 }))}>
                 {tweenStyles => (
                     <div style={style}>
-                        {tweenStyles.map(({key, data: {scene, state, data}, style}) => (
-                            children(style, scene && scene.element, key, state, data)
+                        {tweenStyles.map(({key, data: {scene, state, data, sceneData}, style}) => (
+                            children(style, scene.element, key, state, data, sceneData)
                         ))}
                     </div>
                 )}
@@ -74,8 +72,8 @@ class NavigationMotion extends React.Component {
     }
 }
 
-function getStyle(styleProp, state, data, strip) {
-    var style = typeof styleProp === 'function' ? styleProp(state, data) : styleProp;
+function getStyle(styleProp, {state, data, sceneData}, strip) {
+    var style = typeof styleProp === 'function' ? styleProp(state, data, sceneData) : styleProp;
     var newStyle = {};
     for(var key in style) {
         newStyle[key] = (!strip || typeof style[key] === 'number') ? style[key] : style[key].val;

--- a/NavigationReactNative/sample/web/Scene.js
+++ b/NavigationReactNative/sample/web/Scene.js
@@ -22,14 +22,14 @@ export default ({direction, color, stateNavigator}) => {
         }}>
         {direction} {crumbs.length}
       </div>
-      <div
+      {stateNavigator.canNavigateBack(1) && <div
         style={styles.text}
         onClick={() => {
-          if (url === stateNavigator.stateContext.url && stateNavigator.canNavigateBack(1))
+          if (url === stateNavigator.stateContext.url)
             stateNavigator.navigateBack(1);
         }}>
         Back
-      </div>
+      </div>}
     </div>
   )
 };

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -18,14 +18,8 @@ export default ({color, moveScene, stateNavigator}) => {
       <View
         onLayout={() => {
           this.el.measure((ox, oy, w, h, x, y) => {
-            moveScene({
-              w: spring(w, {stiffness: 250}),
-              h: spring(h, {stiffness: 250}),
-              x: spring(x, {stiffness: 250}),
-              y: spring(y, {stiffness: 250}),
-              show: spring(1, {stiffness: 250}),
-              translate: spring(0, {stiffness: 250}),
-            });
+            var {data} = stateNavigator.stateContext;
+            moveScene({...data, w, h, x, y});
           });
         }}
         ref={el => this.el = el}

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -18,8 +18,7 @@ export default ({color, moveScene, stateNavigator}) => {
       <View
         onLayout={() => {
           this.el.measure((ox, oy, w, h, x, y) => {
-            var {data} = stateNavigator.stateContext;
-            moveScene({...data, w, h, x, y});
+            moveScene({w, h, x, y});
           });
         }}
         ref={el => this.el = el}

--- a/NavigationReactNative/sample/zoom/Zoom.js
+++ b/NavigationReactNative/sample/zoom/Zoom.js
@@ -14,8 +14,8 @@ const getStyle = ({x, y, w, h, width}, show, translate = false) => ({
 export default ({stateNavigator}) => (
   <NavigationMotion
     startStateKey="grid"
-    unmountedStyle={(state, data) => (getStyle(data, 0, true))}
-    mountedStyle={(state, data, sceneData) => (getStyle({...data, ...sceneData}, 1))}
+    unmountedStyle={(state, data) => getStyle(data, 0, true)}
+    mountedStyle={(state, data, sceneData) => getStyle({...data, ...sceneData}, 1)}
     crumbStyle={getStyle({}, 1)}
     style={{flex: 1}}
     stateNavigator={stateNavigator}>

--- a/NavigationReactNative/sample/zoom/Zoom.js
+++ b/NavigationReactNative/sample/zoom/Zoom.js
@@ -14,9 +14,9 @@ const getStyle = ({x, y, w, h, width}, show, translate = false) => ({
 export default ({stateNavigator}) => (
   <NavigationMotion
     startStateKey="grid"
-    unmountedStyle={(state, data) => ({...getStyle(data, 0, true)})}
-    mountedStyle={(state, data, sceneData) => ({...getStyle({...data, ...sceneData}, 1)})}
-    crumbStyle={{...getStyle({}, 1)}}
+    unmountedStyle={(state, data) => (getStyle(data, 0, true))}
+    mountedStyle={(state, data, sceneData) => (getStyle({...data, ...sceneData}, 1))}
+    crumbStyle={getStyle({}, 1)}
     style={{flex: 1}}
     stateNavigator={stateNavigator}>
     {({show, x, y, w, h, translate}, scene, url, state, {color}) => (

--- a/NavigationReactNative/sample/zoom/Zoom.js
+++ b/NavigationReactNative/sample/zoom/Zoom.js
@@ -15,7 +15,7 @@ export default ({stateNavigator}) => (
   <NavigationMotion
     startStateKey="grid"
     unmountedStyle={(state, data) => ({...getStyle(data, 0, true)})}
-    mountedStyle={(state, data) => ({...getStyle(data, 1)})}
+    mountedStyle={(state, data, sceneData) => ({...getStyle({...data, ...sceneData}, 1)})}
     crumbStyle={{...getStyle({}, 1)}}
     style={{flex: 1}}
     stateNavigator={stateNavigator}>

--- a/NavigationReactNative/src/NavigationMotion.tsx
+++ b/NavigationReactNative/src/NavigationMotion.tsx
@@ -56,17 +56,17 @@ class NavigationMotion extends React.Component<any, any> {
         var {unmountedStyle, mountedStyle, crumbStyle, style, children} = this.props;
         return (state &&
             <TransitionMotion
-                willEnter={({data: {state, data}}) => getStyle(unmountedStyle, state, data, true)}
-                willLeave={({data: {state, data}}) => getStyle(unmountedStyle, state, data)}
+                willEnter={({data: {state, data, sceneData}}) => getStyle(unmountedStyle, state, data, sceneData, true)}
+                willLeave={({data: {state, data, sceneData}}) => getStyle(unmountedStyle, state, data, sceneData)}
                 styles={this.getSceneContexts().map(({state, data, url, scene, sceneData, mount}) => ({
                     key: url,
-                    data: {scene, state, data},
-                    style: getStyle(mount ? mountedStyle : crumbStyle, state, sceneData || data)
+                    data: {scene, state, data, sceneData},
+                    style: getStyle(mount ? mountedStyle : crumbStyle, state, data, sceneData)
                 }))}>
                 {tweenStyles => (
                     <View style={style}>
-                        {tweenStyles.map(({key, data: {scene, state, data}, style}) => (
-                            children(style, scene.element, key, state, data)
+                        {tweenStyles.map(({key, data: {scene, state, data, sceneData}, style}) => (
+                            children(style, scene.element, key, state, data, sceneData)
                         ))}
                     </View>
                 )}
@@ -75,8 +75,8 @@ class NavigationMotion extends React.Component<any, any> {
     }
 }
 
-function getStyle(styleProp, state, data, strip = false) {
-    var style = typeof styleProp === 'function' ? styleProp(state, data) : styleProp;
+function getStyle(styleProp, state, data, sceneData, strip = false) {
+    var style = typeof styleProp === 'function' ? styleProp(state, data, sceneData) : styleProp;
     var newStyle: any = {};
     for(var key in style) {
         newStyle[key] = (!strip || typeof style[key] === 'number') ? style[key] : style[key].val;

--- a/NavigationReactNative/src/NavigationMotion.tsx
+++ b/NavigationReactNative/src/NavigationMotion.tsx
@@ -48,7 +48,7 @@ class NavigationMotion extends React.Component<any, any> {
         var {crumbs, nextCrumb} = this.getStateNavigator().stateContext;
         return crumbs.concat(nextCrumb).map(({state, data, url}) => {
             var scene = this.state.scenes[url] || {};
-            return { state, data: scene.data || data, url, scene, mount: url === nextCrumb.url };
+            return { state, data, url, scene, sceneData: scene.data, mount: url === nextCrumb.url };
         });
     }
     render() {
@@ -58,10 +58,10 @@ class NavigationMotion extends React.Component<any, any> {
             <TransitionMotion
                 willEnter={({data: {state, data}}) => getStyle(unmountedStyle, state, data, true)}
                 willLeave={({data: {state, data}}) => getStyle(unmountedStyle, state, data)}
-                styles={this.getSceneContexts().map(({state, data, url, scene, mount}) => ({
+                styles={this.getSceneContexts().map(({state, data, url, scene, sceneData, mount}) => ({
                     key: url,
                     data: {scene, state, data},
-                    style: getStyle(mount ? mountedStyle : crumbStyle, state, data)
+                    style: getStyle(mount ? mountedStyle : crumbStyle, state, sceneData || data)
                 }))}>
                 {tweenStyles => (
                     <View style={style}>

--- a/NavigationReactNative/src/NavigationMotion.tsx
+++ b/NavigationReactNative/src/NavigationMotion.tsx
@@ -44,7 +44,7 @@ class NavigationMotion extends React.Component<any, any> {
             }
         )};
     }
-    getSceneContexts(){
+    getScenes(){
         var {crumbs, nextCrumb} = this.getStateNavigator().stateContext;
         return crumbs.concat(nextCrumb).map(({state, data, url}) => {
             var scene = this.state.scenes[url] || {};
@@ -56,12 +56,12 @@ class NavigationMotion extends React.Component<any, any> {
         var {unmountedStyle, mountedStyle, crumbStyle, style, children} = this.props;
         return (state &&
             <TransitionMotion
-                willEnter={({data: {state, data, sceneData}}) => getStyle(unmountedStyle, state, data, sceneData, true)}
-                willLeave={({data: {state, data, sceneData}}) => getStyle(unmountedStyle, state, data, sceneData)}
-                styles={this.getSceneContexts().map(({state, data, url, scene, sceneData, mount}) => ({
+                willEnter={({data: sceneContext}) => getStyle(unmountedStyle, sceneContext, true)}
+                willLeave={({data: sceneContext}) => getStyle(unmountedStyle, sceneContext)}
+                styles={this.getScenes().map(({url, mount, ...sceneContext}) => ({
                     key: url,
-                    data: {scene, state, data, sceneData},
-                    style: getStyle(mount ? mountedStyle : crumbStyle, state, data, sceneData)
+                    data: sceneContext,
+                    style: getStyle(mount ? mountedStyle : crumbStyle, sceneContext)
                 }))}>
                 {tweenStyles => (
                     <View style={style}>
@@ -75,7 +75,7 @@ class NavigationMotion extends React.Component<any, any> {
     }
 }
 
-function getStyle(styleProp, state, data, sceneData, strip = false) {
+function getStyle(styleProp, {state, data, sceneData}, strip = false) {
     var style = typeof styleProp === 'function' ? styleProp(state, data, sceneData) : styleProp;
     var newStyle: any = {};
     for(var key in style) {

--- a/NavigationReactNative/src/NavigationMotion.tsx
+++ b/NavigationReactNative/src/NavigationMotion.tsx
@@ -48,7 +48,7 @@ class NavigationMotion extends React.Component<any, any> {
         var {crumbs, nextCrumb} = this.getStateNavigator().stateContext;
         return crumbs.concat(nextCrumb).map(({state, data, url}) => {
             var scene = this.state.scenes[url] || {};
-            return { state, data, url, scene, sceneData: scene.data, mount: url === nextCrumb.url };
+            return {state, data, url, scene, sceneData: scene.data, mount: url === nextCrumb.url};
         });
     }
     render() {


### PR DESCRIPTION
Changed `moveScene` to accept data instead of style. That way, styles are always derived from data and only in the three `NavigationMotion` style props. Changed these three style props to accept sceneData as the third parameter. Gives full flexibility to consumer to decide how to combine data and sceneData to produce styles.

In the Zoom example, only the mountedStyle uses the sceneData. The unmountedStyle sticks with the data so that it zooms back to where it started.