### PR TITLE
Prevented double click Url restarting the animation

### DIFF
--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -21,11 +21,12 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
     static getDerivedStateFromProps({stateNavigator}: NavigationMotionProps, {keys: prevKeys, stateNavigator: prevStateNavigator}: NavigationMotionState) {
         if (stateNavigator === prevStateNavigator)
             return null;
-        var {oldState, state, crumbs, nextCrumb} = stateNavigator.stateContext;
+        var {state, crumbs, nextCrumb} = stateNavigator.stateContext;
+        var prevState = prevStateNavigator && prevStateNavigator.stateContext.state;
         var currentKeys = crumbs.concat(nextCrumb).map((_, i) => '' + i);
         var newKeys = currentKeys.slice(prevKeys.length);
         var keys = prevKeys.slice(0, currentKeys.length).concat(newKeys);
-        if (prevKeys.length === keys.length && oldState !== state)
+        if (prevKeys.length === keys.length && prevState !== state)
             keys[keys.length - 1] += '+';
         return {keys, rest: false, stateNavigator};
     }


### PR DESCRIPTION
Take a Url that navigates from A → B and double click it. If the second click happens before the first animation completes then the animation starts over instead of smoothly continuing. `NavigationMotion` sees that the stack before and after the second click is the same length. Then it compares the oldState with the current state and sees that they’re different and so thinks it’s a replace. 

Changed so that the old and current state comparison uses React state to match the old and current stack size (it was using the old state from the current context). Then when the second click happens the old state and current state are both B and it doesn’t do a replace.

Was going to copy the `getDerivedStateFromProps` from Navigation React Native but it broke the zoom example. Select ‘red’ return to grid, select ‘blue’ and return to grid. Quickly jump back and forward through browser history (keep finger on CMD + back/forward arrow) then the shared element animation wasn’t smooth. It stops abruptly. Think it’s because was always assigning a new key to each screen. So ‘red’ and ‘blue’ got different keys and when jumping back between them they get unmounted and the shared elements can\t animate. 

Decided to keep the original keys so that screens can be reused. Going to copy this back to Navigation React Native. It should work fine there now that screens immediately unmounted when the native pop completes. Can't accidentally reuse a screen.
