### PR TITLE
Render One Scene at a Time

### DIFF
--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -5,7 +5,7 @@ import Scene from './Scene';
 import SharedElementContext from './SharedElementContext';
 import withStateNavigator from './withStateNavigator';
 import { NavigationMotionProps, SharedItem } from './Props';
-type NavigationMotionState = { scenes: { [crumbs: number]: React.ReactElement<any> }, rest: boolean };
+type NavigationMotionState = { scenes: { [crumbs: number]: boolean }, rest: boolean };
 type SceneContext = { key: number, state: State, data: any, url: string, crumbs: Crumb[], nextState: State, nextData: any, scene: React.ReactElement<any>, mount: boolean };
 
 class NavigationMotion extends React.Component<NavigationMotionProps, NavigationMotionState> {
@@ -24,9 +24,9 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
             },
         }
         var scenes = {};
-        var {state, data, crumbs} = this.props.stateNavigator.stateContext;
+        var {state, crumbs} = this.props.stateNavigator.stateContext;
         if (state)
-            scenes[crumbs.length] = state.renderScene(data);
+            scenes[crumbs.length] = true;
         this.state = {scenes, rest: false};
     }
     static defaultProps = {
@@ -34,7 +34,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
     }
     static getDerivedStateFromProps({stateNavigator}, {scenes: prevScenes}) {
         var {state, data, crumbs} = stateNavigator.stateContext;
-        var scenes = {...prevScenes, [crumbs.length]: state.renderScene(data)};
+        var scenes = {...prevScenes, [crumbs.length]: true};
         return {scenes, rest: false};
     }
     getSharedElements(crumbs, oldUrl) {
@@ -70,7 +70,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
             var preCrumbs = crumbsAndNext.slice(0, index);
             var {state: nextState, data: nextData} = crumbsAndNext[index + 1] || {state: undefined, data: undefined};
             var {scenes} = this.state;
-            var scene = scenes[index] ? <Scene index={index} crumbs={crumbs.length}>{scenes[index]}</Scene> : null;
+            var scene = scenes[index] ? <Scene index={index} crumbs={crumbs.length}>{state.renderScene(data)}</Scene> : null;
             return {key: index, state, data, url, crumbs: preCrumbs, nextState, nextData, scene, mount: url === nextCrumb.url};
         });
     }

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -30,7 +30,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
         duration: 300
     }
     static getDerivedStateFromProps({stateNavigator}, {scenes: prevScenes}) {
-        var {state, data, crumbs} = stateNavigator.stateContext;
+        var {crumbs} = stateNavigator.stateContext;
         var scenes = {...prevScenes, [crumbs.length]: true};
         return {scenes, rest: false};
     }

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -70,7 +70,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
             var preCrumbs = crumbsAndNext.slice(0, index);
             var {state: nextState, data: nextData} = crumbsAndNext[index + 1] || {state: undefined, data: undefined};
             var {scenes} = this.state;
