### PR TITLE
Replaced ref with currentTarget

### DIFF
--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -55,22 +55,21 @@ class LinkUtility {
             && attr !== 'lazy' && attr !== 'historyAction' && attr !== 'navigating' && attr !== 'children';
     }
     
-    static addListeners(component: React.Component<any, any>, stateNavigator: StateNavigator, props: any, toProps: any, getLink: () => string) {
+    static addListeners(component: React.Component<any, any>, stateNavigator: StateNavigator, props: any, toProps: React.AnchorHTMLAttributes<HTMLAnchorElement>, getLink: () => string) {
         var lazy = !!props.lazy;
-        toProps.onClick = (e: MouseEvent, domId: string) => {
-            var element = <HTMLAnchorElement> component['el'];
-            var href = element.href;
+        toProps.onClick = (e) => {
+            var href = e.currentTarget.href;
             if (lazy) {
                 component.forceUpdate();
                 href = getLink();
                 if (href)
-                    element.href = href;
+                    e.currentTarget.href = href;
             }
             if (!e.ctrlKey && !e.shiftKey && !e.metaKey && !e.altKey && !e.button) {
                 if (href) {
-                    var link = stateNavigator.historyManager.getUrl(element);
+                    var link = stateNavigator.historyManager.getUrl(e.currentTarget);
                     var navigating = this.getNavigating(props);
-                    if (navigating(e, domId, link)) {
+                    if (navigating(e, link)) {
                         e.preventDefault();
                         stateNavigator.navigateLink(link, props.historyAction);
                     }
@@ -78,14 +77,14 @@ class LinkUtility {
             }
         };
         if (lazy)
-            toProps.onContextMenu = (e: MouseEvent) => component.forceUpdate();
+            toProps.onContextMenu = () => component.forceUpdate();
     }
 
-    static getNavigating(props: any): (e: MouseEvent, domId: string, link: string) => boolean {
-        return (e: MouseEvent, domId: string, link: string) => {
+    static getNavigating(props: any): (e, link: string) => boolean {
+        return (e, link: string) => {
             var listener = props.navigating;
             if (listener)
-                return listener(e, domId, link);
+                return listener(e, undefined, link);
             return true;
         }
     }

--- a/NavigationReact/src/NavigationBackLink.ts
+++ b/NavigationReact/src/NavigationBackLink.ts
@@ -48,7 +48,7 @@ class NavigationBackLink extends React.Component<NavigationBackLinkProps, any> {
     }
     
     render() {
-        var props: any = { ref: (el) => this['el'] = el };
+        var props: any = {};
         for(var key in this.props) {
             if (LinkUtility.isValidAttribute(key))
                 props[key] = this.props[key];

--- a/NavigationReact/src/NavigationLink.ts
+++ b/NavigationReact/src/NavigationLink.ts
@@ -46,7 +46,7 @@ class NavigationLink extends React.Component<NavigationLinkProps, any> {
     }
     
     render() {
-        var props: any = { ref: (el) => this['el'] = el };
+        var props: any = {};
         for(var key in this.props) {
             if (LinkUtility.isValidAttribute(key))
                 props[key] = this.props[key];

--- a/NavigationReact/src/Props.ts
+++ b/NavigationReact/src/Props.ts
@@ -1,10 +1,10 @@
 import { StateNavigator } from 'navigation';
-import { HTMLProps } from 'react';
+import { HTMLProps, MouseEvent } from 'react';
 
 interface LinkProps extends HTMLProps<HTMLAnchorElement> {
     lazy?: boolean;
     historyAction?: 'add' | 'replace' | 'none';
-    navigating?: (e: MouseEvent, domId: string, link: string) => boolean;
+    navigating?: (e: MouseEvent<HTMLAnchorElement>, domId: string, link: string) => boolean;
     stateNavigator?: StateNavigator;
 }
 

--- a/NavigationReact/src/RefreshLink.ts
+++ b/NavigationReact/src/RefreshLink.ts
@@ -46,7 +46,7 @@ class RefreshLink extends React.Component<RefreshLinkProps, any> {
     }
     
     render() {
-        var props: any = { ref: (el) => this['el'] = el };
+        var props: any = {};
         for(var key in this.props) {
             if (LinkUtility.isValidAttribute(key))
                 props[key] = this.props[key];

--- a/NavigationReact/test/NavigationBackLinkTest.tsx
+++ b/NavigationReact/test/NavigationBackLinkTest.tsx
@@ -124,9 +124,8 @@ describe('NavigationBackLinkTest', function () {
                 </NavigationBackLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, preventDefault: () => {} });
             assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s0']);
         })
     });
@@ -148,9 +147,8 @@ describe('NavigationBackLinkTest', function () {
                 </NavigationBackLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ ctrlKey: true, preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, ctrlKey: true, preventDefault: () => {} });
             assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
         })
     });
@@ -172,9 +170,8 @@ describe('NavigationBackLinkTest', function () {
                 </NavigationBackLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ shiftKey: true, preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, shiftKey: true, preventDefault: () => {} });
             assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
         })
     });
@@ -196,9 +193,8 @@ describe('NavigationBackLinkTest', function () {
                 </NavigationBackLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ metaKey: true, preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, metaKey: true, preventDefault: () => {} });
             assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
         })
     });
