### PR TITLE
Removed onClick for Invalid or Inactive Links

### DIFF
--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -57,12 +57,10 @@ class LinkUtility {
     static getOnClick(stateNavigator: AsyncStateNavigator, props: LinkProps, link: string) {
         return e => {
             if (!e.ctrlKey && !e.shiftKey && !e.metaKey && !e.altKey && !e.button) {
-                if (link) {
-                    var { navigating, historyAction, defer } = props;
-                    if (!navigating || navigating(e, link)) {
-                        e.preventDefault();
-                        stateNavigator.navigateLink(link, historyAction, false, undefined, defer);
-                    }
+                var { navigating, historyAction, defer } = props;
+                if (!navigating || navigating(e, link)) {
+                    e.preventDefault();
+                    stateNavigator.navigateLink(link, historyAction, false, undefined, defer);
                 }
             }
         };

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -24,8 +24,10 @@ class LinkUtility {
             return;
         if (active && props.activeCssClass)
             toProps.className = (!toProps.className ? '' : toProps.className + ' ') + props.activeCssClass;
-        if (active && props.disableActive)
+        if (active && props.disableActive) {
             toProps.href = null;
+            toProps.onClick = null;
+        }
     }
 
     private static areEqual(val: any, currentVal: any): boolean {

--- a/NavigationReact/src/NavigationBackLink.tsx
+++ b/NavigationReact/src/NavigationBackLink.tsx
@@ -14,7 +14,7 @@ var NavigationBackLink = (props: NavigationBackLinkProps) => {
         var link = stateNavigator.getNavigationBackLink(distance);
     } catch {}
     htmlProps.href = link && stateNavigator.historyManager.getHref(link);
-    htmlProps.onClick = LinkUtility.getOnClick(stateNavigator, props, link);
+    htmlProps.onClick = link && LinkUtility.getOnClick(stateNavigator, props, link);
     return <a {...htmlProps}>{children}</a>;
 }
 export default withStateNavigator(NavigationBackLink);

--- a/NavigationReact/src/NavigationLink.tsx
+++ b/NavigationReact/src/NavigationLink.tsx
@@ -17,7 +17,7 @@ var NavigationLink = (props: NavigationLinkProps) => {
     } catch {}
     var active = state && state.key === stateKey && LinkUtility.isActive(stateNavigator, navigationData);
     htmlProps.href = link && stateNavigator.historyManager.getHref(link);
-    htmlProps.onClick = LinkUtility.getOnClick(stateNavigator, props, link);
+    htmlProps.onClick = link && LinkUtility.getOnClick(stateNavigator, props, link);
     LinkUtility.setActive(active, props, htmlProps);
     return <a {...htmlProps}>{children}</a>;
 }

--- a/NavigationReact/src/RefreshLink.tsx
+++ b/NavigationReact/src/RefreshLink.tsx
@@ -16,7 +16,7 @@ var RefreshLink = (props: RefreshLinkProps) => {
     } catch {}
     var active = LinkUtility.isActive(stateNavigator, navigationData);
     htmlProps.href = link && stateNavigator.historyManager.getHref(link);
-    htmlProps.onClick = LinkUtility.getOnClick(stateNavigator, props, link);
+    htmlProps.onClick = link && LinkUtility.getOnClick(stateNavigator, props, link);
     LinkUtility.setActive(active, props, htmlProps);
     return <a {...htmlProps}>{children}</a>;
 }

--- a/NavigationReact/test/NavigationBackLinkTest.tsx
+++ b/NavigationReact/test/NavigationBackLinkTest.tsx
@@ -100,7 +100,6 @@ describe('NavigationBackLinkTest', function () {
             var link = container.querySelector<HTMLAnchorElement>('a');
             assert.equal(link.hash, '#/r0');
             assert.equal(link.innerHTML, 'link text');
-            assert.notEqual(link.onclick, null);
             assert.equal(link.getAttribute('aria-label'), 'z');
             assert.equal(link.target, '_blank');
             assert.equal(link.attributes.length, 3);

--- a/NavigationReact/test/NavigationLinkTest.tsx
+++ b/NavigationReact/test/NavigationLinkTest.tsx
@@ -97,7 +97,6 @@ describe('NavigationLinkTest', function () {
             var link = container.querySelector<HTMLAnchorElement>('a');
             assert.equal(link.hash, '#/r?x=a');
             assert.equal(link.innerHTML, 'link text');
-            assert.notEqual(link.onclick, null);
             assert.equal(link.getAttribute('aria-label'), 'z');
             assert.equal(link.target, '_blank');
             assert.equal(link.attributes.length, 3);
@@ -341,6 +340,34 @@ describe('NavigationLinkTest', function () {
             var link = container.querySelector<HTMLAnchorElement>('a');
             assert.equal(link.hash, '#/r?x=b');
             assert.equal(link.innerHTML, 'link text');
+        })
+    });
+
+    describe('Disable Active Navigation Link', function () {
+        it('should not navigate', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r' }
+            ]);
+            stateNavigator.navigate('s', {x: 'a'});
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <NavigationLink
+                        stateKey="s"
+                        navigationData={{x: 'a'}}
+                        disableActive={true}>
+                        link text
+                    </NavigationLink>
+                </NavigationHandler>,
+                container
+            );
+            var navigated = false;
+            stateNavigator.onNavigate(() => {
+                navigated = true;
+            })
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            Simulate.click(link);
+            assert.equal(navigated, false);
         })
     });
 

--- a/NavigationReact/test/NavigationLinkTest.tsx
+++ b/NavigationReact/test/NavigationLinkTest.tsx
@@ -343,7 +343,7 @@ describe('NavigationLinkTest', function () {
         })
     });
 
-    describe('Disable Active Navigation Link', function () {
+    describe('Click Disable Active Navigation Link', function () {
         it('should not navigate', function(){
             var stateNavigator = new StateNavigator([
                 { key: 's', route: 'r' }

--- a/NavigationReact/test/RefreshLinkTest.tsx
+++ b/NavigationReact/test/RefreshLinkTest.tsx
@@ -97,7 +97,6 @@ describe('RefreshLinkTest', function () {
             var link = container.querySelector<HTMLAnchorElement>('a');
             assert.equal(link.hash, '#/r?x=a');
             assert.equal(link.innerHTML, 'link text');
-            assert.notEqual(link.onclick, null);
             assert.equal(link.getAttribute('aria-label'), 'z');
             assert.equal(link.target, '_blank');
             assert.equal(link.attributes.length, 3);
@@ -331,6 +330,33 @@ describe('RefreshLinkTest', function () {
             var link = container.querySelector<HTMLAnchorElement>('a');
             assert.equal(link.hash, '#/r?x=b');
             assert.equal(link.innerHTML, 'link text');
+        })
+    });
+
+    describe('Click Disable Active Refresh Link', function () {
+        it('should not navigate', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r' }
+            ]);
+            stateNavigator.navigate('s', {x: 'a'});
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <RefreshLink
+                        navigationData={{x: 'a'}}
+                        disableActive={true}>
+                        link text
+                    </RefreshLink>
+                </NavigationHandler>,
+                container
+            );
+            var navigated = false;
+            stateNavigator.onNavigate(() => {
+                navigated = true;
+            })
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            Simulate.click(link);
+            assert.equal(navigated, false);
         })
     });
 


### PR DESCRIPTION
If the `href` is null, either because the link is null or because it's active and disabled, then the `onClick` should be null too