### PR TITLE
Remapped Shared Elements

### DIFF
--- a/NavigationReactNative/sample/zoom/App.js
+++ b/NavigationReactNative/sample/zoom/App.js
@@ -18,6 +18,10 @@ detail.renderScene = ({color}) => <Detail color={color}/>;
 stateNavigator.navigate('grid');
 addNavigateHandlers(stateNavigator);
 
+detail.truncateCrumbTrail = (state, data, crumbs) => (
+  crumbs.slice(-1)[0].state === detail ? crumbs.slice(0, -1) : crumbs
+);
+
 var openLink = (url) => {
   if (url) {
     var color = url.split('=')[1];
@@ -27,10 +31,6 @@ var openLink = (url) => {
 
 Linking.getInitialURL().then(openLink);
 Linking.addEventListener('url', ({url}) => openLink(url));
-
-detail.truncateCrumbTrail = (state, data, crumbs) => (
-  crumbs.slice(-1)[0].state === detail ? crumbs.slice(0, -1) : crumbs
-);
 
 export default ({crumb}) => (
   <NavigationHandler stateNavigator={stateNavigator}>

--- a/NavigationReactNative/sample/zoom/App.js
+++ b/NavigationReactNative/sample/zoom/App.js
@@ -28,6 +28,10 @@ var openLink = (url) => {
 Linking.getInitialURL().then(openLink);
 Linking.addEventListener('url', ({url}) => openLink(url));
 
+detail.truncateCrumbTrail = (state, data, crumbs) => (
+  crumbs[crumbs.length - 1].state === detail ? crumbs.slice(0, -1) : crumbs
+);
+
 export default ({crumb}) => (
   <NavigationHandler stateNavigator={stateNavigator}>
     <Scene crumb={crumb} />

--- a/NavigationReactNative/sample/zoom/App.js
+++ b/NavigationReactNative/sample/zoom/App.js
@@ -29,7 +29,7 @@ Linking.getInitialURL().then(openLink);
 Linking.addEventListener('url', ({url}) => openLink(url));
 
 detail.truncateCrumbTrail = (state, data, crumbs) => (
-  crumbs[crumbs.length - 1].state === detail ? crumbs.slice(0, -1) : crumbs
+  crumbs.slice(-1)[0].state === detail ? crumbs.slice(0, -1) : crumbs
 );
 
 export default ({crumb}) => (

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -25,7 +25,21 @@ export default ({color}) => (
             <View style={{backgroundColor: color, flex: 1}} />
           </SharedElementAndroid>
           <Text style={styles.text}>{color}</Text>
-      </ScrollView>
+          <View style={styles.colors}>
+            {['red', 'blue', 'green'].map(subcolor => (<TouchableHighlight
+              key={subcolor}
+              style={[
+                {backgroundColor: subcolor},
+                styles.subcolor
+              ]}
+              underlayColor={subcolor}
+              onPress={() => {
+                stateNavigator.navigateBack(1);
+              }}>
+                <View />
+            </TouchableHighlight>))}
+          </View>
+        </ScrollView>
     )}
   </NavigationContext.Consumer>
 );
@@ -49,5 +63,16 @@ const styles = StyleSheet.create({
     color: '#000',
     textAlign:'center',
     fontWeight: 'bold',
+  },
+  colors: {
+    flexDirection: 'row',
+    justifyContent: 'space-evenly',
+    marginTop: 20,
+    marginLeft: 40,
+    marginRight: 40,
+  },
+  subcolor: {
+    width: 100,
+    height: 50,
   },
 });

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -35,18 +35,21 @@ export default ({color}) => (
                 colors[(colors.indexOf(color) + 1) % colors.length],
                 colors[(colors.indexOf(color) + 2) % colors.length],
                 colors[(colors.indexOf(color) + 3) % colors.length]
-              ].map(subcolor => (<TouchableHighlight
-              key={subcolor}
-              style={[
-                {backgroundColor: subcolor},
-                styles.subcolor
-              ]}
-              underlayColor={subcolor}
-              onPress={() => {
-                stateNavigator.navigateBack(1);
-              }}>
-                <View />
-            </TouchableHighlight>))}
+              ].map(subcolor => (
+                <TouchableHighlight
+                  key={subcolor}
+                  style={[
+                    {backgroundColor: subcolor},
+                    styles.subcolor
+                  ]}
+                  underlayColor={subcolor}
+                  onPress={() => {
+                    stateNavigator.navigateBack(1);
+                  }}>
+                    <View />
+                </TouchableHighlight>
+              )
+            )}
           </View>
         </ScrollView>
     )}

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -77,13 +77,13 @@ const styles = StyleSheet.create({
   },
   colors: {
     flexDirection: 'row',
-    justifyContent: 'space-evenly',
+    justifyContent: 'center',
     marginTop: 20,
-    marginLeft: 40,
-    marginRight: 40,
   },
   subcolor: {
     width: 100,
     height: 50,
+    marginLeft: 4,
+    marginRight: 4,
   },
 });

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -3,6 +3,11 @@ import {StyleSheet, ScrollView, Text, View, Platform, TouchableHighlight} from '
 import {NavigationContext} from 'navigation-react';
 import {RightBarIOS, BarButtonIOS, SharedElementAndroid} from 'navigation-react-native';
 
