### PR TITLE
Supported Customised Shared Element Transitions

### DIFF
--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -24,7 +24,10 @@ export default ({color}) => (
             }}>
             <Text style={styles.back}>X</Text>
           </TouchableHighlight>}
-          <SharedElementAndroid name={color} style={styles.color} transition="overshoot">
+          <SharedElementAndroid
+            name={color}
+            style={styles.color}
+            transition="overshoot">
             <View style={{backgroundColor: color, flex: 1}} />
           </SharedElementAndroid>
           <Text style={styles.text}>{color}</Text>

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -24,7 +24,7 @@ export default ({color}) => (
             }}>
             <Text style={styles.back}>X</Text>
           </TouchableHighlight>}
-          <SharedElementAndroid name={color} style={styles.color}>
+          <SharedElementAndroid name={color} style={styles.color} transition="overshoot">
             <View style={{backgroundColor: color, flex: 1}} />
           </SharedElementAndroid>
           <Text style={styles.text}>{color}</Text>

--- a/NavigationReactNative/sample/zoom/android/app/src/main/res/transition/overshoot.xml
+++ b/NavigationReactNative/sample/zoom/android/app/src/main/res/transition/overshoot.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<transitionSet xmlns:android="http://schemas.android.com/apk/res/android">
+    <changeBounds android:interpolator="@android:interpolator/overshoot"/>
+</transitionSet>

--- a/NavigationReactNative/sample/zoom/android/app/src/main/res/values/styles.xml
+++ b/NavigationReactNative/sample/zoom/android/app/src/main/res/values/styles.xml
@@ -3,8 +3,6 @@
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
-        <item name="android:windowSharedElementEnterTransition">@transition/move</item>
-        <item name="android:windowSharedElementExitTransition">@transition/move</item>
     </style>
 
 </resources>

--- a/NavigationReactNative/src/SharedElementAndroid.ts
+++ b/NavigationReactNative/src/SharedElementAndroid.ts
@@ -1,3 +1,0 @@
-import { requireNativeComponent } from 'react-native';
-
-export default requireNativeComponent('NVSharedElement', null);

--- a/NavigationReactNative/src/SharedElementAndroid.tsx
+++ b/NavigationReactNative/src/SharedElementAndroid.tsx
@@ -1,0 +1,14 @@
+import React, { ReactElement } from 'react';
+import { requireNativeComponent } from 'react-native';
+type SharedElementProps = { name: string; transition?: string | ((from: boolean) => string); children: ReactElement<any> };
+type NVSharedElementProps = { name: string; enterTransition: string; exitTransition: string; children: ReactElement<any> };
+
+var SharedElement = ({transition, ...props}: SharedElementProps) => {
+    var enterTransition = typeof transition !== 'function' ? transition : transition(true);
+    var exitTransition = typeof transition !== 'function' ? transition : transition(false);
+    return <NVSharedElement enterTransition={enterTransition} exitTransition={exitTransition} {...props} />
+};
+
+var NVSharedElement = requireNativeComponent<NVSharedElementProps>('NVSharedElement', null);
+
+export default SharedElement;

--- a/NavigationReactNative/src/SharedElementAndroid.tsx
+++ b/NavigationReactNative/src/SharedElementAndroid.tsx
@@ -1,14 +1,11 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
 import { requireNativeComponent } from 'react-native';
-type SharedElementProps = { name: string; transition?: string | ((from: boolean) => string); children: ReactElement<any> };
-type NVSharedElementProps = { name: string; enterTransition: string; exitTransition: string; children: ReactElement<any> };
 
