### PR TITLE
Allowed Customised Animation on Android

### DIFF
--- a/NavigationReactNative/sample/medley/App.js
+++ b/NavigationReactNative/sample/medley/App.js
@@ -17,6 +17,15 @@ east.renderScene = () => <Direction direction="east" color="red" />;
 south.renderScene = () => <Direction direction="south" color="green" />;
 west.renderScene = () => <Direction direction="west" color="black" />;
 
+north.getCrumbStyle = from => from ? 'north_crumb_in' : 'north_crumb_out';
+north.getUnmountStyle = from => from ? 'north_in' : 'north_out';
+east.getCrumbStyle = from => from ? 'east_crumb_in' : 'east_crumb_out';
+east.getUnmountStyle = from => from ? 'east_in' : 'east_out';
+south.getCrumbStyle = from => from ? 'south_crumb_in' : 'south_crumb_out';
+south.getUnmountStyle = from => from ? 'south_in' : 'south_out';
+west.getCrumbStyle = from => from ? 'west_crumb_in' : 'west_crumb_out';
+west.getUnmountStyle = from => from ? 'west_in' : 'west_out';
+
 stateNavigator.navigate('north');
 addNavigateHandlers(stateNavigator);
 

--- a/NavigationReactNative/sample/medley/README.md
+++ b/NavigationReactNative/sample/medley/README.md
@@ -1,0 +1,8 @@
+# Navigation Native Medley
+Navigation gives you complete control over your animation on android. Use the State information to decide how each scene mounts and unmounts.
+
+## Run
+Once you've cloned the repository, you can install the dependencies and start the Medley example:
+
+    npm install
+    react-native run-android

--- a/NavigationReactNative/sample/medley/android/app/src/main/res/anim/east_crumb_in.xml
+++ b/NavigationReactNative/sample/medley/android/app/src/main/res/anim/east_crumb_in.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromXDelta="30%"
+        android:toXDelta="0" />
+</set>

--- a/NavigationReactNative/sample/medley/android/app/src/main/res/anim/east_crumb_out.xml
+++ b/NavigationReactNative/sample/medley/android/app/src/main/res/anim/east_crumb_out.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromXDelta="0"
+        android:toXDelta="30%" />
+</set>

--- a/NavigationReactNative/sample/medley/android/app/src/main/res/anim/east_in.xml
+++ b/NavigationReactNative/sample/medley/android/app/src/main/res/anim/east_in.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromXDelta="100%"
+        android:toXDelta="0" />
+</set>

--- a/NavigationReactNative/sample/medley/android/app/src/main/res/anim/east_out.xml
+++ b/NavigationReactNative/sample/medley/android/app/src/main/res/anim/east_out.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromXDelta="0"
+        android:toXDelta="100%" />
+</set>

--- a/NavigationReactNative/sample/medley/android/app/src/main/res/anim/north_crumb_in.xml
+++ b/NavigationReactNative/sample/medley/android/app/src/main/res/anim/north_crumb_in.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromYDelta="-30%"
+        android:toYDelta="0" />
+</set>

--- a/NavigationReactNative/sample/medley/android/app/src/main/res/anim/north_crumb_out.xml
+++ b/NavigationReactNative/sample/medley/android/app/src/main/res/anim/north_crumb_out.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromYDelta="0"
+        android:toYDelta="-30%" />
+</set>

--- a/NavigationReactNative/sample/medley/android/app/src/main/res/anim/north_in.xml
+++ b/NavigationReactNative/sample/medley/android/app/src/main/res/anim/north_in.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromYDelta="-100%"
+        android:toYDelta="0" />
+</set>

--- a/NavigationReactNative/sample/medley/android/app/src/main/res/anim/north_out.xml
+++ b/NavigationReactNative/sample/medley/android/app/src/main/res/anim/north_out.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromYDelta="0"
+        android:toYDelta="-100%" />
+</set>

--- a/NavigationReactNative/sample/medley/android/app/src/main/res/anim/south_crumb_in.xml
+++ b/NavigationReactNative/sample/medley/android/app/src/main/res/anim/south_crumb_in.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromYDelta="30%"
+        android:toYDelta="0" />
+</set>

--- a/NavigationReactNative/sample/medley/android/app/src/main/res/anim/south_crumb_out.xml
+++ b/NavigationReactNative/sample/medley/android/app/src/main/res/anim/south_crumb_out.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromYDelta="0"
+        android:toYDelta="30%" />
+</set>

