### PR TITLE
Added FluentLink Component

### DIFF
--- a/Navigation/src/FluentNavigator.ts
+++ b/Navigation/src/FluentNavigator.ts
@@ -12,6 +12,8 @@ interface FluentNavigator {
 
 function createFluentNavigator(states: { [index: string]: State }, stateHandler: StateHandler, stateContext = new StateContext()): FluentNavigator {
     function getCrumbTrail(state: State, navigationData: any, crumbs: Crumb[], nextCrumb: Crumb): Crumb[] {
+        if (!state.trackCrumbTrail)
+            return [];
         crumbs = crumbs.slice();
         if (nextCrumb)
             crumbs.push(nextCrumb);

--- a/Navigation/src/FluentNavigator.ts
+++ b/Navigation/src/FluentNavigator.ts
@@ -62,7 +62,7 @@ function createFluentNavigator(states: { [index: string]: State }, stateHandler:
             if (url == null)
                 throw new Error('Invalid route data, a mandatory route parameter has not been supplied a value');
             var data = { ...state.defaults, ...navigationData };
-            var crumbs = getCrumbTrail(state, navigationData, crumbs, nextCrumb);
+            var crumbs = getCrumbTrail(state, data, crumbs, nextCrumb);
             return navigateLink(state, data, crumbs, url);
         }
     }

--- a/Navigation/src/FluentNavigator.ts
+++ b/Navigation/src/FluentNavigator.ts
@@ -47,10 +47,11 @@ function createFluentNavigator(states: { [index: string]: State }, stateHandler:
             return navigateLink(state, data, crumbs, url);
         },
         navigateBack: function(distance: number): FluentNavigator {
-            if (!(distance <= stateContext.crumbs.length && distance > 0))
+            var {crumbs} = stateContext;
+            if (!(distance <= crumbs.length && distance > 0))
                 throw new Error('The distance parameter must be greater than zero and less than or equal to the number of Crumbs (' + stateContext.crumbs.length + ')');
-            var {state, data, url} = stateContext.crumbs[stateContext.crumbs.length - distance];
-            var crumbs = stateContext.crumbs.slice(0, stateContext.crumbs.length - distance);
+            var {state, data, url} = crumbs[crumbs.length - distance];
+            var crumbs = crumbs.slice(0, crumbs.length - distance);
             return navigateLink(state, data, crumbs, url);
         },
         refresh: function(navigationData?: any): FluentNavigator {
@@ -61,7 +62,7 @@ function createFluentNavigator(states: { [index: string]: State }, stateHandler:
             if (url == null)
                 throw new Error('Invalid route data, a mandatory route parameter has not been supplied a value');
             var data = { ...state.defaults, ...navigationData };
-            var crumbs = getCrumbTrail(state, data, crumbs, nextCrumb);
+            var crumbs = getCrumbTrail(state, navigationData, crumbs, nextCrumb);
             return navigateLink(state, data, crumbs, url);
         }
     }

--- a/Navigation/src/FluentNavigator.ts
+++ b/Navigation/src/FluentNavigator.ts
@@ -43,7 +43,7 @@ function createFluentNavigator(states: { [index: string]: State }, stateHandler:
             if (url == null)
                 throw new Error('Invalid route data, a mandatory route parameter has not been supplied a value');
             var data = { ...state.defaults, ...navigationData };
-            var crumbs = getCrumbTrail(state, navigationData, crumbs, nextCrumb);
+            var crumbs = getCrumbTrail(state, data, crumbs, nextCrumb);
             return navigateLink(state, data, crumbs, url);
         },
         navigateBack: function(distance: number): FluentNavigator {
@@ -61,7 +61,7 @@ function createFluentNavigator(states: { [index: string]: State }, stateHandler:
             if (url == null)
                 throw new Error('Invalid route data, a mandatory route parameter has not been supplied a value');
             var data = { ...state.defaults, ...navigationData };
-            var crumbs = getCrumbTrail(state, navigationData, crumbs, nextCrumb);
+            var crumbs = getCrumbTrail(state, data, crumbs, nextCrumb);
             return navigateLink(state, data, crumbs, url);
         }
     }

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -1928,7 +1928,7 @@ describe('Navigation Data', function () {
         }
     });
 
-    describe.only('Wizard Refresh Data Defaults', function() {
+    describe('Wizard Refresh Data Defaults', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {
             stateNavigator = new StateNavigator([

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -6899,7 +6899,8 @@ describe('Navigation Data', function () {
 
         describe('Fluent Navigate', function() {
             it('should throw error', function() {
-                assert.throws(() => stateNavigator.fluent().navigate('s', individualNavigationData), /The Url .+ is invalid/);
+                var link = stateNavigator.fluent().navigate('s', individualNavigationData).url;
+                assert.throws(() => stateNavigator.navigateLink(link), /The Url .+ is invalid/);
             });
         });
     });
@@ -6939,7 +6940,8 @@ describe('Navigation Data', function () {
 
         describe('Fluent Navigate', function() {
             it('should throw error', function() {
-                assert.throws(() => stateNavigator.fluent().navigate('s', arrayNavigationData), /The Url .+ is invalid/);
+                var link = stateNavigator.fluent().navigate('s', arrayNavigationData).url;
+                assert.throws(() => stateNavigator.navigateLink(link), /The Url .+ is invalid/);
             });
         });
     });

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -1928,6 +1928,68 @@ describe('Navigation Data', function () {
         }
     });
 
+    describe.only('Wizard Refresh Data Defaults', function() {
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true, defaults: { b: true } },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+        });
+        var data = {
+            s: 'Hello',
+            n: 5
+        };
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                stateNavigator.navigate('s1');
+                stateNavigator.refresh(data);
+                stateNavigator.navigate('s2', stateNavigator.stateContext.includeCurrentData(null));
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = stateNavigator.getNavigationLink('s1');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getRefreshLink(data);
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s2', stateNavigator.stateContext.includeCurrentData(null));
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s1')
+                    .refresh(data)
+                    .navigate('s2', currentData => currentData)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate data', function () {
+                assert.strictEqual(stateNavigator.stateContext.previousData['s'], 'Hello');
+                assert.strictEqual(stateNavigator.stateContext.previousData['n'], 5);
+                assert.strictEqual(stateNavigator.stateContext.previousData['b'], true);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['s'], 'Hello');
+                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['n'], 5);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['b'], true);
+                assert.strictEqual(stateNavigator.stateContext.data['s'], 'Hello');
+                assert.strictEqual(stateNavigator.stateContext.data['n'], 5);
+                assert.strictEqual(stateNavigator.stateContext.data['b'], true);
+            });
+        }
+    });
+
     describe('Transition Transition', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -2192,6 +2192,66 @@ describe('Navigation Data', function () {
         }
     });
 