@@ -220,9 +216,8 @@ describe('NavigationBackLinkTest', function () {
                 </NavigationBackLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ altKey: true, preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, altKey: true, preventDefault: () => {} });
             assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
         })
     });
@@ -244,9 +239,8 @@ describe('NavigationBackLinkTest', function () {
                 </NavigationBackLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ button: true, preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, button: true, preventDefault: () => {} });
             assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
         })
     });
@@ -269,9 +263,8 @@ describe('NavigationBackLinkTest', function () {
                 </NavigationBackLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, preventDefault: () => {} });
             assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s0']);
         })
     });
@@ -294,9 +287,8 @@ describe('NavigationBackLinkTest', function () {
                 </NavigationBackLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, preventDefault: () => {} });
             assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
         })
     });
@@ -324,9 +316,8 @@ describe('NavigationBackLinkTest', function () {
                 </NavigationBackLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            var evt = { preventDefault: () => {} };
+            var evt = { currentTarget: { href: link.props['href'] }, preventDefault: () => {} };
             link.props['onClick'](evt);
             assert.strictEqual(navigatingEvt, evt);
             assert.equal(navigatingLink, '/r0');
@@ -352,10 +343,9 @@ describe('NavigationBackLinkTest', function () {
             );
             var link = renderer.getRenderOutput();
             var el = { href: null };
-            link['ref'](el);
             stateNavigator.navigate('s1');
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: el, preventDefault: () => {} });
             assert.equal(el.href, '#/r0');
             assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s0']);
         })
@@ -378,11 +368,10 @@ describe('NavigationBackLinkTest', function () {
                 </NavigationBackLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
             var addHistory;
             stateNavigator.historyManager.addHistory = (url, replace) => { addHistory = !replace };
-            link.props['onClick']({ preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, preventDefault: () => {} });
             assert.strictEqual(addHistory, true);
         })
     });
@@ -405,11 +394,10 @@ describe('NavigationBackLinkTest', function () {
                 </NavigationBackLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
             var replaceHistory;
             stateNavigator.historyManager.addHistory = (url, replace) => { replaceHistory = replace };
-            link.props['onClick']({ preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, preventDefault: () => {} });
             assert.strictEqual(replaceHistory, true);
         })
     });
@@ -432,11 +420,10 @@ describe('NavigationBackLinkTest', function () {
                 </NavigationBackLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
             var noneHistory = true;
             stateNavigator.historyManager.addHistory = () => { noneHistory = false };
-            link.props['onClick']({ preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, preventDefault: () => {} });
             assert.strictEqual(noneHistory, true);
         })
     });

--- a/NavigationReact/test/NavigationLinkTest.tsx
+++ b/NavigationReact/test/NavigationLinkTest.tsx
@@ -1430,9 +1430,8 @@ describe('NavigationLinkTest', function () {
                 </NavigationLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, preventDefault: () => {} });
             assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s']);
         })
     });
@@ -1451,9 +1450,8 @@ describe('NavigationLinkTest', function () {
                 </NavigationLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ ctrlKey: true, preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, ctrlKey: true, preventDefault: () => {} });
             assert.equal(stateNavigator.stateContext.state, null);
         })
     });
@@ -1472,9 +1470,8 @@ describe('NavigationLinkTest', function () {
                 </NavigationLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ shiftKey: true, preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, shiftKey: true, preventDefault: () => {} });
             assert.equal(stateNavigator.stateContext.state, null);
         })
     });
@@ -1493,9 +1490,8 @@ describe('NavigationLinkTest', function () {
                 </NavigationLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ metaKey: true, preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, metaKey: true, preventDefault: () => {} });
             assert.equal(stateNavigator.stateContext.state, null);
         })
     });
@@ -1514,9 +1510,8 @@ describe('NavigationLinkTest', function () {
                 </NavigationLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ altKey: true, preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, altKey: true, preventDefault: () => {} });
             assert.equal(stateNavigator.stateContext.state, null);
         })
     });
@@ -1535,9 +1530,8 @@ describe('NavigationLinkTest', function () {
                 </NavigationLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ button: true, preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, button: true, preventDefault: () => {} });
             assert.equal(stateNavigator.stateContext.state, null);
         })
     });
