### PR TITLE
Removed PropType warnings

### DIFF
--- a/NavigationReact/src/NavigationBackLink.ts
+++ b/NavigationReact/src/NavigationBackLink.ts
@@ -16,7 +16,7 @@ class NavigationBackLink extends React.Component<NavigationBackLinkProps, any> {
     }
 
     static contextTypes = {
-        stateNavigator: React.PropTypes.object
+        stateNavigator: () => {}
     }
     
     private getStateNavigator(): StateNavigator {

--- a/NavigationReact/src/NavigationLink.ts
+++ b/NavigationReact/src/NavigationLink.ts
@@ -15,7 +15,7 @@ class NavigationLink extends React.Component<NavigationLinkProps, any> {
     }
 
     static contextTypes = {
-        stateNavigator: React.PropTypes.object
+        stateNavigator: () => {}
     }
     
     private getStateNavigator(): StateNavigator {

--- a/NavigationReact/src/RefreshLink.ts
+++ b/NavigationReact/src/RefreshLink.ts
@@ -15,7 +15,7 @@ class RefreshLink extends React.Component<RefreshLinkProps, any> {
     }
 
     static contextTypes = {
-        stateNavigator: React.PropTypes.object
+        stateNavigator: () => {}
     }
     
     private getStateNavigator(): StateNavigator {

--- a/NavigationReactNative/sample/web/NavigationMotion.js
+++ b/NavigationReactNative/sample/web/NavigationMotion.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Transition } from 'react-move';
 
 class NavigationMotion extends React.Component {
@@ -136,11 +136,11 @@ NavigationMotion.defaultProps = {
     easing: 'easeLinear'
 }
 NavigationMotion.contextTypes = {
-    stateNavigator: React.PropTypes.object
+    stateNavigator: () => {}
 }
 NavigationMotion.childContextTypes = {
-    registerSharedElement: React.PropTypes.func,
-    unregisterSharedElement: React.PropTypes.func
+    registerSharedElement: () => {},
+    unregisterSharedElement: () => {}
 }
 
 export default NavigationMotion;

--- a/NavigationReactNative/sample/web/SharedElement.js
+++ b/NavigationReactNative/sample/web/SharedElement.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 class SharedElement extends React.Component {
     constructor(props, context) {
@@ -44,9 +44,9 @@ class SharedElement extends React.Component {
 }
 
 SharedElement.contextTypes = {
-    stateNavigator: React.PropTypes.object,
-    registerSharedElement: React.PropTypes.func,
-    unregisterSharedElement: React.PropTypes.func
+    stateNavigator: () => {},
+    registerSharedElement: () => {},
+    unregisterSharedElement: () => {}
 }
 
 export default SharedElement;

--- a/NavigationReactNative/sample/web/SharedElementMotion.js
+++ b/NavigationReactNative/sample/web/SharedElementMotion.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Animate } from 'react-move';
 
 class SharedElementMotion extends React.Component {

--- a/NavigationReactNative/src/NavigationBackHandler.android.ts
+++ b/NavigationReactNative/src/NavigationBackHandler.android.ts
@@ -10,7 +10,7 @@ class NavigationBackHandler extends React.Component<any, any> {
         this.url = this.getStateNavigator().stateContext.url;
     }
     static contextTypes = {
-        stateNavigator: React.PropTypes.object
+        stateNavigator: () => {}
     }
     private getStateNavigator(): StateNavigator {
         return this.props.stateNavigator || (this.context as any).stateNavigator;

--- a/NavigationReactNative/src/NavigationMotion.tsx
+++ b/NavigationReactNative/src/NavigationMotion.tsx
@@ -20,11 +20,11 @@ class NavigationMotion extends React.Component<any, any> {
         easing: 'easeLinear'
     }
     static contextTypes = {
-        stateNavigator: React.PropTypes.object
+        stateNavigator: () => {}
     }
     static childContextTypes = {
-        registerSharedElement: React.PropTypes.func,
-        unregisterSharedElement: React.PropTypes.func
+        registerSharedElement: () => {},
+        unregisterSharedElement: () => {}
     }
     getChildContext() {
         return {

--- a/NavigationReactNative/src/SharedElement.tsx
+++ b/NavigationReactNative/src/SharedElement.tsx
@@ -15,9 +15,9 @@ class SharedElement extends React.Component<any, any> {
         this.register = this.register.bind(this);
     }
     static contextTypes = {
-        stateNavigator: React.PropTypes.object,
-        registerSharedElement: React.PropTypes.func,
-        unregisterSharedElement: React.PropTypes.func
+        stateNavigator: () => {},
+        registerSharedElement: () => {},
+        unregisterSharedElement: () => {}
     }
     private getStateNavigator(): StateNavigator {
         return this.props.stateNavigator || this.context.stateNavigator;


### PR DESCRIPTION
Replaced `PropTypes` with noop function. Was only using `PropTypes` because of `context`, not for validation, so no need to bring in a separate `PropType` package which makes build size bigger