### PR TITLE
Made Motion Render Synchronous on Props Change

### DIFF
--- a/NavigationReactMobile/src/Motion.tsx
+++ b/NavigationReactMobile/src/Motion.tsx
@@ -13,9 +13,8 @@ class Motion<T> extends React.Component<MotionProps<T>, any> {
     }
     static getDerivedStateFromProps(props, {items: prevItems}) {
         var tick = typeof performance !== 'undefined' ? performance.now() : 0;
-        var items = Motion.move(tick, prevItems, props);
-        var restart = items.filter(({rest}) => !rest).length !== 0;
-        return {items, restart};
+        var {items, moving} = Motion.move(tick, prevItems, props);
+        return {items, restart: moving};
     }
     componentDidUpdate() {
         if (!this.animateId && this.state.restart)
@@ -26,9 +25,9 @@ class Motion<T> extends React.Component<MotionProps<T>, any> {
     }
     animate(tick) {
         this.setState(({items: prevItems}) => {
-            var items = Motion.move(tick, prevItems, this.props);
+            var {items, moving} = Motion.move(tick, prevItems, this.props);
             this.animateId = null;
-            if (items.filter(({rest}) => !rest).length !== 0)
+            if (moving)
                 this.animateId = requestAnimationFrame(this.animate);
             return {items, restart: false};
         })
@@ -72,7 +71,7 @@ class Motion<T> extends React.Component<MotionProps<T>, any> {
                 })
             )
             .sort((a, b) => a.index - b.index);
