### PR TITLE
Shared Element Transition

### DIFF
--- a/NavigationReactNative/sample/gesture/Gesture.js
+++ b/NavigationReactNative/sample/gesture/Gesture.js
@@ -6,7 +6,7 @@ export default ({stateNavigator}) => (
   <NavigationMotion
     startStateKey="scene"
     unmountedStyle={{translate: spring(1)}}
-    mountedStyle={(state, {translate = 0}) => ({translate: spring(translate)})}
+    mountedStyle={(state, data, {translate = 0}) => ({translate: spring(translate)})}
     crumbStyle={{translate: spring(0)}}
     style={{flex: 1}}
     stateNavigator={stateNavigator}>

--- a/NavigationReactNative/sample/web/NavigationMotion.js
+++ b/NavigationReactNative/sample/web/NavigationMotion.js
@@ -4,18 +4,6 @@ import { Motion, TransitionMotion } from 'react-motion';
 import spring from './spring.js'
 
 class NavigationMotion extends React.Component {
-    onNavigate(oldState, state, data) {
-        this.setState((prevState) => {
-            var scenes = {};
-            var previousScene = null;
-            var {url, crumbs} = this.getStateNavigator().stateContext;
-            for(var i = 0; i < crumbs.length; i++)
-                scenes[crumbs[i].url] = previousScene = prevState.scenes[crumbs[i].url];
-            var element = state.renderScene(data, this.moveScene(url), previousScene && previousScene.data);
-            scenes[url] = {...prevState.scenes[url], element};
-            return {scenes};
-        });
-    }
     constructor(props, context) {
         super(props, context);
         this.onNavigate = this.onNavigate.bind(this);
@@ -34,53 +22,72 @@ class NavigationMotion extends React.Component {
     componentWillUnmount() {
         this.getStateNavigator().offNavigate(this.onNavigate);
     }
+    onNavigate(oldState, state, data) {
+        this.setState(prevState => {
+            var scenes = {...prevState.scenes};
+            var {url, crumbs} = this.getStateNavigator().stateContext;
+            var previousScene = crumbs.length > 0 ? prevState.scenes[crumbs[crumbs.length - 1].url] : null;
+            var element = state.renderScene(data, this.moveScene(url), previousScene && previousScene.data);
+            scenes[url] = {...scenes[url], element};
+            return {scenes};
+        });
+    }
     moveScene(url) {
         return data => {
-            this.setState((prevState) => {
+            this.setState(prevState => {
                 var scenes = {...prevState.scenes};
-                if (scenes[url])
-                    scenes[url].data = data; 
+                scenes[url] = {...scenes[url], data};
                 return {scenes};
-            }
-        )};
+            });
+        };
+    }
+    clearScene(url) {
+        this.setState(prevState => {
+            var scenes = {...prevState.scenes};
+            delete scenes[url];
+            return {scenes};
+        });
     }
     getScenes(){
         var {crumbs, nextCrumb} = this.getStateNavigator().stateContext;
-        return crumbs.concat(nextCrumb).map(({state, data, url}) => {
-            var scene = this.state.scenes[url] || {};
-            return {state, data, url, scene, sceneData: scene.data, mount: url === nextCrumb.url};
-        });
+        return crumbs.concat(nextCrumb).map(({state, data, url}) => (
+            {state, data, url, scene: this.state.scenes[url], mount: url === nextCrumb.url}
+        ));
+    }
+    getSceneData(url) {
+        var scene = this.state.scenes[url];
+        return scene && scene.data;
+    }
+    getStyle(styleProp, {state, data, url}, strip) {
+        var style = typeof styleProp === 'function' ? styleProp(state, data, this.getSceneData(url)) : styleProp;
+        var newStyle = {};
+        for(var key in style) {
+            newStyle[key] = (!strip || typeof style[key] === 'number') ? style[key] : style[key].val;
+        }
+        return newStyle;
     }
     render() {
         var {unmountedStyle, mountedStyle, crumbStyle, style, children} = this.props;
         return (this.getStateNavigator().stateContext.state &&
             <TransitionMotion
-                willEnter={({data: sceneContext}) => getStyle(unmountedStyle, sceneContext, true)}
-                willLeave={({data: sceneContext}) => getStyle(unmountedStyle, sceneContext)}
-                styles={this.getScenes().map(({url, mount, ...sceneContext}) => ({
-                    key: url,
+                willEnter={({data: sceneContext}) => this.getStyle(unmountedStyle, sceneContext, true)}
+                willLeave={({data: sceneContext}) => this.getStyle(unmountedStyle, sceneContext)}
+                didLeave={({data: sceneContext}) => {this.clearScene(sceneContext.url)}}
+                styles={this.getScenes().map(({mount, ...sceneContext}) => ({
+                    key: sceneContext.url,
                     data: sceneContext,
-                    style: getStyle(mount ? mountedStyle : crumbStyle, sceneContext)
+                    style: this.getStyle(mount ? mountedStyle : crumbStyle, sceneContext)
                 }))}>
                 {tweenStyles => (
                     <div style={style}>
-                        {tweenStyles.map(({key, data: {scene, state, data, sceneData}, style}) => (
-                            children(style, scene.element, key, state, data, sceneData)
+                        {tweenStyles.map(({key, data: {scene, state, data, url}, style}) => (
+                            children(style, scene && scene.element, key, state, data, this.getSceneData(url))
                         ))}
                     </div>
                 )}
             </TransitionMotion>
         );
     }
-}
-
-function getStyle(styleProp, {state, data, sceneData}, strip) {
-    var style = typeof styleProp === 'function' ? styleProp(state, data, sceneData) : styleProp;
-    var newStyle = {};
-    for(var key in style) {
-        newStyle[key] = (!strip || typeof style[key] === 'number') ? style[key] : style[key].val;
-    }
-    return newStyle;
 }
 
 NavigationMotion.contextTypes = {

--- a/NavigationReactNative/sample/web/NavigationMotion.js
+++ b/NavigationReactNative/sample/web/NavigationMotion.js
@@ -4,12 +4,15 @@ import { Motion, TransitionMotion } from 'react-motion';
 import spring from './spring.js'
 
 class NavigationMotion extends React.Component {
-    onNavigate(oldState, state, data, asyncData) {
+    onNavigate(oldState, state, data) {
         this.setState((prevState) => {
+            var scenes = {};
+            var previousScene = null;
             var {url, crumbs} = this.getStateNavigator().stateContext;
-            var scenes = {[url]: {element: state.renderScene(data, this.moveScene(url), asyncData)}};
             for(var i = 0; i < crumbs.length; i++)
-                scenes[crumbs[i].url] = prevState.scenes[crumbs[i].url];
+                scenes[crumbs[i].url] = previousScene = prevState.scenes[crumbs[i].url];
+            var element = state.renderScene(data, this.moveScene(url), previousScene && previousScene.data);
+            scenes[url] = {...prevState.scenes[url], element};
             return {scenes};
         });
     }

--- a/NavigationReactNative/sample/web/NavigationMotion.js
+++ b/NavigationReactNative/sample/web/NavigationMotion.js
@@ -26,8 +26,8 @@ class NavigationMotion extends React.Component {
         this.setState(prevState => {
             var scenes = {...prevState.scenes};
             var {url, crumbs} = this.getStateNavigator().stateContext;
-            var previousScene = crumbs.length > 0 ? prevState.scenes[crumbs[crumbs.length - 1].url] : null;
-            var element = state.renderScene(data, this.moveScene(url), previousScene && previousScene.data);
+            var previousUrl = crumbs.length > 0 ? crumbs[crumbs.length - 1].url : null;
+            var element = state.renderScene(data, this.moveScene(url), this.getSceneData(previousUrl));
             scenes[url] = {...scenes[url], element};
             return {scenes};
         });
@@ -56,7 +56,7 @@ class NavigationMotion extends React.Component {
     }
     getSceneData(url) {
         var scene = this.state.scenes[url];
-        return scene && scene.data;
+        return (scene && scene.data) || {};
     }
     getStyle(styleProp, {state, data, url}, strip) {
         var style = typeof styleProp === 'function' ? styleProp(state, data, this.getSceneData(url)) : styleProp;

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -11,9 +11,10 @@ export default ({color, colorRef, moveScene, stateNavigator}) => {
         underlayColor="#fff"
         onPress={() => {
           colorRef.measure((ox, oy, w, h, x, y) => {
-            moveScene({w, h, x, y});
-            if (url === stateNavigator.stateContext.url)
+            if (url === stateNavigator.stateContext.url) {
               stateNavigator.navigateBack(1);
+              moveScene({w, h, x, y});
+            }
           });
         }}>
         <Text style={styles.back}>X</Text>

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {StyleSheet, ScrollView, Text, View, TouchableHighlight} from 'react-native';
+import {StyleSheet, Text, View, TouchableHighlight} from 'react-native';
 import {NavigationBackAndroid, spring} from 'navigation-react-native';
 
 export default ({color, colorRef, moveScene, stateNavigator}) => {

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -20,11 +20,11 @@ export default ({color, colorRef, moveScene, stateNavigator}) => {
       </TouchableHighlight>
       <View
         onLayout={() => {
-          this.el.measure((ox, oy, w, h, x, y) => {
+          this.color.measure((ox, oy, w, h, x, y) => {
             moveScene({w, h, x, y});
           });
         }}
-        ref={el => this.el = el}
+        ref={el => this.color = el}
         style={[
           {backgroundColor: color},
           styles.color

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -12,7 +12,7 @@ export default ({color, colorRef, moveScene, stateNavigator}) => {
         onPress={() => {
           if (url === stateNavigator.stateContext.url){
             colorRef.measure((ox, oy, w, h, x, y) => {
-              moveScene({fromW: w, fromH: h, fromX: x, fromY: y});
+              moveScene({_w: w, _h: h, _x: x, _y: y});
               stateNavigator.navigateBack(1);
             });
           }

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -12,7 +12,7 @@ export default ({color, colorRef, moveScene, stateNavigator}) => {
         onPress={() => {
           if (url === stateNavigator.stateContext.url){
             colorRef.measure((ox, oy, w, h, x, y) => {
-              moveScene({_w: w, _h: h, _x: x, _y: y});
+              moveScene({w, h, x, y});
               stateNavigator.navigateBack(1);
             });
           }

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -22,7 +22,8 @@ export default ({color, colorRef, moveScene, stateNavigator}) => {
       <View
         onLayout={() => {
           this.color.measure((ox, oy, w, h, x, y) => {
-            moveScene({w, h, x, y});
+            if (url === stateNavigator.stateContext.url)
+              moveScene({w, h, x, y});
           });
         }}
         ref={el => this.color = el}

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -10,12 +10,11 @@ export default ({color, colorRef, moveScene, stateNavigator}) => {
       <TouchableHighlight
         underlayColor="#fff"
         onPress={() => {
-          if (url === stateNavigator.stateContext.url){
-            colorRef.measure((ox, oy, w, h, x, y) => {
-              moveScene({w, h, x, y});
+          colorRef.measure((ox, oy, w, h, x, y) => {
+            moveScene({w, h, x, y});
+            if (url === stateNavigator.stateContext.url)
               stateNavigator.navigateBack(1);
-            });
-          }
+          });
         }}>
         <Text style={styles.back}>X</Text>
       </TouchableHighlight>

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {StyleSheet, ScrollView, Text, View, TouchableHighlight} from 'react-native';
 import {NavigationBackAndroid, spring} from 'navigation-react-native';
 
-export default ({color, moveScene, stateNavigator}) => {
+export default ({color, colorRef, moveScene, stateNavigator}) => {
   const {url} = stateNavigator.stateContext;
   return (
     <View style={styles.detail}>
@@ -10,8 +10,12 @@ export default ({color, moveScene, stateNavigator}) => {
       <TouchableHighlight
         underlayColor="#fff"
         onPress={() => {
-          if (url === stateNavigator.stateContext.url)
-            stateNavigator.navigateBack(1);
+          if (url === stateNavigator.stateContext.url){
+            colorRef.measure((ox, oy, w, h, x, y) => {
+              moveScene({fromW: w, fromH: h, fromX: x, fromY: y});
+              stateNavigator.navigateBack(1);
+            });
+          }
         }}>
         <Text style={styles.back}>X</Text>
       </TouchableHighlight>

--- a/NavigationReactNative/sample/zoom/Grid.js
+++ b/NavigationReactNative/sample/zoom/Grid.js
@@ -20,8 +20,7 @@ export default ({moveScene, stateNavigator}) => {
             <TouchableHighlight
               key={color}
               ref={el => {
-                if (!this.colors)
-                  this.colors = {};
+                this.colors = this.colors || {};
                 this.colors[color] = el;
               }}
               style={[

--- a/NavigationReactNative/sample/zoom/Grid.js
+++ b/NavigationReactNative/sample/zoom/Grid.js
@@ -11,11 +11,7 @@ export default ({moveScene, stateNavigator}) => {
   return (
     <View style={styles.grid}>
       <ScrollView>
-        <View
-          onLayout={() => {
-            moveScene({colors: this.colors});
-          }}
-          style={styles.colors}>
+        <View style={styles.colors}>
           {colors.map(color => (
             <TouchableHighlight
               key={color}
@@ -30,6 +26,7 @@ export default ({moveScene, stateNavigator}) => {
               underlayColor={color}
               onPress={() => {
                 this.colors[color].measure((ox, oy, w, h, x, y) => {
+                  moveScene({colorRef: this.colors[color]});
                   if (url === stateNavigator.stateContext.url)
                     stateNavigator.navigate('detail', {w, h, x, y, color});
                 });

--- a/NavigationReactNative/sample/zoom/Grid.js
+++ b/NavigationReactNative/sample/zoom/Grid.js
@@ -6,23 +6,29 @@ const colors = [
   'purple', 'fuchsia', 'indigo', 'green', 'navy', 'blue', 'teal', 'black'
 ];
 
-export default ({stateNavigator}) => {
+export default ({moveScene, stateNavigator}) => {
   const {url} = stateNavigator.stateContext;
   return (
     <View style={styles.grid}>
       <ScrollView>
-        <View style={styles.colors}>
+        <View
+          onLayout={() => { moveScene({colors: this.colors}); }}
+          style={styles.colors}>
           {colors.map(color => (
             <TouchableHighlight
               key={color}
-              ref={el => this[color] = el}
+              ref={el => {
+                if (!this.colors)
+                  this.colors = {};
+                this.colors[color] = el;
+              }}
               style={[
                 {backgroundColor: color},
                 styles.color
               ]}
               underlayColor={color}
               onPress={() => {
-                this[color].measure((ox, oy, w, h, x, y) => {
+                this.colors[color].measure((ox, oy, w, h, x, y) => {
                   if (url === stateNavigator.stateContext.url) {
                     const width = Dimensions.get('window').width;
                     stateNavigator.navigate('detail', {w, h, x, y, color, width});

--- a/NavigationReactNative/sample/zoom/Grid.js
+++ b/NavigationReactNative/sample/zoom/Grid.js
@@ -26,9 +26,10 @@ export default ({moveScene, stateNavigator}) => {
               underlayColor={color}
               onPress={() => {
                 this.colors[color].measure((ox, oy, w, h, x, y) => {
-                  moveScene({colorRef: this.colors[color]});
-                  if (url === stateNavigator.stateContext.url)
+                  if (url === stateNavigator.stateContext.url) {
+                    moveScene({colorRef: this.colors[color]});
                     stateNavigator.navigate('detail', {w, h, x, y, color});
+                  }
                 });
               }}>
               <Text></Text>

--- a/NavigationReactNative/sample/zoom/Grid.js
+++ b/NavigationReactNative/sample/zoom/Grid.js
@@ -12,7 +12,9 @@ export default ({moveScene, stateNavigator}) => {
     <View style={styles.grid}>
       <ScrollView>
         <View
-          onLayout={() => { moveScene({colors: this.colors}); }}
+          onLayout={() => {
+            moveScene({colors: this.colors});
+          }}
           style={styles.colors}>
           {colors.map(color => (
             <TouchableHighlight

--- a/NavigationReactNative/sample/zoom/Grid.js
+++ b/NavigationReactNative/sample/zoom/Grid.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Dimensions, StyleSheet, ScrollView, Text, View, TouchableHighlight} from 'react-native';
+import {StyleSheet, ScrollView, Text, View, TouchableHighlight} from 'react-native';
 
 const colors = [
   'maroon', 'red', 'crimson', 'orange', 'brown', 'sienna', 'olive',
@@ -29,10 +29,8 @@ export default ({moveScene, stateNavigator}) => {
               underlayColor={color}
               onPress={() => {
                 this.colors[color].measure((ox, oy, w, h, x, y) => {
-                  if (url === stateNavigator.stateContext.url) {
-                    const width = Dimensions.get('window').width;
-                    stateNavigator.navigate('detail', {w, h, x, y, color, width});
-                  }
+                  if (url === stateNavigator.stateContext.url)
+                    stateNavigator.navigate('detail', {w, h, x, y, color});
                 });
               }}>
               <Text></Text>

--- a/NavigationReactNative/sample/zoom/Zoom.js
+++ b/NavigationReactNative/sample/zoom/Zoom.js
@@ -13,11 +13,7 @@ const getStyle = ({x, y, w, h, width}, show) => ({
 export default ({stateNavigator}) => (
   <NavigationMotion
     startStateKey="grid"
-    unmountedStyle={(state, data, sceneData) => {
-      if (sceneData && sceneData.fromX)
-        data = {...data, x: sceneData.fromX, y: sceneData.fromY, w: sceneData.fromW, h: sceneData.fromH};
-      return getStyle(data, 0);
-    }}
+    unmountedStyle={(state, data, {_x: x, _y: y, _w: w, _h: h} = {}) => getStyle(!x ? data : {...data, x, y, w, h}, 0)}
     mountedStyle={(state, data, sceneData) => getStyle({...data, ...sceneData}, 1)}
     crumbStyle={getStyle({}, 1)}
     style={{flex: 1}}

--- a/NavigationReactNative/sample/zoom/Zoom.js
+++ b/NavigationReactNative/sample/zoom/Zoom.js
@@ -13,7 +13,7 @@ const getStyle = ({x, y, w, h, width}, show) => ({
 export default ({stateNavigator}) => (
   <NavigationMotion
     startStateKey="grid"
-    unmountedStyle={(state, data, {_x: x, _y: y, _w: w, _h: h} = {}) => getStyle(!x ? data : {...data, x, y, w, h}, 0)}
+    unmountedStyle={(state, data, sceneData) => getStyle({...data, ...sceneData}, 0)}
     mountedStyle={(state, data, sceneData) => getStyle({...data, ...sceneData}, 1)}
     crumbStyle={getStyle({}, 1)}
     style={{flex: 1}}

--- a/NavigationReactNative/sample/zoom/Zoom.js
+++ b/NavigationReactNative/sample/zoom/Zoom.js
@@ -2,13 +2,12 @@ import React from 'react';
 import {Dimensions, StyleSheet, View} from 'react-native';
 import {NavigationMotion, spring} from 'navigation-react-native';
 
-const getStyle = ({x, y, w, h, width}, show, translate = false) => ({
+const getStyle = ({x, y, w, h, width}, show) => ({
   x: spring(x || 0, {stiffness: 250}),
   y: spring(y || 0, {stiffness: 250}),
   w: spring(w || 0, {stiffness: 250}),
   h: spring(h || 0, {stiffness: 250}),
   show: spring(show, {stiffness: 250}),
-  translate: spring(0, {stiffness: 250}),
 });
 
 export default ({stateNavigator}) => (
@@ -17,21 +16,14 @@ export default ({stateNavigator}) => (
     unmountedStyle={(state, data, sceneData) => {
       if (sceneData && sceneData.fromX)
         data = {...data, x: sceneData.fromX, y: sceneData.fromY, w: sceneData.fromW, h: sceneData.fromH};
-      return getStyle(data, 0, true);
+      return getStyle(data, 0);
     }}
     mountedStyle={(state, data, sceneData) => getStyle({...data, ...sceneData}, 1)}
     crumbStyle={getStyle({}, 1)}
     style={{flex: 1}}
     stateNavigator={stateNavigator}>
-    {({show, x, y, w, h, translate}, scene, url, state, {color}) => (
-      <View
-        key={url}
-        style={[
-          styles.scene,
-          {transform: [
-            {translateX: Dimensions.get('window').width * translate},
-          ]},
-        ]}>
+    {({show, x, y, w, h}, scene, url, state, {color}) => (
+      <View key={url} style={styles.scene}>
         <View
           style={{
             position: 'absolute',
@@ -45,7 +37,7 @@ export default ({stateNavigator}) => (
         <View
           style={{
             flex: 1,
-            opacity: Math.ceil(translate) || Math.floor(show),
+            opacity: Math.floor(show),
           }}>
           {scene}
         </View>

--- a/NavigationReactNative/sample/zoom/Zoom.js
+++ b/NavigationReactNative/sample/zoom/Zoom.js
@@ -8,13 +8,17 @@ const getStyle = ({x, y, w, h, width}, show, translate = false) => ({
   w: spring(w || 0, {stiffness: 250}),
   h: spring(h || 0, {stiffness: 250}),
   show: spring(show, {stiffness: 250}),
-  translate: spring(translate && Dimensions.get('window').width !== width ? 1 : 0, {stiffness: 250}),
+  translate: spring(0, {stiffness: 250}),
 });
 
 export default ({stateNavigator}) => (
   <NavigationMotion
     startStateKey="grid"
-    unmountedStyle={(state, data) => getStyle(data, 0, true)}
+    unmountedStyle={(state, data, sceneData) => {
+      if (sceneData && sceneData.fromX)
+        data = {...data, x: sceneData.fromX, y: sceneData.fromY, w: sceneData.fromW, h: sceneData.fromH};
+      return getStyle(data, 0, true);
+    }}
     mountedStyle={(state, data, sceneData) => getStyle({...data, ...sceneData}, 1)}
     crumbStyle={getStyle({}, 1)}
     style={{flex: 1}}

--- a/NavigationReactNative/sample/zoom/Zoom.js
+++ b/NavigationReactNative/sample/zoom/Zoom.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Dimensions, StyleSheet, View} from 'react-native';
+import {StyleSheet, View} from 'react-native';
 import {NavigationMotion, spring} from 'navigation-react-native';
 
 const getStyle = ({x, y, w, h, width}, show) => ({

--- a/NavigationReactNative/sample/zoom/Zoom.js
+++ b/NavigationReactNative/sample/zoom/Zoom.js
@@ -2,11 +2,11 @@ import React from 'react';
 import {StyleSheet, View} from 'react-native';
 import {NavigationMotion, spring} from 'navigation-react-native';
 
-const getStyle = ({x, y, w, h, width}, show) => ({
-  x: spring(x || 0, {stiffness: 250}),
-  y: spring(y || 0, {stiffness: 250}),
-  w: spring(w || 0, {stiffness: 250}),
-  h: spring(h || 0, {stiffness: 250}),
+const getStyle = ({x, y, w, h, width}, show = 1) => ({
+  x: spring(x, {stiffness: 250}),
+  y: spring(y, {stiffness: 250}),
+  w: spring(w, {stiffness: 250}),
+  h: spring(h, {stiffness: 250}),
   show: spring(show, {stiffness: 250}),
 });
 
@@ -14,8 +14,8 @@ export default ({stateNavigator}) => (
   <NavigationMotion
     startStateKey="grid"
     unmountedStyle={(state, data, sceneData) => getStyle({...data, ...sceneData}, 0)}
-    mountedStyle={(state, data, sceneData) => getStyle({...data, ...sceneData}, 1)}
-    crumbStyle={getStyle({}, 1)}
+    mountedStyle={(state, data, sceneData) => getStyle({...data, ...sceneData})}
+    crumbStyle={getStyle({})}
     style={{flex: 1}}
     stateNavigator={stateNavigator}>
     {({show, x, y, w, h}, scene, url, state, {color}) => (

--- a/NavigationReactNative/sample/zoom/createStateNavigator.js
+++ b/NavigationReactNative/sample/zoom/createStateNavigator.js
@@ -11,10 +11,9 @@ export default () => {
 
   const { grid, detail } = stateNavigator.states;
   grid.renderScene = (data, moveScene) => <Grid moveScene={moveScene} stateNavigator={stateNavigator}/>;
-  detail.renderScene = (data, moveScene, previousSceneData) => {
-    var colorRef = previousSceneData.colors[data.color];
-    return <Detail {...data} colorRef={colorRef} moveScene={moveScene} stateNavigator={stateNavigator}/>;
-  }
+  detail.renderScene = (data, moveScene, {colorRef}) => (
+    <Detail {...data} colorRef={colorRef} moveScene={moveScene} stateNavigator={stateNavigator}/>
+  );
   
   return stateNavigator;
 }

--- a/NavigationReactNative/sample/zoom/createStateNavigator.js
+++ b/NavigationReactNative/sample/zoom/createStateNavigator.js
@@ -10,8 +10,11 @@ export default () => {
   ]);
 
   const { grid, detail } = stateNavigator.states;
-  grid.renderScene = data => <Grid stateNavigator={stateNavigator}/>;
-  detail.renderScene = (data, moveScene) => <Detail {...data} moveScene={moveScene} stateNavigator={stateNavigator}/>;
+  grid.renderScene = (data, moveScene) => <Grid moveScene={moveScene} stateNavigator={stateNavigator}/>;
+  detail.renderScene = (data, moveScene, previousSceneData) => {
+    var colorRef = previousSceneData.colors[data.color];
+    return <Detail {...data} colorRef={colorRef} moveScene={moveScene} stateNavigator={stateNavigator}/>;
+  }
   
   return stateNavigator;
 }

--- a/NavigationReactNative/src/NavigationMotion.tsx
+++ b/NavigationReactNative/src/NavigationMotion.tsx
@@ -54,14 +54,16 @@ class NavigationMotion extends React.Component<any, any> {
     }
     getScenes(){
         var {crumbs, nextCrumb} = this.getStateNavigator().stateContext;
-        return crumbs.concat(nextCrumb).map(({state, data, url}) => {
-            var scene = this.state.scenes[url] || {};
-            return {state, data, url, scene, sceneData: scene.data, mount: url === nextCrumb.url};
-        });
+        return crumbs.concat(nextCrumb).map(({state, data, url}) => (
+            {state, data, url, scene: this.state.scenes[url], mount: url === nextCrumb.url}
+        ));
+    }
+    getSceneData(url) {
+        var scene = this.state.scenes[url];
+        return scene && scene.data;
     }
     getStyle(styleProp, {state, data, url}, strip = false) {
-        var scene = this.state.scenes[url];
-        var style = typeof styleProp === 'function' ? styleProp(state, data, scene && scene.data) : styleProp;
+        var style = typeof styleProp === 'function' ? styleProp(state, data, this.getSceneData(url)) : styleProp;
         var newStyle: any = {};
         for(var key in style) {
             newStyle[key] = (!strip || typeof style[key] === 'number') ? style[key] : style[key].val;
@@ -82,8 +84,8 @@ class NavigationMotion extends React.Component<any, any> {
                 }))}>
                 {tweenStyles => (
                     <View style={style}>
-                        {tweenStyles.map(({key, data: {scene, state, data, sceneData}, style}) => (
-                            children(style, scene.element, key, state, data, sceneData)
+                        {tweenStyles.map(({key, data: {scene, state, data, url}, style}) => (
+                            children(style, scene && scene.element, key, state, data, this.getSceneData(url))
                         ))}
                     </View>
                 )}

--- a/NavigationReactNative/src/NavigationMotion.tsx
+++ b/NavigationReactNative/src/NavigationMotion.tsx
@@ -45,6 +45,13 @@ class NavigationMotion extends React.Component<any, any> {
             });
         };
     }
+    clearScene(url) {
+        this.setState((prevState) => {
+            var scenes = {...prevState.scenes};
+            delete scenes[url];
+            return {scenes};
+        });
+    }
     getScenes(){
         var {crumbs, nextCrumb} = this.getStateNavigator().stateContext;
         return crumbs.concat(nextCrumb).map(({state, data, url}) => {
@@ -67,6 +74,7 @@ class NavigationMotion extends React.Component<any, any> {
             <TransitionMotion
                 willEnter={({data: sceneContext}) => this.getStyle(unmountedStyle, sceneContext, true)}
                 willLeave={({data: sceneContext}) => this.getStyle(unmountedStyle, sceneContext)}
+                didLeave={({data: sceneContext}) => { this.clearScene(sceneContext.url); }}
                 styles={this.getScenes().map(({mount, ...sceneContext}) => ({
                     key: sceneContext.url,
                     data: sceneContext,

--- a/NavigationReactNative/src/NavigationMotion.tsx
+++ b/NavigationReactNative/src/NavigationMotion.tsx
@@ -27,7 +27,7 @@ class NavigationMotion extends React.Component<any, any> {
         this.getStateNavigator().offNavigate(this.onNavigate);
     }
     onNavigate(oldState, state, data) {
-        this.setState((prevState) => {
+        this.setState(prevState => {
             var scenes = {...prevState.scenes};
             var {url, crumbs} = this.getStateNavigator().stateContext;
             var previousScene = crumbs.length > 0 ? prevState.scenes[crumbs[crumbs.length - 1].url] : null;
@@ -38,7 +38,7 @@ class NavigationMotion extends React.Component<any, any> {
     }
     moveScene(url) {
         return data => {
-            this.setState((prevState) => {
+            this.setState(prevState => {
                 var scenes = {...prevState.scenes};
                 scenes[url] = {...scenes[url], data};
                 return {scenes};
@@ -46,7 +46,7 @@ class NavigationMotion extends React.Component<any, any> {
         };
     }
     clearScene(url) {
-        this.setState((prevState) => {
+        this.setState(prevState => {
             var scenes = {...prevState.scenes};
             delete scenes[url];
             return {scenes};

--- a/NavigationReactNative/src/NavigationMotion.tsx
+++ b/NavigationReactNative/src/NavigationMotion.tsx
@@ -74,7 +74,7 @@ class NavigationMotion extends React.Component<any, any> {
             <TransitionMotion
                 willEnter={({data: sceneContext}) => this.getStyle(unmountedStyle, sceneContext, true)}
                 willLeave={({data: sceneContext}) => this.getStyle(unmountedStyle, sceneContext)}
-                didLeave={({data: sceneContext}) => { this.clearScene(sceneContext.url); }}
+                didLeave={({data: sceneContext}) => {this.clearScene(sceneContext.url)}}
                 styles={this.getScenes().map(({mount, ...sceneContext}) => ({
                     key: sceneContext.url,
                     data: sceneContext,

--- a/NavigationReactNative/src/NavigationMotion.tsx
+++ b/NavigationReactNative/src/NavigationMotion.tsx
@@ -7,8 +7,8 @@ import spring from './spring.js'
 class NavigationMotion extends React.Component<any, any> {
     constructor(props, context) {
         super(props, context);
-        this.state = {scenes: {}};
         this.onNavigate = this.onNavigate.bind(this);
+        this.state = {scenes: {}};
     }
     static contextTypes = {
         stateNavigator: React.PropTypes.object

--- a/NavigationReactNative/src/NavigationMotion.tsx
+++ b/NavigationReactNative/src/NavigationMotion.tsx
@@ -7,9 +7,9 @@ import spring from './spring.js'
 class NavigationMotion extends React.Component<any, any> {
     private onNavigate = (oldState, state, data) => {
         this.setState((prevState) => {
-            var {url, crumbs} = this.getStateNavigator().stateContext;
             var scenes = {};
             var previousScene = null;
+            var {url, crumbs} = this.getStateNavigator().stateContext;
             for(var i = 0; i < crumbs.length; i++)
                 scenes[crumbs[i].url] = previousScene = prevState.scenes[crumbs[i].url];
             var element = state.renderScene(data, this.moveScene(url), previousScene && previousScene.data);

--- a/NavigationReactNative/src/NavigationMotion.tsx
+++ b/NavigationReactNative/src/NavigationMotion.tsx
@@ -8,9 +8,12 @@ class NavigationMotion extends React.Component<any, any> {
     private onNavigate = (oldState, state, data, asyncData) => {
         this.setState((prevState) => {
             var {url, crumbs} = this.getStateNavigator().stateContext;
-            var scenes = {[url]: {element: state.renderScene(data, this.moveScene(url), asyncData)}};
+            var scenes = {};
+            var previousScene = null;
             for(var i = 0; i < crumbs.length; i++)
-                scenes[crumbs[i].url] = prevState.scenes[crumbs[i].url];
+                scenes[crumbs[i].url] = previousScene = prevState.scenes[crumbs[i].url];
+            var previousSceneData = previousScene && previousScene.data;
+            scenes[url] = {element: state.renderScene(data, this.moveScene(url), previousSceneData)};
             return {scenes};
         });
     }

--- a/NavigationReactNative/src/NavigationMotion.tsx
+++ b/NavigationReactNative/src/NavigationMotion.tsx
@@ -5,21 +5,10 @@ import { View } from 'react-native';
 import spring from './spring.js'
 
 class NavigationMotion extends React.Component<any, any> {
-    private onNavigate = (oldState, state, data) => {
-        this.setState((prevState) => {
-            var scenes = {};
-            var previousScene = null;
-            var {url, crumbs} = this.getStateNavigator().stateContext;
-            for(var i = 0; i < crumbs.length; i++)
-                scenes[crumbs[i].url] = previousScene = prevState.scenes[crumbs[i].url];
-            var element = state.renderScene(data, this.moveScene(url), previousScene && previousScene.data);
-            scenes[url] = {...prevState.scenes[url], element};
-            return {scenes};
-        });
-    }
     constructor(props, context) {
         super(props, context);
         this.state = {scenes: {}};
+        this.onNavigate = this.onNavigate.bind(this);
     }
     static contextTypes = {
         stateNavigator: React.PropTypes.object
@@ -37,15 +26,24 @@ class NavigationMotion extends React.Component<any, any> {
     componentWillUnmount() {
         this.getStateNavigator().offNavigate(this.onNavigate);
     }
+    onNavigate(oldState, state, data) {
+        this.setState((prevState) => {
+            var scenes = {...prevState.scenes};
+            var {url, crumbs} = this.getStateNavigator().stateContext;
+            var previousScene = crumbs.length > 0 ? prevState.scenes[crumbs[crumbs.length - 1].url] : null;
+            var element = state.renderScene(data, this.moveScene(url), previousScene && previousScene.data);
+            scenes[url] = {...scenes[url], element};
+            return {scenes};
+        });
+    }
     moveScene(url) {
         return data => {
             this.setState((prevState) => {
                 var scenes = {...prevState.scenes};
-                if (scenes[url])
-                    scenes[url].data = data; 
+                scenes[url] = {...scenes[url], data};
                 return {scenes};
-            }
-        )};
+            });
+        };
     }
     getScenes(){
         var {crumbs, nextCrumb} = this.getStateNavigator().stateContext;

--- a/NavigationReactNative/src/NavigationMotion.tsx
+++ b/NavigationReactNative/src/NavigationMotion.tsx
@@ -30,8 +30,8 @@ class NavigationMotion extends React.Component<any, any> {
         this.setState(prevState => {
             var scenes = {...prevState.scenes};
             var {url, crumbs} = this.getStateNavigator().stateContext;
-            var previousScene = crumbs.length > 0 ? prevState.scenes[crumbs[crumbs.length - 1].url] : null;
-            var element = state.renderScene(data, this.moveScene(url), previousScene && previousScene.data);
+            var previousUrl = crumbs.length > 0 ? crumbs[crumbs.length - 1].url : null;
+            var element = state.renderScene(data, this.moveScene(url), this.getSceneData(previousUrl));
             scenes[url] = {...scenes[url], element};
             return {scenes};
         });
@@ -60,7 +60,7 @@ class NavigationMotion extends React.Component<any, any> {
     }
     getSceneData(url) {
         var scene = this.state.scenes[url];
-        return scene && scene.data;
+        return (scene && scene.data) || {};
     }
     getStyle(styleProp, {state, data, url}, strip = false) {
         var style = typeof styleProp === 'function' ? styleProp(state, data, this.getSceneData(url)) : styleProp;

--- a/NavigationReactNative/src/NavigationMotion.tsx
+++ b/NavigationReactNative/src/NavigationMotion.tsx
@@ -52,16 +52,25 @@ class NavigationMotion extends React.Component<any, any> {
             return {state, data, url, scene, sceneData: scene.data, mount: url === nextCrumb.url};
         });
     }
+    getStyle(styleProp, {state, data, url}, strip = false) {
+        var scene = this.state.scenes[url];
+        var style = typeof styleProp === 'function' ? styleProp(state, data, scene && scene.data) : styleProp;
+        var newStyle: any = {};
+        for(var key in style) {
+            newStyle[key] = (!strip || typeof style[key] === 'number') ? style[key] : style[key].val;
+        }
+        return newStyle;
+    }
     render() {
         var {unmountedStyle, mountedStyle, crumbStyle, style, children} = this.props;
         return (this.getStateNavigator().stateContext.state &&
             <TransitionMotion
-                willEnter={({data: sceneContext}) => getStyle(unmountedStyle, sceneContext, true)}
-                willLeave={({data: sceneContext}) => getStyle(unmountedStyle, sceneContext)}
-                styles={this.getScenes().map(({url, mount, ...sceneContext}) => ({
-                    key: url,
+                willEnter={({data: sceneContext}) => this.getStyle(unmountedStyle, sceneContext, true)}
+                willLeave={({data: sceneContext}) => this.getStyle(unmountedStyle, sceneContext)}
+                styles={this.getScenes().map(({mount, ...sceneContext}) => ({
+                    key: sceneContext.url,
                     data: sceneContext,
-                    style: getStyle(mount ? mountedStyle : crumbStyle, sceneContext)
+                    style: this.getStyle(mount ? mountedStyle : crumbStyle, sceneContext)
                 }))}>
                 {tweenStyles => (
                     <View style={style}>
@@ -73,15 +82,6 @@ class NavigationMotion extends React.Component<any, any> {
             </TransitionMotion>
         );
     }
-}
-
-function getStyle(styleProp, {state, data, sceneData}, strip = false) {
-    var style = typeof styleProp === 'function' ? styleProp(state, data, sceneData) : styleProp;
-    var newStyle: any = {};
-    for(var key in style) {
-        newStyle[key] = (!strip || typeof style[key] === 'number') ? style[key] : style[key].val;
-    }
-    return newStyle;
 }
 
 export default NavigationMotion;

--- a/NavigationReactNative/src/NavigationMotion.tsx
+++ b/NavigationReactNative/src/NavigationMotion.tsx
@@ -5,7 +5,7 @@ import { View } from 'react-native';
 import spring from './spring.js'
 
 class NavigationMotion extends React.Component<any, any> {
-    private onNavigate = (oldState, state, data, asyncData) => {
+    private onNavigate = (oldState, state, data) => {
         this.setState((prevState) => {
             var {url, crumbs} = this.getStateNavigator().stateContext;
             var scenes = {};
@@ -13,7 +13,7 @@ class NavigationMotion extends React.Component<any, any> {
             for(var i = 0; i < crumbs.length; i++)
                 scenes[crumbs[i].url] = previousScene = prevState.scenes[crumbs[i].url];
             var previousSceneData = previousScene && previousScene.data;
-            scenes[url] = {element: state.renderScene(data, this.moveScene(url), previousSceneData)};
+            scenes[url] = {...prevState.scenes[url], element: state.renderScene(data, this.moveScene(url), previousSceneData)};
             return {scenes};
         });
     }

--- a/NavigationReactNative/src/NavigationMotion.tsx
+++ b/NavigationReactNative/src/NavigationMotion.tsx
@@ -12,8 +12,8 @@ class NavigationMotion extends React.Component<any, any> {
             var previousScene = null;
             for(var i = 0; i < crumbs.length; i++)
                 scenes[crumbs[i].url] = previousScene = prevState.scenes[crumbs[i].url];
-            var previousSceneData = previousScene && previousScene.data;
-            scenes[url] = {...prevState.scenes[url], element: state.renderScene(data, this.moveScene(url), previousSceneData)};
+            var element = state.renderScene(data, this.moveScene(url), previousScene && previousScene.data);
+            scenes[url] = {...prevState.scenes[url], element};
             return {scenes};
         });
     }

--- a/NavigationReactNative/src/node_modules/@types/react-motion.d.ts
+++ b/NavigationReactNative/src/node_modules/@types/react-motion.d.ts
@@ -124,6 +124,7 @@ declare module "react-motion" {
          * @param styleThatLeft
          */
         willLeave?: (styleThatLeft: TransitionStyle) => Style | void;
+        didLeave?: (styleThatEntered: TransitionStyle) => void;
     }
     export class TransitionMotion extends Component<TransitionProps, any> { }
 


### PR DESCRIPTION
The zoom sample shows a [shared element transition](https://github.com/brentvatne/hard-react-native-problems/issues/11), where the selected color is zoomed between scenes. Like selecting a Tweet’s image on Twitter.

The zoom sample was working before this PR but it wasn’t a proper shared element transition implementation. Changing the device orientation then pressing back didn’t zoom back in. Twitter has similar problem because swiping to different image doesn’t zoom that image back in. Gmail, until recently, had similar problem that swiping to a different mail didn’t zoom the title back to that mail.

The key to solution is passing `previousSceneData` into the `renderScene` function on a State. Can use this to pass Component refs from one scene to another. When color is selected call `moveScene` passing the ref of the selected color Component. Then pass this ref as a prop when rendering the Details scene. When navigating back, the Details scene can measure the ref and call `moveScene` passing in the position and size. 

Passed the `sceneData` into the mounted and unmounted styles props so that can construct the styles using the data and `sceneData`. These two styles are built in exactly the same way because the Details scene puts the target position and size in `sceneData` when navigating both forwards and backwards.

The latest `sceneData` is always used instead of letting the `TransitionMotion` Component track it. The `TransitionMotion` tracks the url and this url is used to get the latest `sceneData` from `NavigationMotion` state. This is important because have to be able to update `sceneData` while a scene is leaving and animation is running. The Details component navigates back and then calls `moveScene` with the target position and size. Wait until animation completes (`didLeave`) to remove scenes from `NavigationMotion` state. 