+    describe('Refresh Individual Data Custom Trail', function() {
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
+                { key: 's', route: 'r', trackCrumbTrail: true }
+            ]);
+            var state = stateNavigator.states['s'];
+            state.truncateCrumbTrail = (state, data, crumbs) => {
+                if (data['string'] === 'Hello' && data['boolean'] === true
+                    && data['number'] === 0 && +data['date'] === +new Date(2010, 3, 7))
+                    return crumbs;
+                return [];
+            };
+        });
+        var individualNavigationData = {};
+        individualNavigationData['string'] = 'Hello';
+        individualNavigationData['boolean'] = true;
+        individualNavigationData['number'] = 0;
+        individualNavigationData['date'] = new Date(2010, 3, 7);
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                stateNavigator.navigate('s');
+                stateNavigator.refresh();
+                stateNavigator.refresh(individualNavigationData);
+            });
+            test();
+        });
+        
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = stateNavigator.getNavigationLink('s');
+                stateNavigator.navigateLink(link);
+                var link = stateNavigator.getRefreshLink();
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getRefreshLink(individualNavigationData);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s')
+                    .refresh()
+                    .refresh(individualNavigationData)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+        
+        function test() {
+            it('should populate crumb trail', function() {
+                assert.equal(stateNavigator.stateContext.crumbs.length, 1);
+            });
+        }
+    });
+
     describe('Array Data Custom Trail', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -1866,6 +1866,68 @@ describe('Navigation Data', function () {
         }
     });
 
