### PR TITLE
Removed Reserved Keys from Navigation Data

### DIFF
--- a/NavigationReactNative/sample/twitter/App.js
+++ b/NavigationReactNative/sample/twitter/App.js
@@ -26,6 +26,8 @@ for(var key in stateNavigator.states) {
   state.getUnmountStyle = from => from ? 'slide_in' : 'slide_out';
 }
 
+timeline.getTitle = ({sceneTitle}) => sceneTitle;
+
 var stateNavigators = [stateNavigator, new StateNavigator(stateNavigator)];
 stateNavigator.navigate('home');
 stateNavigators[1].navigate('notifications');

--- a/NavigationReactNative/src/addNavigateHandlers.ts
+++ b/NavigationReactNative/src/addNavigateHandlers.ts
@@ -12,20 +12,19 @@ var addNavigateHandlers = (stateNavigator: StateNavigator | StateNavigator[]) =>
             var {state, data, title, oldData, oldUrl, crumbs, nextCrumb} = stateNavigator.stateContext;
             var appKey = AppRegistry.getAppKeys()[0];
             var titles = crumbs.map(({data, title}) => data.sceneTitle || title).concat(data.sceneTitle || title);
-            var getSharedElements = ({sharedElements}) => sharedElements;
             var {crumbs: oldCrumbs} = stateNavigator.parseLink(oldUrl);
             if (oldCrumbs.length < crumbs.length) {
                 var {state: nextState, data: nextData} = crumbs.concat(nextCrumb)[oldCrumbs.length + 1];
                 var enterAnim = state.getUnmountStyle && state.getUnmountStyle(true, data, crumbs);
                 var exitAnim = oldState.getCrumbStyle && oldState.getCrumbStyle(false, oldData, oldCrumbs, nextState, nextData);
-                var sharedElements = (state.getSharedElements || getSharedElements)(data, crumbs);
+                var sharedElements = state.getSharedElements && state.getSharedElements(data, crumbs);
             }
             if (crumbs.length < oldCrumbs.length) {
                 var nextCrumb = new Crumb(oldData, oldState, null, null, false);
                 var {state: nextState, data: nextData} = oldCrumbs.concat(nextCrumb)[crumbs.length + 1];
                 var enterAnim = state.getCrumbStyle && state.getCrumbStyle(true, data, crumbs, nextState, nextData);
                 var exitAnim = oldState.getUnmountStyle && oldState.getUnmountStyle(false, oldData, oldCrumbs);
-                var oldSharedElements = (oldState.getSharedElements || getSharedElements)(oldData, oldCrumbs);
+                var oldSharedElements = oldState.getSharedElements && oldState.getSharedElements(oldData, oldCrumbs);
             }
             NavigationModule.render(crumbs.length, tab, titles, appKey, sharedElements, oldSharedElements, enterAnim, exitAnim);
         });

--- a/NavigationReactNative/src/addNavigateHandlers.ts
+++ b/NavigationReactNative/src/addNavigateHandlers.ts
@@ -9,9 +9,10 @@ var addNavigateHandlers = (stateNavigator: StateNavigator | StateNavigator[]) =>
             var {history, oldState} = stateNavigator.stateContext;
             if (!oldState || history)
                 return; 
-            var {state, data, title, oldData, oldUrl, crumbs, nextCrumb} = stateNavigator.stateContext;
+            var {state, data, oldData, oldUrl, crumbs, nextCrumb} = stateNavigator.stateContext;
             var appKey = AppRegistry.getAppKeys()[0];
-            var titles = crumbs.map(({data, title}) => data.sceneTitle || title).concat(data.sceneTitle || title);
+            var getTitle = ({state, data, title}: Crumb) => (state.getTitle && state.getTitle(data)) || title;
+            var titles = crumbs.map(getTitle).concat(getTitle(nextCrumb));
             var {crumbs: oldCrumbs} = stateNavigator.parseLink(oldUrl);
             if (oldCrumbs.length < crumbs.length) {
                 var {state: nextState, data: nextData} = crumbs.concat(nextCrumb)[oldCrumbs.length + 1];


### PR DESCRIPTION
Removed 'sceneTitles' and 'sharedElements' from navigation data. Instead added `getTitle` (and `getSharedElements`) to `State`. User can still pass them in navigation data but allows them to decide on the name of the `key`