### PR TITLE
Improved Shared Element Navigation Performance

### DIFF
--- a/NavigationReactMobile/sample/twitter/PhotoZoom.js
+++ b/NavigationReactMobile/sample/twitter/PhotoZoom.js
@@ -6,16 +6,18 @@ export default (props) => (
     {...props}
     onAnimating={(name, ref) => {ref.style.opacity = 0}}
     onAnimated={(name, ref) => {ref.style.opacity = 1}}>
-    {({left, top, width, height}, name, {src}) => (
+    {(style, name, {left, top, width, height, src}) => (
       <img key={name}
         src={src}
         style={{
           position: 'absolute',
-          left,
-          top,
-          width,
-          height,
-        }}/>
+          left, top, width, height,
+          transformOrigin: 'top left',
+          transform: `
+            translate(${style.left - left}px, ${style.top - top}px)
+            scale(${style.width / width}, ${style.height / height})
+          `,      
+          }}/>
     )}
   </SharedElementMotion>
 );

--- a/NavigationReactMobile/sample/zoom/Detail.js
+++ b/NavigationReactMobile/sample/zoom/Detail.js
@@ -12,11 +12,13 @@ export default ({color, stateNavigator}) => (
       data={{color}}>
       <div style={{backgroundColor: color}} />
     </SharedElement>
-    <SharedElement
-      name={`text${color}`}
-      data={{color, fontSize: 300, fontColor: 0}}>
-      <div>{color}</div>
-    </SharedElement>
+    <div>
+      <SharedElement
+        name={`text${color}`}
+        data={{color, fontSize: 300, fontColor: 0}}>
+        <span>{color}</span>
+      </SharedElement>
+    </div>
   </div>
 );
 

