### PR TITLE
Bumped Navigation React and Mobile version numbers

### DIFF
--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -42,7 +42,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
         };
     }
     private getStateNavigator(): StateNavigator {
-        return this.props.stateNavigator || this.context.stateNavigator;
+        return this.context.stateNavigator || this.props.stateNavigator;
     }
     componentDidMount() {
         this.getStateNavigator().onNavigate(this.onNavigate);

--- a/NavigationReactMobile/src/SharedElement.tsx
+++ b/NavigationReactMobile/src/SharedElement.tsx
@@ -22,7 +22,7 @@ class SharedElement extends React.Component<SharedElementProps, any> {
         unregisterSharedElement: () => null
     }
     private getStateNavigator(): StateNavigator {
-        return this.props.stateNavigator || this.context.stateNavigator;
+        return this.context.stateNavigator || this.props.stateNavigator;
     }
     componentDidMount() {
         this.register();

--- a/NavigationReactMobile/src/withStateNavigator.tsx
+++ b/NavigationReactMobile/src/withStateNavigator.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 export default Component => props => (
     <NavigationContext.Consumer>
-        {value => <Component stateNavigator={value && value.stateNavigator} {...props} />}
+        {({ stateNavigator }) => <Component stateNavigator={stateNavigator} {...props} />}
     </NavigationContext.Consumer>
 );
   

--- a/build/npm/navigation-react-mobile/package.json
+++ b/build/npm/navigation-react-mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navigation-react-mobile",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "React Mobile plugin for the Navigation router",
   "main": "navigation-react-mobile.js",
   "repository": {

--- a/build/npm/navigation-react/package.json
+++ b/build/npm/navigation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navigation-react",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "React plugin for the Navigation router",
   "main": "navigation-react.js",
   "repository": {

--- a/build/npm/navigation/package.json
+++ b/build/npm/navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navigation",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "The data-first JavaScript router",
   "main": "navigation.js",
   "repository": {


### PR DESCRIPTION
Fixed Navigation React Mobile to look for context state navigator before props now that a default StateNavigator is always passed in props