### PR TITLE
Ensured openDrawer of DrawerLayoutAndroid works on all screens

### DIFF
--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneView.java
@@ -1,5 +1,6 @@
 package com.navigation.reactnative;
 
+import android.view.View;
 import android.view.ViewGroup;
 
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -9,6 +10,28 @@ public class SceneView extends ViewGroup {
     public SceneView(ThemedReactContext context) {
         super(context);
     }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        View child = getChildAt(0);
+        if (child != null && child.getClass().getSimpleName().contains("DrawerLayout")) {
+            child.requestLayout();
+            post(measureAndLayout);
+        }
+    }
+
+    private final Runnable measureAndLayout =
+        new Runnable() {
+            @Override
+            public void run() {
+                View child = getChildAt(0);
+                child.measure(
+                    MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
+                    MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
+                child.layout(child.getLeft(), child.getTop(), child.getRight(), child.getBottom());
+            }
+        };
 
     @Override
     protected void onLayout(boolean changed, int l, int t, int r, int b) {


### PR DESCRIPTION
Fixes #264

Calling `openDrawer` only worked on the first screen, but not any subsequent ones.

The `DrawerLayout` on Android expects the layout to be done [after it’s attached to the window](https://android.googlesource.com/platform/frameworks/support/+/407e01608ccafe5dc24f82608583f71c34312f9c/v4/java/android/support/v4/widget/DrawerLayout.java#596). If it’s done before [then it doesn’t open](https://android.googlesource.com/platform/frameworks/support/+/407e01608ccafe5dc24f82608583f71c34312f9c/v4/java/android/support/v4/widget/DrawerLayout.java#1022).

When navigating to a second screen React Native renders and does the layout first and then I start a new Activity and set the content. That’s the wrong order for the `DrawerLayout`. I fixed this by doing a second layout pass for the DrawerLayout after it’s attached to the window. I got the [idea from the `ViewPager` component](https://github.com/facebook/react-native/blob/aa5edca0e229940c79f2efcb917f5c8b05022e4d/ReactAndroid/src/main/java/com/facebook/react/views/viewpager/ReactViewPager.java#L217).

To avoid importing an androidx namespace I checked for DrawerLayout using a string. This means it works in both React Native 0.59 and 0.60. Unfortunately couldn’t check for `ReactDrawerLayout` because it’s not public.
