### PR TITLE
Ensured NavigationStack props change every navigation

### DIFF
--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -84,10 +84,12 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
     render() {
         var {keys, finish} = this.state;
         var {stateNavigator, title, renderScene} = this.props;
-        var {crumbs, nextCrumb} = stateNavigator.stateContext;
+        var {url, oldUrl, crumbs, nextCrumb} = stateNavigator.stateContext;
         return (
             <NVNavigationStack
                 ref={this.ref}
+                url={url}
+                oldUrl={oldUrl}
                 finish={finish}
                 style={styles.stack}
                 {...this.getAnimation()}

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -14,6 +14,14 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
         return "NVNavigationStack";
     }
 
+    @ReactProp(name = "url")
+    public void setUrl(NavigationStackView view, String url) {
+    }
+
+    @ReactProp(name = "oldUrl")
+    public void setOldUrl(NavigationStackView view, String oldUrl) {
+    }
+    
     @ReactProp(name = "enterAnim")
     public void setEnterAnim(NavigationStackView view, String enterAnim) {
         view.enterAnim = enterAnim;


### PR DESCRIPTION
Fixes #275

Accidentally deleted this code in #269 thinking it did nothing.  But it ensures that the `NavigationStack` props update every navigation, guaranteeing `onAfterUpdateTransaction` is always called