### PR TITLE
Recycled History Manager in Async

### DIFF
--- a/Navigation/src/history/HTML5HistoryManager.ts
+++ b/Navigation/src/history/HTML5HistoryManager.ts
@@ -1,7 +1,7 @@
 ﻿import HistoryManager from './HistoryManager';
 
 class HTML5HistoryManager implements HistoryManager {
-    private navigateHistory: (e: PopStateEvent) => void;
+    private navigateHistory: (e: PopStateEvent) => void = null;
     private applicationPath: string = '';
     disabled: boolean = (typeof window === 'undefined') || !(window.history && window.history.pushState);
     
@@ -10,8 +10,8 @@ class HTML5HistoryManager implements HistoryManager {
     }
 
     init(navigateHistory: (url?: string) => void) {
-        this.navigateHistory = e => navigateHistory(e.state || undefined);
-        if (!this.disabled) {
+        if (!this.disabled && !this.navigateHistory) {
+            this.navigateHistory = e => navigateHistory(e.state || undefined);
             window.addEventListener('popstate', this.navigateHistory);
         }
     }
@@ -41,8 +41,9 @@ class HTML5HistoryManager implements HistoryManager {
     }
     
     stop() {
-        if (!this.disabled)
+        if (this.navigateHistory)
             window.removeEventListener('popstate', this.navigateHistory);
+        this.navigateHistory = null;
     }
 
     private static prependSlash(url: string): string {

--- a/Navigation/src/history/HashHistoryManager.ts
+++ b/Navigation/src/history/HashHistoryManager.ts
@@ -1,7 +1,7 @@
 ﻿import HistoryManager from './HistoryManager';
 
 class HashHistoryManager implements HistoryManager {
-    private navigateHistory: () => void;
+    private navigateHistory: () => void = null;
     private replaceQueryIdentifier: boolean = false;
     disabled: boolean = (typeof window === 'undefined') || !('onhashchange' in window);
     
@@ -10,8 +10,8 @@ class HashHistoryManager implements HistoryManager {
     }
 
     init(navigateHistory) {
-        this.navigateHistory = () => navigateHistory();
-        if (!this.disabled) {
+        if (!this.disabled && !this.navigateHistory) {
+            this.navigateHistory = () => navigateHistory();
             if (window.addEventListener)
                 window.addEventListener('hashchange', this.navigateHistory);
             else
@@ -44,12 +44,13 @@ class HashHistoryManager implements HistoryManager {
     }
     
     stop() {
-        if (!this.disabled) {
+        if (this.navigateHistory) {
             if (window.removeEventListener)
                 window.removeEventListener('hashchange', this.navigateHistory);
             else
                 window['detachEvent']('onhashchange', this.navigateHistory);
         }
+        this.navigateHistory = null;
     }
 
     private encode(url: string): string {

--- a/NavigationReact/src/AsyncStateNavigator.ts
+++ b/NavigationReact/src/AsyncStateNavigator.ts
@@ -1,5 +1,5 @@
 import NavigationHandler from './NavigationHandler';
-import { StateNavigator, StateContext, HTML5HistoryManager, State } from 'navigation';
+import { StateNavigator, StateContext, State } from 'navigation';
 import * as ReactDOM from 'react-dom';
 
 class AsyncStateNavigator extends StateNavigator {
@@ -7,13 +7,10 @@ class AsyncStateNavigator extends StateNavigator {
     private stateNavigator: StateNavigator;
 
     constructor(navigationHandler: NavigationHandler, stateNavigator: StateNavigator, stateContext: StateContext) {
-        var inertHistoryManager = new HTML5HistoryManager();
-        inertHistoryManager.init = () => {};
-        super(stateNavigator, inertHistoryManager);
+        super(stateNavigator, stateNavigator.historyManager);
         this.navigationHandler = navigationHandler;
         this.stateNavigator = stateNavigator;
         this.stateContext = stateContext;
-        this.historyManager = stateNavigator.historyManager;
         this.configure = stateNavigator.configure.bind(stateNavigator);
         this.onBeforeNavigate = stateNavigator.onBeforeNavigate.bind(stateNavigator);
         this.offBeforeNavigate = stateNavigator.offBeforeNavigate.bind(stateNavigator);

--- a/NavigationReact/src/NavigationContext.ts
+++ b/NavigationReact/src/NavigationContext.ts
@@ -1,6 +1,4 @@
-import AsyncStateNavigator from './AsyncStateNavigator';
-import { StateNavigator, StateContext } from 'navigation';
+import { StateNavigator } from 'navigation';
 import * as React from 'react';
 
-var asyncNavigator = new AsyncStateNavigator(null, new StateNavigator(), new StateContext());
-export default React.createContext({ oldState: null, state: null, data: {}, nextState: null, nextData: {}, stateNavigator: asyncNavigator });
+export default React.createContext({ oldState: null, state: null, data: {}, nextState: null, nextData: {}, stateNavigator: new StateNavigator() });


### PR DESCRIPTION
Instead of temporary inert history manager (so that no new history listeners created by Async navigator), passed the current history manager from async. Changed history managers so that they don't add new listeners if already listening