### PR TITLE
Removed react-dom dependency from Navigation React

### DIFF
--- a/NavigationReact/src/AsyncStateNavigator.ts
+++ b/NavigationReact/src/AsyncStateNavigator.ts
@@ -1,6 +1,5 @@
 import NavigationHandler from './NavigationHandler';
 import { StateNavigator, StateContext } from 'navigation';
-import * as ReactDOM from 'react-dom';
 
 class AsyncStateNavigator extends StateNavigator {
     private navigationHandler: NavigationHandler;
@@ -50,7 +49,7 @@ class AsyncStateNavigator extends StateNavigator {
     }
 
     private suspendNavigation(asyncNavigator: AsyncStateNavigator, resumeNavigation: () => void, defer: boolean) {
-        defer = defer && ReactDOM.unstable_deferredUpdates;
+        defer = false;
         var { oldState, oldUrl, state, data, url, asyncData } = asyncNavigator.stateContext;
         if (defer) {
             this.navigationHandler.setState(({ context }) => {
@@ -59,14 +58,11 @@ class AsyncStateNavigator extends StateNavigator {
                 return null;
             });
         }
-        var wrapDefer = setState => defer ? ReactDOM.unstable_deferredUpdates(() => setState()) : setState();
-        wrapDefer(() => {
-            this.navigationHandler.setState(() => (
-                { context: { oldState, state, data, asyncData, nextState: null, nextData: {}, stateNavigator: asyncNavigator } }
-            ), () => {
-                if (url === this.navigationHandler.state.context.stateNavigator.stateContext.url)
-                    resumeNavigation();
-            });
+        this.navigationHandler.setState(() => (
+            { context: { oldState, state, data, asyncData, nextState: null, nextData: {}, stateNavigator: asyncNavigator } }
+        ), () => {
+            if (url === this.navigationHandler.state.context.stateNavigator.stateContext.url)
+                resumeNavigation();
         });
     }
 }

--- a/NavigationReact/test/NavigationBackLinkTest.tsx
+++ b/NavigationReact/test/NavigationBackLinkTest.tsx
@@ -568,7 +568,7 @@ describe('NavigationBackLinkTest', function () {
         })
     });
 
-    describe('Click Deferred Navigation Back Link', function () {
+    /*describe('Click Deferred Navigation Back Link', function () {
         it('should navigate async', function(done){
             var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
@@ -776,9 +776,9 @@ describe('NavigationBackLinkTest', function () {
             Simulate.click(link);
             header = container.querySelector<HTMLHeadingElement>('h1');
             assert.equal(header.innerHTML, 'world s');
-            // stateNavigator.navigateBack(1);
-            // header = container.querySelector<HTMLHeadingElement>('h1');
-            // assert.equal(header.innerHTML, 'empty first');
+            stateNavigator.navigateBack(1);
+            header = container.querySelector<HTMLHeadingElement>('h1');
+            assert.equal(header.innerHTML, 'empty first');
         })
-    });
+    });*/
 });

--- a/NavigationReact/test/NavigationLinkTest.tsx
+++ b/NavigationReact/test/NavigationLinkTest.tsx
@@ -2561,7 +2561,7 @@ describe('NavigationLinkTest', function () {
         })
     });
 
-    describe('Click Deferred Navigation Link', function () {
+    /*describe('Click Deferred Navigation Link', function () {
         it('should navigate async', function(done){
             var stateNavigator = new StateNavigator([
                 { key: 's', route: 'r' }
@@ -2760,9 +2760,9 @@ describe('NavigationLinkTest', function () {
             Simulate.click(link);
             header = container.querySelector<HTMLHeadingElement>('h1');
             assert.equal(header.innerHTML, 'world s1');
-            // stateNavigator.navigate('s0', {x: 'a'});
-            // header = container.querySelector<HTMLHeadingElement>('h1');
-            // assert.equal(header.innerHTML, 'empty first');
+            stateNavigator.navigate('s0', {x: 'a'});
+            header = container.querySelector<HTMLHeadingElement>('h1');
+            assert.equal(header.innerHTML, 'empty first');
         })
-    });
+    });*/
 });

--- a/NavigationReact/test/RefreshLinkTest.tsx
+++ b/NavigationReact/test/RefreshLinkTest.tsx
@@ -2488,7 +2488,7 @@ describe('RefreshLinkTest', function () {
         })
     });
 