-        return items;
+        return {items, moving: items.filter(({rest}) => !rest).length !== 0};
     }
     static areEqual(from = {}, to = {}) {
         if (Object.keys(from).length !== Object.keys(to).length)

--- a/NavigationReactMobile/src/Motion.tsx
+++ b/NavigationReactMobile/src/Motion.tsx
@@ -6,19 +6,15 @@ class Motion<T> extends React.Component<MotionProps<T>, any> {
     constructor(props) {
         super(props);
         this.move = this.move.bind(this);
-        var {data, enter, getKey} = this.props;
-        var items = data.map(item => {
-            var newItem: any = {key: getKey(item), data: item, progress: 1, tick: 0};
-            newItem.start = newItem.end = newItem.style = enter(item);
-            return newItem;
-        });
-        this.state = {items, restart: false};
+        this.state = {items: [], restart: false};
     }
     static defaultProps = {
         progress: 0,
     }
-    static getDerivedStateFromProps() {
-        return {restart: true};
+    static getDerivedStateFromProps(props, {items: prevItems}) {
+        var tick = typeof performance !== 'undefined' ? performance.now() : 0;
+        var {items} = Motion.getItems(tick, prevItems, props);
+        return {items, restart: true};
     }
     componentDidMount() {
         this.moveId = requestAnimationFrame(this.move)
@@ -32,51 +28,55 @@ class Motion<T> extends React.Component<MotionProps<T>, any> {
     }
     move(tick) {
         this.setState(({items: prevItems}) => {
-            var {data, enter, leave, update, progress, getKey, duration, onRest} = this.props;
-            var dataByKey = data.reduce((acc, item, index) => ({...acc, [getKey(item)]: {...(item as any), index}}), {});
-            var itemsByKey = prevItems.reduce((acc, item) => ({...acc, [item.key]: item}), {});
-            var items = prevItems
-                .map((item, index) => {
-                    var matchedItem = dataByKey[item.key];
-                    var nextItem: any = {key: item.key, data: matchedItem || item.data, tick};
-                    nextItem.end = !matchedItem ? (leave || update)(item.data) : update(matchedItem);
-                    nextItem.index = !matchedItem ? data.length + index : matchedItem.index;
-                    var unchanged = this.areEqual(item.end, nextItem.end);
-                    if (unchanged) {
-                        nextItem.start = item.start;
-                        nextItem.rest = item.progress === 1;
-                        var progressDelta = (nextItem.tick - item.tick) / duration;
-                        nextItem.progress = Math.min(item.progress + progressDelta, 1);
-                    } else {
-                        nextItem.rest = false;
-                        var reverse = !unchanged && this.areEqual(item.start, nextItem.end);
-                        nextItem.start = reverse ? item.end : (!progress ? item.style : item.start);
-                        nextItem.progress = reverse ? 1 - item.progress : progress;
-                    }
-                    nextItem.style = this.interpolateStyle(nextItem);
-                    if (onRest && nextItem.rest && !item.rest)
-                        onRest(item.data);
-                    return nextItem;
-                })
-                .filter(item => dataByKey[item.key] || (!item.rest && leave))
-                .concat(data
-                    .filter(item => !itemsByKey[getKey(item)])
-                    .map(item => {
-                        var index = dataByKey[getKey(item)].index;
-                        var newItem: any = {key: getKey(item), data: item, progress, tick, rest: false, index};
-                        newItem.start = newItem.style = enter(item);
-                        newItem.end = update(item);
-                        return newItem;
-                    })
-                )
-                .sort((a, b) => a.index - b.index);
+            var {items, restart} = Motion.getItems(tick, prevItems, this.props);
             this.moveId = null;
             if (items.filter(({rest}) => !rest).length !== 0)
                 this.moveId = requestAnimationFrame(this.move);
-            return {items, restart: false};
+            return {items, restart};
         })
     }
-    areEqual(from = {}, to = {}) {
+    static getItems(tick, prevItems, props) {
+        var {data, enter, leave, update, progress, getKey, duration, onRest} = props;
+        var dataByKey = data.reduce((acc, item, index) => ({...acc, [getKey(item)]: {...(item as any), index}}), {});
+        var itemsByKey = prevItems.reduce((acc, item) => ({...acc, [item.key]: item}), {});
+        var items = prevItems
+            .map((item, index) => {
+                var matchedItem = dataByKey[item.key];
+                var nextItem: any = {key: item.key, data: matchedItem || item.data, tick};
+                nextItem.end = !matchedItem ? (leave || update)(item.data) : update(matchedItem);
+                nextItem.index = !matchedItem ? data.length + index : matchedItem.index;
+                var unchanged = this.areEqual(item.end, nextItem.end);
+                if (unchanged) {
+                    nextItem.start = item.start;
+                    nextItem.rest = item.progress === 1;
+                    var progressDelta = (nextItem.tick - item.tick) / duration;
+                    nextItem.progress = Math.min(item.progress + progressDelta, 1);
+                } else {
+                    nextItem.rest = false;
+                    var reverse = !unchanged && this.areEqual(item.start, nextItem.end);
+                    nextItem.start = reverse ? item.end : (!progress ? item.style : item.start);
+                    nextItem.progress = reverse ? 1 - item.progress : progress;
+                }
+                nextItem.style = this.interpolateStyle(nextItem);
+                if (onRest && nextItem.rest && !item.rest)
+                    onRest(item.data);
+                return nextItem;
+            })
+            .filter(item => dataByKey[item.key] || (!item.rest && leave))
+            .concat(data
+                .filter(item => !itemsByKey[getKey(item)])
+                .map(item => {
+                    var index = dataByKey[getKey(item)].index;
+                    var newItem: any = {key: getKey(item), data: item, progress, tick, rest: false, index};
+                    newItem.start = newItem.style = enter(item);
+                    newItem.end = update(item);
+                    return newItem;
+                })
+            )
+            .sort((a, b) => a.index - b.index);
+        return {items, restart: false};
+    }
+    static areEqual(from = {}, to = {}) {
         if (Object.keys(from).length !== Object.keys(to).length)
             return false;
         for(var key in from) {
@@ -85,7 +85,7 @@ class Motion<T> extends React.Component<MotionProps<T>, any> {
         }
         return true;
     }
-    interpolateStyle({start, end, progress}) {
+    static interpolateStyle({start, end, progress}) {
         var style = {};
         for(var key in end)
             style[key] = start[key] + (progress * (end[key] - start[key]));

--- a/NavigationReactMobile/src/Motion.tsx
+++ b/NavigationReactMobile/src/Motion.tsx
@@ -42,7 +42,7 @@ class Motion<T> extends React.Component<MotionProps<T>, any> {
                 var nextItem: any = {key: item.key, data: matchedItem || item.data, tick};
                 nextItem.end = !matchedItem ? (leave || update)(item.data) : update(matchedItem);
                 nextItem.index = !matchedItem ? data.length + index : matchedItem.index;
-                var unchanged = this.areEqual(item.end, nextItem.end);
+                var unchanged = Motion.areEqual(item.end, nextItem.end);
                 if (unchanged) {
                     nextItem.start = item.start;
                     nextItem.rest = item.progress === 1;
@@ -50,11 +50,11 @@ class Motion<T> extends React.Component<MotionProps<T>, any> {
                     nextItem.progress = Math.min(item.progress + progressDelta, 1);
                 } else {
                     nextItem.rest = false;
-                    var reverse = !unchanged && this.areEqual(item.start, nextItem.end);
+                    var reverse = !unchanged && Motion.areEqual(item.start, nextItem.end);
                     nextItem.start = reverse ? item.end : (!progress ? item.style : item.start);
                     nextItem.progress = reverse ? 1 - item.progress : progress;
                 }
-                nextItem.style = this.interpolateStyle(nextItem);
+                nextItem.style = Motion.interpolateStyle(nextItem);
                 if (onRest && nextItem.rest && !item.rest)
                     onRest(item.data);
                 return nextItem;

--- a/NavigationReactMobile/src/Motion.tsx
+++ b/NavigationReactMobile/src/Motion.tsx
@@ -35,7 +35,7 @@ class Motion<T> extends React.Component<MotionProps<T>, any> {
             return {items, restart};
         })
     }
-    static getItems(tick, prevItems, props) {
+    static getItems(tick, prevItems, props: MotionProps<any>) {
         var {data, enter, leave, update, progress, getKey, duration, onRest} = props;
         var dataByKey = data.reduce((acc, item, index) => ({...acc, [getKey(item)]: {...(item as any), index}}), {});
         var itemsByKey = prevItems.reduce((acc, item) => ({...acc, [item.key]: item}), {});


### PR DESCRIPTION
Imagine that you do the following two navigations, one after the other:
```javascript
navigateLink('/B?crumb=A')
navigateLink('/C?crumb=A&crumb=B')
```
With the first navigation, `NavigationMotion` sets B to render but, before it can, the second navigation happens. When `NavigationMotion` first renders the new Scenes it renders B and C together. So B and C are given the same `NavigationContext`. B thinks it’s the same crumb as C!!

The problem is that `Motion` doesn’t render synchronously when it receives the new Scenes. It does a `requestAnimationFrame` and so the second navigation squeezes in before the first Scene renders.

Fixed it by making `Motion` render the new Scenes synchronously. Instead of waiting for the next animation frame it derives the new `state` from `props`. Then `NavigationMotion` only renders one new Scene at a time.

This also handles isomorphic rendering, so removed the default `state` from the constructor