+    describe('Wizard Data Defaults', function() {
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true, defaults: { b: true } },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+        });
+        var data = {
+            s: 'Hello',
+            n: 5
+        };
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                stateNavigator.navigate('s0');
+                stateNavigator.navigate('s1', data);
+                stateNavigator.navigate('s2', stateNavigator.stateContext.includeCurrentData(null));
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = stateNavigator.getNavigationLink('s0');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s1', data);
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s2', stateNavigator.stateContext.includeCurrentData(null));
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1', data)
+                    .navigate('s2', currentData => currentData)
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate data', function () {
+                assert.strictEqual(stateNavigator.stateContext.previousData['s'], 'Hello');
+                assert.strictEqual(stateNavigator.stateContext.previousData['n'], 5);
+                assert.strictEqual(stateNavigator.stateContext.previousData['b'], true);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['s'], 'Hello');
+                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['n'], 5);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['b'], true);
+                assert.strictEqual(stateNavigator.stateContext.data['s'], 'Hello');
+                assert.strictEqual(stateNavigator.stateContext.data['n'], 5);
+                assert.strictEqual(stateNavigator.stateContext.data['b'], true);
+            });
+        }
+    });
+
     describe('Transition Transition', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -5759,8 +5759,8 @@ describe('Navigation Data', function () {
         
         describe('Navigate', function() {
             beforeEach(function() {
-                stateNavigator.navigate('s0');
-                stateNavigator.navigate('s1', data);
+                stateNavigator.navigate('s1');
+                stateNavigator.refresh(data);
                 stateNavigator.refresh(stateNavigator.stateContext.includeCurrentData(null));
             });
             test();
@@ -5768,9 +5768,9 @@ describe('Navigation Data', function () {
 
         describe('Navigate Link', function() {
             beforeEach(function() {
-                var link = stateNavigator.getNavigationLink('s0');
+                var link = stateNavigator.getNavigationLink('s1');
                 stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationLink('s1', data);
+                link = stateNavigator.getRefreshLink(data);
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getRefreshLink(stateNavigator.stateContext.includeCurrentData(null));
                 stateNavigator.navigateLink(link);
@@ -5781,8 +5781,8 @@ describe('Navigation Data', function () {
         describe('Fluent Navigate', function() {
             beforeEach(function() {
                 var link = stateNavigator.fluent()
-                    .navigate('s0')
-                    .navigate('s1', data)
+                    .navigate('s1')
+                    .refresh(data)
                     .refresh((currentData) => currentData)
                     .url;
                 stateNavigator.navigateLink(link);

--- a/NavigationReact/src/FluentLink.tsx
+++ b/NavigationReact/src/FluentLink.tsx
@@ -5,9 +5,9 @@ import * as React from 'react';
 
 var FluentLink = (props: FluentLinkProps) => {
     var htmlProps = LinkUtility.toHtmlProps(props);
-    var { withContext, navigate, stateNavigator } = props;
+    var { withContext = false, navigate, stateNavigator } = props;
     try {
-        var link = navigate(stateNavigator.fluent(!!withContext)).url;
+        var link = navigate(stateNavigator.fluent(withContext)).url;
     } catch {}
     htmlProps.href = link && stateNavigator.historyManager.getHref(link);
     htmlProps.onClick = link && LinkUtility.getOnClick(stateNavigator, props, link);

--- a/NavigationReact/src/FluentLink.tsx
+++ b/NavigationReact/src/FluentLink.tsx
@@ -1,0 +1,16 @@
+import LinkUtility from './LinkUtility';
+import withStateNavigator from './withStateNavigator';
+import { FluentLinkProps } from './Props';
+import * as React from 'react';
+
+var FluentLink = (props: FluentLinkProps) => {
+    var htmlProps = LinkUtility.toHtmlProps(props);
+    var { withContext, navigate, stateNavigator } = props;
+    try {
+        var link = navigate(stateNavigator.fluent(!!withContext)).url;
+    } catch {}
+    htmlProps.href = link && stateNavigator.historyManager.getHref(link);
+    htmlProps.onClick = link && LinkUtility.getOnClick(stateNavigator, props, link);
+    return <a {...htmlProps} />;
+}
+export default withStateNavigator(FluentLink);

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -53,7 +53,8 @@ class LinkUtility {
             if (key !== 'stateNavigator' && key !== 'stateKey' && key !== 'navigationData'
                 && key !== 'includeCurrentData' && key !== 'currentDataKeys'&& key !== 'activeStyle'
                 && key !== 'activeCssClass' && key !== 'disableActive' && key !== 'distance'
-                && key !== 'historyAction' && key !== 'navigating' && key !== 'navigate' && key !== 'defer')
+                && key !== 'historyAction' && key !== 'navigating' && key !== 'navigate'
+                && key !== 'withContext' && key !== 'defer')
                 htmlProps[key] = props[key];
         }
         return htmlProps;

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -53,7 +53,7 @@ class LinkUtility {
             if (key !== 'stateNavigator' && key !== 'stateKey' && key !== 'navigationData'
                 && key !== 'includeCurrentData' && key !== 'currentDataKeys'&& key !== 'activeStyle'
                 && key !== 'activeCssClass' && key !== 'disableActive' && key !== 'distance'
-                && key !== 'historyAction' && key !== 'navigating' && key !== 'defer')
+                && key !== 'historyAction' && key !== 'navigating' && key !== 'navigate' && key !== 'defer')
                 htmlProps[key] = props[key];
         }
         return htmlProps;

--- a/NavigationReact/src/NavigationReact.ts
+++ b/NavigationReact/src/NavigationReact.ts
@@ -4,5 +4,6 @@ import NavigationHandler from './NavigationHandler';
 import NavigationBackLink from './NavigationBackLink';
 import NavigationLink from './NavigationLink';
 import RefreshLink from './RefreshLink';
+import FluentLink from './FluentLink';
 
-export { AsyncStateNavigator, NavigationContext, NavigationHandler, NavigationBackLink, NavigationLink, RefreshLink };
+export { AsyncStateNavigator, NavigationContext, NavigationHandler, NavigationBackLink, NavigationLink, RefreshLink, FluentLink };

--- a/NavigationReact/src/Props.ts
+++ b/NavigationReact/src/Props.ts
@@ -1,5 +1,6 @@
 import AsyncStateNavigator from './AsyncStateNavigator';
 import { AnchorHTMLAttributes, DetailedHTMLProps, MouseEvent } from 'react';
+import { FluentNavigator } from 'navigation';
 
 interface LinkProps extends DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> {
     historyAction?: 'add' | 'replace' | 'none';
@@ -25,4 +26,9 @@ interface NavigationBackLinkProps extends LinkProps {
     distance: number;
 }
 
-export { LinkProps, RefreshLinkProps, NavigationLinkProps, NavigationBackLinkProps }
+interface FluentLinkProps extends LinkProps {
+    withContext?: boolean;
+    navigate: (fluentNavigator: FluentNavigator) => FluentNavigator;
+}
+
+export { LinkProps, RefreshLinkProps, NavigationLinkProps, NavigationBackLinkProps, FluentLinkProps }

--- a/NavigationReact/test/FluentLinkTest.tsx
+++ b/NavigationReact/test/FluentLinkTest.tsx
@@ -55,4 +55,31 @@ describe('FluentLinkTest', function () {
             assert.equal(link.innerHTML, 'link text');
         })
     });
+
+    describe('Invalid Fluent Link', function () {
+        it('should render', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            stateNavigator.navigate('s0');
+            stateNavigator.navigate('s1');
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <FluentLink navigate={fluentNavigator => (
+                        fluentNavigator
+                        .navigate('s0')
+                        .navigate('x')
+                    )}>
+                        link text
+                    </FluentLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            assert.equal(link.hash, '');
+            assert.equal(link.innerHTML, 'link text');
+        })
+    });
 });

--- a/NavigationReact/test/FluentLinkTest.tsx
+++ b/NavigationReact/test/FluentLinkTest.tsx
@@ -62,15 +62,13 @@ describe('FluentLinkTest', function () {
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
-            stateNavigator.navigate('s0');
-            stateNavigator.navigate('s1');
             var container = document.createElement('div');
             ReactDOM.render(
                 <NavigationHandler stateNavigator={stateNavigator}>
                     <FluentLink navigate={fluentNavigator => (
                         fluentNavigator
-                        .navigate('s0')
-                        .navigate('x')
+                            .navigate('s0')
+                            .navigate('x')
                     )}>
                         link text
                     </FluentLink>
@@ -80,6 +78,39 @@ describe('FluentLinkTest', function () {
             var link = container.querySelector<HTMLAnchorElement>('a');
             assert.equal(link.hash, '');
             assert.equal(link.innerHTML, 'link text');
+        })
+    });
+
+    describe('Attributes Fluent Link', function () {
+        it('should render', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <FluentLink
+                        navigate={fluentNavigator => (
+                            fluentNavigator
+                                .navigate('s0')
+                                .navigate('s1')
+                        )}
+                        historyAction='replace'
+                        navigating={() => false}
+                        aria-label="z"
+                        target="_blank">
+                        link text
+                    </FluentLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            assert.equal(link.hash, '#/r1?crumb=%2Fr0');
+            assert.equal(link.innerHTML, 'link text');
+            assert.equal(link.getAttribute('aria-label'), 'z');
+            assert.equal(link.target, '_blank');
+            assert.equal(link.attributes.length, 3);
         })
     });
 });

--- a/NavigationReact/test/FluentLinkTest.tsx
+++ b/NavigationReact/test/FluentLinkTest.tsx
@@ -563,4 +563,35 @@ describe('FluentLinkTest', function () {
             assert.equal(stateNavigator.stateContext.state.key, 's1');
         })
     });
+
+    describe('On Before Component Cancel Fluent Navigation', function () {
+        it('should not navigate', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            class Blocker extends React.Component<{ stateNavigator: StateNavigator }> {
+                componentDidMount() {
+                    this.props.stateNavigator.onBeforeNavigate(() => false);
+                }
+                render() {
+                    return null;
+                }
+            }
+            stateNavigator.navigate('s0');
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <NavigationContext.Consumer>
+                        {({ stateNavigator }) => <Blocker stateNavigator={stateNavigator} />}
+                    </NavigationContext.Consumer>
+                </NavigationHandler>,
+                container
+            );
+            assert.equal(stateNavigator.stateContext.state.key, 's0');
+            var link = stateNavigator.fluent(true).navigate('s1').url;
+            stateNavigator.navigateLink(link);
+            assert.equal(stateNavigator.stateContext.state.key, 's0');
+        })
+    });
 });

--- a/NavigationReact/test/FluentLinkTest.tsx
+++ b/NavigationReact/test/FluentLinkTest.tsx
@@ -38,4 +38,21 @@ describe('FluentLinkTest', function () {
             assert.equal(link.innerHTML, '<span>link text</span>');
         })
     });
+
+    describe('Without State Navigator Fluent Link', function () {
+        it('should render', function(){
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <FluentLink navigate={fluentNavigator => (
+                    fluentNavigator.navigate('s')
+                )}>
+                    link text
+                </FluentLink>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            assert.equal(link.hash, '');
+            assert.equal(link.innerHTML, 'link text');
+        })
+    });
 });