-            var scene = scenes[index] ? <Scene crumbs={index} stateNavigator={stateNavigator}>{scenes[index]}</Scene> : null;
+            var scene = scenes[index] ? <Scene index={index} crumbs={crumbs.length}>{scenes[index]}</Scene> : null;
             return {key: index, state, data, url, crumbs: preCrumbs, nextState, nextData, scene, mount: url === nextCrumb.url};
         });
     }

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -90,7 +90,8 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
                     duration={duration}>
                     {tweenStyles => (
                         tweenStyles.map(({data: {key, state, data, url}, style: tweenStyle}) => {
-                            var scene = this.state.scenes[key] && <Scene index={key} crumbs={crumbs.length}>{state.renderScene(data)}</Scene>;
+                            var scene = this.state.scenes[key] &&
+                                <Scene index={key} crumbs={crumbs.length}>{state.renderScene(data)}</Scene>;
                             return children(tweenStyle, scene, key, crumbs.length === key, state, data)
                         }).concat(
                             sharedElementMotion && sharedElementMotion({

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -31,8 +31,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
     }
     static getDerivedStateFromProps({stateNavigator}, {scenes: prevScenes}) {
         var {crumbs} = stateNavigator.stateContext;
-        var scenes = {...prevScenes, [crumbs.length]: true};
-        return {scenes, rest: false};
+        return {scenes: {...prevScenes, [crumbs.length]: true}, rest: false};
     }
     getSharedElements(crumbs, oldUrl) {
         if (oldUrl === null || crumbs.length === oldUrl.split('crumb=').length - 1)

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -52,12 +52,13 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
         return sharedElements;
     }
     clearScene(index) {
-        this.setState(({rest: prevRest}) => {
+        this.setState(({scenes: prevScenes, rest: prevRest}) => {
             var scene = this.getScenes().filter(scene => scene.key === index)[0];
             if (!scene)
                 delete this.sharedElements[index];
+            var scenes = {...prevScenes, [index]: !!scene};
             var rest = prevRest || (scene && scene.mount);
-            return rest !== prevRest ? {rest} : null;
+            return !scene || rest !== prevRest ? {scenes, rest} : null;
         });
     }
     getScenes(): SceneContext[]{

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -56,7 +56,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
             var scene = this.getScenes().filter(scene => scene.key === index)[0];
             if (!scene)
                 delete this.sharedElements[index];
-            var scenes = {...prevScenes, [index]: prevScenes[index] && !!scene};
+            var scenes = {...prevScenes, [index]: !!(prevScenes[index] && scene)};
             var rest = prevRest || (scene && scene.mount);
             return (scenes[index] !== prevScenes[index] || rest !== prevRest) ? {scenes, rest} : null;
         });

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -6,7 +6,7 @@ import SharedElementContext from './SharedElementContext';
 import withStateNavigator from './withStateNavigator';
 import { NavigationMotionProps, SharedItem } from './Props';
 type NavigationMotionState = { scenes: { [crumbs: number]: boolean }, rest: boolean };
-type SceneContext = { key: number, state: State, data: any, url: string, crumbs: Crumb[], nextState: State, nextData: any, scene: React.ReactElement<any>, mount: boolean };
+type SceneContext = { key: number, state: State, data: any, url: string, crumbs: Crumb[], nextState: State, nextData: any, mount: boolean };
 
 class NavigationMotion extends React.Component<NavigationMotionProps, NavigationMotionState> {
     private sharedElements: { [scene: number]: { [name: string]: { ref: HTMLElement; data: any }; }; } = {};
@@ -66,9 +66,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
         return crumbs.concat(nextCrumb).map(({state, data, url}, index, crumbsAndNext) => {
             var preCrumbs = crumbsAndNext.slice(0, index);
             var {state: nextState, data: nextData} = crumbsAndNext[index + 1] || {state: undefined, data: undefined};
-            var {scenes} = this.state;
-            var scene = scenes[index] ? <Scene index={index} crumbs={crumbs.length}>{state.renderScene(data)}</Scene> : null;
-            return {key: index, state, data, url, crumbs: preCrumbs, nextState, nextData, scene, mount: url === nextCrumb.url};
+            return {key: index, state, data, url, crumbs: preCrumbs, nextState, nextData, mount: url === nextCrumb.url};
         });
     }
     getStyle(mounted: boolean, {state, data, crumbs, nextState, nextData, mount}: SceneContext) {
@@ -91,9 +89,10 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
                     onRest={({key}) => this.clearScene(key)}
                     duration={duration}>
                     {tweenStyles => (
-                        tweenStyles.map(({data: {key, state, data, url, scene}, style: tweenStyle}) => (
-                            children(tweenStyle, scene, key, crumbs.length === key, state, data)
-                        )).concat(
+                        tweenStyles.map(({data: {key, state, data, url}, style: tweenStyle}) => {
+                            var scene = this.state.scenes[key] && <Scene index={key} crumbs={crumbs.length}>{state.renderScene(data)}</Scene>;
+                            return children(tweenStyle, scene, key, crumbs.length === key, state, data)
+                        }).concat(
                             sharedElementMotion && sharedElementMotion({
                                 key: 'sharedElements',
                                 sharedElements: !this.state.rest ? this.getSharedElements(crumbs, oldUrl) : [],

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -23,11 +23,8 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
                     delete this.sharedElements[scene][name];
             },
         }
-        var scenes = {};
         var {state, crumbs} = this.props.stateNavigator.stateContext;
-        if (state)
-            scenes[crumbs.length] = true;
-        this.state = {scenes, rest: false};
+        this.state = {scenes: {[crumbs.length]: !!state}, rest: false};
     }
     static defaultProps = {
         duration: 300

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -56,9 +56,9 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
             var scene = this.getScenes().filter(scene => scene.key === index)[0];
             if (!scene)
                 delete this.sharedElements[index];
-            var scenes = {...prevScenes, [index]: !!scene};
+            var scenes = {...prevScenes, [index]: prevScenes[index] && !!scene};
             var rest = prevRest || (scene && scene.mount);
-            return !scene || rest !== prevRest ? {scenes, rest} : null;
+            return (scenes[index] !== prevScenes[index] || rest !== prevRest) ? {scenes, rest} : null;
         });
     }
     getScenes(): SceneContext[]{

--- a/NavigationReactMobile/src/Props.ts
+++ b/NavigationReactMobile/src/Props.ts
@@ -55,8 +55,8 @@ interface NavigationMotionProps {
 }
 
 interface SceneProps {
+    index: number;
     crumbs: number;
-    stateNavigator: StateNavigator;
 }
 
 export { MotionProps, SharedElementProps, SharedItem, SharedElementNavigationMotionProps, SharedElementMotionProps, NavigationMotionProps, SceneProps }

--- a/NavigationReactMobile/src/Props.ts
+++ b/NavigationReactMobile/src/Props.ts
@@ -54,5 +54,10 @@ interface NavigationMotionProps {
     children: (style: any, scene: ReactElement<any>, key: number, active: boolean, state: State, data: any) => ReactElement<any>;
 }
 
-export { MotionProps, SharedElementProps, SharedItem, SharedElementNavigationMotionProps, SharedElementMotionProps, NavigationMotionProps }
+interface SceneProps {
+    crumbs: number;
+    stateNavigator: StateNavigator;
+}
+
+export { MotionProps, SharedElementProps, SharedItem, SharedElementNavigationMotionProps, SharedElementMotionProps, NavigationMotionProps, SceneProps }
 

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -3,7 +3,7 @@ import { SceneProps } from './Props';
 
 class Scene extends React.Component<SceneProps, any> {
     shouldComponentUpdate(props: SceneProps) {
-        return props.crumbs === props.stateNavigator.stateContext.crumbs.length;
+        return props.index === props.crumbs;
     }
     render() {
         return this.props.children;

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
+import { SceneProps } from './Props';
 
-class Scene extends React.Component<any, any> {
-    shouldComponentUpdate(props) {
+class Scene extends React.Component<SceneProps, any> {
+    shouldComponentUpdate(props: SceneProps) {
         return props.crumbs === props.stateNavigator.stateContext.crumbs.length;
     }
     render() {

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -4,7 +4,7 @@ class Scene extends React.Component<any, any> {
     private index: number;
     constructor(props) {
         super(props);
-        this.index = props.stateNavigator.stateContext.crumbs.length;
+        this.index = props.crumbs;
     }
     shouldComponentUpdate(props) {
         return this.index === props.stateNavigator.stateContext.crumbs.length;

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -1,13 +1,8 @@
 import * as React from 'react';
 
 class Scene extends React.Component<any, any> {
-    private index: number;
-    constructor(props) {
-        super(props);
-        this.index = props.crumbs;
-    }
     shouldComponentUpdate(props) {
-        return this.index === props.stateNavigator.stateContext.crumbs.length;
+        return props.crumbs === props.stateNavigator.stateContext.crumbs.length;
     }
     render() {
         return this.props.children;


### PR DESCRIPTION
When `renderScene` was moved into `render` of `NavigationMotion` then all Scenes are rendered together. This works when progressing through the Scenes one by one, but if start on the second Scene then don't want to render the first Scene until navigate back to it.

Stored a boolean in `state` that indicates whether a Scene should be rendered - whether it's ever been navigated to - and only call `renderScene` when true. 