--- a/NavigationReactNative/sample/medley/android/app/src/main/res/anim/south_in.xml
+++ b/NavigationReactNative/sample/medley/android/app/src/main/res/anim/south_in.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromYDelta="100%"
+        android:toYDelta="0" />
+</set>

--- a/NavigationReactNative/sample/medley/android/app/src/main/res/anim/south_out.xml
+++ b/NavigationReactNative/sample/medley/android/app/src/main/res/anim/south_out.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromYDelta="0"
+        android:toYDelta="100%" />
+</set>

--- a/NavigationReactNative/sample/medley/android/app/src/main/res/anim/west_crumb_in.xml
+++ b/NavigationReactNative/sample/medley/android/app/src/main/res/anim/west_crumb_in.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromXDelta="-30%"
+        android:toXDelta="0" />
+</set>

--- a/NavigationReactNative/sample/medley/android/app/src/main/res/anim/west_crumb_out.xml
+++ b/NavigationReactNative/sample/medley/android/app/src/main/res/anim/west_crumb_out.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromXDelta="0"
+        android:toXDelta="-30%" />
+</set>

--- a/NavigationReactNative/sample/medley/android/app/src/main/res/anim/west_in.xml
+++ b/NavigationReactNative/sample/medley/android/app/src/main/res/anim/west_in.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromXDelta="-100%"
+        android:toXDelta="0" />
+</set>

--- a/NavigationReactNative/sample/medley/android/app/src/main/res/anim/west_out.xml
+++ b/NavigationReactNative/sample/medley/android/app/src/main/res/anim/west_out.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromXDelta="0"
+        android:toXDelta="-100%" />
+</set>

--- a/NavigationReactNative/sample/twitter/App.js
+++ b/NavigationReactNative/sample/twitter/App.js
@@ -20,6 +20,12 @@ notifications.renderScene = () => <Notifications follows={getFollows()} />;
 tweet.renderScene = ({id}) => <Tweet tweet={getTweet(id)}  />;
 timeline.renderScene = ({id}) => <Timeline timeline={getTimeline(id)}  />;
 
+for(var key in stateNavigator.states) {
+  var state = stateNavigator.states[key];
+  state.getCrumbStyle = from => from ? 'scale_in' : 'scale_out';
+  state.getUnmountStyle = from => from ? 'slide_in' : 'slide_out';
+}
+
 var stateNavigators = [stateNavigator, new StateNavigator(stateNavigator)];
 stateNavigator.navigate('home');
 stateNavigators[1].navigate('notifications');

--- a/NavigationReactNative/sample/twitter/README.md
+++ b/NavigationReactNative/sample/twitter/README.md
@@ -1,0 +1,8 @@
+# Navigation Native Twitter
+Navigation uses the underlying native API to provide faithful tabbed navigation on iOS.
+
+## Run
+Once you've cloned the repository, you can install the dependencies and start the Twitter example:
+
+    npm install
+    react-native run-ios

--- a/NavigationReactNative/sample/twitter/android/app/src/main/res/anim/scale_in.xml
+++ b/NavigationReactNative/sample/twitter/android/app/src/main/res/anim/scale_in.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <alpha
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromAlpha="0"
+        android:toAlpha="1" />
+    <scale
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromXScale="0.9"
+        android:toXScale="1"
+        android:fromYScale="0.9"
+        android:toYScale="1" />
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromXDelta="5%"
+        android:toXDelta="0"
+        android:fromYDelta="5%"
+        android:toYDelta="0" />
+</set>

--- a/NavigationReactNative/sample/twitter/android/app/src/main/res/anim/scale_out.xml
+++ b/NavigationReactNative/sample/twitter/android/app/src/main/res/anim/scale_out.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <alpha
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromAlpha="1"
+        android:toAlpha="0" />
+    <scale
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromXScale="1"
+        android:toXScale="0.9"
+        android:fromYScale="1"
+        android:toYScale="0.9" />
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromXDelta="0"
+        android:toXDelta="5%"
+        android:fromYDelta="0"
+        android:toYDelta="5%" />
+</set>

--- a/NavigationReactNative/sample/twitter/android/app/src/main/res/anim/slide_in.xml
+++ b/NavigationReactNative/sample/twitter/android/app/src/main/res/anim/slide_in.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromXDelta="100%"
+        android:toXDelta="0" />
+</set>