--- a/NavigationReact/test/FluentLinkTest.tsx
+++ b/NavigationReact/test/FluentLinkTest.tsx
@@ -594,4 +594,31 @@ describe('FluentLinkTest', function () {
             assert.equal(stateNavigator.stateContext.state.key, 's0');
         })
     });
+
+    describe('Click Fluent Navigate', function () {
+        it('should navigate', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <NavigationContext.Consumer>
+                        {({stateNavigator}) => (
+                            <div onClick={() => stateNavigator.navigateLink(stateNavigator.fluent()
+                                .navigate('s0')
+                                .navigate('s1').url)
+                            } />
+                        )}
+                    </NavigationContext.Consumer>
+                </NavigationHandler>,
+                container
+            );
+            var div = container.querySelector<HTMLAnchorElement>('div');
+            Simulate.click(div);
+            assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+        })
+    });
 });

--- a/NavigationReact/test/FluentLinkTest.tsx
+++ b/NavigationReact/test/FluentLinkTest.tsx
@@ -113,4 +113,383 @@ describe('FluentLinkTest', function () {
             assert.equal(link.attributes.length, 3);
         })
     });
+
+    describe('Click Fluent Link', function () {
+        it('should navigate', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <FluentLink navigate={fluentNavigator => (
+                        fluentNavigator
+                            .navigate('s0')
+                            .navigate('s1')
+                    )}>
+                        link text
+                    </FluentLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            Simulate.click(link);
+            assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+        })
+    });
+
+    describe('Ctrl + Click Fluent Link', function () {
+        it('should not navigate', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <FluentLink navigate={fluentNavigator => (
+                        fluentNavigator
+                            .navigate('s0')
+                            .navigate('s1')
+                    )}>
+                        link text
+                    </FluentLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            Simulate.click(link, { ctrlKey: true });
+            assert.equal(stateNavigator.stateContext.state, null);
+        })
+    });
+
+    describe('Shift + Click Fluent Link', function () {
+        it('should not navigate', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <FluentLink navigate={fluentNavigator => (
+                        fluentNavigator
+                            .navigate('s0')
+                            .navigate('s1')
+                    )}>
+                        link text
+                    </FluentLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            Simulate.click(link, { shiftKey: true });
+            assert.equal(stateNavigator.stateContext.state, null);
+        })
+    });
+
+    describe('Meta + Click Fluent Link', function () {
+        it('should not navigate', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <FluentLink navigate={fluentNavigator => (
+                        fluentNavigator
+                            .navigate('s0')
+                            .navigate('s1')
+                    )}>
+                        link text
+                    </FluentLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            Simulate.click(link, { metaKey: true });
+            assert.equal(stateNavigator.stateContext.state, null);
+        })
+    });
+
+    describe('Alt + Click Fluent Link', function () {
+        it('should not navigate', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <FluentLink navigate={fluentNavigator => (
+                        fluentNavigator
+                            .navigate('s0')
+                            .navigate('s1')
+                    )}>
+                        link text
+                    </FluentLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            Simulate.click(link, { altKey: true });
+            assert.equal(stateNavigator.stateContext.state, null);
+        })
+    });
+
+    describe('Button + Click Fluent Link', function () {
+        it('should not navigate', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <FluentLink navigate={fluentNavigator => (
+                        fluentNavigator
+                            .navigate('s0')
+                            .navigate('s1')
+                    )}>
+                        link text
+                    </FluentLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            Simulate.click(link, { button: 1 });
+            assert.equal(stateNavigator.stateContext.state, null);
+        })
+    });
+
+    describe('Navigating Click Fluent Link', function () {
+        it('should navigate', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <FluentLink
+                        navigate={fluentNavigator => (
+                        fluentNavigator
+                            .navigate('s0')
+                            .navigate('s1')
+                        )}
+                        navigating={() => true}>
+                        link text
+                    </FluentLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            Simulate.click(link);
+            assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+        })
+    });
+
+    describe('Not Navigating Click Fluent Link', function () {
+        it('should not navigate', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <FluentLink
+                        navigate={fluentNavigator => (
+                        fluentNavigator
+                            .navigate('s0')
+                            .navigate('s1')
+                    )}
+                        navigating={() => false}>
+                        link text
+                    </FluentLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            Simulate.click(link);
+            assert.equal(stateNavigator.stateContext.state, null);
+        })
+    });
+
+    describe('Navigating Params Click Fluent Link', function () {
+        it('should navigate', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var navigatingEvt, navigatingLink;
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <FluentLink
+                        navigate={fluentNavigator => (
+                        fluentNavigator
+                            .navigate('s0')
+                            .navigate('s1')
+                    )}
+                        navigating={(e, link) => {
+                            navigatingEvt = e;
+                            navigatingLink = link;
+                            return true;
+                        }}>
+                        link text
+                    </FluentLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            Simulate.click(link, { clientX: 224 });
+            assert.strictEqual(navigatingEvt.clientX, 224);
+            assert.equal(navigatingLink, '/r1?crumb=%2Fr0');
+        })
+    });
+
+    describe('History Click Fluent Link', function () {
+        it('should navigate', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <FluentLink navigate={fluentNavigator => (
+                        fluentNavigator
+                            .navigate('s0')
+                            .navigate('s1')
+                    )}>
+                        link text
+                    </FluentLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            var addHistory;
+            stateNavigator.historyManager.addHistory = (url, replace) => { addHistory = !replace };
+            Simulate.click(link);
+            assert.strictEqual(addHistory, true);
+        })
+    });
+
+    describe('Replace History Click Fluent Link', function () {
+        it('should navigate', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <FluentLink
+                        navigate={fluentNavigator => (
+                        fluentNavigator
+                            .navigate('s0')
+                            .navigate('s1')
+                    )}
+                        historyAction="replace">
+                        link text
+                    </FluentLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            var replaceHistory;
+            stateNavigator.historyManager.addHistory = (url, replace) => { replaceHistory = replace };
+            Simulate.click(link);
+            assert.strictEqual(replaceHistory, true);
+        })
+    });
+
+    describe('None History Click Fluent Link', function () {
+        it('should navigate', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <FluentLink
+                        navigate={fluentNavigator => (
+                        fluentNavigator
+                            .navigate('s0')
+                            .navigate('s1')
+                    )}
+                        historyAction="none">
+                        link text
+                    </FluentLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            var noneHistory = true;
+            stateNavigator.historyManager.addHistory = () => { noneHistory = false };
+            Simulate.click(link);
+            assert.strictEqual(noneHistory, true);
+        })
+    });
+
+    describe('Crumb Trail Navigate Fluent Link', function () {
+        it('should update', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <FluentLink
+                        withContext={true}
+                        navigate={fluentNavigator => (
+                        fluentNavigator
+                            .navigate('s1')
+                    )}>
+                        link text
+                    </FluentLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            assert.equal(link.hash, '#/r1');
+            stateNavigator.navigate('s0');
+            assert.equal(link.hash, '#/r1?crumb=%2Fr0');
+        })
+    });
+
+    describe('Click Custom Href Fluent Link', function () {
+        it('should navigate', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            stateNavigator.historyManager.getHref = () => '#/hello/world';
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <FluentLink navigate={fluentNavigator => (
+                        fluentNavigator
+                            .navigate('s0')
+                            .navigate('s1')
+                    )}>
+                        link text
+                    </FluentLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            assert.equal(link.hash, '#/hello/world');
+            Simulate.click(link);
+            assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+        })
+    });
 });

