### PR TITLE
Pinned the Current Scene’s NavigationContext on Navigation

### DIFF
--- a/NavigationReactMobile/src/Motion.tsx
+++ b/NavigationReactMobile/src/Motion.tsx
@@ -67,9 +67,10 @@ class Motion<T> extends React.Component<MotionProps<T>, any> {
                 .filter(item => !itemsByKey[getKey(item)])
                 .map(item => {
                     var index = dataByKey[getKey(item)].index;
-                    var newItem: any = {key: getKey(item), data: item, progress, tick, rest: false, index};
+                    var newItem: any = {key: getKey(item), data: item, tick, rest: false, index};
                     newItem.start = newItem.style = enter(item);
                     newItem.end = update(item);
+                    newItem.progress = Motion.areEqual(newItem.start, newItem.end) ? 1 : 0;
                     return newItem;
                 })
             )

--- a/NavigationReactMobile/src/Motion.tsx
+++ b/NavigationReactMobile/src/Motion.tsx
@@ -16,6 +16,9 @@ class Motion<T> extends React.Component<MotionProps<T>, any> {
         var {items, moving} = Motion.move(tick, prevItems, props);
         return {items, restart: moving};
     }
+    componentDidMount() {
+        this.animateId = requestAnimationFrame(this.animate);
+    }
     componentDidUpdate() {
         if (!this.animateId && this.state.restart)
             this.animateId = requestAnimationFrame(this.animate);

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -93,19 +93,19 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
                     leave={scene => this.getStyle(false, scene)}
                     onRest={({key}) => this.clearScene(key)}
                     duration={duration}>
-                    {tweenStyles => (
-                        tweenStyles.map(({data: {key, state, data, url, navigationEvent}, style: tweenStyle}) => {
+                    {styles => (
+                        styles.map(({data: {key, state, data, navigationEvent}, style}) => {
                             var scene = navigationEvent && (
                                 <Scene navigationEvent={navigationEvent} stateNavigator={stateNavigator}>
                                     {state.renderScene(data)}
                                 </Scene>
                             );
-                            return children(tweenStyle, scene, key, crumbs.length === key, state, data)
+                            return children(style, scene, key, crumbs.length === key, state, data)
                         }).concat(
                             sharedElementMotion && sharedElementMotion({
                                 key: 'sharedElements',
                                 sharedElements: !this.state.rest ? this.getSharedElements(crumbs, oldUrl) : [],
-                                progress: tweenStyles[crumbs.length] && tweenStyles[crumbs.length].progress,
+                                progress: styles[crumbs.length] && styles[crumbs.length].progress,
                                 duration,
                             })
                         )

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -1,12 +1,13 @@
 import { State, Crumb } from 'navigation';
+import { NavigationEvent } from 'navigation-react';
 import * as React from 'react';
 import Motion from './Motion';
 import Scene from './Scene';
 import SharedElementContext from './SharedElementContext';
 import withStateNavigator from './withStateNavigator';
 import { NavigationMotionProps, SharedItem } from './Props';
-type NavigationMotionState = { scenes: { [crumbs: number]: boolean }, rest: boolean };
-type SceneContext = { key: number, state: State, data: any, url: string, crumbs: Crumb[], nextState: State, nextData: any, mount: boolean };
+type NavigationMotionState = { scenes: { [crumbs: number]: NavigationEvent }, rest: boolean };
+type SceneContext = { key: number, state: State, data: any, url: string, crumbs: Crumb[], nextState: State, nextData: any, navigationEvent: NavigationEvent, mount: boolean };
 
 class NavigationMotion extends React.Component<NavigationMotionProps, NavigationMotionState> {
     private sharedElements: { [scene: number]: { [name: string]: { ref: HTMLElement; data: any }; }; } = {};
@@ -23,15 +24,17 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
                     delete this.sharedElements[scene][name];
             },
         }
-        var {state, crumbs} = this.props.stateNavigator.stateContext;
-        this.state = {scenes: {[crumbs.length]: !!state}, rest: false};
+        var {navigationEvent, stateNavigator} = this.props;
+        var {state, crumbs} = stateNavigator.stateContext;
+        this.state = {scenes: {[crumbs.length]: state ? navigationEvent : null }, rest: false};
     }
     static defaultProps = {
         duration: 300
     }
-    static getDerivedStateFromProps({stateNavigator}: NavigationMotionProps, {scenes: prevScenes}: NavigationMotionState) {
+    static getDerivedStateFromProps(props: NavigationMotionProps, {scenes}: NavigationMotionState) {
+        var {navigationEvent, stateNavigator} = props;
         var {crumbs} = stateNavigator.stateContext;
-        return {scenes: {...prevScenes, [crumbs.length]: true}, rest: false};
+        return {scenes: {...scenes, [crumbs.length]: navigationEvent}, rest: false};
     }
     getSharedElements(crumbs, oldUrl) {
         if (oldUrl === null || crumbs.length === oldUrl.split('crumb=').length - 1)
@@ -55,7 +58,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
             var scene = this.getScenes().filter(scene => scene.key === index)[0];
             if (!scene)
                 delete this.sharedElements[index];
-            var scenes = {...prevScenes, [index]: !!(prevScenes[index] && scene)};
+            var scenes = {...prevScenes, [index]: scene ? prevScenes[index] : null};
             var rest = prevRest || (scene && scene.mount);
             return (scenes[index] !== prevScenes[index] || rest !== prevRest) ? {scenes, rest} : null;
         });
@@ -64,18 +67,20 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
         var {stateNavigator} = this.props;
         var {crumbs, nextCrumb} = stateNavigator.stateContext;
         return crumbs.concat(nextCrumb).map(({state, data, url}, index, crumbsAndNext) => {
+            var mount = url === nextCrumb.url;
+            var navigationEvent = this.state.scenes[index];
             var preCrumbs = crumbsAndNext.slice(0, index);
             var {state: nextState, data: nextData} = crumbsAndNext[index + 1] || {state: undefined, data: undefined};
-            return {key: index, state, data, url, crumbs: preCrumbs, nextState, nextData, mount: url === nextCrumb.url};
+            return {key: index, state, data, url, crumbs: preCrumbs, nextState, nextData, navigationEvent, mount};
         });
     }
     getStyle(mounted: boolean, {state, data, crumbs, nextState, nextData, mount}: SceneContext) {
         var {unmountedStyle, mountedStyle, crumbStyle} = this.props;
-        var styleProp = !mounted ? unmountedStyle : (mount ? mountedStyle : crumbStyle)
+        var styleProp = !mounted ? unmountedStyle : (mount ? mountedStyle : crumbStyle);
         return typeof styleProp === 'function' ? styleProp(state, data, crumbs, nextState, nextData) : styleProp;
      }
     render() {
-        var {children, duration, sharedElementMotion, stateNavigator, navigationEvent} = this.props;
+        var {children, duration, sharedElementMotion, stateNavigator} = this.props;
         var {stateContext: {crumbs, oldUrl, oldState}, stateContext} = stateNavigator;
         var SceneMotion: new() => Motion<SceneContext> = Motion as any;
         return (stateContext.state &&
@@ -89,9 +94,12 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
                     onRest={({key}) => this.clearScene(key)}
                     duration={duration}>
                     {tweenStyles => (
-                        tweenStyles.map(({data: {key, state, data, url}, style: tweenStyle}) => {
-                            var scene = this.state.scenes[key] &&
-                                <Scene navigationEvent={navigationEvent}>{state.renderScene(data)}</Scene>;
+                        tweenStyles.map(({data: {key, state, data, url, navigationEvent}, style: tweenStyle}) => {
+                            var scene = navigationEvent && (
+                                <Scene navigationEvent={navigationEvent} stateNavigator={stateNavigator}>
+                                    {state.renderScene(data)}
+                                </Scene>
+                            );
                             return children(tweenStyle, scene, key, crumbs.length === key, state, data)
                         }).concat(
                             sharedElementMotion && sharedElementMotion({

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -26,7 +26,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
         }
         var {navigationEvent, stateNavigator} = this.props;
         var {state, crumbs} = stateNavigator.stateContext;
-        this.state = {scenes: {[crumbs.length]: state ? navigationEvent : null }, rest: false};
+        this.state = {scenes: {[crumbs.length]: state && navigationEvent}, rest: false};
     }
     static defaultProps = {
         duration: 300

--- a/NavigationReactMobile/src/Props.ts
+++ b/NavigationReactMobile/src/Props.ts
@@ -21,7 +21,7 @@ interface SharedElementProps {
     unshare?: boolean;
     registerSharedElement: (scene: number, name: string, ref: HTMLElement, data: any) => void;
     unregisterSharedElement: (scene: number, name: string) => void;
-    stateNavigator?: StateNavigator;
+    stateNavigator: StateNavigator;
     children: ReactElement<any>;
 }
 
@@ -58,6 +58,7 @@ interface NavigationMotionProps {
 
 interface SceneProps {
     navigationEvent: NavigationEvent;
+    stateNavigator: StateNavigator;
 }
 
 export { MotionProps, SharedElementProps, SharedItem, SharedElementNavigationMotionProps, SharedElementMotionProps, NavigationMotionProps, SceneProps }

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -1,26 +1,15 @@
 import { NavigationContext, NavigationEvent } from 'navigation-react';
 import * as React from 'react';
 import { SceneProps } from './Props';
-type SceneState = { context: NavigationEvent };
 
-class Scene extends React.Component<SceneProps, SceneState> {
-    constructor(props: SceneProps) {
-        super(props);
-        this.state = {context: props.navigationEvent};
-    }
-    static getDerivedStateFromProps({navigationEvent}: SceneProps, {context}: SceneState) {
-        if (navigationEvent.stateNavigator.stateContext.crumbs.length 
-            !== context.stateNavigator.stateContext.crumbs.length)
-            return null;
-        return {context: navigationEvent};
-    }
-    shouldComponentUpdate({navigationEvent}: SceneProps, {context}: SceneState) {
-        return navigationEvent.stateNavigator.stateContext.crumbs.length
-            === context.stateNavigator.stateContext.crumbs.length;
+class Scene extends React.Component<SceneProps> {
+    shouldComponentUpdate({navigationEvent, stateNavigator}: SceneProps) {
+        var index = navigationEvent.stateNavigator.stateContext.crumbs.length;
+        return stateNavigator.stateContext.crumbs.length === index;
     }
     render() {
         return (
-            <NavigationContext.Provider value={this.state.context}>
+            <NavigationContext.Provider value={this.props.navigationEvent}>
                 {this.props.children}
             </NavigationContext.Provider>
         );

--- a/NavigationReactMobile/src/SharedElementMotion.tsx
+++ b/NavigationReactMobile/src/SharedElementMotion.tsx
@@ -31,7 +31,7 @@ class SharedElementMotion extends React.Component<SharedElementNavigationMotionP
         return sharedElements.reduce((elements, element) => ({...elements, [element.name]: element}), {});
     }
     getStyle(name, {ref, data}) {
-        var { top, left, width, height } = ref.getBoundingClientRect();
+        var {top, left, width, height} = ref.getBoundingClientRect();
         return this.props.elementStyle(name, ref, { top, left, width, height, ...data});
     }
     getPropValue(prop, name) {

--- a/NavigationReactMobile/src/SharedElementMotion.tsx
+++ b/NavigationReactMobile/src/SharedElementMotion.tsx
@@ -48,8 +48,8 @@ class SharedElementMotion extends React.Component<SharedElementNavigationMotionP
                 update={({name, mountedElement}) => this.getStyle(name, mountedElement)}
                 progress={progress < 1 ? progress : 0}
                 duration={duration}>
-                {tweenStyles => (
-                    tweenStyles.map(({data: {name, oldElement, mountedElement}, style, start, end}) => (
+                {styles => (
+                    styles.map(({data: {name, oldElement, mountedElement}, style, start, end}) => (
                         children(style, name, {...start, ...oldElement.data}, {...end, ...mountedElement.data})
                     ))
                 )}


### PR DESCRIPTION
Can think of this as an alternate fix for #180 where two navigations happen in a row without a render in between. Need Scene B to get the right context even though it renders when Scene C is current.
```javascript
navigateLink('/B?crumb=A')
navigateLink('/C?crumb=A&crumb=B')
```

In #180, the fix ensured Scene B was rendered in between so that the Scene constructor ran when Scene B was current.

Here, the fix moves the creation of the `NavigationContext` out of the Scene constructor and into `getDerivedStateFromProps` of the `NavigationMotion`. That way it doesn’t matter when the Scene renders because the `NavigationContext` was set in `state` when the Scene was current.
