### PR TITLE
Prevented navigation events bubbling when stacks nested

### DIFF
--- a/NavigationReactNative/src/TabBarItemIOS.tsx
+++ b/NavigationReactNative/src/TabBarItemIOS.tsx
@@ -6,7 +6,11 @@ var TabBarItem = ({title, image, systemItem, onPress, children}) => (
         title={title}
         image={image}
         systemItem={systemItem}
-        onPress={onPress}>
+        onPress={event => {
+            event.stopPropagation();
+            if (onPress)
+                onPress(event);
+        }}>
         {children}            
     </NVTabBarItem>
 );

--- a/NavigationReactNative/src/ios/NVNavigationStackManager.m
+++ b/NavigationReactNative/src/ios/NVNavigationStackManager.m
@@ -11,6 +11,6 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_EXPORT_VIEW_PROPERTY(mostRecentEventCount, NSInteger)
-RCT_EXPORT_VIEW_PROPERTY(onDidNavigateBack, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onDidNavigateBack, RCTDirectEventBlock)
 
 @end

--- a/NavigationReactNative/src/ios/NVNavigationStackView.h
+++ b/NavigationReactNative/src/ios/NVNavigationStackView.h
@@ -6,7 +6,7 @@
 
 @property (nonatomic, strong) UINavigationController *navigationController;
 @property (nonatomic, assign) NSInteger mostRecentEventCount;
-@property (nonatomic, copy) RCTBubblingEventBlock onDidNavigateBack;
+@property (nonatomic, copy) RCTDirectEventBlock onDidNavigateBack;
 
 -(id)initWithBridge: (RCTBridge *)bridge;
 

--- a/NavigationReactNative/src/ios/NVSceneManager.m
+++ b/NavigationReactNative/src/ios/NVSceneManager.m
@@ -11,6 +11,6 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_EXPORT_VIEW_PROPERTY(title, NSString)
-RCT_EXPORT_VIEW_PROPERTY(onWillAppear, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onWillAppear, RCTDirectEventBlock)
 
 @end

--- a/NavigationReactNative/src/ios/NVSceneView.h
+++ b/NavigationReactNative/src/ios/NVSceneView.h
@@ -4,7 +4,7 @@
 @interface NVSceneView : UIView
 
 @property (nonatomic, copy) NSString *title;
-@property (nonatomic, copy) RCTBubblingEventBlock onWillAppear;
+@property (nonatomic, copy) RCTDirectEventBlock onWillAppear;
 
 -(void)willAppear;
 


### PR DESCRIPTION
Fixes #262 

Can open a `Modal` containing a `UINavigationController`. This gives a `NavigationStack` inside a `NavigationStack`. Don’t want the `didNavigateBack` event from the Modal stack to bubble up to the main stack because haven’t navigated back on the main stack. Changed from BubblingEvent to DirectEvent to prevent bubbling.

The same applies to the `willAppear` and `onPress` because `Scenes` and `TabBarItems` can be nested in the same way. React Native kept complaining when changing the `onPress` to a `DirectEvent` though, sayng “re-registered bubbling event as direct event". Maybe because the listener was registered in userland?! Anyway, to get around this kept it as a bubbling event and manually stopped the propagation.
