### PR TITLE
Returned Crumbs from parseLink

### DIFF
--- a/Navigation/src/StateNavigator.ts
+++ b/Navigation/src/StateNavigator.ts
@@ -120,8 +120,7 @@ class StateNavigator {
         if (history && this.stateContext.url === url)
             return;
         var oldUrl = this.stateContext.url;
-        var { state, data } = this.stateHandler.parseLink(url);
-        var { [state.crumbTrailKey]: crumbs, ...data } = data;
+        var { state, data, crumbs } = this.parseLink(url);
         for (var id in this.onBeforeNavigateCache.handlers) {
             var handler = this.onBeforeNavigateCache.handlers[id];
             if (oldUrl !== this.stateContext.url || !handler(state, data, url, history, this.stateContext))
@@ -164,10 +163,10 @@ class StateNavigator {
         }
     }
 
-    parseLink(url: string): { state: State, data: any } {
+    parseLink(url: string): { state: State, data: any, crumbs: Crumb[] } {
         var { state, data } = this.stateHandler.parseLink(url);
-        delete data[state.crumbTrailKey];
-        return { state, data };
+        var { [state.crumbTrailKey]: crumbs, ...data } = data;
+        return { state, data, crumbs };
     }
 
     fluent(withContext = false): FluentNavigator {

--- a/Navigation/test/NavigationRoutingTest.ts
+++ b/Navigation/test/NavigationRoutingTest.ts
@@ -6958,4 +6958,44 @@ describe('MatchTest', function () {
             assert.strictEqual(state.key, 's1');
         });
     });
+
+    describe('Crumb Trail Crumbs', function () {
+        var stateNavigator: StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new StateNavigator([
+                { key: 's0', route: 'a' },
+                { key: 's1', route: 'b', trackCrumbTrail: true },
+                { key: 's2', route: 'c', trackCrumbTrail: true },
+            ]);
+        });
+
+        it('should match', function() {
+            var { crumbs } = stateNavigator.parseLink('/a');
+            assert.strictEqual(crumbs.length, 0);
+            var link = stateNavigator.getNavigationLink('s0', { x: 0, y: '1' });
+            ({ crumbs } = stateNavigator.parseLink(link));
+            assert.strictEqual(crumbs.length, 0);
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationLink('s1', { x: 2, y: 3, z: '4' });
+            ({ crumbs } = stateNavigator.parseLink(link));
+            assert.strictEqual(crumbs.length, 1);
+            assert.strictEqual(crumbs[0].state.key, 's0');
+            assert.strictEqual(crumbs[0].data.x, 0);
+            assert.strictEqual(crumbs[0].data.y, '1');
+            assert.strictEqual(Object.keys(crumbs[0].data).length, 2);
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationLink('s2');
+            var { crumbs } = stateNavigator.parseLink(link);
+            assert.strictEqual(crumbs.length, 2);
+            assert.strictEqual(crumbs[0].state.key, 's0');
+            assert.strictEqual(crumbs[0].data.x, 0);
+            assert.strictEqual(crumbs[0].data.y, '1');
+            assert.strictEqual(Object.keys(crumbs[0].data).length, 2);
+            assert.strictEqual(crumbs[1].state.key, 's1');
+            assert.strictEqual(crumbs[1].data.x, 2);
+            assert.strictEqual(crumbs[1].data.y, 3);
+            assert.strictEqual(crumbs[1].data.z, '4');
+            assert.strictEqual(Object.keys(crumbs[1].data).length, 3);
+        });
+    });
 });

--- a/Navigation/test/node_modules/navigation.d.ts
+++ b/Navigation/test/node_modules/navigation.d.ts
@@ -565,7 +565,7 @@ export class StateNavigator {
      * Parses the url out into State and Navigation Data
      * @param url The url to parse
      */
-    parseLink(url: string): { state: State; data: any; };
+    parseLink(url: string): { state: State; data: any; crumbs: Crumb[] };
     /**
      * Creates a FluentNavigator
      * @param withContext a value indicating whether to inherit the current

--- a/NavigationReact/src/node_modules/navigation.d.ts
+++ b/NavigationReact/src/node_modules/navigation.d.ts
@@ -565,7 +565,7 @@ export class StateNavigator {
      * Parses the url out into State and Navigation Data
      * @param url The url to parse
      */
-    parseLink(url: string): { state: State; data: any; };
+    parseLink(url: string): { state: State; data: any; crumbs: Crumb[] };
     /**
      * Creates a FluentNavigator
      * @param withContext a value indicating whether to inherit the current

--- a/NavigationReact/test/node_modules/navigation.d.ts
+++ b/NavigationReact/test/node_modules/navigation.d.ts
@@ -565,7 +565,7 @@ export class StateNavigator {
      * Parses the url out into State and Navigation Data
      * @param url The url to parse
      */
-    parseLink(url: string): { state: State; data: any; };
+    parseLink(url: string): { state: State; data: any; crumbs: Crumb[] };
     /**
      * Creates a FluentNavigator
      * @param withContext a value indicating whether to inherit the current

--- a/NavigationReactMobile/src/node_modules/navigation.d.ts
+++ b/NavigationReactMobile/src/node_modules/navigation.d.ts
@@ -565,7 +565,7 @@ export class StateNavigator {
      * Parses the url out into State and Navigation Data
      * @param url The url to parse
      */
-    parseLink(url: string): { state: State; data: any; };
+    parseLink(url: string): { state: State; data: any; crumbs: Crumb[] };
     /**
      * Creates a FluentNavigator
      * @param withContext a value indicating whether to inherit the current


### PR DESCRIPTION
A link is made up of `state`, `data` and `crumbs` so should return all pieces when parsing