@@ -1557,9 +1551,8 @@ describe('NavigationLinkTest', function () {
                 </NavigationLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, preventDefault: () => {} });
             assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s']);
         })
     });
@@ -1579,9 +1572,8 @@ describe('NavigationLinkTest', function () {
                 </NavigationLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, preventDefault: () => {} });
             assert.equal(stateNavigator.stateContext.state, null);
         })
     });
@@ -1606,9 +1598,8 @@ describe('NavigationLinkTest', function () {
                 </NavigationLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            var evt = { preventDefault: () => {} };
+            var evt = { currentTarget: { href: link.props['href'] }, preventDefault: () => {} };
             link.props['onClick'](evt);
             assert.strictEqual(navigatingEvt, evt);
             assert.equal(navigatingLink, '/r');
@@ -1632,10 +1623,9 @@ describe('NavigationLinkTest', function () {
             );
             var link = renderer.getRenderOutput();
             var el = { href: null };
-            link['ref'](el);
             stateNavigator.navigate('s', { x: 'a' });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: el, preventDefault: () => {} });
             assert.equal(el.href, '#/r?x=a');
             assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s']);
             assert.equal(stateNavigator.stateContext.data.x, 'a');
@@ -1656,11 +1646,10 @@ describe('NavigationLinkTest', function () {
                 </NavigationLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
             var addHistory;
             stateNavigator.historyManager.addHistory = (url, replace) => { addHistory = !replace };
-            link.props['onClick']({ preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, preventDefault: () => {} });
             assert.strictEqual(addHistory, true);
         })
     });
@@ -1680,11 +1669,10 @@ describe('NavigationLinkTest', function () {
                 </NavigationLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
             var replaceHistory;
             stateNavigator.historyManager.addHistory = (url, replace) => { replaceHistory = replace };
-            link.props['onClick']({ preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, preventDefault: () => {} });
             assert.strictEqual(replaceHistory, true);
         })
     });
@@ -1704,11 +1692,10 @@ describe('NavigationLinkTest', function () {
                 </NavigationLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
             var noneHistory = true;
             stateNavigator.historyManager.addHistory = () => { noneHistory = false };
-            link.props['onClick']({ preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, preventDefault: () => {} });
             assert.strictEqual(noneHistory, true);
         })
     });

--- a/NavigationReact/test/RefreshLinkTest.tsx
+++ b/NavigationReact/test/RefreshLinkTest.tsx
@@ -1375,9 +1375,8 @@ describe('RefreshLinkTest', function () {
                 </RefreshLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, preventDefault: () => {} });
             assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s']);
         })
     });
@@ -1396,9 +1395,8 @@ describe('RefreshLinkTest', function () {
                 </RefreshLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ ctrlKey: true, preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, ctrlKey: true, preventDefault: () => {} });
             assert.equal(stateNavigator.stateContext.oldState, null);
         })
     });
@@ -1417,9 +1415,8 @@ describe('RefreshLinkTest', function () {
                 </RefreshLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ shiftKey: true, preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, shiftKey: true, preventDefault: () => {} });
             assert.equal(stateNavigator.stateContext.oldState, null);
         })
     });
@@ -1438,9 +1435,8 @@ describe('RefreshLinkTest', function () {
                 </RefreshLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ metaKey: true, preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, metaKey: true, preventDefault: () => {} });
             assert.equal(stateNavigator.stateContext.oldState, null);
         })
     });
@@ -1459,9 +1455,8 @@ describe('RefreshLinkTest', function () {
                 </RefreshLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ altKey: true, preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, altKey: true, preventDefault: () => {} });
             assert.equal(stateNavigator.stateContext.oldState, null);
         })
     });
@@ -1480,9 +1475,8 @@ describe('RefreshLinkTest', function () {
                 </RefreshLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ button: true, preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, button: true, preventDefault: () => {} });
             assert.equal(stateNavigator.stateContext.oldState, null);
         })
     });
@@ -1502,9 +1496,8 @@ describe('RefreshLinkTest', function () {
                 </RefreshLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, preventDefault: () => {} });
             assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s']);
         })
     });
@@ -1524,9 +1517,8 @@ describe('RefreshLinkTest', function () {
                 </RefreshLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, preventDefault: () => {} });
             assert.equal(stateNavigator.stateContext.oldState, null);
         })
     });
