### PR TITLE
Fix iOS navbar title color not resetting correctly on pop

### DIFF
--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -7,7 +7,7 @@ export default ({colors, color}) => (
   <NavigationContext.Consumer>
     {({stateNavigator}) => (
       <ScrollView contentInsetAdjustmentBehavior="automatic">
-          <NavigationBarIOS tintColor={color} titleColor={color} title="Color">
+          <NavigationBarIOS title="Color">
             <RightBarIOS>
               <BarButtonIOS systemItem="cancel" onPress={() => {
                 stateNavigator.navigateBack(1);

--- a/NavigationReactNative/src/ios/NVSceneController.m
+++ b/NavigationReactNative/src/ios/NVSceneController.m
@@ -55,6 +55,14 @@
     }
 }
 
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+    
+    NVNavigationBarView *navigationBar = (NVNavigationBarView *) [self.view viewWithTag:NAVIGATION_BAR];
+    [navigationBar updateColors];
+}
+
 - (void)viewDidLayoutSubviews
 {
     [super viewDidLayoutSubviews];


### PR DESCRIPTION
Brute force, but it seems to work really well. I tried some other solutions from online but this is the only one that seemed to work. I have never seen this bug before any where else.