### PR TITLE
Tested Local navigation Packages

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,15 +23,10 @@ var tests = [
 function testTask(name, input, file) {
     return rollup.rollup({
         input,
-        external: ['assert', 'react', 'react-dom', 'react-dom/test-utils', 'jsdom' , 'tslib'],
+        external: ['assert', 'react', 'react-dom', 'react-dom/test-utils', 'jsdom' , 'tslib', 'navigation', 'navigation-react'],
         plugins: [
             rollupTypescript({
                 typescript: typescript,
-                baseUrl: '.',
-                paths: {
-                    navigation: ['Navigation/src/Navigation'],
-                    'navigation-react': ['NavigationReact/src/NavigationReact']
-                },
                 importHelpers: true,
                 target: 'es3',
                 module: 'es6',
@@ -46,7 +41,7 @@ var testTasks = tests.reduce((tasks, test) => {
     var folder = './Navigation' + (test.folder || '') + '/test/';
     var file = folder + test.name + 'Test.' + (test.ext || 'ts');
     var to = './build/dist/' + test.to;
-    gulp.task('Test' + test.name, () => testTask(test.name, file, to));
+    gulp.task('Test' + test.name, ['PackageNavigation', 'PackageNavigationReact'], () => testTask(test.name, file, to));
     tasks.push('Test' + test.name);
     return tasks;
 }, []);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,43 +10,6 @@ var rollupTypescript = require('rollup-plugin-typescript');
 var typescript = require('typescript');
 var uglify = require('gulp-uglify');
 
-var tests = [
-    { name: 'NavigationRouting', to: 'navigationRouting.test.js' },
-    { name: 'StateConfig', to: 'stateConfig.test.js' },
-    { name: 'Navigation', to: 'navigation.test.js' },
-    { name: 'NavigationData', to: 'navigationData.test.js' },
-    { name: 'FluentNavigation', to: 'fluentNavigation.test.js' },
-    { name: 'NavigationLink', to: 'navigationLink.test.js', folder: 'React', ext: 'tsx' },
-    { name: 'NavigationBackLink', to: 'navigationBackLink.test.js', folder: 'React', ext: 'tsx' },
-    { name: 'RefreshLink', to: 'refreshLink.test.js', folder: 'React', ext: 'tsx' }
-];
-function testTask(name, input, file) {
-    return rollup.rollup({
-        input,
-        external: ['assert', 'react', 'react-dom', 'react-dom/test-utils', 'jsdom' , 'tslib', 'navigation', 'navigation-react'],
-        plugins: [
-            rollupTypescript({
-                typescript: typescript,
-                importHelpers: true,
-                target: 'es3',
-                module: 'es6',
-                jsx: 'react'
-            })
-        ]
-    })
-    .then((bundle) => bundle.write({ format: 'cjs', file }))
-    .then(() => gulp.src(file).pipe(mocha({ reporter: 'progress' })));
-}
-var testTasks = tests.reduce((tasks, test) => {
-    var folder = './Navigation' + (test.folder || '') + '/test/';
-    var file = folder + test.name + 'Test.' + (test.ext || 'ts');
-    var to = './build/dist/' + test.to;
-    gulp.task('Test' + test.name, ['PackageNavigation', 'PackageNavigationReact'], () => testTask(test.name, file, to));
-    tasks.push('Test' + test.name);
-    return tasks;
-}, []);
-gulp.task('test', testTasks);
-
 var items = [
     require('./build/npm/navigation/package.json'),
     Object.assign({ globals: { navigation: 'Navigation', react: 'React',
@@ -71,7 +34,7 @@ var items = [
 function rollupTask(name, input, file, globals, format) {
     return rollup.rollup({
         input,
-        external: Object.keys(globals),
+        external: Array.isArray(globals) ? globals : Object.keys(globals),
         plugins: [
             rollupTypescript({
                 typescript: typescript,
@@ -119,3 +82,28 @@ var itemTasks = items.reduce((tasks, item) => {
 }, { buildTasks: [], packageTasks: [] });
 gulp.task('build', itemTasks.buildTasks);
 gulp.task('package', itemTasks.packageTasks);
+
+var tests = [
+    { name: 'NavigationRouting', to: 'navigationRouting.test.js' },
+    { name: 'StateConfig', to: 'stateConfig.test.js' },
+    { name: 'Navigation', to: 'navigation.test.js' },
+    { name: 'NavigationData', to: 'navigationData.test.js' },
+    { name: 'FluentNavigation', to: 'fluentNavigation.test.js' },
+    { name: 'NavigationLink', to: 'navigationLink.test.js', folder: 'React', ext: 'tsx' },
+    { name: 'NavigationBackLink', to: 'navigationBackLink.test.js', folder: 'React', ext: 'tsx' },
+    { name: 'RefreshLink', to: 'refreshLink.test.js', folder: 'React', ext: 'tsx' }
+];
+function testTask(name, input, file) {
+    return rollupTask(name, input, file, ['assert', 'react', 'react-dom', 'react-dom/test-utils', 'jsdom' , 'tslib', 'navigation', 'navigation-react'], 'cjs')
+        .then(() => gulp.src(file).pipe(mocha({ reporter: 'progress' })));
+}
+var testTasks = tests.reduce((tasks, test) => {
+    var folder = './Navigation' + (test.folder || '') + '/test/';
+    var file = folder + test.name + 'Test.' + (test.ext || 'ts');
+    var to = './build/dist/' + test.to;
+    gulp.task('Test' + test.name, ['PackageNavigation', 'PackageNavigationReact'], () => testTask(test.name, file, to));
+    tasks.push('Test' + test.name);
+    return tasks;
+}, []);
+gulp.task('test', testTasks);
+

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -94,14 +94,19 @@ var tests = [
     { name: 'RefreshLink', to: 'refreshLink.test.js', folder: 'React', ext: 'tsx' }
 ];
 function testTask(name, input, file) {
-    return rollupTask(name, input, file, ['assert', 'react', 'react-dom', 'react-dom/test-utils', 'jsdom' , 'tslib', 'navigation', 'navigation-react'], 'cjs')
+    var globals = [
+        'assert', 'react', 'react-dom', 'react-dom/test-utils',
+        'jsdom', 'tslib', 'navigation', 'navigation-react'
+    ];
+    return rollupTask(name, input, file, globals, 'cjs')
         .then(() => gulp.src(file).pipe(mocha({ reporter: 'progress' })));
 }
 var testTasks = tests.reduce((tasks, test) => {
     var folder = './Navigation' + (test.folder || '') + '/test/';
     var file = folder + test.name + 'Test.' + (test.ext || 'ts');
     var to = './build/dist/' + test.to;
-    gulp.task('Test' + test.name, ['PackageNavigation', 'PackageNavigationReact'], () => testTask(test.name, file, to));
+    var packageDeps = ['PackageNavigation', 'PackageNavigationReact'];
+    gulp.task('Test' + test.name, packageDeps, () => testTask(test.name, file, to));
     tasks.push('Test' + test.name);
     return tasks;
 }, []);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "navigation",
-  "version": "3.0.0",
+  "name": "navigation-",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2317,6 +2317,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.1.tgz",
       "integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA==",
+      "dev": true
+    },
+    "navigation": {
+      "version": "file:build/npm/navigation",
+      "dev": true
+    },
+    "navigation-react": {
+      "version": "file:build/npm/navigation-react",
       "dev": true
     },
     "node-fetch": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "navigation",
+  "name": "navigation-",
   "version": "5.0.1",
   "description": "The data-first JavaScript router",
   "devDependencies": {
@@ -9,6 +9,8 @@
     "gulp-rename": "^1.2.0",
     "gulp-uglify": "^3.0.0",
     "jsdom": "^11.10.0",
+    "navigation": "file:build/npm/navigation",
+    "navigation-react": "file:build/npm/navigation-react",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "rollup": "^0.59.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navigation-",
-  "version": "5.0.1",
+  "version": "1.0.0",
   "description": "The data-first JavaScript router",
   "devDependencies": {
     "gulp": "^3.8.11",


### PR DESCRIPTION
Followed the advice on [installing npm directories](http://2ality.com/2018/04/npm-install-directory.html) and npm installed `navigation` and `navigation-react` directories. The tests can run against these local packages without having to pass custom `paths` to rollup. The `test`, `build` and `package` tasks can all use the same `rollupTask`. Also speeds up the tests because the `navigation` and `navigation-react` are used like other npm packages and aren't inlined into the generated tests.
