### PR TITLE
Animated replacing a screen (mobile)

### DIFF
--- a/NavigationReactMobile/src/Motion.tsx
+++ b/NavigationReactMobile/src/Motion.tsx
@@ -74,7 +74,7 @@ class Motion<T> extends React.Component<MotionProps<T>, any> {
                     return newItem;
                 })
             )
-            .sort((a, b) => a.index !== b.index ? a.index - b.index : getKey(a).length - getKey(b).length);
+            .sort((a, b) => a.index !== b.index ? a.index - b.index : a.key.length - b.key.length);
         return {items, moving: items.filter(({rest}) => !rest).length !== 0};
     }
     static areEqual(from = {}, to = {}) {

--- a/NavigationReactMobile/src/Motion.tsx
+++ b/NavigationReactMobile/src/Motion.tsx
@@ -40,11 +40,11 @@ class Motion<T> extends React.Component<MotionProps<T>, any> {
         var dataByKey = data.reduce((acc, item, index) => ({...acc, [getKey(item)]: {...(item as any), index}}), {});
         var itemsByKey = prevItems.reduce((acc, item) => ({...acc, [item.key]: item}), {});
         var items = prevItems
-            .map((item, index) => {
+            .map(item => {
                 var matchedItem = dataByKey[item.key];
                 var nextItem: any = {key: item.key, data: matchedItem || item.data, tick};
                 nextItem.end = !matchedItem ? (leave || update)(item.data) : update(matchedItem);
-                nextItem.index = !matchedItem ? data.length + index : matchedItem.index;
+                nextItem.index = !matchedItem ? item.index : matchedItem.index;
                 var unchanged = Motion.areEqual(item.end, nextItem.end);
                 if (unchanged) {
                     nextItem.start = item.start;
@@ -74,7 +74,7 @@ class Motion<T> extends React.Component<MotionProps<T>, any> {
                     return newItem;
                 })
             )
-            .sort((a, b) => a.index - b.index);
+            .sort((a, b) => a.index !== b.index ? a.index - b.index : getKey(a).length - getKey(b).length);
         return {items, moving: items.filter(({rest}) => !rest).length !== 0};
     }
     static areEqual(from = {}, to = {}) {

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -76,7 +76,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
                     duration={duration}>
                     {styles => (
                         styles.map(({data: {key, state, data}, style}) => {
-                            var crumb = +key.replace(/\+/g, '');
+                            var crumb = +key.replace(/\++$/, '');
                             var scene = <Scene crumb={crumb} renderScene={renderScene} /> ;
                             return children(style, scene, key, crumbs.length === crumb, state, data);
                         }).concat(

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -75,9 +75,10 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
                     onRest={({key}) => this.clearScene(key)}
                     duration={duration}>
                     {styles => (
-                        styles.map(({data: {key, state, data}, style}, index) => {
-                            var scene = <Scene crumb={index} renderScene={renderScene} /> ;
-                            return children(style, scene, key, crumbs.length === index, state, data);
+                        styles.map(({data: {key, state, data}, style}) => {
+                            var crumb = +key.replace(/\+/g, '');
+                            var scene = <Scene crumb={crumb} renderScene={renderScene} /> ;
+                            return children(style, scene, key, crumbs.length === crumb, state, data);
                         }).concat(
                             sharedElementMotion && sharedElementMotion({
                                 key: 'sharedElements',

--- a/NavigationReactMobile/src/Props.ts
+++ b/NavigationReactMobile/src/Props.ts
@@ -54,7 +54,7 @@ interface NavigationMotionProps {
     renderScene: (state: State, data: any) => ReactNode,
     stateNavigator?: StateNavigator;
     navigationEvent: NavigationEvent;
-    children: (style: any, scene: ReactElement<any>, key: number, active: boolean, state: State, data: any) => ReactElement<any>;
+    children: (style: any, scene: ReactElement<any>, key: string, active: boolean, state: State, data: any) => ReactElement<any>;
 }
 
 interface SceneProps {

--- a/NavigationReactMobile/src/Props.ts
+++ b/NavigationReactMobile/src/Props.ts
@@ -6,14 +6,14 @@ import { ReactElement, ReactNode } from 'react';
 
 interface MotionProps<T> {
     data: T[];
-    getKey: (item: T) => string | number;
+    getKey: (item: T) => string;
     duration: number;
     enter: (item: T) => any;
     update: (item: T) => any;
     leave?: (item: T) => any;
     onRest?: (item: T) => void;
     progress?: number;
-    children: (items: {style: any, data: T, key: string | number, progress: number, start: any, end: any }[]) => ReactElement<any>[];
+    children: (items: {style: any, data: T, key: string, progress: number, start: any, end: any }[]) => ReactElement<any>[];
 }
 
 interface SharedElementProps {

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -13,10 +13,16 @@ class Scene extends React.Component<SceneProps & {navigationEvent: NavigationEve
     static defaultProps = {
         renderScene: (state: State, data: any) => state.renderScene(data)
     }
-    static getDerivedStateFromProps(props: SceneProps & {navigationEvent: NavigationEvent}) {
+    static getDerivedStateFromProps(props: SceneProps & {navigationEvent: NavigationEvent}, {navigationEvent: prevNavigationEvent}: SceneState) {
         var {crumb, navigationEvent} = props;
-        var {state, crumbs} = navigationEvent.stateNavigator.stateContext;
-        return (state && crumbs.length === crumb) ? {navigationEvent} : null;
+        var {state, oldState, oldUrl, crumbs} = navigationEvent.stateNavigator.stateContext;
+        if (!state || crumbs.length !== crumb)
+            return null;
+        if (!oldUrl || !prevNavigationEvent)
+            return {navigationEvent};
+        var {crumbs: oldCrumbs} = navigationEvent.stateNavigator.parseLink(oldUrl);
+        var replace = oldCrumbs.length === crumb && oldState !== state;
+        return !replace ? {navigationEvent} : null;
     }
     shouldComponentUpdate(_nextProps, nextState) {
         return nextState.navigationEvent !== this.state.navigationEvent;

--- a/NavigationReactMobile/test/node_modules/@types/navigation-react-mobile.d.ts
+++ b/NavigationReactMobile/test/node_modules/@types/navigation-react-mobile.d.ts
@@ -112,7 +112,7 @@ export interface NavigationMotionProps {
     /**
      * Renders the Scene with the interpoated styles
      */
-    children: (style: any, scene: ReactElement<any>, key: number, active: boolean, state: State, data: any) => ReactElement<any>;
+    children: (style: any, scene: ReactElement<any>, key: string, active: boolean, state: State, data: any) => ReactElement<any>;
 }
 
 /**

--- a/build/npm/navigation-react-mobile/README.md
+++ b/build/npm/navigation-react-mobile/README.md
@@ -12,15 +12,19 @@ var stateNavigator = new Navigation.StateNavigator([
 
 stateNavigator.states.hello.renderScene = function() {
   return (
-    <NavigationReact.NavigationLink stateKey="world">
+    <NavigationReact.NavigationLink 
+      stateKey="world"
+      navigationData={{size: 20}}>
       Hello
     </NavigationReact.NavigationLink>
   );
 };
 
-stateNavigator.states.world.renderScene = function() {
+stateNavigator.states.world.renderScene = function(data) {
   return (
-    <NavigationReact.NavigationBackLink distance={1}>
+    <NavigationReact.NavigationBackLink
+      distance={1}
+      style={{fontSize: data.size}}>
       World
     </NavigationReact.NavigationBackLink>
   );

--- a/build/npm/navigation-react-mobile/navigation.react.mobile.d.ts
+++ b/build/npm/navigation-react-mobile/navigation.react.mobile.d.ts
@@ -112,7 +112,7 @@ export interface NavigationMotionProps {
     /**
      * Renders the Scene with the interpoated styles
      */
-    children: (style: any, scene: ReactElement<any>, key: number, active: boolean, state: State, data: any) => ReactElement<any>;
+    children: (style: any, scene: ReactElement<any>, key: string, active: boolean, state: State, data: any) => ReactElement<any>;
 }
 
 /**


### PR DESCRIPTION
Already implemented for native, #269

Navigate from A → B then fluently to A → C. The animation should run because screen B is popped and C is pushed.

Changed the `NavigationMotion` component so that screens are given different React keys when they’re replaced. In the example, the keys start as 0 → 1 and become 0 → 1+. Changing the key means React unmounts screen B and mounts screen C.

Changed `Motion` component so that scenes keep their original index and sub sorted by key so that the replacee appears on top of the replaced. In the example, both B and C have an index of 1 but the C key is longer.

Change `Scene` component so that the replaced scene doesn’t update its navigation context, In the example, both B and C represent crumb 1 but don’t want B to look like C as it leaves.

Navigating from A → B then fluently to A → B, just changing data, doesn’t animate.
Navigation from A → B → C then fluently to A → D → C doesn’t animate.
