### PR TITLE
Removed const from Rollup build output

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,7 @@ var nodeResolve = require('rollup-plugin-node-resolve');
 var rename = require('gulp-rename');
 var rollup = require('rollup');
 var rollupTypescript = require('rollup-plugin-typescript');
+var strip = require('gulp-strip-comments');
 var typescript = require('typescript');
 var uglify = require('gulp-uglify');
 
@@ -105,6 +106,7 @@ function buildTask(file, details) {
  */
 `;
     return gulp.src('./build/dist/' + file)
+        .pipe(strip())
         .pipe(insert.prepend(info))
         .pipe(gulp.dest('./build/dist'))
         .pipe(rename(file.replace(/js$/, 'min.js')))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,7 @@ var gulp = require('gulp');
 var gulpTypescript = require('gulp-tsc');
 var insert = require('gulp-insert');
 var mocha = require('gulp-mocha');
+var nodeResolve = require('rollup-plugin-node-resolve');
 var rename = require('gulp-rename');
 var rollup = require('rollup');
 var rollupTypescript = require('rollup-plugin-typescript');
@@ -28,8 +29,10 @@ function rollupTestTask(name, file, to) {
                 typescript: typescript,
                 target: 'es3',
                 module: 'es6',
-                jsx: 'react'
-            })
+                jsx: 'react',
+                importHelpers: true
+            }),
+            nodeResolve({ jsnext: true, main: true })
         ]
     }).then((bundle) => {
         bundle.write({
@@ -80,8 +83,10 @@ function rollupTask(name, file, to, globals) {
                 typescript: typescript,
                 target: 'es3',
                 module: 'es6',
-                jsx: 'react'
-            })
+                jsx: 'react',
+                importHelpers: true
+            }),
+            nodeResolve({ jsnext: true, main: true })
         ]
     }).then((bundle) => {
         bundle.write({

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,10 +28,10 @@ function rollupTestTask(name, file, to) {
         plugins: [
             rollupTypescript({
                 typescript: typescript,
+                importHelpers: true,
                 target: 'es3',
                 module: 'es6',
-                jsx: 'react',
-                importHelpers: true
+                jsx: 'react'
             }),
             nodeResolve({ jsnext: true, main: true })
         ]
@@ -82,10 +82,10 @@ function rollupTask(name, file, to, globals) {
         plugins: [
             rollupTypescript({
                 typescript: typescript,
+                importHelpers: true,
                 target: 'es3',
                 module: 'es6',
-                jsx: 'react',
-                importHelpers: true
+                jsx: 'react'
             }),
             nodeResolve({ jsnext: true, main: true })
         ]

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "gulp-insert": "^0.5.0",
     "gulp-mocha": "^3.0.1",
     "gulp-rename": "^1.2.0",
+    "gulp-strip-comments": "^2.4.5",
     "gulp-tsc": "^1.3.0",
     "gulp-uglify": "^2.0.1",
     "react": "^15.4.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.4.2",
     "rollup": "^0.36.3",
+    "rollup-plugin-node-resolve": "^2.0.0",
     "rollup-plugin-typescript": "^0.8.1",
+    "tslib": "^1.6.0",
     "typescript": "^2.2.1"
   },
   "scripts": {


### PR DESCRIPTION
The [Rollup Typescript plugin has a bug when using rest/spread](https://github.com/rollup/rollup-plugin-typescript/pull/86). It adds a  `const` to the assign Typescript Helper. Worked around this by getting Typescript to import Helpers instead of the plugin