### PR TITLE
Isolated a Scene's Navigation Context

### DIFF
--- a/NavigationReact/src/NavigationBackLink.tsx
+++ b/NavigationReact/src/NavigationBackLink.tsx
@@ -10,7 +10,6 @@ var NavigationBackLink = (props: NavigationBackLinkProps) => {
             htmlProps[key] = props[key];
     }
     var { distance, stateNavigator, children } = props;
-    var { state } = stateNavigator.stateContext;
     try {
         var link = stateNavigator.getNavigationBackLink(distance);
     } catch {}

--- a/NavigationReact/src/NavigationBackLink.tsx
+++ b/NavigationReact/src/NavigationBackLink.tsx
@@ -2,34 +2,20 @@
 import withStateNavigator from './withStateNavigator';
 import { NavigationBackLinkProps } from './Props';
 import * as React from 'react';
-type NavigationBackLinkState = { link?: string, crumb?: number };
 
-class NavigationBackLink extends React.Component<NavigationBackLinkProps, NavigationBackLinkState> {
-    constructor(props) {
-        super(props);
-        this.state = { crumb: props.stateNavigator.stateContext.crumbs.length };
+var NavigationBackLink = (props: NavigationBackLinkProps) => {
+    var htmlProps: any = {};
+    for(var key in props) {
+        if (LinkUtility.isValidAttribute(key))
+            htmlProps[key] = props[key];
     }
-
-    static getDerivedStateFromProps(props, { crumb }) {
-        var { acrossCrumbs, distance, stateNavigator } = props;
-        var { crumbs, state } = stateNavigator.stateContext;
-        if (!acrossCrumbs && crumb !== crumbs.length)
-            return null;
-        try {
-            var link = stateNavigator.getNavigationBackLink(distance);
-        } catch {}
-        return { link };
-    }
-
-    render() {
-        var props: any = {};
-        for(var key in this.props) {
-            if (LinkUtility.isValidAttribute(key))
-                props[key] = this.props[key];
-        }
-        props.href = this.state.link && this.props.stateNavigator.historyManager.getHref(this.state.link);
-        props.onClick = LinkUtility.getOnClick(this.props.stateNavigator, this.props, this.state.link);
-        return <a {...props}>{this.props.children}</a>;
-    }
-};
+    var { distance, stateNavigator, children } = props;
+    var { state } = stateNavigator.stateContext;
+    try {
+        var link = stateNavigator.getNavigationBackLink(distance);
+    } catch {}
+    htmlProps.href = link && stateNavigator.historyManager.getHref(link);
+    htmlProps.onClick = LinkUtility.getOnClick(stateNavigator, props, link);
+    return <a {...htmlProps}>{children}</a>;
+}
 export default withStateNavigator(NavigationBackLink);

--- a/NavigationReact/src/NavigationLink.tsx
+++ b/NavigationReact/src/NavigationLink.tsx
@@ -9,7 +9,7 @@ var NavigationLink = (props: NavigationLinkProps) => {
         if (LinkUtility.isValidAttribute(key))
             htmlProps[key] = props[key];
     }
-    var { stateKey, navigationData, includeCurrentData, currentDataKeys, stateNavigator } = props;
+    var { stateKey, navigationData, includeCurrentData, currentDataKeys, stateNavigator, children } = props;
     var { state } = stateNavigator.stateContext;
     navigationData = LinkUtility.getData(stateNavigator, navigationData, includeCurrentData, currentDataKeys);
     try {
@@ -19,7 +19,7 @@ var NavigationLink = (props: NavigationLinkProps) => {
     htmlProps.href = link && stateNavigator.historyManager.getHref(link);
     htmlProps.onClick = LinkUtility.getOnClick(stateNavigator, props, link);
     LinkUtility.setActive(active, props, htmlProps);
-    return <a {...htmlProps}>{props.children}</a>;
+    return <a {...htmlProps}>{children}</a>;
 }
 
 export default withStateNavigator(NavigationLink);

--- a/NavigationReact/src/NavigationLink.tsx
+++ b/NavigationReact/src/NavigationLink.tsx
@@ -2,36 +2,24 @@
 import withStateNavigator from './withStateNavigator';
 import { NavigationLinkProps } from './Props';
 import * as React from 'react';
-type NavigationLinkState = { link?: string, active?: boolean, crumb?: number };
 
-class NavigationLink extends React.Component<NavigationLinkProps, NavigationLinkState> {
-    constructor(props) {
-        super(props);
-        this.state = { crumb: props.stateNavigator.stateContext.crumbs.length };
+var NavigationLink = (props: NavigationLinkProps) => {
+    var htmlProps: any = {};
+    for(var key in props) {
+        if (LinkUtility.isValidAttribute(key))
+            htmlProps[key] = props[key];
     }
+    var { stateKey, navigationData, includeCurrentData, currentDataKeys, stateNavigator } = props;
+    var { state } = stateNavigator.stateContext;
+    navigationData = LinkUtility.getData(stateNavigator, navigationData, includeCurrentData, currentDataKeys);
+    try {
+        var link = stateNavigator.getNavigationLink(stateKey, navigationData);
+    } catch {}
+    var active = state && state.key === stateKey && LinkUtility.isActive(stateNavigator, navigationData);
+    htmlProps.href = link && stateNavigator.historyManager.getHref(link);
+    htmlProps.onClick = LinkUtility.getOnClick(stateNavigator, props, link);
+    LinkUtility.setActive(active, props, htmlProps);
+    return <a {...htmlProps}>{props.children}</a>;
+}
 
-    static getDerivedStateFromProps(props, { crumb }) {
-        var { acrossCrumbs, stateKey, navigationData, includeCurrentData, currentDataKeys, stateNavigator } = props;
-        var { crumbs, state } = stateNavigator.stateContext;
-        if (!acrossCrumbs && crumb !== crumbs.length)
-            return null;
-        navigationData = LinkUtility.getData(stateNavigator, navigationData, includeCurrentData, currentDataKeys);
-        try {
-            var link = stateNavigator.getNavigationLink(stateKey, navigationData);
-        } catch {}
-        return { link, active: state && state.key === stateKey && LinkUtility.isActive(stateNavigator, navigationData) };
-    }
-
-    render() {
-        var props: any = {};
-        for(var key in this.props) {
-            if (LinkUtility.isValidAttribute(key))
-                props[key] = this.props[key];
-        }
-        props.href = this.state.link && this.props.stateNavigator.historyManager.getHref(this.state.link);
-        props.onClick = LinkUtility.getOnClick(this.props.stateNavigator, this.props, this.state.link);
-        LinkUtility.setActive(this.state.active, this.props, props);
-        return <a {...props}>{this.props.children}</a>;
-    }
-};
 export default withStateNavigator(NavigationLink);

--- a/NavigationReact/src/NavigationLink.tsx
+++ b/NavigationReact/src/NavigationLink.tsx
@@ -21,5 +21,4 @@ var NavigationLink = (props: NavigationLinkProps) => {
     LinkUtility.setActive(active, props, htmlProps);
     return <a {...htmlProps}>{children}</a>;
 }
-
 export default withStateNavigator(NavigationLink);

--- a/NavigationReact/src/Props.ts
+++ b/NavigationReact/src/Props.ts
@@ -2,7 +2,6 @@ import AsyncStateNavigator from './AsyncStateNavigator';
 import { AnchorHTMLAttributes, DetailedHTMLProps, MouseEvent } from 'react';
 
 interface LinkProps extends DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> {
-    acrossCrumbs?: boolean;
     historyAction?: 'add' | 'replace' | 'none';
     navigating?: (e: MouseEvent<HTMLAnchorElement>, link: string) => boolean;
     defer?: boolean;

--- a/NavigationReact/src/RefreshLink.tsx
+++ b/NavigationReact/src/RefreshLink.tsx
@@ -2,36 +2,24 @@
 import withStateNavigator from './withStateNavigator';
 import { RefreshLinkProps } from './Props';
 import * as React from 'react';
-type RefreshLinkState = { link?: string, active?: boolean, crumb?: number };
 
-class RefreshLink extends React.Component<RefreshLinkProps, RefreshLinkState> {
-    constructor(props) {
-        super(props);
-        this.state = { crumb: props.stateNavigator.stateContext.crumbs.length };
+var RefreshLink = (props: RefreshLinkProps) => {
+    var htmlProps: any = {};
+    for(var key in props) {
+        if (LinkUtility.isValidAttribute(key))
+            htmlProps[key] = props[key];
     }
+    var { navigationData, includeCurrentData, currentDataKeys, stateNavigator, children } = props;
+    var { state } = stateNavigator.stateContext;
+    navigationData = LinkUtility.getData(stateNavigator, navigationData, includeCurrentData, currentDataKeys);
+    try {
+        var link = stateNavigator.getRefreshLink(navigationData);
+    } catch {}
+    var active = LinkUtility.isActive(stateNavigator, navigationData);
+    htmlProps.href = link && stateNavigator.historyManager.getHref(link);
+    htmlProps.onClick = LinkUtility.getOnClick(stateNavigator, props, link);
+    LinkUtility.setActive(active, props, htmlProps);
+    return <a {...htmlProps}>{children}</a>;
+}
 
-    static getDerivedStateFromProps(props, { crumb }) {
-        var { acrossCrumbs, navigationData, includeCurrentData, currentDataKeys, stateNavigator } = props;
-        var { crumbs, state } = stateNavigator.stateContext;
-        if (!acrossCrumbs && crumb !== crumbs.length)
-            return null;
-        navigationData = LinkUtility.getData(stateNavigator, navigationData, includeCurrentData, currentDataKeys);
-        try {
-            var link = stateNavigator.getRefreshLink(navigationData);
-        } catch {}
-        return { link, active: LinkUtility.isActive(stateNavigator, navigationData) };
-    }
-    
-    render() {
-        var props: any = {};
-        for(var key in this.props) {
-            if (LinkUtility.isValidAttribute(key))
-                props[key] = this.props[key];
-        }
-        props.href = this.state.link && this.props.stateNavigator.historyManager.getHref(this.state.link);
-        props.onClick = LinkUtility.getOnClick(this.props.stateNavigator, this.props, this.state.link);
-        LinkUtility.setActive(this.state.active, this.props, props);
-        return <a {...props}>{this.props.children}</a>;
-    }
-};
 export default withStateNavigator(RefreshLink);

--- a/NavigationReact/src/RefreshLink.tsx
+++ b/NavigationReact/src/RefreshLink.tsx
@@ -21,5 +21,4 @@ var RefreshLink = (props: RefreshLinkProps) => {
     LinkUtility.setActive(active, props, htmlProps);
     return <a {...htmlProps}>{children}</a>;
 }
-
 export default withStateNavigator(RefreshLink);

--- a/NavigationReact/src/RefreshLink.tsx
+++ b/NavigationReact/src/RefreshLink.tsx
@@ -10,7 +10,6 @@ var RefreshLink = (props: RefreshLinkProps) => {
             htmlProps[key] = props[key];
     }
     var { navigationData, includeCurrentData, currentDataKeys, stateNavigator, children } = props;
-    var { state } = stateNavigator.stateContext;
     navigationData = LinkUtility.getData(stateNavigator, navigationData, includeCurrentData, currentDataKeys);
     try {
         var link = stateNavigator.getRefreshLink(navigationData);

--- a/NavigationReact/test/NavigationBackLinkTest.tsx
+++ b/NavigationReact/test/NavigationBackLinkTest.tsx
@@ -88,7 +88,6 @@ describe('NavigationBackLinkTest', function () {
                 <NavigationHandler stateNavigator={stateNavigator}>
                     <NavigationBackLink
                         distance={1}
-                        acrossCrumbs={false}
                         historyAction='replace'
                         navigating={() => false}
                         aria-label="z"
@@ -407,30 +406,6 @@ describe('NavigationBackLinkTest', function () {
     });
 
     describe('Crumb Trail Navigate Navigation Back Link', function () {
-        it('should not update', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 's0', route: 'r0' },
-                { key: 's1', route: 'r1', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('s0');
-            stateNavigator.navigate('s1');
-            var container = document.createElement('div');
-            ReactDOM.render(
-                <NavigationHandler stateNavigator={stateNavigator}>
-                    <NavigationBackLink distance={1}>
-                        link text
-                    </NavigationBackLink>
-                </NavigationHandler>,
-                container
-            );
-            var link = container.querySelector<HTMLAnchorElement>('a');
-            assert.equal(link.hash, '#/r0');
-            stateNavigator.navigate('s1');
-            assert.equal(link.hash, '#/r0');
-        })
-    });
-
-    describe('Across Crumbs Crumb Trail Navigate Navigation Back Link', function () {
         it('should update', function(){
             var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
@@ -441,9 +416,7 @@ describe('NavigationBackLinkTest', function () {
             var container = document.createElement('div');
             ReactDOM.render(
                 <NavigationHandler stateNavigator={stateNavigator}>
-                    <NavigationBackLink
-                        acrossCrumbs={true}
-                        distance={1}>
+                    <NavigationBackLink distance={1}>
                         link text
                     </NavigationBackLink>
                 </NavigationHandler>,
@@ -525,9 +498,7 @@ describe('NavigationBackLinkTest', function () {
             var container = document.createElement('div');
             ReactDOM.render(
                 <NavigationHandler stateNavigator={stateNavigator}>
-                    <NavigationBackLink
-                        distance={1}
-                        acrossCrumbs={true}>
+                    <NavigationBackLink distance={1}>
                         link text
                     </NavigationBackLink>
                 </NavigationHandler>,
@@ -670,7 +641,7 @@ describe('NavigationBackLinkTest', function () {
         })
     });
 
-    describe('Across Crumbs Deferred Navigation Back Link', function () {
+    describe('Deferred Navigation Back Link', function () {
         it('should update async', function(done){
             var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
@@ -688,9 +659,7 @@ describe('NavigationBackLinkTest', function () {
                         defer={true}>
                         link text
                     </NavigationBackLink>
-                    <NavigationBackLink
-                        distance={1}
-                        acrossCrumbs={true}>
+                    <NavigationBackLink distance={1}>
                         link text
                     </NavigationBackLink>
                 </NavigationHandler>,
@@ -757,7 +726,6 @@ describe('NavigationBackLinkTest', function () {
                     </NavigationBackLink>
                     <NavigationBackLink
                         distance={1}
-                        acrossCrumbs={true}
                         defer={true}>
                         link text
                     </NavigationBackLink>

--- a/NavigationReact/test/NavigationLinkTest.tsx
+++ b/NavigationReact/test/NavigationLinkTest.tsx
@@ -85,7 +85,6 @@ describe('NavigationLinkTest', function () {
                         currentDataKeys="y"
                         activeCssClass="active"
                         disableActive={true}
-                        acrossCrumbs={false}
                         historyAction='replace'
                         navigating={() => false}
                         aria-label="z"
@@ -1618,32 +1617,6 @@ describe('NavigationLinkTest', function () {
     });
 
     describe('Crumb Trail Navigate Navigation Link', function () {
-        it('should not update', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 's0', route: 'r0' },
-                { key: 's1', route: 'r1', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('s0');
-            var container = document.createElement('div');
-            ReactDOM.render(
-                <NavigationHandler stateNavigator={stateNavigator}>
-                    <NavigationLink
-                        stateKey="s0"
-                        navigationData={{x: 'a'}}
-                        includeCurrentData={true}>
-                        link text
-                    </NavigationLink>
-                </NavigationHandler>,
-                container
-            );
-            var link = container.querySelector<HTMLAnchorElement>('a');
-            assert.equal(link.hash, '#/r0?x=a');
-            stateNavigator.navigate('s1', {y: 'b'});
-            assert.equal(link.hash, '#/r0?x=a');
-        })
-    });
-
-    describe('Across Crumbs Crumb Trail Navigate Navigation Link', function () {
         it('should update', function(){
             var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
@@ -1655,7 +1628,6 @@ describe('NavigationLinkTest', function () {
                 <NavigationHandler stateNavigator={stateNavigator}>
                     <NavigationLink
                         stateKey="s0"
-                        acrossCrumbs={true}
                         navigationData={{x: 'a'}}
                         includeCurrentData={true}>
                         link text
@@ -1671,32 +1643,6 @@ describe('NavigationLinkTest', function () {
     });
 
     describe('Active Css Class Navigate Navigation Link', function () {
-        it('should not update', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 's0', route: 'r0' },
-                { key: 's1', route: 'r1', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('s0', {x: 'a'});
-            var container = document.createElement('div');
-            ReactDOM.render(
-                <NavigationHandler stateNavigator={stateNavigator}>
-                    <NavigationLink
-                        stateKey="s0"
-                        navigationData={{x: 'a'}}
-                        activeCssClass="active">
-                        link text
-                    </NavigationLink>
-                </NavigationHandler>,
-                container
-            );
-            var link = container.querySelector<HTMLAnchorElement>('a');
-            assert.equal(link.className, 'active');
-            stateNavigator.navigate('s1');
-            assert.equal(link.className, 'active');
-        })
-    });
-
-    describe('Across Crumbs Active Css Class Navigate Navigation Link', function () {
         it('should update', function(){
             var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
@@ -1708,7 +1654,6 @@ describe('NavigationLinkTest', function () {
                 <NavigationHandler stateNavigator={stateNavigator}>
                     <NavigationLink
                         stateKey="s0"
-                        acrossCrumbs={true}
                         navigationData={{x: 'a'}}
                         activeCssClass="active">
                         link text
@@ -1724,32 +1669,6 @@ describe('NavigationLinkTest', function () {
     });
 
     describe('Disable Active Navigate Navigation Link', function () {
-        it('should not update', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 's0', route: 'r0' },
-                { key: 's1', route: 'r1', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('s0', {x: 'a'});
-            var container = document.createElement('div');
-            ReactDOM.render(
-                <NavigationHandler stateNavigator={stateNavigator}>
-                    <NavigationLink
-                        stateKey="s0"
-                        navigationData={{x: 'a'}}
-                        disableActive={true}>
-                        link text
-                    </NavigationLink>
-                </NavigationHandler>,
-                container
-            );
-            var link = container.querySelector<HTMLAnchorElement>('a');
-            assert.equal(link.hash, '');
-            stateNavigator.navigate('s1');
-            assert.equal(link.hash, '');
-        })
-    });
-
-    describe('Across Crumbs Disable Active Navigate Navigation Link', function () {
         it('should update', function(){
             var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
@@ -1761,7 +1680,6 @@ describe('NavigationLinkTest', function () {
                 <NavigationHandler stateNavigator={stateNavigator}>
                     <NavigationLink
                         stateKey="s0"
-                        acrossCrumbs={true}
                         navigationData={{x: 'a'}}
                         disableActive={true}>
                         link text

--- a/NavigationReact/test/RefreshLinkTest.tsx
+++ b/NavigationReact/test/RefreshLinkTest.tsx
@@ -85,7 +85,6 @@ describe('RefreshLinkTest', function () {
                         currentDataKeys="y"
                         activeCssClass="active"
                         disableActive={true}
-                        acrossCrumbs={false}
                         historyAction='replace'
                         navigating={() => false}
                         aria-label="z"
@@ -1571,31 +1570,6 @@ describe('RefreshLinkTest', function () {
     });
 
     describe('Crumb Trail Navigate Refresh Link', function () {
-        it('should not update', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 's0', route: 'r0' },
-                { key: 's1', route: 'r1', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('s0');
-            var container = document.createElement('div');
-            ReactDOM.render(
-                <NavigationHandler stateNavigator={stateNavigator}>
-                    <RefreshLink
-                        navigationData={{x: 'a'}}
-                        includeCurrentData={true}>
-                        link text
-                    </RefreshLink>
-                </NavigationHandler>,
-                container
-            );
-            var link = container.querySelector<HTMLAnchorElement>('a');
-            assert.equal(link.hash, '#/r0?x=a');
-            stateNavigator.navigate('s1', {y: 'b'});
-            assert.equal(link.hash, '#/r0?x=a');
-        })
-    });
-
-    describe('Across Crumbs Crumb Trail Navigate Refresh Link', function () {
         it('should update', function(){
             var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
@@ -1606,7 +1580,6 @@ describe('RefreshLinkTest', function () {
             ReactDOM.render(
                 <NavigationHandler stateNavigator={stateNavigator}>
                     <RefreshLink
-                        acrossCrumbs={true}
                         navigationData={{x: 'a'}}
                         includeCurrentData={true}>
                         link text
@@ -1622,31 +1595,6 @@ describe('RefreshLinkTest', function () {
     });
 
     describe('Active Css Class Navigate Refresh Link', function () {
-        it('should not update', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 's0', route: 'r0' },
-                { key: 's1', route: 'r1', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('s0', {x: 'a'});
-            var container = document.createElement('div');
-            ReactDOM.render(
-                <NavigationHandler stateNavigator={stateNavigator}>
-                    <RefreshLink
-                        navigationData={{x: 'a'}}
-                        activeCssClass="active">
-                        link text
-                    </RefreshLink>
-                </NavigationHandler>,
-                container
-            );
-            var link = container.querySelector<HTMLAnchorElement>('a');
-            assert.equal(link.className, 'active');
-            stateNavigator.navigate('s1');
-            assert.equal(link.className, 'active');
-        })
-    });
-
-    describe('Across Crumbs Active Css Class Navigate Refresh Link', function () {
         it('should update', function(){
             var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
@@ -1657,7 +1605,6 @@ describe('RefreshLinkTest', function () {
             ReactDOM.render(
                 <NavigationHandler stateNavigator={stateNavigator}>
                     <RefreshLink
-                        acrossCrumbs={true}
                         navigationData={{x: 'a'}}
                         activeCssClass="active">
                         link text
@@ -1673,31 +1620,6 @@ describe('RefreshLinkTest', function () {
     });
 
     describe('Disable Active Navigate Refresh Link', function () {
-        it('should not update', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 's0', route: 'r0' },
-                { key: 's1', route: 'r1', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('s0', {x: 'a'});
-            var container = document.createElement('div');
-            ReactDOM.render(
-                <NavigationHandler stateNavigator={stateNavigator}>
-                    <RefreshLink
-                        navigationData={{x: 'a'}}
-                        disableActive={true}>
-                        link text
-                    </RefreshLink>
-                </NavigationHandler>,
-                container
-            );
-            var link = container.querySelector<HTMLAnchorElement>('a');
-            assert.equal(link.hash, '');
-            stateNavigator.navigate('s1');
-            assert.equal(link.hash, '');
-        })
-    });
-
-    describe('Across Crumbs Disable Active Navigate Refresh Link', function () {
         it('should update', function(){
             var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
@@ -1708,7 +1630,6 @@ describe('RefreshLinkTest', function () {
             ReactDOM.render(
                 <NavigationHandler stateNavigator={stateNavigator}>
                     <RefreshLink
-                        acrossCrumbs={true}
                         navigationData={{x: 'a'}}
                         disableActive={true}>
                         link text

--- a/NavigationReact/test/node_modules/navigation-react.d.ts
+++ b/NavigationReact/test/node_modules/navigation-react.d.ts
@@ -7,7 +7,7 @@ import { State, StateNavigator, StateContext } from 'navigation';
 import { Component, Context, AnchorHTMLAttributes, DetailedHTMLProps, MouseEvent } from 'react';
 
 /**
- * Makes all navigation deferrable
+ * Makes all navigation immutable and deferrable
  */
 export class AsyncStateNavigator extends StateNavigator {
     /**
@@ -54,12 +54,46 @@ export class AsyncStateNavigator extends StateNavigator {
 }
 
 /**
- * The context for providers and consumers of navigation data
+ * Navigation event data
  */
-export var NavigationContext: Context<{ oldState: State, state: State, data: any, asyncData: any, nextState: State, nextData: any, stateNavigator: AsyncStateNavigator }>;
+export interface NavigationEvent {
+    /**
+     * The last State displayed before the current State
+     */
+    oldState: State;
+    /**
+     * The current State
+     */
+    state: State;
+    /**
+     * The NavigationData for the current State
+     */
+    data: any;
+    /**
+     * The current asynchronous data
+     */
+    asyncData: any;
+    /**
+     * The next State to be displayed when deferred navigation completes
+     */
+    nextState: State;
+    /**
+     * The NavigationData for the next State
+     */
+    nextData: any;
+    /**
+     * State navigator for the current context
+     */
+    stateNavigator: AsyncStateNavigator;
+}
 
 /**
- * Provides the navigation context value
+ * The context for providers and consumers of navigation event data
+ */
+export var NavigationContext: Context<NavigationEvent>;
+
+/**
+ * Provides the navigation event data
  */
 export class NavigationHandler extends Component<{ stateNavigator: StateNavigator }> { }
 

--- a/NavigationReact/test/node_modules/navigation-react.d.ts
+++ b/NavigationReact/test/node_modules/navigation-react.d.ts
@@ -68,10 +68,6 @@ export class NavigationHandler extends Component<{ stateNavigator: StateNavigato
  */
 export interface LinkProps extends DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> {
     /**
-     * Indicates whether the Link can appear across multiple crumbs
-     */
-    acrossCrumbs?: boolean;
-    /**
      * Determines the effect on browser history
      */
     historyAction?: 'add' | 'replace' | 'none';

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -91,7 +91,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
                     {tweenStyles => (
                         tweenStyles.map(({data: {key, state, data, url}, style: tweenStyle}) => {
                             var scene = this.state.scenes[key] &&
-                                <Scene index={key} crumbs={crumbs.length}>{state.renderScene(data)}</Scene>;
+                                <Scene stateNavigator={stateNavigator}>{state.renderScene(data)}</Scene>;
                             return children(tweenStyle, scene, key, crumbs.length === key, state, data)
                         }).concat(
                             sharedElementMotion && sharedElementMotion({

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -75,7 +75,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
         return typeof styleProp === 'function' ? styleProp(state, data, crumbs, nextState, nextData) : styleProp;
      }
     render() {
-        var {children, duration, sharedElementMotion, stateNavigator} = this.props;
+        var {children, duration, sharedElementMotion, stateNavigator, navigationEvent} = this.props;
         var {stateContext: {crumbs, oldUrl, oldState}, stateContext} = stateNavigator;
         var SceneMotion: new() => Motion<SceneContext> = Motion as any;
         return (stateContext.state &&
@@ -91,7 +91,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
                     {tweenStyles => (
                         tweenStyles.map(({data: {key, state, data, url}, style: tweenStyle}) => {
                             var scene = this.state.scenes[key] &&
-                                <Scene stateNavigator={stateNavigator}>{state.renderScene(data)}</Scene>;
+                                <Scene navigationEvent={navigationEvent}>{state.renderScene(data)}</Scene>;
                             return children(tweenStyle, scene, key, crumbs.length === key, state, data)
                         }).concat(
                             sharedElementMotion && sharedElementMotion({

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -11,7 +11,7 @@ type SceneContext = { key: number, state: State, data: any, url: string, crumbs:
 class NavigationMotion extends React.Component<NavigationMotionProps, NavigationMotionState> {
     private sharedElements: { [scene: number]: { [name: string]: { ref: HTMLElement; data: any }; }; } = {};
     private sharedElementContext: any;
-    constructor(props) {
+    constructor(props: NavigationMotionProps) {
         super(props);
         this.sharedElementContext = {
             registerSharedElement: (scene, name, ref, data) => {
@@ -29,7 +29,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
     static defaultProps = {
         duration: 300
     }
-    static getDerivedStateFromProps({stateNavigator}, {scenes: prevScenes}) {
+    static getDerivedStateFromProps({stateNavigator}: NavigationMotionProps, {scenes: prevScenes}: NavigationMotionState) {
         var {crumbs} = stateNavigator.stateContext;
         return {scenes: {...prevScenes, [crumbs.length]: true}, rest: false};
     }

--- a/NavigationReactMobile/src/Props.ts
+++ b/NavigationReactMobile/src/Props.ts
@@ -1,4 +1,5 @@
 import { StateNavigator, State } from 'navigation';
+import { NavigationEvent } from 'navigation-react';
 import SharedElementMotion from './SharedElementMotion';
 import { ReactElement } from 'react';
 
@@ -51,8 +52,13 @@ interface NavigationMotionProps {
     duration?: number;
     sharedElementMotion?: (props: SharedElementNavigationMotionProps) => ReactElement<SharedElementMotion>;
     stateNavigator?: StateNavigator;
+    navigationEvent: NavigationEvent;
     children: (style: any, scene: ReactElement<any>, key: number, active: boolean, state: State, data: any) => ReactElement<any>;
 }
 
-export { MotionProps, SharedElementProps, SharedItem, SharedElementNavigationMotionProps, SharedElementMotionProps, NavigationMotionProps }
+interface SceneProps {
+    navigationEvent: NavigationEvent;
+}
+
+export { MotionProps, SharedElementProps, SharedItem, SharedElementNavigationMotionProps, SharedElementMotionProps, NavigationMotionProps, SceneProps }
 

--- a/NavigationReactMobile/src/Props.ts
+++ b/NavigationReactMobile/src/Props.ts
@@ -54,10 +54,5 @@ interface NavigationMotionProps {
     children: (style: any, scene: ReactElement<any>, key: number, active: boolean, state: State, data: any) => ReactElement<any>;
 }
 
-interface SceneProps {
-    index: number;
-    crumbs: number;
-}
-
-export { MotionProps, SharedElementProps, SharedItem, SharedElementNavigationMotionProps, SharedElementMotionProps, NavigationMotionProps, SceneProps }
+export { MotionProps, SharedElementProps, SharedItem, SharedElementNavigationMotionProps, SharedElementMotionProps, NavigationMotionProps }
 

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -1,12 +1,30 @@
+import { State } from 'navigation';
+import { NavigationContext, AsyncStateNavigator } from 'navigation-react';
 import * as React from 'react';
-import { SceneProps } from './Props';
+type SceneState = { context: { oldState: State, state: State, data: any, asyncData: any, nextState: State, nextData: any, stateNavigator: AsyncStateNavigator } };
 
-class Scene extends React.Component<SceneProps, any> {
-    shouldComponentUpdate(props: SceneProps) {
-        return props.index === props.crumbs;
+class Scene extends React.Component<{ stateNavigator: AsyncStateNavigator }, SceneState> {
+    constructor(props) {
+        super(props);
+        var { stateNavigator } = this.props;
+        var { oldState, state, data, asyncData } = stateNavigator.stateContext;
+        this.state = { context: { oldState, state, data, asyncData, nextState: null, nextData: {}, stateNavigator } };
+    }
+    static getDerivedStateFromProps({ stateNavigator }, { context }) {
+        if (stateNavigator.stateContext.crumbs.length !== context.stateNavigator.stateContext.crumbs.length)
+            return null;
+        var { oldState, state, data, asyncData } = stateNavigator.stateContext;
+        return { context: { oldState, state, data, asyncData, nextState: null, nextData: {}, stateNavigator } };
+    }
+    shouldComponentUpdate({ stateNavigator }, { context }) {
+        return stateNavigator.stateContext.crumbs.length === context.stateNavigator.stateContext.crumbs.length;
     }
     render() {
-        return this.props.children;
+        return (
+            <NavigationContext.Provider value={this.state.context}>
+                {this.props.children}
+            </NavigationContext.Provider>
+        );
     }
 }
 

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -1,4 +1,3 @@
-import { State } from 'navigation';
 import { NavigationContext, NavigationEvent } from 'navigation-react';
 import * as React from 'react';
 import { SceneProps } from './Props';

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -8,13 +8,13 @@ class Scene extends React.Component<SceneProps, SceneState> {
         super(props);
         this.state = {context: props.navigationEvent};
     }
-    static getDerivedStateFromProps({ navigationEvent }: SceneProps, { context }: SceneState) {
+    static getDerivedStateFromProps({navigationEvent}: SceneProps, {context}: SceneState) {
         if (navigationEvent.stateNavigator.stateContext.crumbs.length 
             !== context.stateNavigator.stateContext.crumbs.length)
             return null;
         return {context: navigationEvent};
     }
-    shouldComponentUpdate({ navigationEvent }: SceneProps, { context }: SceneState) {
+    shouldComponentUpdate({navigationEvent}: SceneProps, {context}: SceneState) {
         return navigationEvent.stateNavigator.stateContext.crumbs.length
             === context.stateNavigator.stateContext.crumbs.length;
     }

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -1,24 +1,23 @@
 import { State } from 'navigation';
-import { NavigationContext, AsyncStateNavigator } from 'navigation-react';
+import { NavigationContext, NavigationEvent } from 'navigation-react';
 import * as React from 'react';
-type SceneState = { context: { oldState: State, state: State, data: any, asyncData: any, nextState: State, nextData: any, stateNavigator: AsyncStateNavigator } };
+import { SceneProps } from './Props';
+type SceneState = { context: NavigationEvent };
 
-class Scene extends React.Component<{ stateNavigator: AsyncStateNavigator }, SceneState> {
-    constructor(props) {
+class Scene extends React.Component<SceneProps, SceneState> {
+    constructor(props: SceneProps) {
         super(props);
-        this.state = Scene.createContext(this.props.stateNavigator);
+        this.state = {context: props.navigationEvent};
     }
-    static getDerivedStateFromProps({ stateNavigator }, { context }) {
-        if (stateNavigator.stateContext.crumbs.length !== context.stateNavigator.stateContext.crumbs.length)
+    static getDerivedStateFromProps({ navigationEvent }: SceneProps, { context }: SceneState) {
+        if (navigationEvent.stateNavigator.stateContext.crumbs.length 
+            !== context.stateNavigator.stateContext.crumbs.length)
             return null;
-        return Scene.createContext(stateNavigator);
+        return {context: navigationEvent};
     }
-    static createContext(stateNavigator: AsyncStateNavigator) {
-        var { oldState, state, data, asyncData } = stateNavigator.stateContext;
-        return { context: { oldState, state, data, asyncData, nextState: null, nextData: {}, stateNavigator } };        
-    }
-    shouldComponentUpdate({ stateNavigator }, { context }) {
-        return stateNavigator.stateContext.crumbs.length === context.stateNavigator.stateContext.crumbs.length;
+    shouldComponentUpdate({ navigationEvent }: SceneProps, { context }: SceneState) {
+        return navigationEvent.stateNavigator.stateContext.crumbs.length
+            === context.stateNavigator.stateContext.crumbs.length;
     }
     render() {
         return (

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -6,15 +6,16 @@ type SceneState = { context: { oldState: State, state: State, data: any, asyncDa
 class Scene extends React.Component<{ stateNavigator: AsyncStateNavigator }, SceneState> {
     constructor(props) {
         super(props);
-        var { stateNavigator } = this.props;
-        var { oldState, state, data, asyncData } = stateNavigator.stateContext;
-        this.state = { context: { oldState, state, data, asyncData, nextState: null, nextData: {}, stateNavigator } };
+        this.state = Scene.createContext(this.props.stateNavigator);
     }
     static getDerivedStateFromProps({ stateNavigator }, { context }) {
         if (stateNavigator.stateContext.crumbs.length !== context.stateNavigator.stateContext.crumbs.length)
             return null;
+        return Scene.createContext(stateNavigator);
+    }
+    static createContext(stateNavigator: AsyncStateNavigator) {
         var { oldState, state, data, asyncData } = stateNavigator.stateContext;
-        return { context: { oldState, state, data, asyncData, nextState: null, nextData: {}, stateNavigator } };
+        return { context: { oldState, state, data, asyncData, nextState: null, nextData: {}, stateNavigator } };        
     }
     shouldComponentUpdate({ stateNavigator }, { context }) {
         return stateNavigator.stateContext.crumbs.length === context.stateNavigator.stateContext.crumbs.length;

--- a/NavigationReactMobile/src/node_modules/navigation-react.d.ts
+++ b/NavigationReactMobile/src/node_modules/navigation-react.d.ts
@@ -53,10 +53,12 @@ export class AsyncStateNavigator extends StateNavigator {
         suspendNavigation?: (stateContext: StateContext, resumeNavigation: () => void) => void, defer?: boolean);
 }
 
+export type NavigationEvent = { oldState: State, state: State, data: any, asyncData: any, nextState: State, nextData: any, stateNavigator: AsyncStateNavigator };
+
 /**
  * The context for providers and consumers of navigation data
  */
-export var NavigationContext: Context<{ oldState: State, state: State, data: any, asyncData: any, nextState: State, nextData: any, stateNavigator: AsyncStateNavigator }>;
+export var NavigationContext: Context<NavigationEvent>;
 
 /**
  * Provides the navigation context value

--- a/NavigationReactMobile/src/node_modules/navigation-react.d.ts
+++ b/NavigationReactMobile/src/node_modules/navigation-react.d.ts
@@ -70,10 +70,6 @@ export class NavigationHandler extends Component<{ stateNavigator: StateNavigato
  */
 export interface LinkProps extends DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> {
     /**
-     * Indicates whether the Link can appear across multiple crumbs
-     */
-    acrossCrumbs?: boolean;
-    /**
      * Determines the effect on browser history
      */
     historyAction?: 'add' | 'replace' | 'none';

--- a/NavigationReactMobile/src/node_modules/navigation-react.d.ts
+++ b/NavigationReactMobile/src/node_modules/navigation-react.d.ts
@@ -7,7 +7,7 @@ import { State, StateNavigator, StateContext } from 'navigation';
 import { Component, Context, AnchorHTMLAttributes, DetailedHTMLProps, MouseEvent } from 'react';
 
 /**
- * Makes all navigation deferrable
+ * Makes all navigation immutable and deferrable
  */
 export class AsyncStateNavigator extends StateNavigator {
     /**
@@ -53,15 +53,47 @@ export class AsyncStateNavigator extends StateNavigator {
         suspendNavigation?: (stateContext: StateContext, resumeNavigation: () => void) => void, defer?: boolean);
 }
 
-export type NavigationEvent = { oldState: State, state: State, data: any, asyncData: any, nextState: State, nextData: any, stateNavigator: AsyncStateNavigator };
+/**
+ * Navigation event data
+ */
+export interface NavigationEvent {
+    /**
+     * The last State displayed before the current State
+     */
+    oldState: State;
+    /**
+     * The current State
+     */
+    state: State;
+    /**
+     * The NavigationData for the current State
+     */
+    data: any;
+    /**
+     * The current asynchronous data
+     */
+    asyncData: any;
+    /**
+     * The next State to be displayed when deferred navigation completes
+     */
+    nextState: State;
+    /**
+     * The NavigationData for the next State
+     */
+    nextData: any;
+    /**
+     * State navigator for the current context
+     */
+    stateNavigator: AsyncStateNavigator;
+}
 
 /**
- * The context for providers and consumers of navigation data
+ * The context for providers and consumers of navigation event data
  */
 export var NavigationContext: Context<NavigationEvent>;
 
 /**
- * Provides the navigation context value
+ * Provides the navigation event data
  */
 export class NavigationHandler extends Component<{ stateNavigator: StateNavigator }> { }
 

--- a/NavigationReactMobile/src/withStateNavigator.tsx
+++ b/NavigationReactMobile/src/withStateNavigator.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 export default Component => props => (
     <NavigationContext.Consumer>
-        {({stateNavigator}) => <Component stateNavigator={stateNavigator} {...props} />}
+        {(navigationEvent) => <Component stateNavigator={navigationEvent.stateNavigator} navigationEvent={navigationEvent} {...props} />}
     </NavigationContext.Consumer>
 );
   

--- a/NavigationReactMobile/test/node_modules/navigation-react.d.ts
+++ b/NavigationReactMobile/test/node_modules/navigation-react.d.ts
@@ -7,7 +7,7 @@ import { State, StateNavigator, StateContext } from 'navigation';
 import { Component, Context, AnchorHTMLAttributes, DetailedHTMLProps, MouseEvent } from 'react';
 
 /**
- * Makes all navigation deferrable
+ * Makes all navigation immutable and deferrable
  */
 export class AsyncStateNavigator extends StateNavigator {
     /**
@@ -54,12 +54,46 @@ export class AsyncStateNavigator extends StateNavigator {
 }
 
 /**
- * The context for providers and consumers of navigation data
+ * Navigation event data
  */
-export var NavigationContext: Context<{ oldState: State, state: State, data: any, asyncData: any, nextState: State, nextData: any, stateNavigator: AsyncStateNavigator }>;
+export interface NavigationEvent {
+    /**
+     * The last State displayed before the current State
+     */
+    oldState: State;
+    /**
+     * The current State
+     */
+    state: State;
+    /**
+     * The NavigationData for the current State
+     */
+    data: any;
+    /**
+     * The current asynchronous data
+     */
+    asyncData: any;
+    /**
+     * The next State to be displayed when deferred navigation completes
+     */
+    nextState: State;
+    /**
+     * The NavigationData for the next State
+     */
+    nextData: any;
+    /**
+     * State navigator for the current context
+     */
+    stateNavigator: AsyncStateNavigator;
+}
 
 /**
- * Provides the navigation context value
+ * The context for providers and consumers of navigation event data
+ */
+export var NavigationContext: Context<NavigationEvent>;
+
+/**
+ * Provides the navigation event data
  */
 export class NavigationHandler extends Component<{ stateNavigator: StateNavigator }> { }
 
@@ -67,10 +101,6 @@ export class NavigationHandler extends Component<{ stateNavigator: StateNavigato
  * Defines the Link Props contract
  */
 export interface LinkProps extends DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> {
-    /**
-     * Indicates whether the Link can appear across multiple crumbs
-     */
-    acrossCrumbs?: boolean;
     /**
      * Determines the effect on browser history
      */


### PR DESCRIPTION
To see the problem, let’s take Twitter as an example. You scroll down to load more tweets and, before the next tweets come back, you get bored and click a visible tweet instead. While you’re viewing the tweet the next tweets finish loading in the background. When these new tweets load the Navigation Context is on the tweet details not the list of tweets. So all the Links in the newly loaded tweets are assigned the wrong crumb and think the current `State` is the tweet details. When you navigate back to the list and select a newly loaded tweet and then navigate back it will go back to the first selected tweet’s details instead of back to the list.

The solution is to give each `Scene` its own `Navigation Context`. In the example, when you click a tweet the `Navigation Context` for the list of tweets isn’t changed. So when the tweets load in the background the Links still think the current `State` is the list of tweets.

Each `Scene` is a `Navigation Context` provider. To components inside a `Scene` it seems like their `Scene` is always current. This isolates `Scenes` navigationally from the top level `Navigation Context`.

Removed `acrossCrumbs prop` from Links. It prevented Links changing `href` when their `Scene` wasn’t current. Isolating a `Scene’s Navigation Context` fixes this because a Link can safely regenerate its `href` and will always get the same answer. So updated all Link components to be functional stateless Components.

Isolating `Navigation Context` stops Links on non-current `Scenes` from updating. Before, there was only one `Navigation Context` so all Links updated whenever a navigation happened. Now a `Scene’s Navigation Context` only updates when current.