@@ -1544,15 +1536,15 @@ describe('RefreshLinkTest', function () {
                     navigating={(e, domId, link) => {
                         navigatingEvt = e;
                         navigatingLink = link;
+                        return true;
                     }}
                     stateNavigator={stateNavigator}>
                     link text
                 </RefreshLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            var evt = { preventDefault: () => {} };
+            var evt = { currentTarget: { href: link.props['href'] }, preventDefault: () => {} };
             link.props['onClick'](evt);
             assert.strictEqual(navigatingEvt, evt);
             assert.equal(navigatingLink, '/r');
@@ -1576,10 +1568,9 @@ describe('RefreshLinkTest', function () {
             );
             var link = renderer.getRenderOutput();
             var el = { href: null };
-            link['ref'](el);
             stateNavigator.navigate('s', { x: 'a' });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
-            link.props['onClick']({ preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: el, preventDefault: () => {} });
             assert.equal(el.href, '#/r?x=a');
             assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s']);
             assert.equal(stateNavigator.stateContext.data.x, 'a');
@@ -1600,11 +1591,10 @@ describe('RefreshLinkTest', function () {
                 </RefreshLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
             var addHistory;
             stateNavigator.historyManager.addHistory = (url, replace) => { addHistory = !replace };
-            link.props['onClick']({ preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, preventDefault: () => {} });
             assert.strictEqual(addHistory, true);
         })
     });
@@ -1624,11 +1614,10 @@ describe('RefreshLinkTest', function () {
                 </RefreshLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
             var replaceHistory;
             stateNavigator.historyManager.addHistory = (url, replace) => { replaceHistory = replace };
-            link.props['onClick']({ preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, preventDefault: () => {} });
             assert.strictEqual(replaceHistory, true);
         })
     });
@@ -1648,11 +1637,10 @@ describe('RefreshLinkTest', function () {
                 </RefreshLink>
             );
             var link = renderer.getRenderOutput();
-            link['ref']({ href: link.props['href'] });
             stateNavigator.historyManager.getUrl = (el) => el.href.substring(1);
             var noneHistory = true;
             stateNavigator.historyManager.addHistory = () => { noneHistory = false };
-            link.props['onClick']({ preventDefault: () => {} });
+            link.props['onClick']({ currentTarget: { href: link.props['href'] }, preventDefault: () => {} });
             assert.strictEqual(noneHistory, true);
         })
     });

--- a/NavigationReact/test/navigation-react-tests.tsx
+++ b/NavigationReact/test/navigation-react-tests.tsx
@@ -20,7 +20,7 @@ RefreshLinkTest = () => {
             disableActive={true}
             lazy={false}
             historyAction="replace"
-            navigating= {(e: MouseEvent, domId: string, link: string) => true}
+            navigating= {(e: React.MouseEvent<HTMLAnchorElement>, domId: string, link: string) => true}
             stateNavigator={stateNavigator}
             target="_blank"
             aria-label="Go to the second page of people">
@@ -43,7 +43,7 @@ NavigationLinkTest = () => {
             disableActive={false}
             lazy={false}
             historyAction="add"
-            navigating= {(e: MouseEvent, domId: string, link: string) => true}
+            navigating= {(e: React.MouseEvent<HTMLAnchorElement>, domId: string, link: string) => true}
             stateNavigator={stateNavigator}
             target="_blank"
             aria-label="View the person's details">
@@ -61,7 +61,7 @@ NavigationBackLinkTest = () => {
             distance={1}
             lazy={false}
             historyAction="none"
-            navigating= {(e: MouseEvent, domId: string, link: string) => true}
+            navigating= {(e: React.MouseEvent<HTMLAnchorElement>, domId: string, link: string) => true}
             stateNavigator={stateNavigator}
             target="_blank"
             aria-label="Go back to the list of people">

--- a/NavigationReact/test/node_modules/navigation-react.d.ts
+++ b/NavigationReact/test/node_modules/navigation-react.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { StateNavigator } from 'navigation';
-import { Component, HTMLProps } from 'react';
+import { Component, HTMLProps, MouseEvent } from 'react';
 
 /**
  * Defines the Link Props contract
@@ -21,7 +21,7 @@ export interface LinkProps extends HTMLProps<HTMLAnchorElement> {
     /**
      * Handles Link click events
      */
-    navigating?(e: MouseEvent, domId: string, link: string): boolean;
+    navigating?(e: MouseEvent<HTMLAnchorElement>, domId: string, link: string): boolean;
     /**
      * The State Navigator
      */


### PR DESCRIPTION
Current target points at the anchor even if, for example, a span inside the anchor is clicked. Not sure if React sets current target properly in ie8 (ie8 doesn't support it) but React doesn't support ie8 anymore not relevant.
The domId parameter isn't passed to React events anymore. Not sure if it ever was? Maybe it was in an old definitely typed?! Anyway, left it in the `navigating` parameters so it's not a breaking change, but hard-coded to undefined