### PR TITLE
Documented React Native 0.59 iOS Setup Changes

### DIFF
--- a/documentation/native/push-navigation.html
+++ b/documentation/native/push-navigation.html
@@ -113,7 +113,7 @@ var Inbox = () => (
 mail.renderScene = ({id}) => &lt;Mail mailId={id} />;</code></pre>
             <div class="Note">
                 <h2>Note</h2>
-                Wrap each scene in a <code>ScrollView</code> component with <code>contentInsetAdjustmentBehavior</code> set to 'automatic' to prevent the iOS navigation bar overlapping the content
+                Wrap each scene in a <code>SafeAreaView</code> component or a <code>ScrollView</code> component with <code>contentInsetAdjustmentBehavior</code> set to 'automatic' to prevent the iOS navigation bar overlapping the content
             </div>
         </div>
     </div>

--- a/documentation/native/setup.html
+++ b/documentation/native/setup.html
@@ -100,10 +100,11 @@ export default ({crumb}) => (
                 Locate the <code>AppDelegate.h</code> in the iOS project and replace the code with the following:
             </p>
             <pre><code class="language-js">#import &lt;UIKit/UIKit.h>
+#import &lt;React/RCTBridgeDelegate.h>
 #import &lt;React/RCTBridge.h>
 #import "NVApplicationHostDelegate.h"
 
-@interface AppDelegate : UIResponder &lt;NVApplicationHostDelegate>
+@interface AppDelegate : UIResponder &lt;UIApplicationDelegate, RCTBridgeDelegate, NVApplicationHostDelegate>
 
 @property (nonatomic, strong) UIWindow *window;
 @property (nonatomic, strong) RCTBridge *bridge;
@@ -113,6 +114,7 @@ export default ({crumb}) => (
                 Locate the <code>AppDelegate.m</code> in the iOS project and replace the code with that shown below. Change the <code>"Title"</code> placeholder string to the title of your first scene. Change the <code>"appKey"</code> placeholder string to the name of your application (it should match the key used in the <code>registerComponent</code> call in <code>index.js</code>).
             </p>
 <pre><code class="language-js">#import "AppDelegate.h"
+#import &lt;React/RCTBridge.h>
 #import &lt;React/RCTBundleURLProvider.h>
 #import &lt;React/RCTRootView.h>
 #import "NVSceneController.h"
@@ -121,9 +123,7 @@ export default ({crumb}) => (
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-  NSURL *jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
-  
-  self.bridge = [[RCTBridge alloc] initWithBundleURL:jsCodeLocation moduleProvider:nil launchOptions:launchOptions];  
+  self.bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
 
   NSString *title = @"Title";
@@ -137,7 +137,17 @@ export default ({crumb}) => (
   return YES;
 }
 
-@end</code></pre>
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+{
+#if DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+#else
+  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+#endif
+}
+
+@end
+</code></pre>
           </div>
     </div>
     <script type="text/javascript" src="../../js/prism.js"></script>

--- a/documentation/native/tabs-setup.html
+++ b/documentation/native/tabs-setup.html
@@ -103,19 +103,22 @@ export default ({crumb, tab = 0}) => (
                 Locate the <code>AppDelegate.h</code> in the iOS project and replace the code with the following:
             </p>
             <pre><code class="language-js">#import &lt;UIKit/UIKit.h>
+#import &lt;React/RCTBridgeDelegate.h>
 #import &lt;React/RCTBridge.h>
 #import "NVApplicationHostDelegate.h"
 
-@interface AppDelegate : UIResponder &lt;NVApplicationHostDelegate>
+@interface AppDelegate : UIResponder &lt;UIApplicationDelegate, RCTBridgeDelegate, NVApplicationHostDelegate>
 
 @property (nonatomic, strong) UIWindow *window;
 @property (nonatomic, strong) RCTBridge *bridge;
 
-@end</code></pre>
+@end
+</code></pre>
             <p>
                 Locate the <code>AppDelegate.m</code> in the iOS project and replace the code with that shown below. Change the <code>"Tab1"</code> and <code>"Tab2"</code> placeholder strings to the names of your tabs. Change the <code>"appKey"</code> placeholder string to the name of your application (it should match the key used in the <code>registerComponent</code> call in <code>index.js</code>). This setup is for 2 tabs. For each extra tab you require add an extra item to the <code>tabs</code> array.
             </p>
 <pre><code class="language-js">#import "AppDelegate.h"
+#import &lt;React/RCTBridge.h>
 #import &lt;React/RCTBundleURLProvider.h>
 #import &lt;React/RCTRootView.h>
 #import "NVSceneController.h"
@@ -124,9 +127,7 @@ export default ({crumb, tab = 0}) => (
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-  NSURL *jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
-  
-  self.bridge = [[RCTBridge alloc] initWithBundleURL:jsCodeLocation moduleProvider:nil launchOptions:launchOptions];  
+  self.bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
 
   NSArray *tabs = @[@"Tab1", @"Tab2"];
@@ -147,7 +148,17 @@ export default ({crumb, tab = 0}) => (
   return YES;
 }
 
-@end</code></pre>
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+{
+#if DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+#else
+  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+#endif
+}
+
+@end
+</code></pre>
         </div>
     </div>
     <script type="text/javascript" src="../../js/prism.js"></script>


### PR DESCRIPTION
React Native changed `AppDelegate.h` and `AppDelegate.m`. Incorporated these changes into the setup docs. The instructions work for old versions of React Native too (checked 0.57) so no need for separate docs