--- a/NavigationReact/test/FluentLinkTest.tsx
+++ b/NavigationReact/test/FluentLinkTest.tsx
@@ -1,0 +1,41 @@
+import * as assert from 'assert';
+import * as mocha from 'mocha';
+import { StateNavigator } from 'navigation';
+import { FluentLink, NavigationHandler, NavigationContext } from 'navigation-react';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { Simulate } from 'react-dom/test-utils';
+import { JSDOM } from 'jsdom';
+
+declare var global: any;
+var { window } = new JSDOM('<!doctype html><html><body></body></html>');
+window.addEventListener = () => {};
+global.window = window;
+global.document = window.document;
+
+describe('FluentLinkTest', function () {
+    describe('Fluent Link', function () {
+        it('should render', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <FluentLink navigate={fluentNavigator => (
+                        fluentNavigator
+                            .navigate('s0')
+                            .navigate('s1')
+                    )}>
+                        <span>link text</span>
+                    </FluentLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            assert.equal(link.hash, '#/r1?crumb=%2Fr0');
+            assert.equal(link.innerHTML, '<span>link text</span>');
+        })
+    });
+});

--- a/NavigationReact/test/FluentLinkTest.tsx
+++ b/NavigationReact/test/FluentLinkTest.tsx
@@ -114,6 +114,35 @@ describe('FluentLinkTest', function () {
         })
     });
 
