### PR TITLE
Packaged as a Single File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ Navigation*/src/**/*.js
 Navigation*/test/**/*.js
 !Navigation*/sample/**/*.js
 build/dist
-build/**/lib
+build/npm/**/navigation*.js
 npm-debug.log
 node_modules
 !Navigation*/src/node_modules

--- a/build/npm/navigation-angular/navigation-angular.js
+++ b/build/npm/navigation-angular/navigation-angular.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/NavigationAngular');

--- a/build/npm/navigation-angular/package.json
+++ b/build/npm/navigation-angular/package.json
@@ -2,7 +2,7 @@
   "name": "navigation-angular",
   "version": "2.0.0",
   "description": "Angular plugin for the Navigation router",
-  "main": "navigation-angular.js",
+  "main": "navigation.angular.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/grahammendick/navigation"

--- a/build/npm/navigation-cycle/navigation-cycle.js
+++ b/build/npm/navigation-cycle/navigation-cycle.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/NavigationCycle');

--- a/build/npm/navigation-cycle/package.json
+++ b/build/npm/navigation-cycle/package.json
@@ -2,7 +2,7 @@
   "name": "navigation-cycle",
   "version": "1.0.0",
   "description": "Cycle plugin for the Navigation router",
-  "main": "navigation-cycle.js",
+  "main": "navigation.cycle.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/grahammendick/navigation"

--- a/build/npm/navigation-knockout/navigation-knockout.js
+++ b/build/npm/navigation-knockout/navigation-knockout.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/NavigationKnockout');

--- a/build/npm/navigation-knockout/package.json
+++ b/build/npm/navigation-knockout/package.json
@@ -2,7 +2,7 @@
   "name": "navigation-knockout",
   "version": "2.0.0",
   "description": "Knockout plugin for the Navigation router",
-  "main": "navigation-knockout.js",
+  "main": "navigation.knockout.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/grahammendick/navigation"

--- a/build/npm/navigation-react-mobile/navigation-react-mobile.js
+++ b/build/npm/navigation-react-mobile/navigation-react-mobile.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/NavigationReactMobile');

--- a/build/npm/navigation-react-mobile/package.json
+++ b/build/npm/navigation-react-mobile/package.json
@@ -2,7 +2,7 @@
   "name": "navigation-react-mobile",
   "version": "1.1.0",
   "description": "React Mobile plugin for the Navigation router",
-  "main": "navigation-react-mobile.js",
+  "main": "navigation.react.mobile.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/grahammendick/navigation"

--- a/build/npm/navigation-react-native/navigation-react-native.js
+++ b/build/npm/navigation-react-native/navigation-react-native.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/NavigationReactNative');

--- a/build/npm/navigation-react-native/package.json
+++ b/build/npm/navigation-react-native/package.json
@@ -2,7 +2,7 @@
   "name": "navigation-react-native",
   "version": "2.0.0",
   "description": "React Native plugin for the Navigation router",
-  "main": "navigation-react-native.js",
+  "main": "navigation.react.native.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/grahammendick/navigation"

--- a/build/npm/navigation-react/navigation-react.js
+++ b/build/npm/navigation-react/navigation-react.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/NavigationReact');

--- a/build/npm/navigation-react/package.json
+++ b/build/npm/navigation-react/package.json
@@ -2,7 +2,7 @@
   "name": "navigation-react",
   "version": "3.1.0",
   "description": "React plugin for the Navigation router",
-  "main": "navigation-react.js",
+  "main": "navigation.react.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/grahammendick/navigation"

--- a/build/npm/navigation/navigation.js
+++ b/build/npm/navigation/navigation.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/Navigation');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -105,14 +105,14 @@ function rollupTask(name, input, file, globals, format) {
         })
     ));        
 }