+const colors = [
+  'maroon', 'red', 'crimson', 'orange', 'brown', 'sienna', 'olive',
+  'purple', 'fuchsia', 'indigo', 'green', 'navy', 'blue', 'teal', 'black'
+];
+
 export default ({color}) => (
   <NavigationContext.Consumer>
     {({stateNavigator}) => (
@@ -26,7 +31,11 @@ export default ({color}) => (
           </SharedElementAndroid>
           <Text style={styles.text}>{color}</Text>
           <View style={styles.colors}>
-            {['red', 'blue', 'green'].map(subcolor => (<TouchableHighlight
+            {[
+                colors[(colors.indexOf(color) + 1) % colors.length],
+                colors[(colors.indexOf(color) + 2) % colors.length],
+                colors[(colors.indexOf(color) + 3) % colors.length]
+              ].map(subcolor => (<TouchableHighlight
               key={subcolor}
               style={[
                 {backgroundColor: subcolor},

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -39,13 +39,12 @@ const styles = StyleSheet.create({
     paddingTop: 10,
   },
   color: {
-    flex: .6,
+    height: 300,
     marginTop: 10,
     marginLeft: 15,
     marginRight: 15,
   },
   text:{
-    flex: .4,
     fontSize: 80,
     color: '#000',
     textAlign:'center',

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -31,11 +31,8 @@ export default ({color}) => (
           </SharedElementAndroid>
           <Text style={styles.text}>{color}</Text>
           <View style={styles.colors}>
-            {[
-                colors[(colors.indexOf(color) + 1) % colors.length],
-                colors[(colors.indexOf(color) + 2) % colors.length],
-                colors[(colors.indexOf(color) + 3) % colors.length]
-              ].map(subcolor => (
+            {[1,2,3].map(i => colors[(colors.indexOf(color) + i) % 15])
+              .map(subcolor => (
                 <TouchableHighlight
                   key={subcolor}
                   style={[

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -33,10 +33,7 @@ export default ({color}) => (
               .map(subcolor => (
                 <TouchableHighlight
                   key={subcolor}
-                  style={[
-                    {backgroundColor: subcolor},
-                    styles.subcolor
-                  ]}
+                  style={[styles.subcolor, {backgroundColor: subcolor}]}
                   underlayColor={subcolor}
                   onPress={() => {
                     stateNavigator.navigate('detail', {

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -44,7 +44,9 @@ export default ({color}) => (
                   ]}
                   underlayColor={subcolor}
                   onPress={() => {
-                    stateNavigator.navigateBack(1);
+                    stateNavigator.navigate('detail', {
+                      color: subcolor, sharedElements: [subcolor]
+                    });
                   }}>
                     <View />
                 </TouchableHighlight>

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -11,8 +11,7 @@ const colors = [
 export default ({color}) => (
   <NavigationContext.Consumer>
     {({stateNavigator}) => (
-      <ScrollView
-        contentInsetAdjustmentBehavior="automatic">
+      <ScrollView contentInsetAdjustmentBehavior="automatic">
           <RightBarIOS>
             <BarButtonIOS systemItem="cancel" onPress={() => {
               stateNavigator.navigateBack(1);

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -12,8 +12,7 @@ export default ({color}) => (
   <NavigationContext.Consumer>
     {({stateNavigator}) => (
       <ScrollView
-        contentInsetAdjustmentBehavior="automatic"
-        contentContainerStyle={{flex:1}}>
+        contentInsetAdjustmentBehavior="automatic">
           <RightBarIOS>
             <BarButtonIOS systemItem="cancel" onPress={() => {
               stateNavigator.navigateBack(1);
@@ -85,5 +84,6 @@ const styles = StyleSheet.create({
     height: 50,
     marginLeft: 4,
     marginRight: 4,
+    marginBottom: 10,
   },
 });

--- a/NavigationReactNative/sample/zoom/Grid.js
+++ b/NavigationReactNative/sample/zoom/Grid.js
@@ -24,9 +24,7 @@ export default () => (
                 });
               }}>
               <SharedElementAndroid name={color} style={{flex: 1}}>
-                <View style={[styles.box, {backgroundColor: color}]}>
-                  <Text style={styles.text}>{color}</Text>
-                </View>
+                <View style={{backgroundColor: color, flex: 1}} />
               </SharedElementAndroid>
             </TouchableHighlight>
           ))}
@@ -50,15 +48,4 @@ const styles = StyleSheet.create({
     marginRight: 10,
     marginBottom: 20,
   },
-  box: {
-    flex: 1,
-    justifyContent: 'center'
-  },
-  text: {
-    color: '#fff',
-    fontSize: 20,
-    lineHeight: 20,
-    textAlign: 'center',
-    fontWeight: 'bold',
-  }
 });

--- a/NavigationReactNative/sample/zoom/Grid.js
+++ b/NavigationReactNative/sample/zoom/Grid.js
@@ -25,7 +25,9 @@ export default () => (
                 ]}
                 underlayColor={color}                
                 onPress={() => {
-                  stateNavigator.navigate('detail', {color, sharedElements: [color]});
+                  stateNavigator.navigate('detail', {
+                    color, sharedElements: [color]
+                  });
                 }}>
                 <Text style={styles.text}>{color}</Text>
               </TouchableHighlight>

--- a/NavigationReactNative/sample/zoom/Grid.js
+++ b/NavigationReactNative/sample/zoom/Grid.js
@@ -14,24 +14,20 @@ export default () => (
       <ScrollView contentInsetAdjustmentBehavior="automatic">
         <View style={styles.colors}>
           {colors.map(color => (
-            <SharedElementAndroid
+            <TouchableHighlight
               key={color}
-              name={color}
-              style={styles.shared}>
-              <TouchableHighlight
-                style={[
-                  {backgroundColor: color},
-                  styles.color
-                ]}
-                underlayColor={color}                
-                onPress={() => {
-                  stateNavigator.navigate('detail', {
-                    color, sharedElements: [color]
-                  });
-                }}>
+              style={styles.color}
+              underlayColor={color}                
+              onPress={() => {
+                stateNavigator.navigate('detail', {
+                  color, sharedElements: [color]
+                });
+              }}>
+              <SharedElementAndroid name={color}
+                style={{flex: 1, backgroundColor: color}}>
                 <Text style={styles.text}>{color}</Text>
-              </TouchableHighlight>
-            </SharedElementAndroid>
+              </SharedElementAndroid>
+            </TouchableHighlight>
           ))}
         </View>
       </ScrollView>
@@ -46,20 +42,18 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     marginTop: 10,
   },
-  shared: {
-    marginLeft:10,
-    marginRight: 10,
-    marginBottom: 20,
-  },
   color: {
     width: 100,
     height: 150,
-    justifyContent: 'center',
+    marginLeft: 10,
+    marginRight: 10,
+    marginBottom: 20,
   },
   text: {
     color: '#fff',
     fontSize: 20,
     textAlign: 'center',
     fontWeight: 'bold',
+    textAlignVertical: 'center',
   }
 });

--- a/NavigationReactNative/sample/zoom/Grid.js
+++ b/NavigationReactNative/sample/zoom/Grid.js
@@ -24,7 +24,7 @@ export default () => (
                 });
               }}>
               <SharedElementAndroid name={color}
-                style={{flex: 1, backgroundColor: color}}>
+                style={[styles.shared, {backgroundColor: color}]}>
                 <Text style={styles.text}>{color}</Text>
               </SharedElementAndroid>
             </TouchableHighlight>
@@ -49,9 +49,14 @@ const styles = StyleSheet.create({
     marginRight: 10,
     marginBottom: 20,
   },
+  shared: {
+    flex: 1,
+    justifyContent: 'center',
+  },
   text: {
     color: '#fff',
     fontSize: 20,
+    lineHeight: 20,
     textAlign: 'center',
     fontWeight: 'bold',
     textAlignVertical: 'center',

--- a/NavigationReactNative/sample/zoom/Grid.js
+++ b/NavigationReactNative/sample/zoom/Grid.js
@@ -23,9 +23,10 @@ export default () => (
                   color, sharedElements: [color]
                 });
               }}>
-              <SharedElementAndroid name={color}
-                style={[styles.shared, {backgroundColor: color}]}>
-                <Text style={styles.text}>{color}</Text>
+              <SharedElementAndroid name={color} style={{flex: 1}}>
+                <View style={[styles.box, {backgroundColor: color}]}>
+                  <Text style={styles.text}>{color}</Text>
+                </View>
               </SharedElementAndroid>
             </TouchableHighlight>
           ))}
@@ -49,9 +50,9 @@ const styles = StyleSheet.create({
     marginRight: 10,
     marginBottom: 20,
   },
-  shared: {
+  box: {
     flex: 1,
-    justifyContent: 'center',
+    justifyContent: 'center'
   },
   text: {
     color: '#fff',
@@ -59,6 +60,5 @@ const styles = StyleSheet.create({
     lineHeight: 20,
     textAlign: 'center',
     fontWeight: 'bold',
-    textAlignVertical: 'center',
   }
 });

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
@@ -67,8 +67,8 @@ public class NavigationModule extends ReactContextBaseJavaModule {
             }
             final int enter = this.getAnimationResourceId(enterAnim, this.activityCloseEnterAnimationId);
             final int exit = this.getAnimationResourceId(exitAnim, this.activityCloseExitAnimationId);
-            final HashMap<String, View> sharedElementsMap = getSharedElementsMap();
-            final Pair[] oldSharedElements = currentCrumb - crumb == 1 ? getSharedElements(sharedElementsMap, oldSharedElementNames) : null;
+            final HashMap<String, View> oldSharedElementsMap = getSharedElementsMap();
+            final Pair[] oldSharedElements = currentCrumb - crumb == 1 ? getSharedElements(oldSharedElementsMap, oldSharedElementNames) : null;
             currentActivity.runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
@@ -81,8 +81,8 @@ public class NavigationModule extends ReactContextBaseJavaModule {
                                 for(int i = 0; i < oldSharedElementNames.size(); i++) {
                                     String name = oldSharedElementNames.getString(i);
                                     names.add(name);
-                                    if (sharedElementsMap.containsKey(name))
-                                        elements.put(name, sharedElementsMap.get(name));
+                                    if (oldSharedElementsMap.containsKey(name))
+                                        elements.put(name, oldSharedElementsMap.get(name));
                                 }
                             }
                         });

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 
 public class NavigationModule extends ReactContextBaseJavaModule {
     private HashMap<Integer, Intent> mIntents = new HashMap<>();
@@ -53,7 +54,7 @@ public class NavigationModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void render(int crumb, int tab, ReadableArray titles, String appKey, ReadableArray sharedElementNames, ReadableArray oldSharedElementNames, String enterAnim, String exitAnim) {
+    public void render(int crumb, int tab, ReadableArray titles, String appKey, ReadableArray sharedElementNames, final ReadableArray oldSharedElementNames, String enterAnim, String exitAnim) {
         final Activity currentActivity = getCurrentActivity();
         if (mIntents.size() == 0) {
             mIntents.put(0, currentActivity.getIntent());
@@ -66,14 +67,29 @@ public class NavigationModule extends ReactContextBaseJavaModule {
             }
             final int enter = this.getAnimationResourceId(enterAnim, this.activityCloseEnterAnimationId);
             final int exit = this.getAnimationResourceId(exitAnim, this.activityCloseExitAnimationId);
-            final Pair[] oldSharedElements = currentCrumb - crumb == 1 ? getSharedElements(oldSharedElementNames) : null;
+            final HashMap<String, View> sharedElementsMap = getSharedElementsMap();
+            final Pair[] oldSharedElements = currentCrumb - crumb == 1 ? getSharedElements(sharedElementsMap, oldSharedElementNames) : null;
             currentActivity.runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && oldSharedElements != null && oldSharedElements.length != 0)
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && oldSharedElements != null && oldSharedElements.length != 0) {
+                        currentActivity.setEnterSharedElementCallback(new SharedElementCallback() {
+                            @Override
+                            public void onMapSharedElements(List<String> names, Map<String, View> elements) {
+                                names.clear();
+                                elements.clear();
+                                for(int i = 0; i < oldSharedElementNames.size(); i++) {
+                                    String name = oldSharedElementNames.getString(i);
+                                    names.add(name);
+                                    if (sharedElementsMap.containsKey(name))
+                                        elements.put(name, sharedElementsMap.get(name));
+                                }
+                            }
+                        });
                         currentActivity.finishAfterTransition();
-                    else
+                    } else {
                         currentActivity.navigateUpTo(intent);
+                    }
                     currentActivity.overridePendingTransition(enter, exit);
                 }
             });
@@ -91,7 +107,8 @@ public class NavigationModule extends ReactContextBaseJavaModule {
             }
             final int enter = this.getAnimationResourceId(enterAnim, this.activityOpenEnterAnimationId);
             final int exit = this.getAnimationResourceId(exitAnim, this.activityOpenExitAnimationId);
-            final Pair[] sharedElements = crumb - currentCrumb == 1 ? getSharedElements(sharedElementNames) : null;
+            final HashMap<String, View> sharedElementsMap = getSharedElementsMap();
+            final Pair[] sharedElements = crumb - currentCrumb == 1 ? getSharedElements(sharedElementsMap, sharedElementNames) : null;
             currentActivity.runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
@@ -103,6 +120,14 @@ public class NavigationModule extends ReactContextBaseJavaModule {
                                     View childView = ((ViewGroup) view).getChildAt(0);
                                     if (childView instanceof ReactImageView)
                                         ((ReactImageView) childView).getDrawable().setVisible(true, true);
+                                }
+                            }
+                            @Override
+                            public void onMapSharedElements(List<String> names, Map<String, View> elements) {
+                                elements.clear();
+                                for(String name : names) {
+                                    if (sharedElementsMap.containsKey(name))
+                                        elements.put(name, sharedElementsMap.get(name));
                                 }
                             }
                         });
@@ -125,15 +150,21 @@ public class NavigationModule extends ReactContextBaseJavaModule {
         return getReactApplicationContext().getResources().getIdentifier(animationName, "anim", packageName);
     }
 
-    private Pair[] getSharedElements(ReadableArray sharedElementNames) {
+    private HashMap<String, View> getSharedElementsMap() {
         View contentView = getCurrentActivity().findViewById(android.R.id.content);
         HashSet<View> sharedElements = SharedElementManager.getSharedElements(contentView.getRootView());
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP || sharedElementNames == null || sharedElements == null)
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP || sharedElements == null)
             return null;
         HashMap<String, View> sharedElementMap = new HashMap<>();
         for(View sharedElement : sharedElements) {
             sharedElementMap.put(sharedElement.getTransitionName(), sharedElement);
         }
+        return sharedElementMap;
+    }
+
+    private Pair[] getSharedElements(HashMap<String, View> sharedElementMap, ReadableArray sharedElementNames) {
+        if (sharedElementMap == null || sharedElementNames == null)
+            return null;
         ArrayList<Pair> sharedElementPairs = new ArrayList<>();
         for(int i = 0; i < sharedElementNames.size(); i++) {
             String name = sharedElementNames.getString(i);


### PR DESCRIPTION
Allowed a shared element to be changed when navigating back. In the Zoom sample, pick 'blue' (grid -> details), change to 'red' (details -> details with truncated crumb trail). Make 'red' the shared element when navigating back to the grid even though 'blue' was the originally shared element when going from grid to details.

When going from 'blue' to 'red', pass `{sharedElements: ['red']}` to update the shared elements navigation data. When navigating back, add a `SharedElementCallback` (enter) to the 'details' `Activity` and remap the shared elements using the updated navigation data. Also add a corresponding `SharedElementCallback` (exit) on the 'grid' `Activity` to complete the remapping.