+    describe('With Context Fluent Link', function () {
+        it('should render', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+            stateNavigator.navigate('s0');
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <FluentLink
+                        withContext={true}
+                        navigate={fluentNavigator => (
+                            fluentNavigator
+                                .navigate('s1')
+                                .navigate('s2')
+                    )}>
+                        link text
+                    </FluentLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            assert.equal(link.hash, '#/r2?crumb=%2Fr0&crumb=%2Fr1');
+            assert.equal(link.innerHTML, 'link text');
+        })
+    });
+
     describe('Click Fluent Link', function () {
         it('should navigate', function(){
             var stateNavigator = new StateNavigator([

--- a/NavigationReact/test/FluentLinkTest.tsx
+++ b/NavigationReact/test/FluentLinkTest.tsx
@@ -530,4 +530,37 @@ describe('FluentLinkTest', function () {
             assert.equal(header.innerHTML, 'world');
         })
     });
+
+    describe('On Before Cancel Fluent Link', function () {
+        it('should not navigate', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('s0');
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <FluentLink
+                        withContext={true}
+                        navigate={fluentNavigator => (
+                            fluentNavigator
+                                .navigate('s1')
+                                .navigate('s1')
+                    )}>
+                        link text
+                    </FluentLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelectorAll<HTMLAnchorElement>('a')[0];
+            Simulate.click(link);
+            assert.equal(stateNavigator.stateContext.crumbs.length, 2);
+            assert.equal(stateNavigator.stateContext.state.key, 's1');
+            stateNavigator.onBeforeNavigate(() => false);
+            Simulate.click(link);
+            assert.equal(stateNavigator.stateContext.crumbs.length, 2);
+            assert.equal(stateNavigator.stateContext.state.key, 's1');
+        })
+    });
 });

--- a/NavigationReact/test/FluentLinkTest.tsx
+++ b/NavigationReact/test/FluentLinkTest.tsx
@@ -492,4 +492,42 @@ describe('FluentLinkTest', function () {
             assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
         })
     });