-function buildTask(name, input, file, globals, format, details) {
+function buildTask(name, input, file, globals, details) {
     var info = `/**
- * ${name} v${details.version}
+ * ${details.name} v${details.version}
  * (c) Graham Mendick - ${details.homepage}
  * License: ${details.license}
  */
 `;
-    return rollupTask(name, input, file, globals, format)
+    return rollupTask(name, input, file, globals, 'iife')
         .then(() => (
             gulp.src(file)
                 .pipe(insert.prepend(info))
@@ -131,7 +131,7 @@ var itemTasks = items.reduce((tasks, item) => {
     var jsTo = './build/dist/' + packageName.replace(/-/g, '.') + '.js';
     var jsPackageTo = './build/npm/' + packageName + '/' + packageName.replace(/-/g, '.') + '.js';
     item.name = upperName.replace(/-/g, ' ');
-    gulp.task('Build' + name, () => buildTask(name, tsFrom, jsTo, item.globals || {}, 'iife', item));
+    gulp.task('Build' + name, () => buildTask(name, tsFrom, jsTo, item.globals || {}, item));
     gulp.task('Package' + name, () => rollupTask(name, tsFrom, jsPackageTo, item.globals || {}, 'cjs'));
     tasks.buildTasks.push('Build' + name);
     tasks.packageTasks.push('Package' + name);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -88,14 +88,7 @@ function rollupTask(name, input, file, globals, format) {
             nodeResolve({ jsnext: true, main: true }),
             cleanup()
         ]
-    }).then((bundle) => (
-        bundle.write({
-            format,
-            name,
-            globals,
-            file
-        })
-    ));        
+    }).then((bundle) => bundle.write({ format, name, globals, file }));
 }
 function buildTask(name, input, file, globals, details) {
     var info = `/**

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -128,10 +128,10 @@ var itemTasks = items.reduce((tasks, item) => {
     var jsTo = './build/dist/' + packageName.replace(/-/g, '.') + '.js';
     var jsPackageTo = './build/npm/' + packageName + '/' + packageName.replace(/-/g, '.') + '.js';
     item.name = upperName.replace(/-/g, ' ');
-    var makeRollupTask = (to, format) => () => rollupTask(name, tsFrom, to, item.globals || {}, format);
-    gulp.task('Rollup' + name, makeRollupTask(jsTo, 'iife'));
+    var makeRollupTask = (to, format) => rollupTask(name, tsFrom, to, item.globals || {}, format);
+    gulp.task('Rollup' + name, () => makeRollupTask(jsTo, 'iife'));
     gulp.task('Build' + name, ['Rollup' + name], () => buildTask(jsTo, item));
-    gulp.task('Package' + name, makeRollupTask(jsPackageTo, 'cjs'));
+    gulp.task('Package' + name, () => makeRollupTask(jsPackageTo, 'cjs'));
     tasks.buildTasks.push('Build' + name);
     tasks.packageTasks.push('Package' + name);
     return tasks;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -103,7 +103,7 @@ function buildTask(name, input, file, globals, details) {
                 .pipe(insert.prepend(info))
                 .pipe(gulp.dest('./build/dist'))
                 .pipe(rename(file.replace(/js$/, 'min.js')))
-                .pipe(uglify())
+                .pipe(uglify({ mangle: { except: ['$parse'] } }))
                 .pipe(insert.prepend(info))
                 .pipe(gulp.dest('.'))
         ));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,7 @@ var tests = [
     { name: 'NavigationBackLink', to: 'navigationBackLink.test.js', folder: 'React', ext: 'tsx' },
     { name: 'RefreshLink', to: 'refreshLink.test.js', folder: 'React', ext: 'tsx' }
 ];
-function rollupTestTask(name, input, file) {
+function testTask(name, input, file) {
     return rollup.rollup({
         input,
         external: ['assert', 'react', 'react-dom', 'react-dom/test-utils', 'jsdom' , 'tslib'],
@@ -43,18 +43,16 @@ function rollupTestTask(name, input, file) {
             format: 'cjs',
             file
         })
+    )).then(() => (
+        gulp.src(file)
+            .pipe(mocha({ reporter: 'progress' }))
     ));
-}
-function testTask(file) {
-    return gulp.src(file)
-        .pipe(mocha({ reporter: 'progress' }));
 }
 var testTasks = tests.reduce((tasks, test) => {
     var folder = './Navigation' + (test.folder || '') + '/test/';
     var file = folder + test.name + 'Test.' + (test.ext || 'ts');
     var to = './build/dist/' + test.to;
-    gulp.task('RollupTest' + test.name, () => rollupTestTask(test.name, file, to));
-    gulp.task('Test' + test.name, ['RollupTest' + test.name], () => testTask(to));
+    gulp.task('Test' + test.name, () => testTask(test.name, file, to));
     tasks.push('Test' + test.name);
     return tasks;
 }, []);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -128,7 +128,7 @@ var itemTasks = items.reduce((tasks, item) => {
     var jsTo = './build/dist/' + packageName.replace(/-/g, '.') + '.js';
     var jsPackageTo = './build/npm/' + packageName + '/' + packageName.replace(/-/g, '.') + '.js';
     item.name = upperName.replace(/-/g, ' ');
-    var makeRollupTask = (to, format) => () => rollupTask(name, tsFrom, to, item.globals || {}, format)
+    var makeRollupTask = (to, format) => () => rollupTask(name, tsFrom, to, item.globals || {}, format);
     gulp.task('Rollup' + name, makeRollupTask(jsTo, 'iife'));
     gulp.task('Build' + name, ['Rollup' + name], () => buildTask(jsTo, item));
     gulp.task('Package' + name, () => makeRollupTask(jsPackageTo, 'cjs'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,7 +23,7 @@ var tests = [
 ];
 function rollupTestTask(name, file, to) {
     return rollup.rollup({
-        entry: file,
+        input: file,
         external: ['assert', 'react', 'react-dom', 'react-dom/test-utils', 'jsdom' , 'tslib'],
         plugins: [
             rollupTypescript({
@@ -40,9 +40,9 @@ function rollupTestTask(name, file, to) {
             })
         ]
     }).then((bundle) => {
-        bundle.write({
+        return bundle.write({
             format: 'cjs',
-            dest: to
+            file: to
         });
     });
 }
@@ -84,7 +84,7 @@ var items = [
 ];
 function rollupTask(name, file, to, globals) {
     return rollup.rollup({
-        entry: file,
+        input: file,
         external: Object.keys(globals),
         plugins: [
             rollupTypescript({
@@ -97,11 +97,11 @@ function rollupTask(name, file, to, globals) {
             nodeResolve({ jsnext: true, main: true })
         ]
     }).then((bundle) => {
-        bundle.write({
+        return bundle.write({
             format: 'iife',
-            moduleName: name,
+            name,
             globals,
-            dest: './build/dist/' + to
+            file: './build/dist/' + to
         });
     });        
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -103,7 +103,7 @@ function buildTask(name, input, file, globals, details) {
                 .pipe(insert.prepend(info))
                 .pipe(gulp.dest('./build/dist'))
                 .pipe(rename(file.replace(/js$/, 'min.js')))
-                .pipe(uglify({ mangle: { except: ['$parse'] } }))
+                .pipe(uglify({ mangle: { reserved: ['$parse'] } }))
                 .pipe(insert.prepend(info))
                 .pipe(gulp.dest('.'))
         ));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,11 +1,11 @@
 ﻿'use strict'
+var cleanup = require('rollup-plugin-cleanup');
 var gulp = require('gulp');
 var insert = require('gulp-insert');
 var mocha = require('gulp-mocha');
 var nodeResolve = require('rollup-plugin-node-resolve');
 var rename = require('gulp-rename');
 var rollup = require('rollup');
-var rollupCleanup = require('rollup-plugin-cleanup');
 var rollupTypescript = require('rollup-plugin-typescript');
 var typescript = require('typescript');
 var uglify = require('gulp-uglify');
@@ -94,7 +94,7 @@ function rollupTask(name, input, file, globals, format) {
                 jsx: 'react'
             }),
             nodeResolve({ jsnext: true, main: true }),
-            rollupCleanup()
+            cleanup()
         ]
     }).then((bundle) => (
         bundle.write({

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,12 +39,12 @@ function rollupTestTask(name, file, to) {
                 jsx: 'react'
             })
         ]
-    }).then((bundle) => {
-        return bundle.write({
+    }).then((bundle) => (
+        bundle.write({
             format: 'cjs',
             file: to
-        });
-    });
+        })
+    ));
 }
 function testTask(file) {
     return gulp.src(file)
@@ -96,14 +96,14 @@ function rollupTask(name, file, to, globals) {
             }),
             nodeResolve({ jsnext: true, main: true })
         ]
-    }).then((bundle) => {
-        return bundle.write({
+    }).then((bundle) => (
+        bundle.write({
             format: 'iife',
             name,
             globals,
             file: './build/dist/' + to
-        });
-    });        
+        })
+    ));        
 }
 function buildTask(file, details) {
     var info = `/**

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,7 +60,7 @@ var items = [
         require('./NavigationReact/src/tsconfig.json')),
     Object.assign({ globals: { knockout: 'ko' } },
         require('./build/npm/navigation-knockout/package.json')),
-    Object.assign({ globals: { angular: 'angular' } },
+    Object.assign({ globals: { angular: 'angular' }, reserved: ['$parse'] },
         require('./build/npm/navigation-angular/package.json')),
     Object.assign({ globals: { '@cycle/dom': 'CycleDOM', rx: 'Rx' } },
         require('./build/npm/navigation-cycle/package.json')),
@@ -103,7 +103,7 @@ function buildTask(name, input, file, globals, details) {
                 .pipe(insert.prepend(info))
                 .pipe(gulp.dest('./build/dist'))
                 .pipe(rename(file.replace(/js$/, 'min.js')))
-                .pipe(uglify({ mangle: { reserved: ['$parse'] } }))
+                .pipe(uglify({ mangle: { reserved: details.reserved } }))
                 .pipe(insert.prepend(info))
                 .pipe(gulp.dest('.'))
         ));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -82,7 +82,7 @@ var items = [
         require('./build/npm/navigation-react-native/package.json'),
         require('./NavigationReactNative/src/tsconfig.json')),
 ];
-function rollupTask(name, input, file, globals) {
+function rollupTask(name, input, file, globals, format) {
     return rollup.rollup({
         input,
         external: Object.keys(globals),
@@ -98,7 +98,7 @@ function rollupTask(name, input, file, globals) {
         ]
     }).then((bundle) => (
         bundle.write({
-            format: 'iife',
+            format,
             name,
             globals,
             file
@@ -132,10 +132,12 @@ var itemTasks = items.reduce((tasks, item) => {
     var name = upperName.replace(/-/g, '');
     var tsFrom = './' + name + '/src/' + name + '.ts';
     var jsTo = './build/dist/' + packageName.replace(/-/g, '.') + '.js';
+    var jsPackageTo = './build/npm/' + packageName + '/' + packageName.replace(/-/g, '.') + '.js';
     item.name = upperName.replace(/-/g, ' ');
-    gulp.task('Rollup' + name, () => rollupTask(name, tsFrom, jsTo, item.globals || {}));
+    gulp.task('Rollup' + name, () => rollupTask(name, tsFrom, jsTo, item.globals || {}, 'iife'));
     gulp.task('Build' + name, ['Rollup' + name], () => buildTask(jsTo, item));
-    gulp.task('Package' + name, () => packageTask(packageName, tsFrom, item));
+    gulp.task('Package' + name, () => rollupTask(name, tsFrom, jsPackageTo, item.globals || {}, 'cjs'));
+    //gulp.task('Package' + name, () => packageTask(packageName, tsFrom, item));
     tasks.buildTasks.push('Build' + name);
     tasks.packageTasks.push('Package' + name);
     return tasks;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -100,7 +100,7 @@ function rollupTask(name, file, to, globals) {
         bundle.write({
             format: 'iife',
             moduleName: name,
-            globals: Object.assign({ navigation: 'Navigation'}, globals),
+            globals,
             dest: './build/dist/' + to
         });
     });        

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -105,20 +105,23 @@ function rollupTask(name, input, file, globals, format) {
         })
     ));        
 }
-function buildTask(file, details) {
+function buildTask(name, input, file, globals, format, details) {
     var info = `/**
- * ${details.name} v${details.version}
+ * ${name} v${details.version}
  * (c) Graham Mendick - ${details.homepage}
  * License: ${details.license}
  */
 `;
-    return gulp.src(file)
-        .pipe(insert.prepend(info))
-        .pipe(gulp.dest('./build/dist'))
-        .pipe(rename(file.replace(/js$/, 'min.js')))
-        .pipe(uglify())
-        .pipe(insert.prepend(info))
-        .pipe(gulp.dest('.'));
+    return rollupTask(name, input, file, globals, format)
+        .then(() => (
+            gulp.src(file)
+                .pipe(insert.prepend(info))
+                .pipe(gulp.dest('./build/dist'))
+                .pipe(rename(file.replace(/js$/, 'min.js')))
+                .pipe(uglify())
+                .pipe(insert.prepend(info))
+                .pipe(gulp.dest('.'))
+        ));
 }
 var itemTasks = items.reduce((tasks, item) => {
     var packageName = item.name;
@@ -129,8 +132,8 @@ var itemTasks = items.reduce((tasks, item) => {
     var jsPackageTo = './build/npm/' + packageName + '/' + packageName.replace(/-/g, '.') + '.js';
     item.name = upperName.replace(/-/g, ' ');
     var makeRollupTask = (to, format) => rollupTask(name, tsFrom, to, item.globals || {}, format);
-    gulp.task('Rollup' + name, () => makeRollupTask(jsTo, 'iife'));
-    gulp.task('Build' + name, ['Rollup' + name], () => buildTask(jsTo, item));
+    //gulp.task('Rollup' + name, () => makeRollupTask(jsTo, 'iife'));
+    gulp.task('Build' + name, () => buildTask(name, tsFrom, jsTo, item.globals || {}, 'iife', item));
     gulp.task('Package' + name, () => makeRollupTask(jsPackageTo, 'cjs'));
     tasks.buildTasks.push('Build' + name);
     tasks.packageTasks.push('Package' + name);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,15 +38,9 @@ function testTask(name, input, file) {
                 jsx: 'react'
             })
         ]
-    }).then((bundle) => (
-        bundle.write({
-            format: 'cjs',
-            file
-        })
-    )).then(() => (
-        gulp.src(file)
-            .pipe(mocha({ reporter: 'progress' }))
-    ));
+    })
+    .then((bundle) => bundle.write({ format: 'cjs', file }))
+    .then(() => gulp.src(file).pipe(mocha({ reporter: 'progress' })));
 }
 var testTasks = tests.reduce((tasks, test) => {
     var folder = './Navigation' + (test.folder || '') + '/test/';

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -128,9 +128,10 @@ var itemTasks = items.reduce((tasks, item) => {
     var jsTo = './build/dist/' + packageName.replace(/-/g, '.') + '.js';
     var jsPackageTo = './build/npm/' + packageName + '/' + packageName.replace(/-/g, '.') + '.js';
     item.name = upperName.replace(/-/g, ' ');
-    gulp.task('Rollup' + name, () => rollupTask(name, tsFrom, jsTo, item.globals || {}, 'iife'));
+    var makeRollupTask = (to, format) => () => rollupTask(name, tsFrom, to, item.globals || {}, format)
+    gulp.task('Rollup' + name, makeRollupTask(jsTo, 'iife'));
     gulp.task('Build' + name, ['Rollup' + name], () => buildTask(jsTo, item));
-    gulp.task('Package' + name, () => rollupTask(name, tsFrom, jsPackageTo, item.globals || {}, 'cjs'));
+    gulp.task('Package' + name, () => makeRollupTask(jsPackageTo, 'cjs'));
     tasks.buildTasks.push('Build' + name);
     tasks.packageTasks.push('Package' + name);
     return tasks;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,5 @@
 ﻿'use strict'
 var gulp = require('gulp');
-var gulpTypescript = require('gulp-tsc');
 var insert = require('gulp-insert');
 var mocha = require('gulp-mocha');
 var nodeResolve = require('rollup-plugin-node-resolve');
@@ -121,11 +120,6 @@ function buildTask(file, details) {
         .pipe(insert.prepend(info))
         .pipe(gulp.dest('.'));
 }
-function packageTask(name, file, details) {
-    return gulp.src(file)
-        .pipe(gulpTypescript(details.compilerOptions))
-        .pipe(gulp.dest('./build/npm/' + name + '/lib'));
-}
 var itemTasks = items.reduce((tasks, item) => {
     var packageName = item.name;
     var upperName = packageName.replace(/\b./g, (val) => val.toUpperCase());
@@ -137,7 +131,6 @@ var itemTasks = items.reduce((tasks, item) => {
     gulp.task('Rollup' + name, () => rollupTask(name, tsFrom, jsTo, item.globals || {}, 'iife'));
     gulp.task('Build' + name, ['Rollup' + name], () => buildTask(jsTo, item));
     gulp.task('Package' + name, () => rollupTask(name, tsFrom, jsPackageTo, item.globals || {}, 'cjs'));
-    //gulp.task('Package' + name, () => packageTask(packageName, tsFrom, item));
     tasks.buildTasks.push('Build' + name);
     tasks.packageTasks.push('Package' + name);
     return tasks;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -131,10 +131,8 @@ var itemTasks = items.reduce((tasks, item) => {
     var jsTo = './build/dist/' + packageName.replace(/-/g, '.') + '.js';
     var jsPackageTo = './build/npm/' + packageName + '/' + packageName.replace(/-/g, '.') + '.js';
     item.name = upperName.replace(/-/g, ' ');
-    var makeRollupTask = (to, format) => rollupTask(name, tsFrom, to, item.globals || {}, format);
-    //gulp.task('Rollup' + name, () => makeRollupTask(jsTo, 'iife'));
     gulp.task('Build' + name, () => buildTask(name, tsFrom, jsTo, item.globals || {}, 'iife', item));
-    gulp.task('Package' + name, () => makeRollupTask(jsPackageTo, 'cjs'));
+    gulp.task('Package' + name, () => rollupTask(name, tsFrom, jsPackageTo, item.globals || {}, 'cjs'));
     tasks.buildTasks.push('Build' + name);
     tasks.packageTasks.push('Package' + name);
     return tasks;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,9 +21,9 @@ var tests = [
     { name: 'NavigationBackLink', to: 'navigationBackLink.test.js', folder: 'React', ext: 'tsx' },
     { name: 'RefreshLink', to: 'refreshLink.test.js', folder: 'React', ext: 'tsx' }
 ];
-function rollupTestTask(name, file, to) {
+function rollupTestTask(name, input, file) {
     return rollup.rollup({
-        input: file,
+        input,
         external: ['assert', 'react', 'react-dom', 'react-dom/test-utils', 'jsdom' , 'tslib'],
         plugins: [
             rollupTypescript({
@@ -42,7 +42,7 @@ function rollupTestTask(name, file, to) {
     }).then((bundle) => (
         bundle.write({
             format: 'cjs',
-            file: to
+            file
         })
     ));
 }
@@ -82,9 +82,9 @@ var items = [
         require('./build/npm/navigation-react-native/package.json'),
         require('./NavigationReactNative/src/tsconfig.json')),
 ];
-function rollupTask(name, file, to, globals) {
+function rollupTask(name, input, file, globals) {
     return rollup.rollup({
-        input: file,
+        input,
         external: Object.keys(globals),
         plugins: [
             rollupTypescript({
@@ -101,7 +101,7 @@ function rollupTask(name, file, to, globals) {
             format: 'iife',
             name,
             globals,
-            file: './build/dist/' + to
+            file
         })
     ));        
 }
@@ -112,14 +112,14 @@ function buildTask(file, details) {
  * License: ${details.license}
  */
 `;
-    return gulp.src('./build/dist/' + file)
+    return gulp.src(file)
         .pipe(strip())
         .pipe(insert.prepend(info))
         .pipe(gulp.dest('./build/dist'))
         .pipe(rename(file.replace(/js$/, 'min.js')))
         .pipe(uglify())
         .pipe(insert.prepend(info))
-        .pipe(gulp.dest('./build/dist'));
+        .pipe(gulp.dest('.'));
 }
 function packageTask(name, file, details) {
     return gulp.src(file)
@@ -131,7 +131,7 @@ var itemTasks = items.reduce((tasks, item) => {
     var upperName = packageName.replace(/\b./g, (val) => val.toUpperCase());
     var name = upperName.replace(/-/g, '');
     var tsFrom = './' + name + '/src/' + name + '.ts';
-    var jsTo = packageName.replace(/-/g, '.') + '.js';
+    var jsTo = './build/dist/' + packageName.replace(/-/g, '.') + '.js';
     item.name = upperName.replace(/-/g, ' ');
     gulp.task('Rollup' + name, () => rollupTask(name, tsFrom, jsTo, item.globals || {}));
     gulp.task('Build' + name, ['Rollup' + name], () => buildTask(jsTo, item));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@ var mocha = require('gulp-mocha');
 var nodeResolve = require('rollup-plugin-node-resolve');
 var rename = require('gulp-rename');
 var rollup = require('rollup');
+var rollupCleanup = require('rollup-plugin-cleanup');
 var rollupTypescript = require('rollup-plugin-typescript');
 var strip = require('gulp-strip-comments');
 var typescript = require('typescript');
@@ -93,7 +94,8 @@ function rollupTask(name, input, file, globals, format) {
                 module: 'es6',
                 jsx: 'react'
             }),
-            nodeResolve({ jsnext: true, main: true })
+            nodeResolve({ jsnext: true, main: true }),
+            rollupCleanup()
         ]
     }).then((bundle) => (
         bundle.write({
@@ -131,7 +133,7 @@ var itemTasks = items.reduce((tasks, item) => {
     var makeRollupTask = (to, format) => () => rollupTask(name, tsFrom, to, item.globals || {}, format);
     gulp.task('Rollup' + name, makeRollupTask(jsTo, 'iife'));
     gulp.task('Build' + name, ['Rollup' + name], () => buildTask(jsTo, item));
-    gulp.task('Package' + name, () => makeRollupTask(jsPackageTo, 'cjs'));
+    gulp.task('Package' + name, makeRollupTask(jsPackageTo, 'cjs'));
     tasks.buildTasks.push('Build' + name);
     tasks.packageTasks.push('Package' + name);
     return tasks;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,6 @@ var rename = require('gulp-rename');
 var rollup = require('rollup');
 var rollupCleanup = require('rollup-plugin-cleanup');
 var rollupTypescript = require('rollup-plugin-typescript');
-var strip = require('gulp-strip-comments');
 var typescript = require('typescript');
 var uglify = require('gulp-uglify');
 
@@ -114,7 +113,6 @@ function buildTask(file, details) {
  */
 `;
     return gulp.src(file)
-        .pipe(strip())
         .pipe(insert.prepend(info))
         .pipe(gulp.dest('./build/dist'))
         .pipe(rename(file.replace(/js$/, 'min.js')))

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,28 +49,6 @@
         "json-schema-traverse": "0.3.1"
       }
     },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
-        }
-      }
-    },
     "ansi-gray": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
@@ -333,35 +311,11 @@
         "unset-value": "1.0.0"
       }
     },
-    "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-      "dev": true
-    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
-    },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
-      "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
-      },
-      "dependencies": {
-        "lazy-cache": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-          "dev": true
-        }
-      }
     },
     "chalk": {
       "version": "1.1.3",
@@ -415,17 +369,6 @@
           "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
           "dev": true
         }
-      }
-    },
-    "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "dev": true,
-      "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
-        "wordwrap": "0.0.2"
       }
     },
     "clone": {
@@ -585,12 +528,6 @@
       "requires": {
         "ms": "2.0.0"
       }
-    },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -1347,25 +1284,24 @@
       "dev": true
     },
     "gulp-uglify": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-2.1.2.tgz",
-      "integrity": "sha1-bbhbHQ7mPRgFhZK2WGSdZcLsRUE=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-3.0.0.tgz",
+      "integrity": "sha1-DfAzHXKg0wLj434QlIXd3zPG0co=",
       "dev": true,
       "requires": {
         "gulplog": "1.0.0",
         "has-gulplog": "0.1.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.10",
         "make-error-cause": "1.2.2",
         "through2": "2.0.3",
-        "uglify-js": "2.8.29",
-        "uglify-save-license": "0.4.1",
+        "uglify-js": "3.4.0",
         "vinyl-sourcemaps-apply": "0.2.1"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         }
       }
@@ -2103,12 +2039,6 @@
         "lodash.escape": "3.2.0"
       }
     },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
-    },
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
@@ -2134,9 +2064,9 @@
       }
     },
     "make-error": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
-      "integrity": "sha1-Uq06M5zPEM5itAQLcI/nByRLi5Y=",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
+      "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g==",
       "dev": true
     },
     "make-error-cause": {
@@ -2145,7 +2075,7 @@
       "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
       "dev": true,
       "requires": {
-        "make-error": "1.3.0"
+        "make-error": "1.3.4"
       }
     },
     "make-iterator": {
@@ -3013,15 +2943,6 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
-      "requires": {
-        "align-text": "0.1.4"
-      }
-    },
     "rimraf": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
@@ -3758,28 +3679,28 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.0.tgz",
+      "integrity": "sha512-Jcf5naPkX3rVPSQpRn9Vm6Rr572I1gTtR9LnqKgXjmOgfYQ/QS0V2WRStFR53Bdj520M66aCZqt9uzYXgtGrJQ==",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "commander": "2.15.1",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
-    },
-    "uglify-save-license": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/uglify-save-license/-/uglify-save-license-0.4.1.tgz",
-      "integrity": "sha1-lXJsF8xv0XHDYX479NjYKqjEzOE=",
-      "dev": true
-    },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
-      "optional": true
     },
     "unc-path-regex": {
       "version": "0.1.2",
@@ -4080,18 +4001,6 @@
         "isexe": "2.0.0"
       }
     },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true
-    },
-    "wordwrap": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-      "dev": true
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -4119,18 +4028,6 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
-    },
-    "yargs": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "dev": true,
-      "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
-        "window-size": "0.1.0"
-      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -176,12 +176,6 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
-    "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-      "dev": true
-    },
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
@@ -320,12 +314,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
-    },
-    "byline": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/byline/-/byline-4.2.2.tgz",
-      "integrity": "sha1-wgOpilsCkIIqk4anjtosvVvNsy8=",
       "dev": true
     },
     "cache-base": {
@@ -683,68 +671,6 @@
       "dev": true,
       "requires": {
         "readable-stream": "1.1.14"
-      }
-    },
-    "duplexify": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
-      "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "1.4.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "stream-shift": "1.0.0"
-      },
-      "dependencies": {
-        "end-of-stream": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-          "dev": true,
-          "requires": {
-            "once": "1.4.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
       }
     },
     "ecc-jsbn": {
@@ -1330,142 +1256,6 @@
         "through2": "2.0.3"
       }
     },
-    "gulp-tsc": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/gulp-tsc/-/gulp-tsc-1.3.2.tgz",
-      "integrity": "sha1-Wmb4CvOXYAXm9fBrnPzLDm1zmc4=",
-      "dev": true,
-      "requires": {
-        "async": "1.5.2",
-        "byline": "4.2.2",
-        "gulp-util": "3.0.8",
-        "lodash": "3.10.1",
-        "node-version-compare": "1.0.1",
-        "resolve": "1.5.0",
-        "rimraf": "2.2.8",
-        "temp": "0.8.3",
-        "through2": "2.0.3",
-        "vinyl-fs": "1.0.0",
-        "which": "1.3.0"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-          "dev": true
-        },
-        "glob-stream": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-4.1.1.tgz",
-          "integrity": "sha1-uELfENaIx+trz869hG84UilrMgA=",
-          "dev": true,
-          "requires": {
-            "glob": "4.5.3",
-            "glob2base": "0.0.12",
-            "minimatch": "2.0.10",
-            "ordered-read-streams": "0.1.0",
-            "through2": "0.6.5",
-            "unique-stream": "2.2.1"
-          },
-          "dependencies": {
-            "through2": {
-              "version": "0.6.5",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-              "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-              "dev": true,
-              "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "4.0.1"
-              }
-            }
-          }
-        },
-        "glob-watcher": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.8.tgz",
-          "integrity": "sha1-aK62Yefizo02NDgbLsQV8AxrwqQ=",
-          "dev": true,
-          "requires": {
-            "gaze": "0.5.2"
-          }
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "unique-stream": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
-          "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
-          "dev": true,
-          "requires": {
-            "json-stable-stringify": "1.0.1",
-            "through2-filter": "2.0.0"
-          }
-        },
-        "vinyl": {
-          "version": "0.4.6",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-          "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-          "dev": true,
-          "requires": {
-            "clone": "0.2.0",
-            "clone-stats": "0.0.1"
-          }
-        },
-        "vinyl-fs": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-1.0.0.tgz",
-          "integrity": "sha1-0VdS5owtrXQ2Tn6FNHNzU1RpLt8=",
-          "dev": true,
-          "requires": {
-            "duplexify": "3.5.1",
-            "glob-stream": "4.1.1",
-            "glob-watcher": "0.0.8",
-            "graceful-fs": "3.0.11",
-            "merge-stream": "0.1.8",
-            "mkdirp": "0.5.1",
-            "object-assign": "2.1.1",
-            "strip-bom": "1.0.0",
-            "through2": "0.6.5",
-            "vinyl": "0.4.6"
-          },
-          "dependencies": {
-            "through2": {
-              "version": "0.6.5",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-              "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-              "dev": true,
-              "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "4.0.1"
-              }
-            }
-          }
-        }
-      }
-    },
     "gulp-uglify": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-2.1.2.tgz",
@@ -1967,15 +1757,6 @@
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
       "dev": true
     },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "0.0.0"
-      }
-    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -1986,12 +1767,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-      "dev": true
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
     "jsprim": {
@@ -2282,39 +2057,6 @@
         "object-visit": "1.0.1"
       }
     },
-    "merge-stream": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.8.tgz",
-      "integrity": "sha1-SKB7O0oSHXSj7b/c20sIrb8CQLE=",
-      "dev": true,
-      "requires": {
-        "through2": "0.6.5"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
-          }
-        }
-      }
-    },
     "micromatch": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.4.tgz",
@@ -2524,12 +2266,6 @@
         "encoding": "0.1.12",
         "is-stream": "1.1.0"
       }
-    },
-    "node-version-compare": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/node-version-compare/-/node-version-compare-1.0.1.tgz",
-      "integrity": "sha1-2Fv9IPCsreM1d/VmgscQnDTFUM0=",
-      "dev": true
     },
     "nwmatcher": {
       "version": "1.4.4",
@@ -3397,12 +3133,6 @@
       "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8=",
       "dev": true
     },
-    "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-      "dev": true
-    },
     "streamqueue": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/streamqueue/-/streamqueue-0.0.6.tgz",
@@ -3511,16 +3241,6 @@
             "safe-buffer": "5.1.1"
           }
         }
-      }
-    },
-    "through2-filter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
-      "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
-      "dev": true,
-      "requires": {
-        "through2": "2.0.3",
-        "xtend": "4.0.1"
       }
     },
     "tildify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -598,15 +598,6 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
-    "decomment": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/decomment/-/decomment-0.9.1.tgz",
-      "integrity": "sha512-9vwabbCoArDvgbZnFqWcGPVvSIIvWTNu1yaAc3Tg3q5pOzORo6nANO3TPwBuiKwN7stMDZJgNnR6USU3H6EQrQ==",
-      "dev": true,
-      "requires": {
-        "esprima": "4.0.0"
-      }
-    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -734,12 +725,6 @@
           "optional": true
         }
       }
-    },
-    "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-      "dev": true
     },
     "estraverse": {
       "version": "4.2.0",
@@ -1360,17 +1345,6 @@
       "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
       "integrity": "sha1-OtRCh2PwXidk3sHGfYaNsnVoeBc=",
       "dev": true
-    },
-    "gulp-strip-comments": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/gulp-strip-comments/-/gulp-strip-comments-2.5.1.tgz",
-      "integrity": "sha512-PKb2WGj4VNFhXzXnh7H7GO7YWTQqQ7u2dagyhjXGdAd+lFXwCsYUVXpXKA0rW2AzLo7RZipYIf2VH5hjUzVy4g==",
-      "dev": true,
-      "requires": {
-        "decomment": "0.9.1",
-        "gulp-util": "3.0.8",
-        "through2": "2.0.3"
-      }
     },
     "gulp-uglify": {
       "version": "2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,18 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.0.tgz",
+      "integrity": "sha512-hWzNviaVFIr1TqcRA8ou49JaSHp+Rfabmnqg2kNvusKqLhPU0rIsGPUj5WJJ7ld4Bb7qdgLmIhLfCD1qS08IVA==",
+      "dev": true
+    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -3050,12 +3062,13 @@
       "dev": true
     },
     "rollup": {
-      "version": "0.36.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.36.4.tgz",
-      "integrity": "sha1-oiRJTFOGwdc9OPe7hvafXrARo9I=",
+      "version": "0.59.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.59.4.tgz",
+      "integrity": "sha512-ISiMqq/aJa+57QxX2MRcvLESHdJ7wSavmr6U1euMr+6UgFe6KM+3QANrYy8LQofwhTC1I7BcAdlLnDiaODs1BA==",
       "dev": true,
       "requires": {
-        "source-map-support": "0.4.18"
+        "@types/estree": "0.0.39",
+        "@types/node": "10.3.0"
       }
     },
     "rollup-plugin-node-resolve": {
@@ -3275,15 +3288,6 @@
         "resolve-url": "0.2.1",
         "source-map-url": "0.4.0",
         "urix": "0.1.0"
-      }
-    },
-    "source-map-support": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-      "dev": true,
-      "requires": {
-        "source-map": "0.5.7"
       }
     },
     "source-map-url": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -802,6 +802,63 @@
         }
       }
     },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "dev": true,
+      "requires": {
+        "fill-range": "2.2.4"
+      },
+      "dependencies": {
+        "fill-range": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+          "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+          "dev": true,
+          "requires": {
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "3.0.0",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
+          }
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "dev": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
     "expand-tilde": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
@@ -899,6 +956,12 @@
           "dev": true
         }
       }
+    },
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "dev": true
     },
     "fill-range": {
       "version": "4.0.0",
@@ -1036,6 +1099,59 @@
         "inherits": "2.0.3",
         "minimatch": "2.0.10",
         "once": "1.3.3"
+      }
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "dev": true,
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        }
+      }
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "dev": true,
+      "requires": {
+        "is-glob": "2.0.1"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        }
       }
     },
     "glob-stream": {
@@ -1563,6 +1679,21 @@
         }
       }
     },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "dev": true
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "dev": true,
+      "requires": {
+        "is-primitive": "2.0.0"
+      }
+    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -1621,6 +1752,18 @@
       "requires": {
         "isobject": "3.0.1"
       }
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "dev": true
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "dev": true
     },
     "is-relative": {
       "version": "0.2.1",
@@ -2007,6 +2150,15 @@
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
     },
+    "magic-string": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.24.1.tgz",
+      "integrity": "sha512-YBfNxbJiixMzxW40XqJEIldzHyh5f7CZKalo1uZffevyrPEX8Qgo9s0dmcORLHdV47UyvJg8/zD+6hQG3qvJrA==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "1.4.1"
+      }
+    },
     "make-error": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
@@ -2056,6 +2208,12 @@
       "requires": {
         "object-visit": "1.0.1"
       }
+    },
+    "math-random": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+      "dev": true
     },
     "micromatch": {
       "version": "3.1.4",
@@ -2267,6 +2425,15 @@
         "is-stream": "1.1.0"
       }
     },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "1.1.0"
+      }
+    },
     "nwmatcher": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
@@ -2377,6 +2544,27 @@
         }
       }
     },
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "dev": true,
+      "requires": {
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
+      },
+      "dependencies": {
+        "for-own": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+          "dev": true,
+          "requires": {
+            "for-in": "1.0.2"
+          }
+        }
+      }
+    },
     "object.pick": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
@@ -2457,6 +2645,35 @@
         "path-root": "0.1.1"
       }
     },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "dev": true,
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        }
+      }
+    },
     "parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
@@ -2535,6 +2752,12 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true
+    },
     "pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -2586,6 +2809,25 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
+    },
+    "randomatic": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+      "dev": true,
+      "requires": {
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        }
+      }
     },
     "react": {
       "version": "16.3.0",
@@ -2648,6 +2890,15 @@
         "resolve": "1.5.0"
       }
     },
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "dev": true,
+      "requires": {
+        "is-equal-shallow": "0.1.3"
+      }
+    },
     "regex-not": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz",
@@ -2656,6 +2907,12 @@
       "requires": {
         "extend-shallow": "2.0.1"
       }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
     },
     "repeat-element": {
       "version": "1.1.2",
@@ -2805,6 +3062,124 @@
       "requires": {
         "@types/estree": "0.0.39",
         "@types/node": "10.3.0"
+      }
+    },
+    "rollup-plugin-cleanup": {
+      "version": "3.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-cleanup/-/rollup-plugin-cleanup-3.0.0-beta.1.tgz",
+      "integrity": "sha512-cJDQfGR4pzVx7hJaTy9fHB5Cg4sIIEId23OyqeareXza9IS+gfKIO5ypZaUnkVmStZ6ye0+IpDyu4VMOoUkt1Q==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.5.3",
+        "magic-string": "0.24.1",
+        "rollup-pluginutils": "2.3.0"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0"
+          }
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "dev": true
+        },
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "dev": true,
+          "requires": {
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
+          }
+        },
+        "estree-walker": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz",
+          "integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==",
+          "dev": true
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "0.1.1"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "dev": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
+          }
+        },
+        "rollup-pluginutils": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.3.0.tgz",
+          "integrity": "sha512-xB6hsRsjdJdIYWEyYUJy/3ki5g69wrf0luHPGNK3ZSocV6HLNfio59l3dZ3TL4xUwEKgROhFi9jOCt6c5gfUWw==",
+          "dev": true,
+          "requires": {
+            "estree-walker": "0.5.2",
+            "micromatch": "2.3.11"
+          }
+        }
       }
     },
     "rollup-plugin-node-resolve": {
@@ -3030,6 +3405,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "sourcemap-codec": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.1.tgz",
+      "integrity": "sha512-hX1eNBNuilj8yfFnECh0DzLgwKpBLMIvmhgEhixXNui8lMLBInTI8Kyxt++RwJnMNu7cAUo635L2+N1TxMJCzA==",
       "dev": true
     },
     "sparkles": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "gulp-insert": "^0.5.0",
     "gulp-mocha": "^3.0.1",
     "gulp-rename": "^1.2.0",
-    "gulp-strip-comments": "^2.4.5",
     "gulp-uglify": "^2.0.1",
     "jsdom": "^11.10.0",
     "react": "^16.3.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "rollup": "^0.59.4",
+    "rollup-plugin-cleanup": "^3.0.0-beta.1",
     "rollup-plugin-node-resolve": "^2.0.0",
     "rollup-plugin-typescript": "^0.8.1",
     "tslib": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "gulp-mocha": "^3.0.1",
     "gulp-rename": "^1.2.0",
     "gulp-strip-comments": "^2.4.5",
-    "gulp-tsc": "^1.3.2",
     "gulp-uglify": "^2.0.1",
     "jsdom": "^11.10.0",
     "react": "^16.3.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "gulp-insert": "^0.5.0",
     "gulp-mocha": "^3.0.1",
     "gulp-rename": "^1.2.0",
-    "gulp-uglify": "^2.0.1",
+    "gulp-uglify": "^3.0.0",
     "jsdom": "^11.10.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "jsdom": "^11.10.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "rollup": "^0.36.3",
+    "rollup": "^0.59.4",
     "rollup-plugin-node-resolve": "^2.0.0",
     "rollup-plugin-typescript": "^0.8.1",
     "tslib": "^1.6.0",


### PR DESCRIPTION
Reduces the module size because don't need `tslib` in each module, just included once.
Simplifies the `gulp.js` as `package` and `build` tasks both use `rollup`.
(React ship single file packages and think Ryan Dahl advocated that in his jsconf talk)

The minified `angular` never worked because it looked for `$parse` param which is `uglified` away. Fixed by preserving this param in output. Reminder to test the min files