### PR TITLE
Updated Scene when Peeking on iOS

### DIFF
--- a/NavigationReactNative/sample/twitter/App.js
+++ b/NavigationReactNative/sample/twitter/App.js
@@ -34,6 +34,6 @@ addNavigateHandlers(stateNavigators);
 
 export default ({crumb, tab = 0}) => (
   <NavigationHandler stateNavigator={stateNavigators[tab]}>
-    <Scene crumb={crumb} />
+    <Scene crumb={crumb} tab={tab} />
   </NavigationHandler>
 );

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -48,9 +48,9 @@ class Scene extends React.Component<NavigationMotionProps, NavigationMotionState
         }
         return false;
     }
-    willNavigate({crumb}) {
-        if (this.props.crumb === crumb) {
-            var {navigationEvent} = this.props;
+    willNavigate({crumb: targetCrumb}) {
+        var {crumb, navigationEvent} = this.props;
+        if (targetCrumb === crumb) {
             var {crumbs} = navigationEvent.stateNavigator.stateContext;
             var {nextCrumb} = this.state.navigationEvent.stateNavigator.stateContext;
             if (crumb < crumbs.length && crumbs[crumb].crumblessUrl !== nextCrumb.crumblessUrl) {

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -59,16 +59,16 @@ class Scene extends React.Component<NavigationMotionProps, NavigationMotionState
             }
             if (changed) {
                 var {stateNavigator} = navigationEvent;
-                var stackNavigator = new StateNavigator(stateNavigator, stateNavigator.historyManager);
-                stackNavigator.stateContext = Scene.createStateContext(crumbs, crumb);
-                stackNavigator.configure = stateNavigator.configure;
-                stackNavigator.onBeforeNavigate = stateNavigator.onBeforeNavigate;
-                stackNavigator.offBeforeNavigate = stateNavigator.offBeforeNavigate;
-                stackNavigator.onNavigate = stateNavigator.onNavigate;
-                stackNavigator.offNavigate = stateNavigator.offNavigate;
-                stackNavigator.navigateLink = stateNavigator.navigateLink.bind(stateNavigator);
-                var {oldState, state, data, asyncData} = stackNavigator.stateContext;
-                this.setState({navigationEvent: {oldState, state, data, asyncData, stateNavigator: stackNavigator, nextState: undefined, nextData: undefined}});
+                var tempNavigator = new StateNavigator(stateNavigator, stateNavigator.historyManager);
+                tempNavigator.stateContext = Scene.createStateContext(crumbs, crumb);
+                tempNavigator.configure = stateNavigator.configure;
+                tempNavigator.onBeforeNavigate = stateNavigator.onBeforeNavigate;
+                tempNavigator.offBeforeNavigate = stateNavigator.offBeforeNavigate;
+                tempNavigator.onNavigate = stateNavigator.onNavigate;
+                tempNavigator.offNavigate = stateNavigator.offNavigate;
+                tempNavigator.navigateLink = stateNavigator.navigateLink.bind(stateNavigator);
+                var {oldState, state, data, asyncData} = tempNavigator.stateContext;
+                this.setState({navigationEvent: {oldState, state, data, asyncData, stateNavigator: tempNavigator, nextState: undefined, nextData: undefined}});
             }
         }
     }

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -21,21 +21,14 @@ class Scene extends React.Component<NavigationMotionProps, NavigationMotionState
         if (state && crumbs.length === crumb)
             return {navigationEvent};
         if (state && !prevNavigationEvent && crumb < crumbs.length) {
-            var {stateNavigator} = navigationEvent;
-            var stackNavigator = new StateNavigator(stateNavigator, stateNavigator.historyManager);
-            stackNavigator.stateContext = Scene.createStateContext(crumbs, crumb);
-            stackNavigator.configure = stateNavigator.configure;
-            stackNavigator.onBeforeNavigate = stateNavigator.onBeforeNavigate;
-            stackNavigator.offBeforeNavigate = stateNavigator.offBeforeNavigate;
-            stackNavigator.onNavigate = stateNavigator.onNavigate;
-            stackNavigator.offNavigate = stateNavigator.offNavigate;
-            stackNavigator.navigateLink = stateNavigator.navigateLink.bind(stateNavigator);
-            var {oldState, state, data, asyncData} = stackNavigator.stateContext;
-            return {navigationEvent: {oldState, state, data, asyncData, stateNavigator: stackNavigator}};
+            var stackNavigationEvent = Scene.createNavigationEvent(navigationEvent, crumbs, crumb);
+            return {navigationEvent: stackNavigationEvent};
         }
         return null;
     }
-    static createStateContext(crumbs: Crumb[], crumb: number) {
+    static createNavigationEvent(navigationEvent: NavigationEvent, crumbs: Crumb[], crumb: number): NavigationEvent {
+        var {stateNavigator} = navigationEvent;
+        var stackNavigator = new StateNavigator(stateNavigator, stateNavigator.historyManager);
         var stateContext = new StateContext();
         var {state, data, url, title} = crumbs[crumb];
         stateContext.state = state;
@@ -50,7 +43,15 @@ class Scene extends React.Component<NavigationMotionProps, NavigationMotionState
             stateContext.previousData = stateContext.oldData = data;
             stateContext.previousUrl = stateContext.oldUrl = url;
         }
-        return stateContext;
+        stackNavigator.stateContext = stateContext;
+        stackNavigator.configure = stateNavigator.configure;
+        stackNavigator.onBeforeNavigate = stateNavigator.onBeforeNavigate;
+        stackNavigator.offBeforeNavigate = stateNavigator.offBeforeNavigate;
+        stackNavigator.onNavigate = stateNavigator.onNavigate;
+        stackNavigator.offNavigate = stateNavigator.offNavigate;
+        stackNavigator.navigateLink = stateNavigator.navigateLink.bind(stateNavigator);
+        var {oldState, state, data, asyncData} = stackNavigator.stateContext;
+        return {oldState, state, data, asyncData, stateNavigator: stackNavigator, nextState: undefined, nextData: undefined};
     }
     componentDidMount() {
         BackHandler.addEventListener('hardwareBackPress', this.handleBack);

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -46,7 +46,7 @@ class Scene extends React.Component<NavigationMotionProps, NavigationMotionState
     }
     willNavigate({crumb: targetCrumb}) {
         var {crumb, navigationEvent} = this.props;
-        var {crumbs} = navigationEvent.stateNavigator.stateContext;
+        var {crumbs, nextCrumb} = navigationEvent.stateNavigator.stateContext;
         if (targetCrumb === crumb && crumb < crumbs.length) {
             var changed = !this.state.navigationEvent;
             if (!changed) {
@@ -60,7 +60,7 @@ class Scene extends React.Component<NavigationMotionProps, NavigationMotionState
             if (changed) {
                 var {stateNavigator} = navigationEvent;
                 var tempNavigator = new StateNavigator(stateNavigator, stateNavigator.historyManager);
-                tempNavigator.stateContext = Scene.createStateContext(crumbs, crumb);
+                tempNavigator.stateContext = Scene.createStateContext(crumbs, nextCrumb, crumb);
                 tempNavigator.configure = stateNavigator.configure;
                 tempNavigator.onBeforeNavigate = stateNavigator.onBeforeNavigate;
                 tempNavigator.offBeforeNavigate = stateNavigator.offBeforeNavigate;
@@ -72,7 +72,7 @@ class Scene extends React.Component<NavigationMotionProps, NavigationMotionState
             }
         }
     }
-    static createStateContext(crumbs: Crumb[], crumb: number) {
+    static createStateContext(crumbs: Crumb[], nextCrumb: Crumb, crumb: number) {
         var stateContext = new StateContext();
         var {state, data, url, title} = crumbs[crumb];
         stateContext.state = state;
@@ -81,11 +81,15 @@ class Scene extends React.Component<NavigationMotionProps, NavigationMotionState
         stateContext.title = title;
         stateContext.crumbs = crumbs.slice(0, crumb);
         stateContext.nextCrumb = crumbs[crumb];
+        var {state, data, url} = nextCrumb;
+        stateContext.oldState = state;
+        stateContext.oldData = data;
+        stateContext.oldUrl = url;
         if (crumb > 1) {
             var {state, data, url} = crumbs[crumb - 1];
-            stateContext.previousState = stateContext.oldState = state;
-            stateContext.previousData = stateContext.oldData = data;
-            stateContext.previousUrl = stateContext.oldUrl = url;
+            stateContext.previousState = state;
+            stateContext.previousData = data;
+            stateContext.previousUrl = url;
         }
         return stateContext;
     }

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -50,10 +50,15 @@ class Scene extends React.Component<NavigationMotionProps, NavigationMotionState
     }
     willNavigate({crumb: targetCrumb}) {
         var {crumb, navigationEvent} = this.props;
-        if (targetCrumb === crumb) {
-            var {crumbs} = navigationEvent.stateNavigator.stateContext;
-            var {nextCrumb} = this.state.navigationEvent.stateNavigator.stateContext;
-            if (crumb < crumbs.length && crumbs[crumb].crumblessUrl !== nextCrumb.crumblessUrl) {
+        var {crumbs} = navigationEvent.stateNavigator.stateContext;
+        if (targetCrumb === crumb && crumb < crumbs.length) {
+            var {state: latestState, data: latestData} = crumbs[crumb];
+            var {state, data} = this.state.navigationEvent.stateNavigator.stateContext;
+            var unchanged = state === latestState && data.length === latestData.length;
+            for(var key in data) {
+                unchanged = unchanged && data[key] === latestData[key];
+            }
+            if (!unchanged) {
                 var stackNavigationEvent = Scene.createNavigationEvent(navigationEvent, crumbs, crumb);
                 this.setState({navigationEvent: stackNavigationEvent});
             }

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -26,6 +26,23 @@ class Scene extends React.Component<NavigationMotionProps, NavigationMotionState
         }
         return null;
     }
+    componentDidMount() {
+        BackHandler.addEventListener('hardwareBackPress', this.handleBack);
+    }
+    shouldComponentUpdate(props, state) {
+        return state.navigationEvent === props.navigationEvent;
+    }
+    componentWillUnmount() {
+        BackHandler.removeEventListener('hardwareBackPress', this.handleBack); 
+    }
+    handleBack() {
+        var {navigationEvent} = this.state;
+        if (navigationEvent && navigationEvent.stateNavigator.canNavigateBack(1)) {
+            navigationEvent.stateNavigator.navigateBack(1);
+            return true;
+        }
+        return false;
+    }
     static createNavigationEvent(navigationEvent: NavigationEvent, crumbs: Crumb[], crumb: number): NavigationEvent {
         var {stateNavigator} = navigationEvent;
         var stackNavigator = new StateNavigator(stateNavigator, stateNavigator.historyManager);
@@ -52,23 +69,6 @@ class Scene extends React.Component<NavigationMotionProps, NavigationMotionState
         stackNavigator.navigateLink = stateNavigator.navigateLink.bind(stateNavigator);
         var {oldState, state, data, asyncData} = stackNavigator.stateContext;
         return {oldState, state, data, asyncData, stateNavigator: stackNavigator, nextState: undefined, nextData: undefined};
-    }
-    componentDidMount() {
-        BackHandler.addEventListener('hardwareBackPress', this.handleBack);
-    }
-    shouldComponentUpdate(props, state) {
-        return state.navigationEvent === props.navigationEvent;
-    }
-    componentWillUnmount() {
-        BackHandler.removeEventListener('hardwareBackPress', this.handleBack); 
-    }
-    handleBack() {
-        var {navigationEvent} = this.state;
-        if (navigationEvent && navigationEvent.stateNavigator.canNavigateBack(1)) {
-            navigationEvent.stateNavigator.navigateBack(1);
-            return true;
-        }
-        return false;
     }
     render() {
         var {navigationEvent} = this.state;

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -29,8 +29,8 @@ class Scene extends React.Component<NavigationMotionProps, NavigationMotionState
     componentDidMount() {
         BackHandler.addEventListener('hardwareBackPress', this.handleBack);
     }
-    shouldComponentUpdate(props, state) {
-        return state.navigationEvent === props.navigationEvent;
+    shouldComponentUpdate(_nextProps, nextState) {
+        return nextState.navigationEvent !== this.state.navigationEvent;
     }
     componentWillUnmount() {
         BackHandler.removeEventListener('hardwareBackPress', this.handleBack); 

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -6,12 +6,12 @@ type NavigationMotionProps = { crumb?: number, tab?: number, renderScene: (state
 type NavigationMotionState = { navigationEvent: NavigationEvent };
 
 class Scene extends React.Component<NavigationMotionProps, NavigationMotionState> {
-    private willNavigateSubscription: EmitterSubscription;
+    private peekNavigateSubscription: EmitterSubscription;
     constructor(props) {
         super(props);
         this.state = {navigationEvent: null};
         this.handleBack = this.handleBack.bind(this);
-        this.willNavigate = this.willNavigate.bind(this);
+        this.peekNavigate = this.peekNavigate.bind(this);
     }
     static defaultProps = {
         crumb: 0,
@@ -26,14 +26,14 @@ class Scene extends React.Component<NavigationMotionProps, NavigationMotionState
     componentDidMount() {
         BackHandler.addEventListener('hardwareBackPress', this.handleBack);
         var navigationEmitter = new NativeEventEmitter(NativeModules.NavigationModule);
-        this.willNavigateSubscription = navigationEmitter.addListener('WillNavigate', this.willNavigate);
+        this.peekNavigateSubscription = navigationEmitter.addListener('PeekNavigate', this.peekNavigate);
     }
     shouldComponentUpdate(_nextProps, nextState) {
         return nextState.navigationEvent !== this.state.navigationEvent;
     }
     componentWillUnmount() {
         BackHandler.removeEventListener('hardwareBackPress', this.handleBack);
-        this.willNavigateSubscription.remove();
+        this.peekNavigateSubscription.remove();
     }
     handleBack() {
         var {navigationEvent} = this.state;
@@ -43,7 +43,7 @@ class Scene extends React.Component<NavigationMotionProps, NavigationMotionState
         }
         return false;
     }
-    willNavigate({crumb: targetCrumb, tab: targetTab}) {
+    peekNavigate({crumb: targetCrumb, tab: targetTab}) {
         var {crumb, tab, navigationEvent} = this.props;
         var {crumbs, nextCrumb} = navigationEvent.stateNavigator.stateContext;
         if (targetCrumb === crumb && targetTab === tab && crumb < crumbs.length) {

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -20,9 +20,7 @@ class Scene extends React.Component<NavigationMotionProps, NavigationMotionState
     static getDerivedStateFromProps(props: NavigationMotionProps) {
         var {crumb, navigationEvent} = props;
         var {state, crumbs} = navigationEvent.stateNavigator.stateContext;
-        if (state && crumbs.length === crumb)
-            return {navigationEvent};
-        return null;
+        return (state && crumbs.length === crumb) ? {navigationEvent} : null;
     }
     componentDidMount() {
         BackHandler.addEventListener('hardwareBackPress', this.handleBack);

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -10,8 +10,8 @@ class Scene extends React.Component<NavigationMotionProps, NavigationMotionState
     constructor(props) {
         super(props);
         this.state = {navigationEvent: null};
-        this.willNavigate = this.willNavigate.bind(this);
         this.handleBack = this.handleBack.bind(this);
+        this.willNavigate = this.willNavigate.bind(this);
     }
     static defaultProps = {
         crumb: 0,
@@ -29,16 +29,16 @@ class Scene extends React.Component<NavigationMotionProps, NavigationMotionState
         return null;
     }
     componentDidMount() {
+        BackHandler.addEventListener('hardwareBackPress', this.handleBack);
         var navigationEmitter = new NativeEventEmitter(NativeModules.NavigationModule);
         this.willNavigateSubscription = navigationEmitter.addListener('WillNavigate', this.willNavigate);
-        BackHandler.addEventListener('hardwareBackPress', this.handleBack);
     }
     shouldComponentUpdate(_nextProps, nextState) {
         return nextState.navigationEvent !== this.state.navigationEvent;
     }
     componentWillUnmount() {
-        this.willNavigateSubscription.remove();
         BackHandler.removeEventListener('hardwareBackPress', this.handleBack);
+        this.willNavigateSubscription.remove();
     }
     handleBack() {
         var {navigationEvent} = this.state;

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -50,7 +50,7 @@ class Scene extends React.Component<NavigationMotionProps, NavigationMotionState
             if (!changed) {
                 var {state: latestState, data: latestData} = crumbs[crumb];
                 var {state, data} = this.state.navigationEvent.stateNavigator.stateContext;
-                changed = state !== latestState || data.length !== latestData.length;
+                changed = state !== latestState || Object.keys(data).length !== Object.keys(latestData).length;
                 for(var key in data) {
                     changed = changed || data[key] !== latestData[key];
                 }

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -16,7 +16,7 @@ class Scene extends React.Component<NavigationMotionProps, NavigationMotionState
     static defaultProps = {
         crumb: 0,
         tab: 0,
-        renderScene: (state, data) => state.renderScene(data)
+        renderScene: (state: State, data: any) => state.renderScene(data)
     }
     static getDerivedStateFromProps(props: NavigationMotionProps) {
         var {crumb, navigationEvent} = props;

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -43,6 +43,17 @@ class Scene extends React.Component<NavigationMotionProps, NavigationMotionState
         }
         return false;
     }
+    willNavigate({crumb}) {
+        if (this.props.crumb === crumb) {
+            var {navigationEvent} = this.props;
+            var {crumbs} = navigationEvent.stateNavigator.stateContext;
+            var {nextCrumb} = this.state.navigationEvent.stateNavigator.stateContext;
+            if (crumb < crumbs.length && crumbs[crumb].crumblessUrl !== nextCrumb.crumblessUrl) {
+                var stackNavigationEvent = Scene.createNavigationEvent(navigationEvent, crumbs, crumb);
+                this.setState({navigationEvent: stackNavigationEvent});
+            }
+        }
+    }
     static createNavigationEvent(navigationEvent: NavigationEvent, crumbs: Crumb[], crumb: number): NavigationEvent {
         var {stateNavigator} = navigationEvent;
         var stackNavigator = new StateNavigator(stateNavigator, stateNavigator.historyManager);

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -58,16 +58,16 @@ class Scene extends React.Component<NavigationMotionProps, NavigationMotionState
             }
             if (changed) {
                 var {stateNavigator} = navigationEvent;
-                var tempNavigator = new StateNavigator(stateNavigator, stateNavigator.historyManager);
-                tempNavigator.stateContext = Scene.createStateContext(crumbs, nextCrumb, crumb);
-                tempNavigator.configure = stateNavigator.configure;
-                tempNavigator.onBeforeNavigate = stateNavigator.onBeforeNavigate;
-                tempNavigator.offBeforeNavigate = stateNavigator.offBeforeNavigate;
-                tempNavigator.onNavigate = stateNavigator.onNavigate;
-                tempNavigator.offNavigate = stateNavigator.offNavigate;
-                tempNavigator.navigateLink = stateNavigator.navigateLink.bind(stateNavigator);
-                var {oldState, state, data, asyncData} = tempNavigator.stateContext;
-                this.setState({navigationEvent: {oldState, state, data, asyncData, stateNavigator: tempNavigator, nextState: undefined, nextData: undefined}});
+                var peekNavigator = new StateNavigator(stateNavigator, stateNavigator.historyManager);
+                peekNavigator.stateContext = Scene.createStateContext(crumbs, nextCrumb, crumb);
+                peekNavigator.configure = stateNavigator.configure;
+                peekNavigator.onBeforeNavigate = stateNavigator.onBeforeNavigate;
+                peekNavigator.offBeforeNavigate = stateNavigator.offBeforeNavigate;
+                peekNavigator.onNavigate = stateNavigator.onNavigate;
+                peekNavigator.offNavigate = stateNavigator.offNavigate;
+                peekNavigator.navigateLink = stateNavigator.navigateLink.bind(stateNavigator);
+                var {oldState, state, data, asyncData} = peekNavigator.stateContext;
+                this.setState({navigationEvent: {oldState, state, data, asyncData, stateNavigator: peekNavigator, nextState: undefined, nextData: undefined}});
             }
         }
     }

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react';
 import { BackHandler, NativeEventEmitter, NativeModules, EmitterSubscription } from 'react-native';
 import { StateNavigator, StateContext, State, Crumb } from 'navigation';
 import { NavigationContext, NavigationEvent } from 'navigation-react';
-type NavigationMotionProps = { crumb?: number, renderScene: (state: State, data: any) => ReactNode, navigationEvent: NavigationEvent };
+type NavigationMotionProps = { crumb?: number, tab?: number, renderScene: (state: State, data: any) => ReactNode, navigationEvent: NavigationEvent };
 type NavigationMotionState = { navigationEvent: NavigationEvent };
 
 class Scene extends React.Component<NavigationMotionProps, NavigationMotionState> {
@@ -15,6 +15,7 @@ class Scene extends React.Component<NavigationMotionProps, NavigationMotionState
     }
     static defaultProps = {
         crumb: 0,
+        tab: 0,
         renderScene: (state, data) => state.renderScene(data)
     }
     static getDerivedStateFromProps(props: NavigationMotionProps) {
@@ -42,10 +43,10 @@ class Scene extends React.Component<NavigationMotionProps, NavigationMotionState
         }
         return false;
     }
-    willNavigate({crumb: targetCrumb}) {
-        var {crumb, navigationEvent} = this.props;
+    willNavigate({crumb: targetCrumb, tab: targetTab}) {
+        var {crumb, tab, navigationEvent} = this.props;
         var {crumbs, nextCrumb} = navigationEvent.stateNavigator.stateContext;
-        if (targetCrumb === crumb && crumb < crumbs.length) {
+        if (targetCrumb === crumb && targetTab === tab && crumb < crumbs.length) {
             var changed = !this.state.navigationEvent;
             if (!changed) {
                 var {state: latestState, data: latestData} = crumbs[crumb];

--- a/NavigationReactNative/src/ios/NVSceneController.m
+++ b/NavigationReactNative/src/ios/NVSceneController.m
@@ -34,7 +34,7 @@
 {  
     [super viewWillAppear:animated];  
     if (self.navigationModule && self.navigationModule.bridge) {
-        [self.navigationModule sendEventWithName:@"WillNavigate" body:@{@"crumb": @(self.crumb), @"tab": @(self.tab)}];
+        [self.navigationModule sendEventWithName:@"PeekNavigate" body:@{@"crumb": @(self.crumb), @"tab": @(self.tab)}];
     }
 }
 

--- a/NavigationReactNative/src/ios/NVSceneController.m
+++ b/NavigationReactNative/src/ios/NVSceneController.m
@@ -30,6 +30,14 @@
     }
 }
 
+-(void)viewWillAppear:(BOOL)animated  
+{  
+    [super viewWillAppear:animated];  
+    if (self.navigationModule && self.navigationModule.bridge) {
+        [self.navigationModule sendEventWithName:@"WillNavigate" body:@{@"crumb": @(self.crumb), @"tab": @(self.tab)}];
+    }
+}
+
 - (void)loadView
 {
     NVApplicationHostDelegate *delegate = (NVApplicationHostDelegate *)[[UIApplication sharedApplication] delegate];

--- a/NavigationReactNative/src/ios/NavigationModule.m
+++ b/NavigationReactNative/src/ios/NavigationModule.m
@@ -11,7 +11,7 @@ RCT_EXPORT_MODULE();
 
 - (NSArray<NSString *> *)supportedEvents
 {
-    return @[@"Navigate"];
+    return @[@"Navigate", @"WillNavigate"];
 }
 
 - (dispatch_queue_t)methodQueue

--- a/NavigationReactNative/src/ios/NavigationModule.m
+++ b/NavigationReactNative/src/ios/NavigationModule.m
@@ -28,6 +28,7 @@ RCT_EXPORT_METHOD(render:(NSInteger)crumb tab:(NSInteger)tab titles:(NSArray *)t
     } else {
         navigationController = (UINavigationController *)rootViewController;
     }
+    ((NVSceneController *) [navigationController viewControllers][0]).navigationModule = self;
     
     NSInteger currentCrumb = [navigationController.viewControllers count] - 1;
     if (crumb < currentCrumb) {

--- a/NavigationReactNative/src/ios/NavigationModule.m
+++ b/NavigationReactNative/src/ios/NavigationModule.m
@@ -43,7 +43,9 @@ RCT_EXPORT_METHOD(render:(NSInteger)crumb tab:(NSInteger)tab titles:(NSArray *)t
         }
         [navigationController setViewControllers:controllers animated:true];
     }
-    navigationController.viewControllers[crumb].title = titles[crumb];
+    for (NVSceneController *controller in [navigationController viewControllers]) {
+        controller.title = titles[controller.crumb];
+    }
     if ([rootViewController isKindOfClass:[UITabBarController class]]) {
         ((UITabBarController *)rootViewController).selectedViewController = navigationController;
     }

--- a/NavigationReactNative/src/ios/NavigationModule.m
+++ b/NavigationReactNative/src/ios/NavigationModule.m
@@ -11,7 +11,7 @@ RCT_EXPORT_MODULE();
 
 - (NSArray<NSString *> *)supportedEvents
 {
-    return @[@"Navigate", @"WillNavigate"];
+    return @[@"Navigate", @"PeekNavigate"];
 }
 
 - (dispatch_queue_t)methodQueue

--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -17,6 +17,10 @@ export interface SceneProps {
      */
     crumb?: number;
     /**
+     * The iOS tab the scene belongs to
+     */
+    tab?: number;
+    /**
      * Renders the scene for the State and data
      */
     renderScene?: (state: State, data: any) => ReactNode;

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -17,6 +17,10 @@ export interface SceneProps {
      */
     crumb?: number;
     /**
+     * The iOS tab the scene belongs to
+     */
+    tab?: number;
+    /**
      * Renders the scene for the State and data
      */
     renderScene?: (state: State, data: any) => ReactNode;


### PR DESCRIPTION
Fluently navigate from A → B → C  to A → D → C. Don’t want to update scene B to D until navigate back to it. On Android, this works because the navigation happens in JavaScript first before the client. So the scene updates before it’s visible on the client. But on iOS, can peek the previous scene before navigating to it, by swiping back (even pressing back reveals the previous scene on the client before the navigation happens). In both these scenarios see the stale scene B and it only changes to D once the animation completes.

Added a `viewWillAppear` listener on iOS client that calls into JavaScript (via `PeekNavigate` event on `NavigationModule`). The `Scene` component then calls a `setState` if the `State` or navigation data has changed (`State` changed from B to D in the example). 

This also works when opening multiple scenes at once. Fluently navigate from A  to A → B → C. Then swiping back should see B and not a blank scene. Used to derive a dummy state in `Scene` component but the `viewWillAppear` listener handles this case, too.