+
+    describe('Consumer Fluent Link', function () {
+        it('should update', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+            var {s0, s1, s2} = stateNavigator.states;
+            s0.renderView = () => (
+                <FluentLink
+                    withContext={true}
+                    navigate={fluentNavigator => (
+                        fluentNavigator
+                            .navigate('s1')
+                            .navigate('s2', {hello: 'world'})
+                )}>
+                    link text
+                </FluentLink>
+            );
+            s1.renderView = () => <h1>s1</h1>
+            s2.renderView = ({hello}) => <h1>{hello}</h1>
+            stateNavigator.navigate('s0');
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <NavigationContext.Consumer>
+                        {({state, data}) => state.renderView(data)}
+                    </NavigationContext.Consumer>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            Simulate.click(link);
+            var header = container.querySelector<HTMLHeadingElement>('h1');
+            assert.equal(header.innerHTML, 'world');
+        })
+    });
 });

--- a/NavigationReact/test/FluentLinkTest.tsx
+++ b/NavigationReact/test/FluentLinkTest.tsx
@@ -143,6 +143,35 @@ describe('FluentLinkTest', function () {
         })
     });
 
+    describe('Without Context Fluent Link', function () {
+        it('should render', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+            stateNavigator.navigate('s0');
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <FluentLink
+                        withContext={false}
+                        navigate={fluentNavigator => (
+                            fluentNavigator
+                                .navigate('s1')
+                                .navigate('s2')
+                    )}>
+                        link text
+                    </FluentLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            assert.equal(link.hash, '#/r2?crumb=%2Fr1');
+            assert.equal(link.innerHTML, 'link text');
+        })
+    });
+
     describe('Click Fluent Link', function () {
         it('should navigate', function(){
             var stateNavigator = new StateNavigator([

--- a/NavigationReact/test/node_modules/@types/navigation-react.d.ts
+++ b/NavigationReact/test/node_modules/@types/navigation-react.d.ts
@@ -141,7 +141,7 @@ export interface RefreshLinkProps extends LinkProps {
 }
 
 /**
- * Hyperlink Component the navigates to the current State
+ * Hyperlink Component that navigates to the current State
  */
 export class RefreshLink extends Component<RefreshLinkProps> { }
 
@@ -156,7 +156,7 @@ export interface NavigationLinkProps extends RefreshLinkProps {
 }
 
 /**
- * Hyperlink Component the navigates to a State
+ * Hyperlink Component that navigates to a State
  */
 export class NavigationLink extends Component<NavigationLinkProps> { }
 
@@ -171,7 +171,7 @@ export interface NavigationBackLinkProps extends LinkProps {
 }
 
 /**
- * Hyperlink Component the navigates back along the crumb trail
+ * Hyperlink Component that navigates back along the crumb trail
  */
 export class NavigationBackLink extends Component<NavigationBackLinkProps> { }
 

--- a/NavigationReact/test/node_modules/@types/navigation-react.d.ts
+++ b/NavigationReact/test/node_modules/@types/navigation-react.d.ts
@@ -1,4 +1,4 @@
-import { State, StateNavigator, StateContext } from 'navigation';
+import { State, StateNavigator, StateContext, FluentNavigator } from 'navigation';
 import { Component, Context, AnchorHTMLAttributes, DetailedHTMLProps, MouseEvent } from 'react';
 
 /**
@@ -163,7 +163,7 @@ export class NavigationLink extends Component<NavigationLinkProps> { }
 /**
  * Defines the Navigation Back Link Props contract
  */
-export interface NavigationBackLinkProps extends RefreshLinkProps {
+export interface NavigationBackLinkProps extends LinkProps {
     /**
      * Starting at 1, The number of Crumb steps to go back
      */
@@ -175,3 +175,21 @@ export interface NavigationBackLinkProps extends RefreshLinkProps {
  */
 export class NavigationBackLink extends Component<NavigationBackLinkProps> { }
 
+/**
+ * Defines the Fluent Link Props contract
+ */
+export interface FluentLinkProps extends LinkProps {
+    /**
+     * Indicates whether to inherit the current context
+     */
+    withContext?: boolean;
+    /**
+     * The function that fluently navigates to a State
+     */
+    navigate: (fluentNavigator: FluentNavigator) => FluentNavigator;
+}
+
+/**
+ * Hyperlink Component that fluently navigates to a State
+ */
+export class FluentLink extends Component<FluentLinkProps> { }

--- a/build/npm/navigation-react/navigation.react.d.ts
+++ b/build/npm/navigation-react/navigation.react.d.ts
@@ -1,4 +1,4 @@
-import { State, StateNavigator } from 'navigation';
+import { State, StateNavigator, FluentNavigator } from 'navigation';
 import { Component, Context, AnchorHTMLAttributes, DetailedHTMLProps, MouseEvent } from 'react';
 
 /**
@@ -82,7 +82,7 @@ export interface RefreshLinkProps extends LinkProps {
 }
 
 /**
- * Hyperlink Component the navigates to the current State
+ * Hyperlink Component that navigates to the current State
  */
 export class RefreshLink extends Component<RefreshLinkProps> { }
 
@@ -97,14 +97,14 @@ export interface NavigationLinkProps extends RefreshLinkProps {
 }
 
 /**
- * Hyperlink Component the navigates to a State
+ * Hyperlink Component that navigates to a State
  */
 export class NavigationLink extends Component<NavigationLinkProps> { }
 
 /**
  * Defines the Navigation Back Link Props contract
  */
-export interface NavigationBackLinkProps extends RefreshLinkProps {
+export interface NavigationBackLinkProps extends LinkProps {
     /**
      * Starting at 1, The number of Crumb steps to go back
      */
@@ -112,7 +112,25 @@ export interface NavigationBackLinkProps extends RefreshLinkProps {
 }
 
 /**
- * Hyperlink Component the navigates back along the crumb trail
+ * Hyperlink Component that navigates back along the crumb trail
  */
 export class NavigationBackLink extends Component<NavigationBackLinkProps> { }
 
+/**
+ * Defines the Fluent Link Props contract
+ */
+export interface FluentLinkProps extends LinkProps {
+    /**
+     * Indicates whether to inherit the current context
+     */
+    withContext?: boolean;
+    /**
+     * The function that fluently navigates to a State
+     */
+    navigate: (fluentNavigator: FluentNavigator) => FluentNavigator;
+}
+
+/**
+ * Hyperlink Component that fluently navigates to a State
+ */
+export class FluentLink extends Component<FluentLinkProps> { }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -99,7 +99,8 @@ var tests = [
     { name: 'FluentNavigation', to: 'fluentNavigation.test.js' },
     { name: 'NavigationLink', to: 'navigationLink.test.js', folder: 'React', ext: 'tsx' },
     { name: 'NavigationBackLink', to: 'navigationBackLink.test.js', folder: 'React', ext: 'tsx' },
-    { name: 'RefreshLink', to: 'refreshLink.test.js', folder: 'React', ext: 'tsx' }
+    { name: 'RefreshLink', to: 'refreshLink.test.js', folder: 'React', ext: 'tsx' },
+    { name: 'FluentLink', to: 'fluentLink.test.js', folder: 'React', ext: 'tsx' }
 ];
 function testTask(name, input, file) {
     var globals = [


### PR DESCRIPTION
```jsx
<FluentLink
  navigate{fluentNavigator => (
    fluentNavigator
      .navigate('people')
      .navigate('person', { id: 12 })
  )}
>
  Jane Doe
</FluentLink>
```

Sped up the creation of fluent navigation links by removing calls to the 'expensive' `parseLink`. They’re slower because they go through the matching process which tests the link against each route regex.