--- a/NavigationReactNative/sample/twitter/android/app/src/main/res/anim/slide_out.xml
+++ b/NavigationReactNative/sample/twitter/android/app/src/main/res/anim/slide_out.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromXDelta="0"
+        android:toXDelta="100%" />
+</set>

--- a/NavigationReactNative/src/addNavigateHandlers.ts
+++ b/NavigationReactNative/src/addNavigateHandlers.ts
@@ -14,13 +14,13 @@ var addNavigateHandlers = (stateNavigator: StateNavigator | StateNavigator[]) =>
                 var appKey = AppRegistry.getAppKeys()[0];
                 if (oldCrumbs.length < crumbs.length) {
                     var {state: nextState, data: nextData} = crumbs.concat(nextCrumb)[oldCrumbs.length + 1];
-                    var exitAnim = oldState.getCrumbStyle && oldState.getCrumbStyle(true, oldData, oldCrumbs, nextState, nextData);
-                    var enterAnim = state.getUnmountStyle && state.getUnmountStyle(false, data, crumbs);
+                    var enterAnim = state.getUnmountStyle && state.getUnmountStyle(true, data, crumbs);
+                    var exitAnim = oldState.getCrumbStyle && oldState.getCrumbStyle(false, oldData, oldCrumbs, nextState, nextData);
                 } else {
                     var nextCrumb = new Crumb(oldData, oldState, null, null, false);
                     var {state: nextState, data: nextData} = oldCrumbs.concat(nextCrumb)[crumbs.length + 1];
-                    var exitAnim = oldState.getUnmountStyle && oldState.getUnmountStyle(true, oldData, oldCrumbs);
-                    var enterAnim = state.getCrumbStyle && state.getCrumbStyle(false, data, crumbs, nextState, nextData);
+                    var enterAnim = state.getCrumbStyle && state.getCrumbStyle(true, data, crumbs, nextState, nextData);
+                    var exitAnim = oldState.getUnmountStyle && oldState.getUnmountStyle(false, oldData, oldCrumbs);
                 }
                 NavigationModule.render(crumbs.length, tab, titles, appKey, enterAnim, exitAnim);
             }

