### PR TITLE
Passed StateContext to Event Handlers

### DIFF
--- a/Navigation/src/FluentNavigator.ts
+++ b/Navigation/src/FluentNavigator.ts
@@ -13,11 +13,11 @@ interface FluentNavigator {
 function createFluentNavigator(states: { [index: string]: State }, stateHandler: StateHandler, stateContext = new StateContext()): FluentNavigator {
     function navigateLink(url): FluentNavigator {
         var { state, data } = stateHandler.parseLink(url);
+        var { [state.crumbTrailKey]: crumbs, ...data } = data;
         var fluentContext = new StateContext();
         fluentContext.state = state;
         fluentContext.url = url;
-        fluentContext.crumbs = data[state.crumbTrailKey];
-        delete data[state.crumbTrailKey];
+        fluentContext.crumbs = crumbs;
         fluentContext.data = data;
         fluentContext.nextCrumb = new Crumb(data, state, url, stateHandler.getLink(state, data), false);
         return createFluentNavigator(states, stateHandler, fluentContext);

--- a/Navigation/src/StateNavigator.ts
+++ b/Navigation/src/StateNavigator.ts
@@ -7,7 +7,7 @@ import State from './config/State';
 import StateInfo from './config/StateInfo';
 import StateContext from './StateContext';
 import StateHandler from './StateHandler';
-type NavigateHandler = (oldState: State, state: State, data: any, asyncData: any) => void;
+type NavigateHandler = (oldState: State, state: State, data: any, asyncData: any, stateContext: StateContext) => void;
 type BeforeNavigateHandler = (state: State, data: any, url: string, history: boolean, currentContext: StateContext) => boolean;
 
 class StateNavigator {
@@ -153,7 +153,7 @@ class StateNavigator {
         state.navigated(this.stateContext.data, asyncData);
         for (var id in this.onNavigateCache.handlers) {
             if (url === this.stateContext.url)
-            this.onNavigateCache.handlers[id](oldState, state, data, asyncData);
+            this.onNavigateCache.handlers[id](oldState, state, data, asyncData, stateContext);
         }
         if (url === this.stateContext.url) {
             if (historyAction !== 'none')

--- a/Navigation/src/StateNavigator.ts
+++ b/Navigation/src/StateNavigator.ts
@@ -8,7 +8,7 @@ import StateInfo from './config/StateInfo';
 import StateContext from './StateContext';
 import StateHandler from './StateHandler';
 type NavigateHandler = (oldState: State, state: State, data: any, asyncData: any) => void;
-type BeforeNavigateHandler = (state: State, data: any, url: string, history: boolean) => boolean;
+type BeforeNavigateHandler = (state: State, data: any, url: string, history: boolean, stateContext: StateContext) => boolean;
 
 class StateNavigator {
     private stateHandler = new StateHandler();
@@ -123,7 +123,7 @@ class StateNavigator {
         var { state, data: { [state.crumbTrailKey]: crumbs, ...data } } = this.stateHandler.parseLink(url);
         for (var id in this.onBeforeNavigateCache.handlers) {
             var handler = this.onBeforeNavigateCache.handlers[id];
-            if (oldUrl !== this.stateContext.url || !handler(state, data, url, history))
+            if (oldUrl !== this.stateContext.url || !handler(state, data, url, history, this.stateContext))
                 return;
         }
         var navigateContinuation = (asyncData?: any) => {

--- a/Navigation/src/StateNavigator.ts
+++ b/Navigation/src/StateNavigator.ts
@@ -120,15 +120,14 @@ class StateNavigator {
         if (history && this.stateContext.url === url)
             return;
         var oldUrl = this.stateContext.url;
-        var { state, data } = this.stateHandler.parseLink(url);
-        var { [state.crumbTrailKey]: crumbs, ...crumblessData } = data;
+        var { state, data: { [state.crumbTrailKey]: crumbs, ...data } } = this.stateHandler.parseLink(url);
         for (var id in this.onBeforeNavigateCache.handlers) {
             var handler = this.onBeforeNavigateCache.handlers[id];
-            if (oldUrl !== this.stateContext.url || !handler(state, crumblessData, url, history))
+            if (oldUrl !== this.stateContext.url || !handler(state, data, url, history))
                 return;
         }
         var navigateContinuation = (asyncData?: any) => {
-            var stateContext = this.createStateContext(state, crumblessData, crumbs, url, asyncData, history);
+            var stateContext = this.createStateContext(state, data, crumbs, url, asyncData, history);
             if (oldUrl === this.stateContext.url) {
                 suspendNavigation(stateContext, () => {
                     if (oldUrl === this.stateContext.url)
@@ -138,12 +137,12 @@ class StateNavigator {
         };
         var unloadContinuation = () => {
             if (oldUrl === this.stateContext.url)
-                state.navigating(crumblessData, url, navigateContinuation, history);
+                state.navigating(data, url, navigateContinuation, history);
         };
         if (this.stateContext.state)
-            this.stateContext.state.unloading(state, crumblessData, url, unloadContinuation, history);
+            this.stateContext.state.unloading(state, data, url, unloadContinuation, history);
         else
-            state.navigating(crumblessData, url, navigateContinuation, history);
+            state.navigating(data, url, navigateContinuation, history);
     }
     
     private resumeNavigation(stateContext: StateContext, historyAction: 'add' | 'replace' | 'none') {

--- a/Navigation/src/StateNavigator.ts
+++ b/Navigation/src/StateNavigator.ts
@@ -120,7 +120,8 @@ class StateNavigator {
         if (history && this.stateContext.url === url)
             return;
         var oldUrl = this.stateContext.url;
-        var { state, data: { [state.crumbTrailKey]: crumbs, ...data } } = this.stateHandler.parseLink(url);
+        var { state, data } = this.stateHandler.parseLink(url);
+        var { [state.crumbTrailKey]: crumbs, ...data } = data;
         for (var id in this.onBeforeNavigateCache.handlers) {
             var handler = this.onBeforeNavigateCache.handlers[id];
             if (oldUrl !== this.stateContext.url || !handler(state, data, url, history, this.stateContext))

--- a/Navigation/src/StateNavigator.ts
+++ b/Navigation/src/StateNavigator.ts
@@ -49,7 +49,7 @@ class StateNavigator {
         return !(<StateNavigator> stateInfos).stateHandler;
     };
 
-    private createStateContext(state: State, data: any, url: string, asyncData: any, history: boolean): StateContext {
+    private createStateContext(state: State, data: any, crumbs: Crumb[], url: string, asyncData: any, history: boolean): StateContext {
         var stateContext = new StateContext();
         stateContext.oldState = this.stateContext.state;
         stateContext.oldData = this.stateContext.data;
@@ -59,8 +59,7 @@ class StateNavigator {
         stateContext.asyncData = asyncData;
         stateContext.title = state.title;
         stateContext.history = history;
-        stateContext.crumbs = data[state.crumbTrailKey];
-        delete data[state.crumbTrailKey];
+        stateContext.crumbs = crumbs;
         stateContext.data = data;
         stateContext.nextCrumb = new Crumb(data, state, url, this.stateHandler.getLink(state, data), false);
         stateContext.previousState = null;
@@ -122,13 +121,14 @@ class StateNavigator {
             return;
         var oldUrl = this.stateContext.url;
         var { state, data } = this.stateHandler.parseLink(url);
+        var { [state.crumbTrailKey]: crumbs, ...crumblessData } = data;
         for (var id in this.onBeforeNavigateCache.handlers) {
             var handler = this.onBeforeNavigateCache.handlers[id];
-            if (oldUrl !== this.stateContext.url || !handler(state, data, url, history))
+            if (oldUrl !== this.stateContext.url || !handler(state, crumblessData, url, history))
                 return;
         }
         var navigateContinuation = (asyncData?: any) => {
-            var stateContext = this.createStateContext(state, data, url, asyncData, history);
+            var stateContext = this.createStateContext(state, crumblessData, crumbs, url, asyncData, history);
             if (oldUrl === this.stateContext.url) {
                 suspendNavigation(stateContext, () => {
                     if (oldUrl === this.stateContext.url)
@@ -138,12 +138,12 @@ class StateNavigator {
         };
         var unloadContinuation = () => {
             if (oldUrl === this.stateContext.url)
-                state.navigating(data, url, navigateContinuation, history);
+                state.navigating(crumblessData, url, navigateContinuation, history);
         };
         if (this.stateContext.state)
-            this.stateContext.state.unloading(state, data, url, unloadContinuation, history);
+            this.stateContext.state.unloading(state, crumblessData, url, unloadContinuation, history);
         else
-            state.navigating(data, url, navigateContinuation, history);
+            state.navigating(crumblessData, url, navigateContinuation, history);
     }
     
     private resumeNavigation(stateContext: StateContext, historyAction: 'add' | 'replace' | 'none') {

--- a/Navigation/src/StateNavigator.ts
+++ b/Navigation/src/StateNavigator.ts
@@ -8,7 +8,7 @@ import StateInfo from './config/StateInfo';
 import StateContext from './StateContext';
 import StateHandler from './StateHandler';
 type NavigateHandler = (oldState: State, state: State, data: any, asyncData: any) => void;
-type BeforeNavigateHandler = (state: State, data: any, url: string, history: boolean, stateContext: StateContext) => boolean;
+type BeforeNavigateHandler = (state: State, data: any, url: string, history: boolean, currentContext: StateContext) => boolean;
 
 class StateNavigator {
     private stateHandler = new StateHandler();

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -3487,14 +3487,15 @@ describe('Navigation', function () {
         it('should pass old State, State and Data', function() {
             var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
-                { key: 's1', route: 'r1' }
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
             var link = stateNavigator.getNavigationLink('s0');
             stateNavigator.navigateLink(link);
-            var unloadingState, unloadingUrl, navigatedOldState, navigatedState, navigatedData, navigatedAsyncData, navigatingData,
-                navigatingUrl, beforeNavigateOldState, beforeNavigateState, beforeNavigateData, beforeNavigateUrl;
+            var unloadingState, unloadingData, unloadingUrl, navigatedOldState, navigatedState, navigatedData, navigatedAsyncData,
+                navigatingData, navigatingUrl, beforeNavigateOldState, beforeNavigateState, beforeNavigateData, beforeNavigateUrl;
             stateNavigator.states['s0'].unloading = (state, data, url, unload) => {
                 unloadingState = state;
+                unloadingData = data;
                 unloadingUrl = url;
                 unload();
             }
@@ -3525,15 +3526,20 @@ describe('Navigation', function () {
             assert.strictEqual(beforeNavigateOldState, stateNavigator.states['s0']);
             assert.strictEqual(beforeNavigateState, stateNavigator.states['s1']);
             assert.strictEqual(beforeNavigateData.s, 'Hello');
+            assert.strictEqual(Object.keys(beforeNavigateData).length, 1);
             assert.strictEqual(beforeNavigateUrl, url);
             assert.strictEqual(unloadingState, stateNavigator.states['s1']);
+            assert.strictEqual(unloadingData.s, 'Hello');
+            assert.strictEqual(Object.keys(unloadingData).length, 1);
             assert.strictEqual(unloadingUrl, url);
             assert.strictEqual(navigatingData.s, 'Hello');
+            assert.strictEqual(Object.keys(navigatingData).length, 1);
             assert.strictEqual(navigatingUrl, url);
             assert.strictEqual(navigatedOldState, stateNavigator.states['s0']);
             assert.strictEqual(navigatedState, stateNavigator.states['s1']);
             assert.strictEqual(navigatedData.s, 'Hello');
             assert.strictEqual(navigatedAsyncData, 'World');
+            assert.strictEqual(Object.keys(navigatedData).length, 1);
         });
     });
 

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -2818,8 +2818,8 @@ describe('Navigation', function () {
             var oldStates = [];
             var states = [];
             stateNavigator.navigate('s0');
-            var beforeNavigateHandler = (state, data, url, history) => {
-                oldStates.push(stateNavigator.stateContext.state);
+            var beforeNavigateHandler = (state, data, url, history, {state: oldState}) => {
+                oldStates.push(oldState);
                 states.push(state);
                 return true;
             };
@@ -2875,8 +2875,8 @@ describe('Navigation', function () {
             var oldStates = [];
             var states = [];
             stateNavigator.navigate('s');
-            var beforeNavigateHandler = (state, data, url, history) => {
-                oldStates.push(stateNavigator.stateContext.state);
+            var beforeNavigateHandler = (state, data, url, history, {state: oldState}) => {
+                oldStates.push(oldState);
                 states.push(state);
                 return true;
             };
@@ -2912,8 +2912,8 @@ describe('Navigation', function () {
             var oldStates = [];
             var states = [];
             stateNavigator.navigate('s0');
-            var beforeNavigateHandler = (state, data, url, history) => {
-                oldStates.push(stateNavigator.stateContext.state);
+            var beforeNavigateHandler = (state, data, url, history, {state: oldState}) => {
+                oldStates.push(oldState);
                 states.push(state);
                 return true;
             };
@@ -2975,13 +2975,13 @@ describe('Navigation', function () {
             var oldStates = [];
             var states = [];
             stateNavigator.navigate('s0');
-            var beforeNavigateHandler1 = (state, data, url, history) => {
-                oldStates.push(stateNavigator.stateContext.state);
+            var beforeNavigateHandler1 = (state, data, url, history, {state: oldState}) => {
+                oldStates.push(oldState);
                 states.push(state);
                 return true;
             };
-            var beforeNavigateHandler2 = (state, data, url, history) => {
-                oldStates.push(stateNavigator.stateContext.state);
+            var beforeNavigateHandler2 = (state, data, url, history, {state: oldState}) => {
+                oldStates.push(oldState);
                 states.push(state);
                 return true;
             };
@@ -3057,13 +3057,13 @@ describe('Navigation', function () {
             var oldStates2 = [];
             var states2 = [];
             stateNavigator.navigate('s0');
-            var beforeNavigateHandler1 = (state, data, url, history) => {
-                oldStates1.push(stateNavigator.stateContext.state);
+            var beforeNavigateHandler1 = (state, data, url, history, {state: oldState}) => {
+                oldStates1.push(oldState);
                 states1.push(state);
                 return true;
             };
-            var beforeNavigateHandler2 = (state, data, url, history) => {
-                oldStates2.push(stateNavigator.stateContext.state);
+            var beforeNavigateHandler2 = (state, data, url, history, {state: oldState}) => {
+                oldStates2.push(oldState);
                 states2.push(state);
                 return true;
             };
@@ -3143,8 +3143,8 @@ describe('Navigation', function () {
             var oldStates = [];
             var states = [];
             stateNavigator.navigate('s0');
-            var beforeNavigateHandler = (state, data, url, history) => {
-                oldStates.push(stateNavigator.stateContext.state);
+            var beforeNavigateHandler = (state, data, url, history, {state: oldState}) => {
+                oldStates.push(oldState);
                 states.push(state);
                 return true;
             };
@@ -3202,13 +3202,13 @@ describe('Navigation', function () {
             var oldStates2 = [];
             var states2 = [];
             stateNavigator.navigate('s0');
-            var beforeNavigateHandler1 = (state, data, url, history) => {
-                oldStates1.push(stateNavigator.stateContext.state);
+            var beforeNavigateHandler1 = (state, data, url, history, {state: oldState}) => {
+                oldStates1.push(oldState);
                 states1.push(state);
                 return true;
             };
-            var beforeNavigateHandler2 = (state, data, url, history) => {
-                oldStates2.push(stateNavigator.stateContext.state);
+            var beforeNavigateHandler2 = (state, data, url, history, {state: oldState}) => {
+                oldStates2.push(oldState);
                 states2.push(state);
                 return true;
             };
@@ -3450,8 +3450,8 @@ describe('Navigation', function () {
                 navigatingUrl = url;
                 navigating('World');
             }
-            var beforeNavigateHandler = (state, data, url, history) => {
-                beforeNavigateOldState = stateNavigator.stateContext.state;
+            var beforeNavigateHandler = (state, data, url, history, {state: oldState}) => {
+                beforeNavigateOldState = oldState;
                 beforeNavigateState = state;
                 beforeNavigateData = data;
                 beforeNavigateUrl = url;
@@ -3504,8 +3504,8 @@ describe('Navigation', function () {
                 navigatingUrl = url;
                 navigating('World');
             }
-            var beforeNavigateHandler = (state, data, url, history) => {
-                beforeNavigateOldState = stateNavigator.stateContext.state;
+            var beforeNavigateHandler = (state, data, url, history, {state: oldState}) => {
+                beforeNavigateOldState = oldState;
                 beforeNavigateState = state;
                 beforeNavigateData = data;
                 beforeNavigateUrl = url;

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -3443,8 +3443,8 @@ describe('Navigation', function () {
             var stateNavigator = new StateNavigator([
                 { key: 's', route: 'r' }
             ]);
-            var navigatedOldState, navigatedState, navigatedData, navigatedAsyncData, navigatingData, navigatingUrl,
-                beforeNavigateOldState, beforeNavigateState, beforeNavigateData, beforeNavigateUrl;
+            var navigatedOldState, navigatedState, navigatedData, navigatedUrl, navigatedAsyncData, navigatingData,
+                navigatingUrl, beforeNavigateOldState, beforeNavigateState, beforeNavigateData, beforeNavigateUrl;
             stateNavigator.states['s'].navigating = (data, url, navigating) => {
                 navigatingData = data;
                 navigatingUrl = url;
@@ -3457,11 +3457,12 @@ describe('Navigation', function () {
                 beforeNavigateUrl = url;
                 return true;
             };
-            var navigatedHandler = (oldState, state, data, asyncData) => {
+            var navigatedHandler = (oldState, state, data, asyncData, {url}) => {
                 navigatedOldState = oldState;
                 navigatedState = state;
                 navigatedData = data;
                 navigatedAsyncData = asyncData;
+                navigatedUrl = url;
             };
             stateNavigator.onBeforeNavigate(beforeNavigateHandler);
             stateNavigator.onNavigate(navigatedHandler);
@@ -3479,6 +3480,7 @@ describe('Navigation', function () {
             assert.strictEqual(navigatedState, stateNavigator.states['s']);
             assert.strictEqual(navigatedData.s, 'Hello');
             assert.strictEqual(navigatedAsyncData, 'World');
+            assert.strictEqual(navigatedUrl, url);
             assert.strictEqual(stateNavigator.stateContext.data.s, 'Hello');
         });
     });
@@ -3491,7 +3493,7 @@ describe('Navigation', function () {
             ]);
             var link = stateNavigator.getNavigationLink('s0');
             stateNavigator.navigateLink(link);
-            var unloadingState, unloadingData, unloadingUrl, navigatedOldState, navigatedState, navigatedData, navigatedAsyncData,
+            var unloadingState, unloadingData, unloadingUrl, navigatedOldState, navigatedState, navigatedData, navigatedAsyncData, navigatedUrl,
                 navigatingData, navigatingUrl, beforeNavigateOldState, beforeNavigateState, beforeNavigateData, beforeNavigateUrl;
             stateNavigator.states['s0'].unloading = (state, data, url, unload) => {
                 unloadingState = state;
@@ -3511,11 +3513,12 @@ describe('Navigation', function () {
                 beforeNavigateUrl = url;
                 return true;
             };
-            var navigatedHandler = (oldState, state, data, asyncData) => {
+            var navigatedHandler = (oldState, state, data, asyncData, {url}) => {
                 navigatedOldState = oldState;
                 navigatedState = state;
                 navigatedData = data;
                 navigatedAsyncData = asyncData;
+                navigatedUrl = url;
             };
             stateNavigator.onBeforeNavigate(beforeNavigateHandler);
             stateNavigator.onNavigate(navigatedHandler);
@@ -3539,6 +3542,7 @@ describe('Navigation', function () {
             assert.strictEqual(navigatedState, stateNavigator.states['s1']);
             assert.strictEqual(navigatedData.s, 'Hello');
             assert.strictEqual(navigatedAsyncData, 'World');
+            assert.strictEqual(navigatedUrl, url);
             assert.strictEqual(Object.keys(navigatedData).length, 1);
         });
     });

--- a/Navigation/test/node_modules/navigation.d.ts
+++ b/Navigation/test/node_modules/navigation.d.ts
@@ -478,22 +478,22 @@ export class StateNavigator {
      * Registers a before navigate event listener
      * @param handler The before navigate event listener
      */
-    onBeforeNavigate(handler: (state: State, data: any, url: string, history: boolean, stateContext: StateContext) => boolean): void;
+    onBeforeNavigate(handler: (state: State, data: any, url: string, history: boolean, currentContext: StateContext) => boolean): void;
     /**
      * Unregisters a before navigate event listener
      * @param handler The before navigate event listener
      */
-    offBeforeNavigate(handler: (state: State, data: any, url: string, history: boolean, stateContext: StateContext) => boolean): void;
+    offBeforeNavigate(handler: (state: State, data: any, url: string, history: boolean, currentContext: StateContext) => boolean): void;
     /**
      * Registers a navigate event listener
      * @param handler The navigate event listener
      */
-    onNavigate(handler: (oldState: State, state: State, data: any, asyncData: any) => void): void;
+    onNavigate(handler: (oldState: State, state: State, data: any, asyncData: any, stateContext: StateContext) => void): void;
     /**
      * Unregisters a navigate event listener
      * @param handler The navigate event listener
      */
-    offNavigate(handler: (oldState: State, state: State, data: any, asyncData: any) => void): void;
+    offNavigate(handler: (oldState: State, state: State, data: any, asyncData: any, stateContext: StateContext) => void): void;
     /**
      * Navigates to a State
      * @param stateKey The key of a State

--- a/Navigation/test/node_modules/navigation.d.ts
+++ b/Navigation/test/node_modules/navigation.d.ts
@@ -478,12 +478,12 @@ export class StateNavigator {
      * Registers a before navigate event listener
      * @param handler The before navigate event listener
      */
-    onBeforeNavigate(handler: (state: State, data: any, url: string, history: boolean) => boolean): void;
+    onBeforeNavigate(handler: (state: State, data: any, url: string, history: boolean, stateContext: StateContext) => boolean): void;
     /**
      * Unregisters a before navigate event listener
      * @param handler The before navigate event listener
      */
-    offBeforeNavigate(handler: (state: State, data: any, url: string, history: boolean) => boolean): void;
+    offBeforeNavigate(handler: (state: State, data: any, url: string, history: boolean, stateContext: StateContext) => boolean): void;
     /**
      * Registers a navigate event listener
      * @param handler The navigate event listener

--- a/NavigationReact/src/node_modules/navigation.d.ts
+++ b/NavigationReact/src/node_modules/navigation.d.ts
@@ -478,22 +478,22 @@ export class StateNavigator {
      * Registers a before navigate event listener
      * @param handler The before navigate event listener
      */
-    onBeforeNavigate(handler: (state: State, data: any, url: string, history: boolean) => boolean): void;
+    onBeforeNavigate(handler: (state: State, data: any, url: string, history: boolean, currentContext: StateContext) => boolean): void;
     /**
      * Unregisters a before navigate event listener
      * @param handler The before navigate event listener
      */
-    offBeforeNavigate(handler: (state: State, data: any, url: string, history: boolean) => boolean): void;
+    offBeforeNavigate(handler: (state: State, data: any, url: string, history: boolean, currentContext: StateContext) => boolean): void;
     /**
      * Registers a navigate event listener
      * @param handler The navigate event listener
      */
-    onNavigate(handler: (oldState: State, state: State, data: any, asyncData: any) => void): void;
+    onNavigate(handler: (oldState: State, state: State, data: any, asyncData: any, stateContext: StateContext) => void): void;
     /**
      * Unregisters a navigate event listener
      * @param handler The navigate event listener
      */
-    offNavigate(handler: (oldState: State, state: State, data: any, asyncData: any) => void): void;
+    offNavigate(handler: (oldState: State, state: State, data: any, asyncData: any, stateContext: StateContext) => void): void;
     /**
      * Navigates to a State
      * @param stateKey The key of a State

--- a/NavigationReact/test/node_modules/navigation.d.ts
+++ b/NavigationReact/test/node_modules/navigation.d.ts
@@ -478,22 +478,22 @@ export class StateNavigator {
      * Registers a before navigate event listener
      * @param handler The before navigate event listener
      */
-    onBeforeNavigate(handler: (state: State, data: any, url: string, history: boolean) => boolean): void;
+    onBeforeNavigate(handler: (state: State, data: any, url: string, history: boolean, currentContext: StateContext) => boolean): void;
     /**
      * Unregisters a before navigate event listener
      * @param handler The before navigate event listener
      */
-    offBeforeNavigate(handler: (state: State, data: any, url: string, history: boolean) => boolean): void;
+    offBeforeNavigate(handler: (state: State, data: any, url: string, history: boolean, currentContext: StateContext) => boolean): void;
     /**
      * Registers a navigate event listener
      * @param handler The navigate event listener
      */
-    onNavigate(handler: (oldState: State, state: State, data: any, asyncData: any) => void): void;
+    onNavigate(handler: (oldState: State, state: State, data: any, asyncData: any, stateContext: StateContext) => void): void;
     /**
      * Unregisters a navigate event listener
      * @param handler The navigate event listener
      */
-    offNavigate(handler: (oldState: State, state: State, data: any, asyncData: any) => void): void;
+    offNavigate(handler: (oldState: State, state: State, data: any, asyncData: any, stateContext: StateContext) => void): void;
     /**
      * Navigates to a State
      * @param stateKey The key of a State

--- a/NavigationReactMobile/src/node_modules/navigation.d.ts
+++ b/NavigationReactMobile/src/node_modules/navigation.d.ts
@@ -478,22 +478,22 @@ export class StateNavigator {
      * Registers a before navigate event listener
      * @param handler The before navigate event listener
      */
-    onBeforeNavigate(handler: (state: State, data: any, url: string, history: boolean) => boolean): void;
+    onBeforeNavigate(handler: (state: State, data: any, url: string, history: boolean, currentContext: StateContext) => boolean): void;
     /**
      * Unregisters a before navigate event listener
      * @param handler The before navigate event listener
      */
-    offBeforeNavigate(handler: (state: State, data: any, url: string, history: boolean) => boolean): void;
+    offBeforeNavigate(handler: (state: State, data: any, url: string, history: boolean, currentContext: StateContext) => boolean): void;
     /**
      * Registers a navigate event listener
      * @param handler The navigate event listener
      */
-    onNavigate(handler: (oldState: State, state: State, data: any, asyncData: any) => void): void;
+    onNavigate(handler: (oldState: State, state: State, data: any, asyncData: any, stateContext: StateContext) => void): void;
     /**
      * Unregisters a navigate event listener
      * @param handler The navigate event listener
      */
-    offNavigate(handler: (oldState: State, state: State, data: any, asyncData: any) => void): void;
+    offNavigate(handler: (oldState: State, state: State, data: any, asyncData: any, stateContext: StateContext) => void): void;
     /**
      * Navigates to a State
      * @param stateKey The key of a State

--- a/NavigationReactMobile/test/node_modules/navigation.d.ts
+++ b/NavigationReactMobile/test/node_modules/navigation.d.ts
@@ -478,22 +478,22 @@ export class StateNavigator {
      * Registers a before navigate event listener
      * @param handler The before navigate event listener
      */
-    onBeforeNavigate(handler: (state: State, data: any, url: string, history: boolean) => boolean): void;
+    onBeforeNavigate(handler: (state: State, data: any, url: string, history: boolean, currentContext: StateContext) => boolean): void;
     /**
      * Unregisters a before navigate event listener
      * @param handler The before navigate event listener
      */
-    offBeforeNavigate(handler: (state: State, data: any, url: string, history: boolean) => boolean): void;
+    offBeforeNavigate(handler: (state: State, data: any, url: string, history: boolean, currentContext: StateContext) => boolean): void;
     /**
      * Registers a navigate event listener
      * @param handler The navigate event listener
      */
-    onNavigate(handler: (oldState: State, state: State, data: any, asyncData: any) => void): void;
+    onNavigate(handler: (oldState: State, state: State, data: any, asyncData: any, stateContext: StateContext) => void): void;
     /**
      * Unregisters a navigate event listener
      * @param handler The navigate event listener
      */
-    offNavigate(handler: (oldState: State, state: State, data: any, asyncData: any) => void): void;
+    offNavigate(handler: (oldState: State, state: State, data: any, asyncData: any, stateContext: StateContext) => void): void;
     /**
      * Navigates to a State
      * @param stateKey The key of a State


### PR DESCRIPTION
Thought it wasn’t necessary because could always get the contet from the `stateNavigator`. But in Mobile, each `Scene` has its own `NavigationContext`. In an onBeforeNavigate handler a Scene might need to check if it’s current. It can only do this by comparing its context to the current one.