-    describe('Click Deferred Refresh Link', function () {
+    /*describe('Click Deferred Refresh Link', function () {
         it('should navigate async', function(done){
             var stateNavigator = new StateNavigator([
                 { key: 's', route: 'r' }
@@ -2682,9 +2682,9 @@ describe('RefreshLinkTest', function () {
             Simulate.click(link);
             header = container.querySelector<HTMLHeadingElement>('h1');
             assert.equal(header.innerHTML, 'world s');
-            // stateNavigator.refresh({x: 'a'});
-            // header = container.querySelector<HTMLHeadingElement>('h1');
-            // assert.equal(header.innerHTML, 'empty first');
+            stateNavigator.refresh({x: 'a'});
+            header = container.querySelector<HTMLHeadingElement>('h1');
+            assert.equal(header.innerHTML, 'empty first');
         })
-    });
+    });*/
 });

--- a/NavigationReactNative/sample/medley/package-lock.json
+++ b/NavigationReactNative/sample/medley/package-lock.json
@@ -8041,17 +8041,6 @@
         }
       }
     },
-    "react-dom": {
-      "version": "16.4.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
-      "integrity": "sha512-1Gin+wghF/7gl4Cqcvr1DxFX2Osz7ugxSwl6gBqCMpdrxHjIFUS7GYxrFftZ9Ln44FHw0JxCFD9YtZsrbR5/4A==",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.2"
-      }
-    },
     "react-is": {
       "version": "16.4.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.4.1.tgz",

--- a/NavigationReactNative/sample/medley/package.json
+++ b/NavigationReactNative/sample/medley/package.json
@@ -10,7 +10,6 @@
     "navigation": "^5.1.0",
     "navigation-react": "^4.0.0",
     "react": "16.4.1",
-    "react-dom": "^16.4.1",
     "react-native": "0.56.0"
   },
   "devDependencies": {

--- a/NavigationReactNative/sample/twitter/package-lock.json
+++ b/NavigationReactNative/sample/twitter/package-lock.json
@@ -8041,17 +8041,6 @@
         }
       }
     },
-    "react-dom": {
-      "version": "16.4.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
-      "integrity": "sha512-1Gin+wghF/7gl4Cqcvr1DxFX2Osz7ugxSwl6gBqCMpdrxHjIFUS7GYxrFftZ9Ln44FHw0JxCFD9YtZsrbR5/4A==",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.2"
-      }
-    },
     "react-is": {
       "version": "16.4.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.4.1.tgz",

--- a/NavigationReactNative/sample/twitter/package.json
+++ b/NavigationReactNative/sample/twitter/package.json
@@ -10,7 +10,6 @@
     "navigation": "^5.1.0",
     "navigation-react": "^4.0.0",
     "react": "16.4.1",
-    "react-dom": "^16.4.1",
     "react-native": "0.56.0"
   },
   "devDependencies": {

--- a/NavigationReactNative/sample/zoom/package-lock.json
+++ b/NavigationReactNative/sample/zoom/package-lock.json
@@ -8041,17 +8041,6 @@
         }
       }
     },
-    "react-dom": {
-      "version": "16.4.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
-      "integrity": "sha512-1Gin+wghF/7gl4Cqcvr1DxFX2Osz7ugxSwl6gBqCMpdrxHjIFUS7GYxrFftZ9Ln44FHw0JxCFD9YtZsrbR5/4A==",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.2"
-      }
-    },
     "react-is": {
       "version": "16.4.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.4.1.tgz",

--- a/NavigationReactNative/sample/zoom/package.json
+++ b/NavigationReactNative/sample/zoom/package.json
@@ -10,7 +10,6 @@
     "navigation": "^5.1.0",
     "navigation-react": "^4.0.0",
     "react": "16.4.1",
-    "react-dom": "^16.4.1",
     "react-native": "0.56.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Navigation React Native depends on Navigation React but shouldn't need `react-dom`.

It was only there to test out deferred updates. When React Suspense lands, deferred updates will come back but then they should be part of the React API so still won't need the `react-dom` dependency. Commented out the deferred tests because they'll be coming back with Suspense. Left some deferred code in `AsyncStateNavigator` as a reminder.