--- a/NavigationReactNative/src/addNavigateHandlers.ts
+++ b/NavigationReactNative/src/addNavigateHandlers.ts
@@ -6,24 +6,26 @@ var addNavigateHandlers = (stateNavigator: StateNavigator | StateNavigator[]) =>
     var stateNavigators = isStateNavigator(stateNavigator) ? [stateNavigator] : stateNavigator;
     stateNavigators.forEach((stateNavigator, tab) => {
         stateNavigator.onNavigate(() => {
-            var {crumbs, history, oldState, oldData, oldUrl} = stateNavigator.stateContext;
+            var {crumbs, history, oldState, oldUrl} = stateNavigator.stateContext;
+            if (!oldState || history)
+                return; 
             var {crumbs: oldCrumbs} = stateNavigator.parseLink(oldUrl);
-            if (!history && crumbs.length !== oldCrumbs.length) {
-                var {state, data, title, oldData, nextCrumb} = stateNavigator.stateContext;
-                var titles = crumbs.map(({title}) => title).concat(title);
-                var appKey = AppRegistry.getAppKeys()[0];
-                if (oldCrumbs.length < crumbs.length) {
-                    var {state: nextState, data: nextData} = crumbs.concat(nextCrumb)[oldCrumbs.length + 1];
-                    var enterAnim = state.getUnmountStyle && state.getUnmountStyle(true, data, crumbs);
-                    var exitAnim = oldState.getCrumbStyle && oldState.getCrumbStyle(false, oldData, oldCrumbs, nextState, nextData);
-                } else {
-                    var nextCrumb = new Crumb(oldData, oldState, null, null, false);
-                    var {state: nextState, data: nextData} = oldCrumbs.concat(nextCrumb)[crumbs.length + 1];
-                    var enterAnim = state.getCrumbStyle && state.getCrumbStyle(true, data, crumbs, nextState, nextData);
-                    var exitAnim = oldState.getUnmountStyle && oldState.getUnmountStyle(false, oldData, oldCrumbs);
-                }
-                NavigationModule.render(crumbs.length, tab, titles, appKey, enterAnim, exitAnim);
+            if (crumbs.length === oldCrumbs.length)
+                return;
+            var {state, data, title, oldData, nextCrumb} = stateNavigator.stateContext;
+            var titles = crumbs.map(({title}) => title).concat(title);
+            var appKey = AppRegistry.getAppKeys()[0];
+            if (oldCrumbs.length < crumbs.length) {
+                var {state: nextState, data: nextData} = crumbs.concat(nextCrumb)[oldCrumbs.length + 1];
+                var enterAnim = state.getUnmountStyle && state.getUnmountStyle(true, data, crumbs);
+                var exitAnim = oldState.getCrumbStyle && oldState.getCrumbStyle(false, oldData, oldCrumbs, nextState, nextData);
+            } else {
+                var nextCrumb = new Crumb(oldData, oldState, null, null, false);
+                var {state: nextState, data: nextData} = oldCrumbs.concat(nextCrumb)[crumbs.length + 1];
+                var enterAnim = state.getCrumbStyle && state.getCrumbStyle(true, data, crumbs, nextState, nextData);
+                var exitAnim = oldState.getUnmountStyle && oldState.getUnmountStyle(false, oldData, oldCrumbs);
             }
+            NavigationModule.render(crumbs.length, tab, titles, appKey, enterAnim, exitAnim);
         });
     });
     new NativeEventEmitter(NavigationModule).addListener('Navigate', ({crumb, tab}) => {

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
@@ -50,12 +50,11 @@ public class NavigationModule extends ReactContextBaseJavaModule {
         int currentCrumb = mIntents.size() - 1;
         if (crumb < currentCrumb) {
             final Intent intent = mIntents.get(crumb);
-            currentActivity.navigateUpTo(mIntents.get(crumb));
             for(int i = crumb + 1; i <= currentCrumb; i++) {
                 mIntents.remove(i);
             }
-            final int enter = this.activityCloseEnterAnimationId;
-            final int exit = this.activityCloseExitAnimationId;
+            final int enter = this.getAnimationResourceId(null, this.activityCloseEnterAnimationId);
+            final int exit = this.getAnimationResourceId(null, this.activityCloseExitAnimationId);
             currentActivity.runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
@@ -75,8 +74,8 @@ public class NavigationModule extends ReactContextBaseJavaModule {
                 mIntents.put(nextCrumb, intent);
                 intents[i] = intent;
             }
-            final int enter = this.activityOpenEnterAnimationId;
-            final int exit = this.activityOpenExitAnimationId;
+            final int enter = this.getAnimationResourceId(null, this.activityOpenEnterAnimationId);
+            final int exit = this.getAnimationResourceId(null, this.activityOpenExitAnimationId);
             currentActivity.runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
@@ -85,6 +84,14 @@ public class NavigationModule extends ReactContextBaseJavaModule {
                 }
             });
         }
+    }
+
+    private int getAnimationResourceId(String animationName, int defaultId) {
+        if (animationName == null)
+            return defaultId;
+        Activity currentActivity = getCurrentActivity();
+        String packageName = currentActivity.getApplication().getPackageName();
+        return currentActivity.getResources().getIdentifier(animationName, "anim", packageName);
     }
 }
 

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
@@ -42,7 +42,7 @@ public class NavigationModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void render(int crumb, int tab, ReadableArray titles, String appKey) {
+    public void render(int crumb, int tab, ReadableArray titles, String appKey, String enterAnim, String exitAnim) {
         final Activity currentActivity = getCurrentActivity();
         if (mIntents.size() == 0) {
             mIntents.put(0, currentActivity.getIntent());
@@ -53,8 +53,8 @@ public class NavigationModule extends ReactContextBaseJavaModule {
             for(int i = crumb + 1; i <= currentCrumb; i++) {
                 mIntents.remove(i);
             }
-            final int enter = this.getAnimationResourceId(null, this.activityCloseEnterAnimationId);
-            final int exit = this.getAnimationResourceId(null, this.activityCloseExitAnimationId);
+            final int enter = this.getAnimationResourceId(enterAnim, this.activityCloseEnterAnimationId);
+            final int exit = this.getAnimationResourceId(exitAnim, this.activityCloseExitAnimationId);
             currentActivity.runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
@@ -74,8 +74,8 @@ public class NavigationModule extends ReactContextBaseJavaModule {
                 mIntents.put(nextCrumb, intent);
                 intents[i] = intent;
             }
-            final int enter = this.getAnimationResourceId(null, this.activityOpenEnterAnimationId);
-            final int exit = this.getAnimationResourceId(null, this.activityOpenExitAnimationId);
+            final int enter = this.getAnimationResourceId(enterAnim, this.activityOpenEnterAnimationId);
+            final int exit = this.getAnimationResourceId(exitAnim, this.activityOpenExitAnimationId);
             currentActivity.runOnUiThread(new Runnable() {
                 @Override
                 public void run() {

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
@@ -2,6 +2,7 @@ package com.navigation.reactnative;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.content.res.TypedArray;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -12,9 +13,27 @@ import java.util.HashMap;
 
 public class NavigationModule extends ReactContextBaseJavaModule {
     private HashMap<Integer, Intent> mIntents = new HashMap<>();
+    private int activityOpenEnterAnimationId = 0;
+    private int activityOpenExitAnimationId = 0;
+    private int activityCloseEnterAnimationId = 0;
+    private int activityCloseExitAnimationId = 0;
 
     public NavigationModule(ReactApplicationContext reactContext) {
         super(reactContext);
+
+        TypedArray activityStyle = getReactApplicationContext().getTheme().obtainStyledAttributes(new int[] {android.R.attr.windowAnimationStyle});
+        int windowAnimationStyleResId = activityStyle.getResourceId(0, 0);
+        activityStyle.recycle();
+
+        activityStyle = getReactApplicationContext().getTheme().obtainStyledAttributes(windowAnimationStyleResId, new int[] {
+            android.R.attr.activityOpenEnterAnimation, android.R.attr.activityOpenExitAnimation,
+            android.R.attr.activityCloseEnterAnimation, android.R.attr.activityCloseExitAnimation
+        });
+        activityOpenEnterAnimationId = activityStyle.getResourceId(0, 0);
+        activityOpenExitAnimationId = activityStyle.getResourceId(1, 0);
+        activityCloseEnterAnimationId = activityStyle.getResourceId(2, 0);
+        activityCloseExitAnimationId = activityStyle.getResourceId(3, 0);
+        activityStyle.recycle();
     }
 
     @Override

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
@@ -89,9 +89,8 @@ public class NavigationModule extends ReactContextBaseJavaModule {
     private int getAnimationResourceId(String animationName, int defaultId) {
         if (animationName == null)
             return defaultId;
-        Activity currentActivity = getCurrentActivity();
-        String packageName = currentActivity.getApplication().getPackageName();
-        return currentActivity.getResources().getIdentifier(animationName, "anim", packageName);
+        String packageName = getReactApplicationContext().getPackageName();
+        return getReactApplicationContext().getResources().getIdentifier(animationName, "anim", packageName);
     }
 }
 

--- a/NavigationReactNative/src/ios/NavigationModule.m
+++ b/NavigationReactNative/src/ios/NavigationModule.m
@@ -19,7 +19,7 @@ RCT_EXPORT_MODULE();
     return dispatch_get_main_queue();
 }
 
-RCT_EXPORT_METHOD(render:(NSInteger)crumb tab:(NSInteger)tab titles:(NSArray *)titles appKey:(NSString *)appKey)
+RCT_EXPORT_METHOD(render:(NSInteger)crumb tab:(NSInteger)tab titles:(NSArray *)titles appKey:(NSString *)appKey enterAnim:(NSString *)enterAnim exitAnim:(NSString *)exitAnim)
 {
     UINavigationController *navigationController;
     UIViewController *rootViewController = [UIApplication sharedApplication].keyWindow.rootViewController;


### PR DESCRIPTION
Used native `overridePendingTransition` because allows the enter and the exit animation to be customised. The exit can either be unmounting or becoming a crumb; the enter can either be mounting from unmounted or from crumb. So there’s four different animations that can be overridden. Had to run the override on the ui thread. Had to get [the default andorid animations](https://stackoverflow.com/questions/15412743/how-to-switch-animations-between-onactivitystart-and-onbackpressed-events) so that can only override enter, for example, but leave exit as the default.

Made the `getCrumbStyle` and `getUnmountedStyle` match the params of the corresponding functions on Navigation React Mobile. Had to parse the old url to get the `Crumbs`, unlike on Mobile because, because need to call `getCrumbStyle` when remounting.