--- a/NavigationReactMobile/sample/zoom/Grid.js
+++ b/NavigationReactMobile/sample/zoom/Grid.js
@@ -22,7 +22,7 @@ export default () => (
               <SharedElement
                 data={{color, fontSize: 150, fontColor: 255}}
                 name={`text${color}`}>
-                <div>{color}</div>
+                <span>{color}</span>
               </SharedElement>
             </div>
           </NavigationLink>

--- a/NavigationReactMobile/sample/zoom/ZoomShared.js
+++ b/NavigationReactMobile/sample/zoom/ZoomShared.js
@@ -6,40 +6,33 @@ export default (props) => (
     {...props}
     onAnimating={(name, ref) => {ref.style.opacity = 0}}
     onAnimated={(name, ref) => {ref.style.opacity = 1}}>
-    {({fontColor, ...style}, name, {left, top, width, height, fontSize, color}) => (
-      !name.startsWith('text') ? <div key={name}
+    {({fontColor, ...style}, name, {left, top, width, height, fontSize, color}) => {
+      var position = {
+        position: 'absolute',
+        left,
+        top,
+        width,
+        height,
+        transformOrigin: 'top left',
+        transform: `
+          translate(${style.left - left}px, ${style.top - top}px)
+          scale(${style.width / width}, ${style.height / height})
+        `,      
+      };
+      return !name.startsWith('text') ? <div key={name}
         style={{
-          position: 'absolute',
-          left,
-          top,
-          width,
-          height,
+          ...position,
           backgroundColor: color,
-          transformOrigin: 'top left',
-          transform: `
-            translate(${style.left - left}px, ${style.top - top}px)
-            scale(${style.width / width}, ${style.height / height})
-          `,
         }}>
       </div> : <div key={name}     
         style={{
-          position: 'absolute',
-          left,
-          top,
-          width,
-          height,
+          ...position,
           fontSize: `${fontSize}%`,
-          textAlign: 'center',
           color: `rgb(${Array(3).fill(Math.round(fontColor)).join(',')})`,
           zIndex: 1,
-          transformOrigin: 'top left',
-          transform: `
-            translate(${style.left - left}px, ${style.top - top}px)
-            scale(${style.width / width}, ${style.height / height})
-          `,
         }}>
           {color}
         </div>
-    )}
+    }}
   </SharedElementMotion>
 );

--- a/NavigationReactMobile/sample/zoom/ZoomShared.js
+++ b/NavigationReactMobile/sample/zoom/ZoomShared.js
@@ -16,7 +16,10 @@ export default (props) => (
           height,
           backgroundColor: color,
           transformOrigin: 'top left',
-          transform: `translate(${style.left - left}px, ${style.top - top}px) scale(${style.width/width}, ${style.height/height})`,
+          transform: `
+            translate(${style.left - left}px, ${style.top - top}px)
+            scale(${style.width / width}, ${style.height / height})
+          `,
         }}>
       </div> : <div key={name}     
         style={{
@@ -30,7 +33,10 @@ export default (props) => (
           color: `rgb(${Array(3).fill(Math.round(fontColor)).join(',')})`,
           zIndex: 1,
           transformOrigin: 'top left',
-          transform: `translate(${style.left - left}px, ${style.top - top}px) scale(${style.width/width}, ${style.height/height})`,
+          transform: `
+            translate(${style.left - left}px, ${style.top - top}px)
+            scale(${style.width / width}, ${style.height / height})
+          `,
         }}>
           {color}
         </div>

--- a/NavigationReactMobile/sample/zoom/ZoomShared.js
+++ b/NavigationReactMobile/sample/zoom/ZoomShared.js
@@ -6,7 +6,7 @@ export default (props) => (
     {...props}
     onAnimating={(name, ref) => {ref.style.opacity = 0}}
     onAnimated={(name, ref) => {ref.style.opacity = 1}}>
-    {({left, top, width, height, fontSize, fontColor}, name, {color}) => (
+    {({fontColor, ...style}, name, {left, top, width, height, fontSize, color}) => (
       !name.startsWith('text') ? <div key={name}
         style={{
           position: 'absolute',
@@ -15,6 +15,8 @@ export default (props) => (
           width,
           height,
           backgroundColor: color,
+          transformOrigin: 'top left',
+          transform: `translate(${style.left - left}px, ${style.top - top}px) scale(${style.width/width}, ${style.height/height})`,
         }}>
       </div> : <div key={name}     
         style={{
@@ -27,6 +29,8 @@ export default (props) => (
           textAlign: 'center',
           color: `rgb(${Array(3).fill(Math.round(fontColor)).join(',')})`,
           zIndex: 1,
+          transformOrigin: 'top left',
+          transform: `translate(${style.left - left}px, ${style.top - top}px) scale(${style.width/width}, ${style.height/height})`,
         }}>
           {color}
         </div>

--- a/NavigationReactMobile/sample/zoom/ZoomShared.js
+++ b/NavigationReactMobile/sample/zoom/ZoomShared.js
@@ -9,10 +9,7 @@ export default (props) => (
     {({fontColor, ...style}, name, {left, top, width, height, fontSize, color}) => {
       var position = {
         position: 'absolute',
-        left,
-        top,
-        width,
-        height,
+        left, top, width, height,
         transformOrigin: 'top left',
         transform: `
           translate(${style.left - left}px, ${style.top - top}px)

--- a/NavigationReactMobile/src/Props.ts
+++ b/NavigationReactMobile/src/Props.ts
@@ -11,7 +11,7 @@ interface MotionProps<T> {
     leave?: (item: T) => any;
     onRest?: (item: T) => void;
     progress?: number;
-    children: (items: {style: any, data: T, key: string | number, progress: number }[]) => ReactElement<any>[];
+    children: (items: {style: any, data: T, key: string | number, progress: number, start: any, end: any }[]) => ReactElement<any>[];
 }
 
 interface SharedElementProps {

--- a/NavigationReactMobile/src/SharedElementMotion.tsx
+++ b/NavigationReactMobile/src/SharedElementMotion.tsx
@@ -30,9 +30,12 @@ class SharedElementMotion extends React.Component<SharedElementNavigationMotionP
     getSharedElements(sharedElements: SharedItem[]): { [name: string]: SharedItem } {
         return sharedElements.reduce((elements, element) => ({...elements, [element.name]: element}), {});
     }
+    addMeasurements(data, measurements) {
+        var { top, left, width, height } = measurements;
+        return { top, left, width, height, ...data};
+    }
     getStyle(name, {ref, data}) {
-        var { top, left, width, height } = ref.getBoundingClientRect();
-        return this.props.elementStyle(name, ref, { top, left, width, height, ...data});
+        return this.props.elementStyle(name, ref, this.addMeasurements(data, ref.getBoundingClientRect()));
     }
     getPropValue(prop, name) {
         return typeof prop === 'function' ? prop(name) : prop;
@@ -49,9 +52,11 @@ class SharedElementMotion extends React.Component<SharedElementNavigationMotionP
                 progress={progress < 1 ? progress : 0}
                 duration={duration}>
                 {tweenStyles => (
-                    tweenStyles.map(({data: {name, oldElement, mountedElement}, style: tweenStyle}) => (
-                        children(tweenStyle, name, oldElement.data, mountedElement.data)
-                    ))
+                    tweenStyles.map(({data: {name, oldElement, mountedElement}, style, start, end}) => {
+                        var oldElementData = this.addMeasurements(oldElement.data, start);
+                        var mountedElementData = this.addMeasurements(mountedElement.data, end);
+                        return children(style, name, oldElementData, mountedElementData)
+                    })
                 )}
             </ElementMotion>
         );

--- a/NavigationReactMobile/src/SharedElementMotion.tsx
+++ b/NavigationReactMobile/src/SharedElementMotion.tsx
@@ -30,12 +30,9 @@ class SharedElementMotion extends React.Component<SharedElementNavigationMotionP
     getSharedElements(sharedElements: SharedItem[]): { [name: string]: SharedItem } {
         return sharedElements.reduce((elements, element) => ({...elements, [element.name]: element}), {});
     }
-    addMeasurements(data, measurements) {
-        var { top, left, width, height } = measurements;
-        return { top, left, width, height, ...data};
-    }
     getStyle(name, {ref, data}) {
-        return this.props.elementStyle(name, ref, this.addMeasurements(data, ref.getBoundingClientRect()));
+        var { top, left, width, height } = ref.getBoundingClientRect();
+        return this.props.elementStyle(name, ref, { top, left, width, height, ...data});
     }
     getPropValue(prop, name) {
         return typeof prop === 'function' ? prop(name) : prop;
@@ -52,11 +49,9 @@ class SharedElementMotion extends React.Component<SharedElementNavigationMotionP
                 progress={progress < 1 ? progress : 0}
                 duration={duration}>
                 {tweenStyles => (
-                    tweenStyles.map(({data: {name, oldElement, mountedElement}, style, start, end}) => {
-                        var oldElementData = this.addMeasurements(oldElement.data, start);
-                        var mountedElementData = this.addMeasurements(mountedElement.data, end);
-                        return children(style, name, oldElementData, mountedElementData)
-                    })
+                    tweenStyles.map(({data: {name, oldElement, mountedElement}, style, start, end}) => (
+                        children(style, name, {...start, ...oldElement.data}, {...end, ...mountedElement.data})
+                    ))
                 )}
             </ElementMotion>
         );


### PR DESCRIPTION
As per advice from [High Performance Animations](https://www.html5rocks.com/en/tutorials/speed/high-performance-animations/), changed Shared Element Navigations to transformations (translate and scale) instead of changing top, left, width and height.