### PR TITLE
Prevented Scene re-rendering while Navigating

### DIFF
--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -5,7 +5,8 @@ import { SceneProps } from './Props';
 class Scene extends React.Component<SceneProps> {
     shouldComponentUpdate({navigationEvent, stateNavigator}: SceneProps) {
         var index = navigationEvent.stateNavigator.stateContext.crumbs.length;
-        return stateNavigator.stateContext.crumbs.length === index;
+        return stateNavigator.stateContext.crumbs.length === index
+            && navigationEvent !== this.props.navigationEvent;
     }
     render() {
         return (


### PR DESCRIPTION
During a navigation only want the Scenes to animate. Don't want them to re-render when applying the new styles. Changed the `shouldComponentUpdate` to return false if the `NavigationContext` hasn't changed so they'll only re-render once when refreshing and never when animating