-var SharedElement = ({transition, ...props}: SharedElementProps) => {
+var SharedElement = ({transition, ...props}) => {
     var enterTransition = typeof transition !== 'function' ? transition : transition(true);
     var exitTransition = typeof transition !== 'function' ? transition : transition(false);
     return <NVSharedElement enterTransition={enterTransition} exitTransition={exitTransition} {...props} />
 };
-
-var NVSharedElement = requireNativeComponent<NVSharedElementProps>('NVSharedElement', null);
+var NVSharedElement = requireNativeComponent<any>('NVSharedElement', null);
 
 export default SharedElement;

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
@@ -113,7 +113,11 @@ public class NavigationModule extends ReactContextBaseJavaModule {
                 @Override
                 public void run() {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && sharedElements != null && sharedElements.length != 0) {
-                        intents[0].putExtra(SceneActivity.SHARED_ELEMENTS, sharedElementNames.toArrayList());
+                        HashSet<String> sharedElementSet = new HashSet<>();
+                        for(int i = 0; i < sharedElementNames.size(); i++) {
+                            sharedElementSet.add(sharedElementNames.getString(i));
+                        }
+                        intents[0].putExtra(SceneActivity.SHARED_ELEMENTS, sharedElementSet);
                         currentActivity.setExitSharedElementCallback(new SharedElementCallback() {
                             @Override
                             public void onSharedElementEnd(List<String> names, List<View> elements, List<View> snapshots) {

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
@@ -73,6 +73,13 @@ public class NavigationModule extends ReactContextBaseJavaModule {
                 @Override
                 public void run() {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && oldSharedElements != null && oldSharedElements.length != 0) {
+                        HashSet<String> oldSharedElementSet = new HashSet<>();
+                        for(int i = 0; i < oldSharedElementNames.size(); i++) {
+                            oldSharedElementSet.add(oldSharedElementNames.getString(i));
+                        }
+                        SharedElementTransitioner transitioner = new SharedElementTransitioner(currentActivity, oldSharedElementSet);
+                        for(String oldSharedElement : oldSharedElementSet)
+                            transitioner.load(oldSharedElement, null);
                         currentActivity.setEnterSharedElementCallback(new SharedElementCallback() {
                             @Override
                             public void onMapSharedElements(List<String> names, Map<String, View> elements) {

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
@@ -9,7 +9,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.util.Pair;
 import android.view.View;
-import android.view.ViewGroup;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -67,13 +66,13 @@ public class NavigationModule extends ReactContextBaseJavaModule {
             }
             final int enter = this.getAnimationResourceId(enterAnim, this.activityCloseEnterAnimationId);
             final int exit = this.getAnimationResourceId(exitAnim, this.activityCloseExitAnimationId);
-            final HashMap<String, View> oldSharedElementsMap = getSharedElementsMap();
+            final HashMap<String, View> oldSharedElementsMap = getSharedElementMap();
             final Pair[] oldSharedElements = currentCrumb - crumb == 1 ? getSharedElements(oldSharedElementsMap, oldSharedElementNames) : null;
             currentActivity.runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && oldSharedElements != null && oldSharedElements.length != 0) {
-                        HashSet<String> oldSharedElementSet = getSharedElementsSet(oldSharedElementNames);
+                        HashSet<String> oldSharedElementSet = getSharedElementSet(oldSharedElementNames);
                         SharedElementTransitioner transitioner = new SharedElementTransitioner(currentActivity, oldSharedElementSet);
                         for(String oldSharedElement : oldSharedElementSet)
                             transitioner.load(oldSharedElement, null);
@@ -111,13 +110,13 @@ public class NavigationModule extends ReactContextBaseJavaModule {
             }
             final int enter = this.getAnimationResourceId(enterAnim, this.activityOpenEnterAnimationId);
             final int exit = this.getAnimationResourceId(exitAnim, this.activityOpenExitAnimationId);
-            final HashMap<String, View> sharedElementsMap = getSharedElementsMap();
+            final HashMap<String, View> sharedElementsMap = getSharedElementMap();
             final Pair[] sharedElements = crumb - currentCrumb == 1 ? getSharedElements(sharedElementsMap, sharedElementNames) : null;
             currentActivity.runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && sharedElements != null && sharedElements.length != 0) {
-                        intents[0].putExtra(SceneActivity.SHARED_ELEMENTS, getSharedElementsSet(sharedElementNames));
+                        intents[0].putExtra(SceneActivity.SHARED_ELEMENTS, getSharedElementSet(sharedElementNames));
                         currentActivity.setExitSharedElementCallback(new SharedElementCallback() {
                             @Override
                             public void onSharedElementEnd(List<String> names, List<View> elements, List<View> snapshots) {
@@ -154,7 +153,7 @@ public class NavigationModule extends ReactContextBaseJavaModule {
         return getReactApplicationContext().getResources().getIdentifier(animationName, "anim", packageName);
     }
 
-    private HashSet<String> getSharedElementsSet(ReadableArray sharedElementNames) {
+    private HashSet<String> getSharedElementSet(ReadableArray sharedElementNames) {
         HashSet<String> sharedElementSet = new HashSet<>();
         for(int i = 0; i < sharedElementNames.size(); i++) {
             sharedElementSet.add(sharedElementNames.getString(i));
@@ -162,7 +161,7 @@ public class NavigationModule extends ReactContextBaseJavaModule {
         return sharedElementSet;
     }
 
-    private HashMap<String, View> getSharedElementsMap() {
+    private HashMap<String, View> getSharedElementMap() {
         View contentView = getCurrentActivity().findViewById(android.R.id.content);
         HashSet<View> sharedElements = SharedElementManager.getSharedElements(contentView.getRootView());
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP || sharedElements == null)

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
@@ -72,8 +72,7 @@ public class NavigationModule extends ReactContextBaseJavaModule {
                 @Override
                 public void run() {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && oldSharedElements != null && oldSharedElements.length != 0) {
-                        HashSet<String> oldSharedElementSet = getSharedElementSet(oldSharedElementNames);
-                        final SharedElementTransitioner transitioner = new SharedElementTransitioner(currentActivity, oldSharedElementSet);
+                        final SharedElementTransitioner transitioner = new SharedElementTransitioner(currentActivity, getSharedElementSet(oldSharedElementNames));
                         currentActivity.setEnterSharedElementCallback(new SharedElementCallback() {
                             @Override
                             public void onMapSharedElements(List<String> names, Map<String, View> elements) {

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
@@ -73,10 +73,7 @@ public class NavigationModule extends ReactContextBaseJavaModule {
                 public void run() {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && oldSharedElements != null && oldSharedElements.length != 0) {
                         HashSet<String> oldSharedElementSet = getSharedElementSet(oldSharedElementNames);
-                        SharedElementTransitioner transitioner = new SharedElementTransitioner(currentActivity, oldSharedElementSet);
-                        for(String oldSharedElement : oldSharedElementSet) {
-                            transitioner.load(oldSharedElement, null);
-                        }
+                        final SharedElementTransitioner transitioner = new SharedElementTransitioner(currentActivity, oldSharedElementSet);
                         currentActivity.setEnterSharedElementCallback(new SharedElementCallback() {
                             @Override
                             public void onMapSharedElements(List<String> names, Map<String, View> elements) {
@@ -85,8 +82,11 @@ public class NavigationModule extends ReactContextBaseJavaModule {
                                 for(int i = 0; i < oldSharedElementNames.size(); i++) {
                                     String name = oldSharedElementNames.getString(i);
                                     names.add(name);
-                                    if (oldSharedElementsMap.containsKey(name))
+                                    if (oldSharedElementsMap.containsKey(name)) {
                                         elements.put(name, oldSharedElementsMap.get(name));
+                                        SharedElementView sharedElementView = (SharedElementView) oldSharedElementsMap.get(name).getParent();
+                                        transitioner.load(name, sharedElementView.getExitTransition());
+                                    }
                                 }
                             }
                         });

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
@@ -74,8 +74,9 @@ public class NavigationModule extends ReactContextBaseJavaModule {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && oldSharedElements != null && oldSharedElements.length != 0) {
                         HashSet<String> oldSharedElementSet = getSharedElementSet(oldSharedElementNames);
                         SharedElementTransitioner transitioner = new SharedElementTransitioner(currentActivity, oldSharedElementSet);
-                        for(String oldSharedElement : oldSharedElementSet)
+                        for(String oldSharedElement : oldSharedElementSet) {
                             transitioner.load(oldSharedElement, null);
+                        }
                         currentActivity.setEnterSharedElementCallback(new SharedElementCallback() {
                             @Override
                             public void onMapSharedElements(List<String> names, Map<String, View> elements) {

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
@@ -83,9 +83,10 @@ public class NavigationModule extends ReactContextBaseJavaModule {
                                     String name = oldSharedElementNames.getString(i);
                                     names.add(name);
                                     if (oldSharedElementsMap.containsKey(name)) {
-                                        elements.put(name, oldSharedElementsMap.get(name));
-                                        SharedElementView sharedElementView = (SharedElementView) oldSharedElementsMap.get(name).getParent();
-                                        transitioner.load(name, sharedElementView.getExitTransition());
+                                        View oldSharedElement = oldSharedElementsMap.get(name);
+                                        elements.put(name, oldSharedElement);
+                                        SharedElementView oldSharedElementView = (SharedElementView) oldSharedElement.getParent();
+                                        transitioner.load(name, oldSharedElementView.getExitTransition());
                                     }
                                 }
                             }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
@@ -54,7 +54,7 @@ public class NavigationModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void render(int crumb, int tab, ReadableArray titles, String appKey, ReadableArray sharedElementNames, final ReadableArray oldSharedElementNames, String enterAnim, String exitAnim) {
+    public void render(int crumb, int tab, ReadableArray titles, String appKey, final ReadableArray sharedElementNames, final ReadableArray oldSharedElementNames, String enterAnim, String exitAnim) {
         final Activity currentActivity = getCurrentActivity();
         if (mIntents.size() == 0) {
             mIntents.put(0, currentActivity.getIntent());
@@ -113,7 +113,7 @@ public class NavigationModule extends ReactContextBaseJavaModule {
                 @Override
                 public void run() {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && sharedElements != null && sharedElements.length != 0) {
-                        intents[0].putExtra(SceneActivity.SHARED_ELEMENTS, new HashSet<>(sharedElementsMap.keySet()));
+                        intents[0].putExtra(SceneActivity.SHARED_ELEMENTS, sharedElementNames.toArrayList());
                         currentActivity.setExitSharedElementCallback(new SharedElementCallback() {
                             @Override
                             public void onSharedElementEnd(List<String> names, List<View> elements, List<View> snapshots) {

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
@@ -113,6 +113,7 @@ public class NavigationModule extends ReactContextBaseJavaModule {
                 @Override
                 public void run() {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && sharedElements != null && sharedElements.length != 0) {
+                        intents[0].putExtra(SceneActivity.SHARED_ELEMENTS, new HashSet<>(sharedElementsMap.keySet()));
                         currentActivity.setExitSharedElementCallback(new SharedElementCallback() {
                             @Override
                             public void onSharedElementEnd(List<String> names, List<View> elements, List<View> snapshots) {

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
@@ -73,10 +73,7 @@ public class NavigationModule extends ReactContextBaseJavaModule {
                 @Override
                 public void run() {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && oldSharedElements != null && oldSharedElements.length != 0) {
-                        HashSet<String> oldSharedElementSet = new HashSet<>();
-                        for(int i = 0; i < oldSharedElementNames.size(); i++) {
-                            oldSharedElementSet.add(oldSharedElementNames.getString(i));
-                        }
+                        HashSet<String> oldSharedElementSet = getSharedElementsSet(oldSharedElementNames);
                         SharedElementTransitioner transitioner = new SharedElementTransitioner(currentActivity, oldSharedElementSet);
                         for(String oldSharedElement : oldSharedElementSet)
                             transitioner.load(oldSharedElement, null);
@@ -120,11 +117,7 @@ public class NavigationModule extends ReactContextBaseJavaModule {
                 @Override
                 public void run() {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && sharedElements != null && sharedElements.length != 0) {
-                        HashSet<String> sharedElementSet = new HashSet<>();
-                        for(int i = 0; i < sharedElementNames.size(); i++) {
-                            sharedElementSet.add(sharedElementNames.getString(i));
-                        }
-                        intents[0].putExtra(SceneActivity.SHARED_ELEMENTS, sharedElementSet);
+                        intents[0].putExtra(SceneActivity.SHARED_ELEMENTS, getSharedElementsSet(sharedElementNames));
                         currentActivity.setExitSharedElementCallback(new SharedElementCallback() {
                             @Override
                             public void onSharedElementEnd(List<String> names, List<View> elements, List<View> snapshots) {
@@ -159,6 +152,14 @@ public class NavigationModule extends ReactContextBaseJavaModule {
             return defaultId;
         String packageName = getReactApplicationContext().getPackageName();
         return getReactApplicationContext().getResources().getIdentifier(animationName, "anim", packageName);
+    }
+
+    private HashSet<String> getSharedElementsSet(ReadableArray sharedElementNames) {
+        HashSet<String> sharedElementSet = new HashSet<>();
+        for(int i = 0; i < sharedElementNames.size(); i++) {
+            sharedElementSet.add(sharedElementNames.getString(i));
+        }
+        return sharedElementSet;
     }
 
     private HashMap<String, View> getSharedElementsMap() {

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationModule.java
@@ -117,9 +117,8 @@ public class NavigationModule extends ReactContextBaseJavaModule {
                             @Override
                             public void onSharedElementEnd(List<String> names, List<View> elements, List<View> snapshots) {
                                 for (View view : elements) {
-                                    View childView = ((ViewGroup) view).getChildAt(0);
-                                    if (childView instanceof ReactImageView)
-                                        ((ReactImageView) childView).getDrawable().setVisible(true, true);
+                                    if (view instanceof ReactImageView)
+                                        ((ReactImageView) view).getDrawable().setVisible(true, true);
                                 }
                             }
                             @Override

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -34,11 +34,10 @@ public class SceneActivity extends Activity implements DefaultHardwareBackBtnHan
         mReactRootView.startReactApplication(getReactNativeHost().getReactInstanceManager(), appKey, props);
         setContentView(mReactRootView);
         if (sharedElements != null ) {
+            this.postponeEnterTransition();
             SharedElementTransitioner transitioner = new SharedElementTransitioner(this, sharedElements);
             mReactRootView.getRootView().setTag(R.id.sharedElementTransitioner, transitioner);
         }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            this.postponeEnterTransition();
     }
 
     private ReactNativeHost getReactNativeHost() {

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -34,7 +34,7 @@ public class SceneActivity extends Activity implements DefaultHardwareBackBtnHan
         HashSet<String> sharedElements = (HashSet<String>) getIntent().getSerializableExtra(SHARED_ELEMENTS);
         mReactRootView.startReactApplication(getReactNativeHost().getReactInstanceManager(), appKey, props);
         setContentView(mReactRootView);
-        if (sharedElements != null ) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && sharedElements != null ) {
             this.postponeEnterTransition();
             SharedElementTransitioner transitioner = new SharedElementTransitioner(this, sharedElements);
             mReactRootView.getRootView().setTag(R.id.sharedElementTransitioner, transitioner);

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -30,6 +30,7 @@ public class SceneActivity extends Activity implements DefaultHardwareBackBtnHan
         Bundle props = new Bundle();
         props.putInt("crumb", getIntent().getIntExtra(CRUMB, 0));
         String appKey = getIntent().getStringExtra(APP_KEY);
+        @SuppressWarnings("unchecked")
         HashSet<String> sharedElements = (HashSet<String>) getIntent().getSerializableExtra(SHARED_ELEMENTS);
         mReactRootView.startReactApplication(getReactNativeHost().getReactInstanceManager(), appKey, props);
         setContentView(mReactRootView);

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -3,6 +3,8 @@ package com.navigation.reactnative;
 import android.app.Activity;
 import android.os.Build;
 import android.os.Bundle;
+import android.transition.Transition;
+import android.transition.TransitionInflater;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -33,8 +35,11 @@ public class SceneActivity extends Activity implements DefaultHardwareBackBtnHan
             @Override
             public void onChildViewAdded(View view, View view1) {
                 mReactRootView.setOnHierarchyChangeListener(null);
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    Transition transition = TransitionInflater.from(activity).inflateTransition(R.transition.move);
+                    getWindow().setSharedElementEnterTransition(transition);
                     activity.startPostponedEnterTransition();
+                }
             }
 
             @Override

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -38,7 +38,6 @@ public class SceneActivity extends Activity implements DefaultHardwareBackBtnHan
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
             this.postponeEnterTransition();
-        });
     }
 
     private ReactNativeHost getReactNativeHost() {

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -18,6 +18,7 @@ public class SceneActivity extends Activity implements DefaultHardwareBackBtnHan
     private ReactRootView mReactRootView;
     public static final String CRUMB = "Navigation.CRUMB";
     public static final String APP_KEY = "Navigation.APP_KEY";
+    public static final String SHARED_ELEMENTS = "Navigation.SHARED_ELEMENTS";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -14,6 +14,7 @@ import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactRootView;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 
 public class SceneActivity extends Activity implements DefaultHardwareBackBtnHandler {
@@ -29,11 +30,15 @@ public class SceneActivity extends Activity implements DefaultHardwareBackBtnHan
         Bundle props = new Bundle();
         props.putInt("crumb", getIntent().getIntExtra(CRUMB, 0));
         String appKey = getIntent().getStringExtra(APP_KEY);
-        HashSet<String> sharedElements = (HashSet<String>) getIntent().getSerializableExtra(SHARED_ELEMENTS);
+        ArrayList<Object> sharedElements = (ArrayList<Object>) getIntent().getSerializableExtra(SHARED_ELEMENTS);
         mReactRootView.startReactApplication(getReactNativeHost().getReactInstanceManager(), appKey, props);
         setContentView(mReactRootView);
         if (sharedElements != null ) {
-            SharedElementTransitioner transitioner = new SharedElementTransitioner(this, sharedElements);
+            HashSet<String> sharedElementSet = new HashSet<String>();
+            for(Object sharedElement : sharedElements) {
+                sharedElementSet.add((String) sharedElement);
+            }
+            SharedElementTransitioner transitioner = new SharedElementTransitioner(this, sharedElementSet);
             mReactRootView.getRootView().setTag(R.id.sharedElementTransitioner, transitioner);
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -14,6 +14,8 @@ import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactRootView;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 
+import java.util.HashSet;
+
 public class SceneActivity extends Activity implements DefaultHardwareBackBtnHandler {
     private ReactRootView mReactRootView;
     public static final String CRUMB = "Navigation.CRUMB";
@@ -27,8 +29,13 @@ public class SceneActivity extends Activity implements DefaultHardwareBackBtnHan
         Bundle props = new Bundle();
         props.putInt("crumb", getIntent().getIntExtra(CRUMB, 0));
         String appKey = getIntent().getStringExtra(APP_KEY);
+        HashSet<String> sharedElements = (HashSet<String>) getIntent().getSerializableExtra(SHARED_ELEMENTS);
         mReactRootView.startReactApplication(getReactNativeHost().getReactInstanceManager(), appKey, props);
         setContentView(mReactRootView);
+        if (sharedElements != null ) {
+            SharedElementTransitioner transitioner = new SharedElementTransitioner(this, sharedElements);
+            mReactRootView.getRootView().setTag(R.id.sharedElementTransitioner, transitioner);
+        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
             this.postponeEnterTransition();
         final Activity activity = this;

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -30,15 +30,11 @@ public class SceneActivity extends Activity implements DefaultHardwareBackBtnHan
         Bundle props = new Bundle();
         props.putInt("crumb", getIntent().getIntExtra(CRUMB, 0));
         String appKey = getIntent().getStringExtra(APP_KEY);
-        ArrayList<Object> sharedElements = (ArrayList<Object>) getIntent().getSerializableExtra(SHARED_ELEMENTS);
+        HashSet<String> sharedElements = (HashSet<String>) getIntent().getSerializableExtra(SHARED_ELEMENTS);
         mReactRootView.startReactApplication(getReactNativeHost().getReactInstanceManager(), appKey, props);
         setContentView(mReactRootView);
         if (sharedElements != null ) {
-            HashSet<String> sharedElementSet = new HashSet<String>();
-            for(Object sharedElement : sharedElements) {
-                sharedElementSet.add((String) sharedElement);
-            }
-            SharedElementTransitioner transitioner = new SharedElementTransitioner(this, sharedElementSet);
+            SharedElementTransitioner transitioner = new SharedElementTransitioner(this, sharedElements);
             mReactRootView.getRootView().setTag(R.id.sharedElementTransitioner, transitioner);
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -38,22 +38,6 @@ public class SceneActivity extends Activity implements DefaultHardwareBackBtnHan
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
             this.postponeEnterTransition();
-        final Activity activity = this;
-        mReactRootView.setOnHierarchyChangeListener(new ViewGroup.OnHierarchyChangeListener() {
-            @Override
-            public void onChildViewAdded(View view, View view1) {
-                mReactRootView.setOnHierarchyChangeListener(null);
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                    Transition transition = TransitionInflater.from(activity).inflateTransition(R.transition.move);
-                    getWindow().setSharedElementEnterTransition(transition);
-                    activity.startPostponedEnterTransition();
-                }
-            }
-
-            @Override
-            public void onChildViewRemoved(View view, View view1) {
-
-            }
         });
     }
 

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
@@ -2,6 +2,7 @@ package com.navigation.reactnative;
 
 import android.os.Build;
 import android.view.View;
+import android.view.ViewTreeObserver;
 
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
@@ -44,6 +45,17 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
                     sharedElement.setTransitionName(null);
                     sharedElements.remove(sharedElement);
                 }
+            }
+        });
+        view.getViewTreeObserver().addOnPreDrawListener(new ViewTreeObserver.OnPreDrawListener() {
+            @Override
+            public boolean onPreDraw() {
+                view.getViewTreeObserver().removeOnPreDrawListener(this);
+                View rootView = view.getRootView();
+                SharedElementTransitioner transitioner = (SharedElementTransitioner) rootView.getTag(R.id.sharedElements);
+                if (transitioner != null)
+                    transitioner.load(view.getName());
+                return true;
             }
         });
         return view;

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
@@ -54,7 +54,7 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
                 View rootView = view.getRootView();
                 SharedElementTransitioner transitioner = (SharedElementTransitioner) rootView.getTag(R.id.sharedElementTransitioner);
                 if (transitioner != null)
-                    transitioner.load(view.getName());
+                    transitioner.load(view.getName(), null);
                 return true;
             }
         });

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
@@ -61,6 +61,23 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
         return view;
     }
 
+    public void addView(SharedElementView parent, View child, int index) {
+        parent.addView(child, index);
+        HashSet<View> sharedElements = getSharedElements(parent.getRootView());
+        if (sharedElements != null && !sharedElements.contains(child))
+            sharedElements.add(child);
+    }
+
+    public void removeViewAt(SharedElementView parent, int index) {
+        HashSet<View> sharedElements = getSharedElements(parent.getRootView());
+        View sharedElement = parent.getChildAt(0);
+        if (sharedElements != null && sharedElements.contains(sharedElement)) {
+            sharedElement.setTransitionName(null);
+            sharedElements.remove(sharedElement);
+        }
+        parent.removeViewAt(index);
+    }
+
     @ReactProp(name = "name")
     public void setName(SharedElementView view, String name) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
@@ -2,8 +2,6 @@ package com.navigation.reactnative;
 
 import android.os.Build;
 import android.view.View;
-import android.view.ViewTreeObserver;
-import android.widget.FrameLayout;
 
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
@@ -11,7 +9,7 @@ import com.facebook.react.uimanager.annotations.ReactProp;
 
 import java.util.HashSet;
 
-public class SharedElementManager extends ViewGroupManager<FrameLayout> {
+public class SharedElementManager extends ViewGroupManager<SharedElementView> {
 
     @Override
     public String getName() {
@@ -19,8 +17,8 @@ public class SharedElementManager extends ViewGroupManager<FrameLayout> {
     }
 
     @Override
-    protected FrameLayout createViewInstance(ThemedReactContext reactContext) {
-        final FrameLayout view = new FrameLayout(reactContext);
+    protected SharedElementView createViewInstance(ThemedReactContext reactContext) {
+        final SharedElementView view = new SharedElementView(reactContext);
         view.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
             @Override
             public void onViewAttachedToWindow(View v) {
@@ -30,25 +28,31 @@ public class SharedElementManager extends ViewGroupManager<FrameLayout> {
                     sharedElements = new HashSet<>();
                     rootView.setTag(R.id.sharedElements, sharedElements);
                 }
-                if (!sharedElements.contains(view))
-                    sharedElements.add(view);
+                View sharedElement = view.getChildAt(0);
+                if (!sharedElements.contains(sharedElement)) {
+                    sharedElement.setTransitionName(view.getName());
+                    sharedElements.add(sharedElement);
+                }
             }
 
             @Override
             public void onViewDetachedFromWindow(View v) {
                 view.removeOnAttachStateChangeListener(this);
                 HashSet<View> sharedElements = getSharedElements(view.getRootView());
-                if (sharedElements != null && sharedElements.contains(view))
-                    sharedElements.remove(view);
+                View sharedElement = view.getChildAt(0);
+                if (sharedElements != null && sharedElements.contains(sharedElement)) {
+                    sharedElement.setTransitionName(null);
+                    sharedElements.remove(sharedElement);
+                }
             }
         });
         return view;
     }
 
     @ReactProp(name = "name")
-    public void setName(FrameLayout view, String name) {
+    public void setName(SharedElementView view, String name) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            view.setTransitionName(name);
+            view.setName(name);
     }
 
     @SuppressWarnings("unchecked")

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
@@ -31,7 +31,7 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
                 }
                 View sharedElement = view.getChildAt(0);
                 if (!sharedElements.contains(sharedElement)) {
-                    sharedElement.setTransitionName(view.getName());
+                    setTransitionName(sharedElement, view.getName());
                     sharedElements.add(sharedElement);
                 }
             }
@@ -42,7 +42,7 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
                 HashSet<View> sharedElements = getSharedElements(view.getRootView());
                 View sharedElement = view.getChildAt(0);
                 if (sharedElements != null && sharedElements.contains(sharedElement)) {
-                    sharedElement.setTransitionName(null);
+                    setTransitionName(sharedElement, null);
                     sharedElements.remove(sharedElement);
                 }
             }
@@ -74,7 +74,7 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
         HashSet<View> sharedElements = getSharedElements(parent.getRootView());
         View sharedElement = parent.getChildAt(0);
         if (sharedElements != null && sharedElements.contains(sharedElement)) {
-            sharedElement.setTransitionName(null);
+            setTransitionName(sharedElement, null);
             sharedElements.remove(sharedElement);
         }
         super.removeViewAt(parent, index);
@@ -82,10 +82,13 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
 
     @ReactProp(name = "name")
     public void setName(SharedElementView view, String name) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            view.setName(name);
+        view.setName(name);
         View sharedElement = view.getChildAt(0);
-        if (sharedElement != null)
+        setTransitionName(sharedElement, name);
+    }
+
+    private void setTransitionName(View sharedElement, String name) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && sharedElement != null)
             sharedElement.setTransitionName(name);
     }
 

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
@@ -52,7 +52,7 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
             public boolean onPreDraw() {
                 view.getViewTreeObserver().removeOnPreDrawListener(this);
                 View rootView = view.getRootView();
-                SharedElementTransitioner transitioner = (SharedElementTransitioner) rootView.getTag(R.id.sharedElements);
+                SharedElementTransitioner transitioner = (SharedElementTransitioner) rootView.getTag(R.id.sharedElementTransitioner);
                 if (transitioner != null)
                     transitioner.load(view.getName());
                 return true;

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
@@ -54,7 +54,7 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
                 View rootView = view.getRootView();
                 SharedElementTransitioner transitioner = (SharedElementTransitioner) rootView.getTag(R.id.sharedElementTransitioner);
                 if (transitioner != null)
-                    transitioner.load(view.getName(), null);
+                    transitioner.load(view.getName(), view.getEnterTransition());
                 return true;
             }
         });
@@ -70,6 +70,16 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
             sharedElement.setTransitionName(name);
     }
 
+    @ReactProp(name = "enterTransition")
+    public void setEnterTransition(SharedElementView view, String enterTransition) {
+        view.setEnterTransition(enterTransition);
+    }
+
+    @ReactProp(name = "exitTransition")
+    public void setExitTransition(SharedElementView view, String exitTransition) {
+        view.setExitTransition(exitTransition);
+    }
+    
     @SuppressWarnings("unchecked")
     public static HashSet<View> getSharedElements(View rootView) {
         return (HashSet<View>) rootView.getTag(R.id.sharedElements);

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
@@ -65,6 +65,9 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
     public void setName(SharedElementView view, String name) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
             view.setName(name);
+        View sharedElement = view.getChildAt(0);
+        if (sharedElement != null)
+            sharedElement.setTransitionName(name);
     }
 
     @SuppressWarnings("unchecked")

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
@@ -83,8 +83,7 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
     @ReactProp(name = "name")
     public void setName(SharedElementView view, String name) {
         view.setName(name);
-        View sharedElement = view.getChildAt(0);
-        setTransitionName(sharedElement, name);
+        setTransitionName(view.getChildAt(0), name);
     }
 
     private void setTransitionName(View sharedElement, String name) {

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
@@ -61,13 +61,15 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
         return view;
     }
 
+    @Override
     public void addView(SharedElementView parent, View child, int index) {
-        parent.addView(child, index);
+        super.addView(parent, child, index);
         HashSet<View> sharedElements = getSharedElements(parent.getRootView());
         if (sharedElements != null && !sharedElements.contains(child))
             sharedElements.add(child);
     }
 
+    @Override
     public void removeViewAt(SharedElementView parent, int index) {
         HashSet<View> sharedElements = getSharedElements(parent.getRootView());
         View sharedElement = parent.getChildAt(0);
@@ -75,7 +77,7 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
             sharedElement.setTransitionName(null);
             sharedElements.remove(sharedElement);
         }
-        parent.removeViewAt(index);
+        super.removeViewAt(parent, index);
     }
 
     @ReactProp(name = "name")

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
@@ -1,6 +1,7 @@
 package com.navigation.reactnative;
 
 import android.app.Activity;
+import android.os.Build;
 import android.transition.Transition;
 import android.transition.TransitionInflater;
 import android.transition.TransitionSet;
@@ -21,6 +22,8 @@ public class SharedElementTransitioner {
     }
 
     public void load(String sharedElement, String transitionKey) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP)
+            return;
         if (sharedElements.contains(sharedElement) && !loadedSharedElements.contains(sharedElement)) {
             loadedSharedElements.add(sharedElement);
             if (transitionKey == null)

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
@@ -1,15 +1,26 @@
 package com.navigation.reactnative;
 
 import android.app.Activity;
+import android.view.View;
 
 import java.util.HashSet;
 
 public class SharedElementTransitioner {
     private Activity activity;
     private HashSet<String> sharedElements;
+    private HashSet<String> loadedSharedElements;
 
     public SharedElementTransitioner(Activity activity, HashSet<String> sharedElements) {
         this.activity = activity;
         this.sharedElements = sharedElements;
+        this.loadedSharedElements = new HashSet<>();
+    }
+
+    public void load(String sharedElement) {
+        if (sharedElements.contains(sharedElement) && !loadedSharedElements.contains(sharedElement)) {
+            loadedSharedElements.add(sharedElement);
+        }
+        if(sharedElements.size() == loadedSharedElements.size())
+            activity.startPostponedEnterTransition();
     }
 }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
@@ -1,0 +1,15 @@
+package com.navigation.reactnative;
+
+import android.app.Activity;
+
+import java.util.HashSet;
+
+public class SharedElementTransitioner {
+    private Activity activity;
+    private HashSet<String> sharedElements;
+
+    public SharedElementTransitioner(Activity activity, HashSet<String> sharedElements) {
+        this.activity = activity;
+        this.sharedElements = sharedElements;
+    }
+}

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
@@ -1,6 +1,8 @@
 package com.navigation.reactnative;
 
 import android.app.Activity;
+import android.transition.Transition;
+import android.transition.TransitionInflater;
 import android.view.View;
 
 import java.util.HashSet;
@@ -21,6 +23,8 @@ public class SharedElementTransitioner {
             loadedSharedElements.add(sharedElement);
         }
         if(sharedElements.size() == loadedSharedElements.size()) {
+            Transition transition = TransitionInflater.from(activity).inflateTransition(R.transition.move);
+            activity.getWindow().setSharedElementEnterTransition(transition);
             activity.startPostponedEnterTransition();
             View contentView = activity.findViewById(android.R.id.content);
             contentView.getRootView().setTag(R.id.sharedElementTransitioner, null);

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
@@ -20,7 +20,10 @@ public class SharedElementTransitioner {
         if (sharedElements.contains(sharedElement) && !loadedSharedElements.contains(sharedElement)) {
             loadedSharedElements.add(sharedElement);
         }
-        if(sharedElements.size() == loadedSharedElements.size())
+        if(sharedElements.size() == loadedSharedElements.size()) {
             activity.startPostponedEnterTransition();
+            View contentView = activity.findViewById(android.R.id.content);
+            contentView.getRootView().setTag(R.id.sharedElementTransitioner, null);
+        }
     }
 }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
@@ -41,7 +41,7 @@ public class SharedElementTransitioner {
             for(String key : transitions.keySet()) {
                 transitionSet.addTransition(transitions.get(key));
             }
-            activity.getWindow().setSharedElementEnterTransition(transitionSet  );
+            activity.getWindow().setSharedElementEnterTransition(transitionSet);
             activity.startPostponedEnterTransition();
             View contentView = activity.findViewById(android.R.id.content);
             contentView.getRootView().setTag(R.id.sharedElementTransitioner, null);

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -1,0 +1,20 @@
+package com.navigation.reactnative;
+
+import android.content.Context;
+import android.widget.FrameLayout;
+
+public class SharedElementView extends FrameLayout {
+    private String name;
+
+    public SharedElementView(Context context) {
+        super(context);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -5,6 +5,8 @@ import android.widget.FrameLayout;
 
 public class SharedElementView extends FrameLayout {
     private String name;
+    private String enterTransition;
+    private String exitTransition;
 
     public SharedElementView(Context context) {
         super(context);
@@ -16,5 +18,21 @@ public class SharedElementView extends FrameLayout {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getEnterTransition() {
+        return enterTransition;
+    }
+
+    public void setEnterTransition(String enterTransition) {
+        this.enterTransition = enterTransition;
+    }
+
+    public String getExitTransition() {
+        return exitTransition;
+    }
+
+    public void setExitTransition(String exitTransition) {
+        this.exitTransition = exitTransition;
     }
 }

--- a/NavigationReactNative/src/android/app/src/main/res/values/strings.xml
+++ b/NavigationReactNative/src/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <item type="id" name="sharedElements" />
+    <item type="id" name="sharedElementTransitioner" />
 </resources>

--- a/NavigationReactNative/test/navigation-react-native-tests.tsx
+++ b/NavigationReactNative/test/navigation-react-native-tests.tsx
@@ -37,7 +37,7 @@ var Person = ({ name }) => (
                         stateNavigator.navigateBack(1)
                     }} />
                 </RightBarIOS>
-                <SharedElementAndroid name={name}>
+                <SharedElementAndroid name={name} transition="bounce">
                     <Text>{name}</Text>
                 </SharedElementAndroid>
             </View>

--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -1,5 +1,5 @@
 import { Component, ReactNode } from 'react';
-import { ImageURISource } from 'react-native';
+import { ImageURISource, StyleProp, ViewStyle } from 'react-native';
 import { StateNavigator, State } from 'navigation';
 
 /**
@@ -76,6 +76,16 @@ export interface SharedElementAndroidProps {
      * The name shared across scenes by the two elements
      */
     name: string;
+
+    /**
+     * The resource for the transition
+     */
+    transition?: string | ((mount: boolean) => string);
+
+    /**
+     * The style
+     */
+    style?: StyleProp<ViewStyle>;
 }
 
 /**

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -1,5 +1,5 @@
 import { Component, ReactNode } from 'react';
-import { ImageURISource } from 'react-native';
+import { ImageURISource, StyleProp, ViewStyle } from 'react-native';
 import { StateNavigator, State } from 'navigation';
 
 /**
@@ -76,6 +76,16 @@ export interface SharedElementAndroidProps {
      * The name shared across scenes by the two elements
      */
     name: string;
+
+    /**
+     * The resource for the transition
+     */
+    transition?: string | ((mount: boolean) => string);
+
+    /**
+     * The style
+     */
+    style?: StyleProp<ViewStyle>;
 }
 
 /**


### PR DESCRIPTION
Used the in-built transition resource files to specify the custom transitions. In JavaScript, the transition resource is specified on the target `SharedElement` component so that different shared elements can have different transitions. In native, the transition resource is inflated and the shared element is added as a target so that the transition only applies to that element.

Calling `addTarget` on the `Transition` didn't work at first because the `transitionName` was assigned to the containing component instead of the child component, .e.g., the `ReactImageView`. Once changed, it still didn't work because `startPostponedEnterTransition` was called too early, before these "new" shared elements weren't positioned yet. Attached PreDraw listeners to each shared element and only restarted the enter transition once all these listeners had run.
