### PR TITLE
Shared elements after orientation change

### DIFF
--- a/NavigationReactNative/src/SharedElementAndroid.tsx
+++ b/NavigationReactNative/src/SharedElementAndroid.tsx
@@ -1,24 +1,11 @@
 import React from 'react';
 import { requireNativeComponent } from 'react-native';
-import { NavigationContext } from 'navigation-react';
 
-var SharedElement = ({navigationEvent, transition, ...props}) => {
-    var crumb = navigationEvent.stateNavigator.stateContext.crumbs.length;
+var SharedElement = ({transition, ...props}) => {
     var enterTransition = typeof transition !== 'function' ? transition : transition(true);
     var exitTransition = typeof transition !== 'function' ? transition : transition(false);
-    return (
-        <NVSharedElement
-            crumb={crumb}
-            enterTransition={enterTransition}
-            exitTransition={exitTransition}
-            {...props} />
-    );
+    return <NVSharedElement enterTransition={enterTransition} exitTransition={exitTransition} {...props} />
 };
 var NVSharedElement = requireNativeComponent<any>('NVSharedElement', null);
 
-
-export default props => (
-    <NavigationContext.Consumer>
-        {(navigationEvent) => <SharedElement navigationEvent={navigationEvent} {...props} />}
-    </NavigationContext.Consumer>
-)
+export default SharedElement;

--- a/NavigationReactNative/src/SharedElementAndroid.tsx
+++ b/NavigationReactNative/src/SharedElementAndroid.tsx
@@ -1,11 +1,24 @@
 import React from 'react';
 import { requireNativeComponent } from 'react-native';
+import { NavigationContext } from 'navigation-react';
 
-var SharedElement = ({transition, ...props}) => {
+var SharedElement = ({navigationEvent, transition, ...props}) => {
+    var crumb = navigationEvent.stateNavigator.stateContext.crumbs.length;
     var enterTransition = typeof transition !== 'function' ? transition : transition(true);
     var exitTransition = typeof transition !== 'function' ? transition : transition(false);
-    return <NVSharedElement enterTransition={enterTransition} exitTransition={exitTransition} {...props} />
+    return (
+        <NVSharedElement
+            crumb={crumb}
+            enterTransition={enterTransition}
+            exitTransition={exitTransition}
+            {...props} />
+    );
 };
 var NVSharedElement = requireNativeComponent<any>('NVSharedElement', null);
 
-export default SharedElement;
+
+export default props => (
+    <NavigationContext.Consumer>
+        {(navigationEvent) => <SharedElement navigationEvent={navigationEvent} {...props} />}
+    </NavigationContext.Consumer>
+)

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -5,8 +5,6 @@ import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
 
-import javax.annotation.Nonnull;
-
 public class NavigationStackManager extends ViewGroupManager<NavigationStackView> {
 
     @Override
@@ -50,7 +48,7 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
     }
 
     @Override
-    protected void onAfterUpdateTransaction(@Nonnull NavigationStackView view) {
+    protected void onAfterUpdateTransaction(NavigationStackView view) {
         super.onAfterUpdateTransaction(view);
         view.onAfterUpdateTransaction();
     }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -92,7 +92,7 @@ public class NavigationStackView extends ViewGroup {
             int enter = getAnimationResourceId(enterAnim, activityCloseEnterAnimationId);
             int exit = getAnimationResourceId(exitAnim, activityCloseExitAnimationId);
             final HashMap<String, View> oldSharedElementsMap = getSharedElementMap();
-            boolean orientationChanged = currentActivity.getIntent().getIntExtra(SceneActivity.ORIENTATION, 0)!= currentActivity.getResources().getConfiguration().orientation;
+            boolean orientationChanged = currentActivity.getIntent().getIntExtra(SceneActivity.ORIENTATION, 0) != currentActivity.getResources().getConfiguration().orientation;
             Pair[] oldSharedElements = (!orientationChanged && crumb < 20 && currentCrumb - crumb == 1) ? getSharedElements(oldSharedElementsMap, oldSharedElementNames) : null;
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && oldSharedElements != null && oldSharedElements.length != 0) {
                 final SharedElementTransitioner transitioner = new SharedElementTransitioner(currentActivity, getSharedElementSet(oldSharedElementNames));

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -3,6 +3,7 @@ package com.navigation.reactnative;
 import android.app.Activity;
 import android.app.ActivityOptions;
 import android.app.SharedElementCallback;
+import android.content.Context;
 import android.content.Intent;
 import android.content.res.TypedArray;
 import android.os.Build;
@@ -38,7 +39,7 @@ public class NavigationStackView extends ViewGroup {
     private int activityCloseEnterAnimationId;
     private int activityCloseExitAnimationId;
 
-    public NavigationStackView(ThemedReactContext context) {
+    public NavigationStackView(Context context) {
         super(context);
 
         TypedArray activityStyle = context.getTheme().obtainStyledAttributes(new int[] {android.R.attr.windowAnimationStyle});

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -214,8 +214,8 @@ public class NavigationStackView extends ViewGroup {
     }
 
     private HashMap<String, View> getSharedElementMap() {
-        View contentView = ((ThemedReactContext) getContext()).getCurrentActivity().findViewById(android.R.id.content);
-        HashSet<View> sharedElements = SharedElementManager.getSharedElements(contentView.getRootView());
+        Activity currentActivity = ((ThemedReactContext) getContext()).getCurrentActivity();
+        HashSet<View> sharedElements = SharedElementManager.getSharedElements(currentActivity);
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP || sharedElements == null)
             return null;
         HashMap<String, View> sharedElementMap = new HashMap<>();

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -37,7 +37,7 @@ public class NavigationStackView extends ViewGroup {
     private int activityOpenExitAnimationId;
     private int activityCloseEnterAnimationId;
     private int activityCloseExitAnimationId;
-   
+
     public NavigationStackView(ThemedReactContext context) {
         super(context);
 
@@ -238,7 +238,7 @@ public class NavigationStackView extends ViewGroup {
             if (sharedElementMap.containsKey(name))
                 sharedElementPairs.add(Pair.create(sharedElementMap.get(name), name));
         }
-        return sharedElementPairs.toArray(new Pair[sharedElementPairs.size()]);
+        return sharedElementPairs.toArray(new Pair[0]);
     }
 
     @Override

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -217,7 +217,9 @@ public class NavigationStackView extends ViewGroup {
 
     private HashMap<String, View> getSharedElementMap() {
         Activity currentActivity = ((ThemedReactContext) getContext()).getCurrentActivity();
-        HashSet<View> sharedElements = SharedElementManager.getSharedElements(currentActivity);
+        if (!(currentActivity instanceof SceneActivity))
+            return null;
+        HashSet<View> sharedElements = (HashSet<View>) ((SceneActivity) currentActivity).scene.getTag(R.id.sharedElements);
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP || sharedElements == null)
             return null;
         HashMap<String, View> sharedElementMap = new HashMap<>();

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -59,8 +59,6 @@ public class NavigationStackView extends ViewGroup {
     @Override
     public void addView(View child, int index) {
         SceneView scene = (SceneView) child;
-        Activity currentActivity = ((ThemedReactContext) getContext()).getCurrentActivity();
-        scene.orientation = currentActivity.getResources().getConfiguration().orientation;
         sceneKeys.add(index, scene.sceneKey);
         scenes.put(scene.sceneKey, scene);
     }
@@ -130,6 +128,7 @@ public class NavigationStackView extends ViewGroup {
             int enter = getAnimationResourceId(enterAnim, activityOpenEnterAnimationId);
             int exit = getAnimationResourceId(exitAnim, activityOpenExitAnimationId);
             final HashMap<String, View> sharedElementsMap = getSharedElementMap();
+            scenes.get(keys.getString(crumb)).orientation = currentActivity.getResources().getConfiguration().orientation;
             final Pair[] sharedElements = crumb - currentCrumb == 1 ? getSharedElements(sharedElementsMap, sharedElementNames) : null;
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && sharedElements != null && sharedElements.length != 0) {
                 intents[0].putExtra(SceneActivity.SHARED_ELEMENTS, getSharedElementSet(sharedElementNames));

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -92,7 +92,7 @@ public class NavigationStackView extends ViewGroup {
             int enter = getAnimationResourceId(enterAnim, activityCloseEnterAnimationId);
             int exit = getAnimationResourceId(exitAnim, activityCloseExitAnimationId);
             final HashMap<String, View> oldSharedElementsMap = getSharedElementMap();
-            boolean orientationChanged = scenes.get(currentActivity.getIntent().getStringExtra(SceneActivity.KEY)).orientation != currentActivity.getResources().getConfiguration().orientation;
+            boolean orientationChanged = currentActivity.getIntent().getIntExtra("orientation", 0)!= currentActivity.getResources().getConfiguration().orientation;
             Pair[] oldSharedElements = (!orientationChanged && crumb < 20 && currentCrumb - crumb == 1) ? getSharedElements(oldSharedElementsMap, oldSharedElementNames) : null;
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && oldSharedElements != null && oldSharedElements.length != 0) {
                 final SharedElementTransitioner transitioner = new SharedElementTransitioner(currentActivity, getSharedElementSet(oldSharedElementNames));
@@ -126,12 +126,12 @@ public class NavigationStackView extends ViewGroup {
                 Intent intent = new Intent(getContext(), SceneActivity.getActivity(nextCrumb));
                 String key = keys.getString(nextCrumb);
                 intent.putExtra(SceneActivity.KEY, key);
+                intent.putExtra("orientation", currentActivity.getResources().getConfiguration().orientation);
                 intents[i] = intent;
             }
             int enter = getAnimationResourceId(enterAnim, activityOpenEnterAnimationId);
             int exit = getAnimationResourceId(exitAnim, activityOpenExitAnimationId);
             final HashMap<String, View> sharedElementsMap = getSharedElementMap();
-            scenes.get(keys.getString(crumb)).orientation = currentActivity.getResources().getConfiguration().orientation;
             final Pair[] sharedElements = crumb - currentCrumb == 1 ? getSharedElements(sharedElementsMap, sharedElementNames) : null;
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && sharedElements != null && sharedElements.length != 0) {
                 intents[0].putExtra(SceneActivity.SHARED_ELEMENTS, getSharedElementSet(sharedElementNames));

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -219,11 +219,11 @@ public class NavigationStackView extends ViewGroup {
         Activity currentActivity = ((ThemedReactContext) getContext()).getCurrentActivity();
         if (!(currentActivity instanceof SceneActivity))
             return null;
-        HashSet<View> sharedElements = (HashSet<View>) ((SceneActivity) currentActivity).scene.getTag(R.id.sharedElements);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP || sharedElements == null)
+        SceneView scene = ((SceneActivity) currentActivity).scene;
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP)
             return null;
         HashMap<String, View> sharedElementMap = new HashMap<>();
-        for(View sharedElement : sharedElements) {
+        for(View sharedElement : scene.sharedElements) {
             sharedElementMap.put(sharedElement.getTransitionName(), sharedElement);
         }
         return sharedElementMap;

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -59,6 +59,8 @@ public class NavigationStackView extends ViewGroup {
     @Override
     public void addView(View child, int index) {
         SceneView scene = (SceneView) child;
+        Activity currentActivity = ((ThemedReactContext) getContext()).getCurrentActivity();
+        scene.orientation = currentActivity.getResources().getConfiguration().orientation;
         sceneKeys.add(index, scene.sceneKey);
         scenes.put(scene.sceneKey, scene);
     }
@@ -89,7 +91,8 @@ public class NavigationStackView extends ViewGroup {
             int enter = getAnimationResourceId(enterAnim, activityCloseEnterAnimationId);
             int exit = getAnimationResourceId(exitAnim, activityCloseExitAnimationId);
             final HashMap<String, View> oldSharedElementsMap = getSharedElementMap();
-            Pair[] oldSharedElements = (crumb < 20 && currentCrumb - crumb == 1) ? getSharedElements(oldSharedElementsMap, oldSharedElementNames) : null;
+            boolean orientationChanged = scenes.get(currentActivity.getIntent().getStringExtra(SceneActivity.KEY)).orientation != currentActivity.getResources().getConfiguration().orientation;
+            Pair[] oldSharedElements = (!orientationChanged && crumb < 20 && currentCrumb - crumb == 1) ? getSharedElements(oldSharedElementsMap, oldSharedElementNames) : null;
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && oldSharedElements != null && oldSharedElements.length != 0) {
                 final SharedElementTransitioner transitioner = new SharedElementTransitioner(currentActivity, getSharedElementSet(oldSharedElementNames));
                 currentActivity.setEnterSharedElementCallback(new SharedElementCallback() {

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -159,17 +159,15 @@ public class NavigationStackView extends ViewGroup {
             }
             currentActivity.overridePendingTransition(enter, exit);
         }
-        if (crumb == currentCrumb) {
-            if (keys.getString(crumb) != null && !keys.getString(crumb).equals(oldKey)) {
-                Intent intent = new Intent(getContext(), SceneActivity.getActivity(crumb));
-                String key = keys.getString(crumb);
-                intent.putExtra(SceneActivity.KEY, key);
-                int enter = getAnimationResourceId(enterAnim, activityOpenEnterAnimationId);
-                int exit = getAnimationResourceId(exitAnim, activityOpenExitAnimationId);
-                currentActivity.finish();
-                currentActivity.startActivity(intent);
-                currentActivity.overridePendingTransition(enter, exit);
-            }
+        if (crumb == currentCrumb && !oldKey.equals(keys.getString(crumb))) {
+            Intent intent = new Intent(getContext(), SceneActivity.getActivity(crumb));
+            String key = keys.getString(crumb);
+            intent.putExtra(SceneActivity.KEY, key);
+            int enter = getAnimationResourceId(enterAnim, activityOpenEnterAnimationId);
+            int exit = getAnimationResourceId(exitAnim, activityOpenExitAnimationId);
+            currentActivity.finish();
+            currentActivity.startActivity(intent);
+            currentActivity.overridePendingTransition(enter, exit);
         }
         oldCrumb = keys.size() - 1;
         oldKey = keys.getString(oldCrumb);

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -71,6 +71,8 @@ public class NavigationStackView extends ViewGroup {
 
     protected void onAfterUpdateTransaction() {
         Activity currentActivity = ((ThemedReactContext) getContext()).getCurrentActivity();
+        if (currentActivity == null)
+            return;
         if (mainActivity == null)
             mainActivity = currentActivity;
         if (finish) {
@@ -157,15 +159,17 @@ public class NavigationStackView extends ViewGroup {
             }
             currentActivity.overridePendingTransition(enter, exit);
         }
-        if (crumb == currentCrumb && !keys.getString(crumb).equals(oldKey)) {
-            Intent intent = new Intent(getContext(), SceneActivity.getActivity(crumb));
-            String key = keys.getString(crumb);
-            intent.putExtra(SceneActivity.KEY, key);
-            int enter = getAnimationResourceId(enterAnim, activityOpenEnterAnimationId);
-            int exit = getAnimationResourceId(exitAnim, activityOpenExitAnimationId);
-            currentActivity.finish();
-            currentActivity.startActivity(intent);
-            currentActivity.overridePendingTransition(enter, exit);
+        if (crumb == currentCrumb) {
+            if (keys.getString(crumb) != null && !keys.getString(crumb).equals(oldKey)) {
+                Intent intent = new Intent(getContext(), SceneActivity.getActivity(crumb));
+                String key = keys.getString(crumb);
+                intent.putExtra(SceneActivity.KEY, key);
+                int enter = getAnimationResourceId(enterAnim, activityOpenEnterAnimationId);
+                int exit = getAnimationResourceId(exitAnim, activityOpenExitAnimationId);
+                currentActivity.finish();
+                currentActivity.startActivity(intent);
+                currentActivity.overridePendingTransition(enter, exit);
+            }
         }
         oldCrumb = keys.size() - 1;
         oldKey = keys.getString(oldCrumb);
@@ -189,10 +193,11 @@ public class NavigationStackView extends ViewGroup {
 
     @Override
     public void onDetachedFromWindow() {
-        if (keys.size() > 0) {
+        Activity currentActivity = ((ThemedReactContext) getContext()).getCurrentActivity();
+        if (keys.size() > 0 && currentActivity != null) {
             Intent mainIntent = mainActivity.getIntent();
             mainIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-            ((ThemedReactContext) getContext()).getCurrentActivity().navigateUpTo(mainIntent);
+            currentActivity.navigateUpTo(mainIntent);
         }
         scenes.clear();
         super.onDetachedFromWindow();

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 
 public class NavigationStackView extends ViewGroup {
-    private static final String ORIENTATION = "Navigation.ORIENTATION";
     private ArrayList<String> sceneKeys = new ArrayList<>();
     public static HashMap<String, SceneView> scenes = new HashMap<>();
     protected ReadableArray keys;
@@ -93,7 +92,7 @@ public class NavigationStackView extends ViewGroup {
             int enter = getAnimationResourceId(enterAnim, activityCloseEnterAnimationId);
             int exit = getAnimationResourceId(exitAnim, activityCloseExitAnimationId);
             final HashMap<String, View> oldSharedElementsMap = getSharedElementMap();
-            boolean orientationChanged = currentActivity.getIntent().getIntExtra(ORIENTATION, 0)!= currentActivity.getResources().getConfiguration().orientation;
+            boolean orientationChanged = currentActivity.getIntent().getIntExtra(SceneActivity.ORIENTATION, 0)!= currentActivity.getResources().getConfiguration().orientation;
             Pair[] oldSharedElements = (!orientationChanged && crumb < 20 && currentCrumb - crumb == 1) ? getSharedElements(oldSharedElementsMap, oldSharedElementNames) : null;
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && oldSharedElements != null && oldSharedElements.length != 0) {
                 final SharedElementTransitioner transitioner = new SharedElementTransitioner(currentActivity, getSharedElementSet(oldSharedElementNames));
@@ -127,7 +126,7 @@ public class NavigationStackView extends ViewGroup {
                 Intent intent = new Intent(getContext(), SceneActivity.getActivity(nextCrumb));
                 String key = keys.getString(nextCrumb);
                 intent.putExtra(SceneActivity.KEY, key);
-                intent.putExtra(ORIENTATION, currentActivity.getResources().getConfiguration().orientation);
+                intent.putExtra(SceneActivity.ORIENTATION, currentActivity.getResources().getConfiguration().orientation);
                 intents[i] = intent;
             }
             int enter = getAnimationResourceId(enterAnim, activityOpenEnterAnimationId);

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 public class NavigationStackView extends ViewGroup {
+    private static final String ORIENTATION = "Navigation.ORIENTATION";
     private ArrayList<String> sceneKeys = new ArrayList<>();
     public static HashMap<String, SceneView> scenes = new HashMap<>();
     protected ReadableArray keys;
@@ -92,7 +93,7 @@ public class NavigationStackView extends ViewGroup {
             int enter = getAnimationResourceId(enterAnim, activityCloseEnterAnimationId);
             int exit = getAnimationResourceId(exitAnim, activityCloseExitAnimationId);
             final HashMap<String, View> oldSharedElementsMap = getSharedElementMap();
-            boolean orientationChanged = currentActivity.getIntent().getIntExtra("orientation", 0)!= currentActivity.getResources().getConfiguration().orientation;
+            boolean orientationChanged = currentActivity.getIntent().getIntExtra(ORIENTATION, 0)!= currentActivity.getResources().getConfiguration().orientation;
             Pair[] oldSharedElements = (!orientationChanged && crumb < 20 && currentCrumb - crumb == 1) ? getSharedElements(oldSharedElementsMap, oldSharedElementNames) : null;
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && oldSharedElements != null && oldSharedElements.length != 0) {
                 final SharedElementTransitioner transitioner = new SharedElementTransitioner(currentActivity, getSharedElementSet(oldSharedElementNames));
@@ -126,7 +127,7 @@ public class NavigationStackView extends ViewGroup {
                 Intent intent = new Intent(getContext(), SceneActivity.getActivity(nextCrumb));
                 String key = keys.getString(nextCrumb);
                 intent.putExtra(SceneActivity.KEY, key);
-                intent.putExtra("orientation", currentActivity.getResources().getConfiguration().orientation);
+                intent.putExtra(ORIENTATION, currentActivity.getResources().getConfiguration().orientation);
                 intents[i] = intent;
             }
             int enter = getAnimationResourceId(enterAnim, activityOpenEnterAnimationId);

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -49,6 +49,7 @@ public class SceneActivity extends ReactActivity implements DefaultHardwareBackB
     @Override
     public void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
+        intent.putExtra("Navigation.ORIENTATION", getIntent().getIntExtra("Navigation.ORIENTATION", 0));
         setIntent(intent);
         String key = intent.getStringExtra(KEY);
         if (rootView.getChildCount() > 0)

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -39,10 +39,10 @@ public class SceneActivity extends ReactActivity implements DefaultHardwareBackB
         }
         setContentView(rootView);
         @SuppressWarnings("unchecked")
-        HashSet<String> sharedElements = (HashSet<String>) getIntent().getSerializableExtra(SHARED_ELEMENTS);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && sharedElements != null ) {
+        HashSet<String> sharedElementNames = (HashSet<String>) getIntent().getSerializableExtra(SHARED_ELEMENTS);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && sharedElementNames != null ) {
             this.postponeEnterTransition();
-            scene.transitioner = new SharedElementTransitioner(this, sharedElements);
+            scene.transitioner = new SharedElementTransitioner(this, sharedElementNames);
         }
     }
 

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -65,7 +65,6 @@ public class SceneActivity extends ReactActivity implements DefaultHardwareBackB
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        String key = getIntent().getStringExtra(KEY);
         if (scene.getParent() != null && scene.getParent() == rootView)
             scene.popped();
     }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -24,6 +24,7 @@ public class SceneActivity extends ReactActivity implements DefaultHardwareBackB
     public static final String KEY = "Navigation.KEY";
     public static final String SHARED_ELEMENTS = "Navigation.SHARED_ELEMENTS";
     private SceneRootViewGroup rootView;
+    public SceneView scene;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -31,10 +32,10 @@ public class SceneActivity extends ReactActivity implements DefaultHardwareBackB
         String key = getIntent().getStringExtra(KEY);
         rootView = new SceneRootViewGroup(getReactNativeHost().getReactInstanceManager().getCurrentReactContext());
         if (NavigationStackView.scenes.containsKey(key)) {
-            View view = NavigationStackView.scenes.get(key);
-            if (view.getParent() != null)
-                ((ViewGroup) view.getParent()).removeView(view);
-            rootView.addView(view);
+            scene = NavigationStackView.scenes.get(key);
+            if (scene.getParent() != null)
+                ((ViewGroup) scene.getParent()).removeView(scene);
+            rootView.addView(scene);
         }
         setContentView(rootView);
         @SuppressWarnings("unchecked")
@@ -42,7 +43,7 @@ public class SceneActivity extends ReactActivity implements DefaultHardwareBackB
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && sharedElements != null ) {
             this.postponeEnterTransition();
             SharedElementTransitioner transitioner = new SharedElementTransitioner(this, sharedElements);
-            findViewById(android.R.id.content).getRootView().setTag(R.id.sharedElementTransitioner, transitioner);
+            scene.setTag(R.id.sharedElementTransitioner, transitioner);
         }
     }
 
@@ -54,10 +55,10 @@ public class SceneActivity extends ReactActivity implements DefaultHardwareBackB
         if (rootView.getChildCount() > 0)
             rootView.removeViewAt(0);
         if (NavigationStackView.scenes.containsKey(key)) {
-            View view = NavigationStackView.scenes.get(key);
-            if (view.getParent() != null)
-                ((ViewGroup) view.getParent()).removeView(view);
-            rootView.addView(view);
+            scene = NavigationStackView.scenes.get(key);
+            if (scene.getParent() != null)
+                ((ViewGroup) scene.getParent()).removeView(scene);
+            rootView.addView(scene);
         }
     }
 
@@ -65,11 +66,8 @@ public class SceneActivity extends ReactActivity implements DefaultHardwareBackB
     protected void onDestroy() {
         super.onDestroy();
         String key = getIntent().getStringExtra(KEY);
-        if (NavigationStackView.scenes.containsKey(key)) {
-            SceneView view = NavigationStackView.scenes.get(key);
-            if (view.getParent() != null && view.getParent() == rootView)
-                view.popped();
-        }
+        if (scene.getParent() != null && scene.getParent() == rootView)
+            scene.popped();
     }
 
     static class SceneRootViewGroup extends ReactViewGroup implements RootView {

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -42,8 +42,7 @@ public class SceneActivity extends ReactActivity implements DefaultHardwareBackB
         HashSet<String> sharedElements = (HashSet<String>) getIntent().getSerializableExtra(SHARED_ELEMENTS);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && sharedElements != null ) {
             this.postponeEnterTransition();
-            SharedElementTransitioner transitioner = new SharedElementTransitioner(this, sharedElements);
-            scene.setTag(R.id.sharedElementTransitioner, transitioner);
+            scene.transitioner = new SharedElementTransitioner(this, sharedElements);
         }
     }
 

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 public class SceneActivity extends ReactActivity implements DefaultHardwareBackBtnHandler {
     public static final String KEY = "Navigation.KEY";
     public static final String SHARED_ELEMENTS = "Navigation.SHARED_ELEMENTS";
+    public static final String ORIENTATION = "Navigation.ORIENTATION";
     private SceneRootViewGroup rootView;
     public SceneView scene;
 
@@ -49,7 +50,7 @@ public class SceneActivity extends ReactActivity implements DefaultHardwareBackB
     @Override
     public void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
-        intent.putExtra("Navigation.ORIENTATION", getIntent().getIntExtra("Navigation.ORIENTATION", 0));
+        intent.putExtra(ORIENTATION, getIntent().getIntExtra(ORIENTATION, 0));
         setIntent(intent);
         String key = intent.getStringExtra(KEY);
         if (rootView.getChildCount() > 0)

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneView.java
@@ -1,16 +1,21 @@
 package com.navigation.reactnative;
 
+import android.content.Context;
 import android.view.View;
 import android.view.ViewGroup;
 
 import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+import java.util.HashSet;
 
 public class SceneView extends ViewGroup {
     protected String sceneKey;
+    public int orientation;
+    public HashSet<View> sharedElements = new HashSet<>();
+    public SharedElementTransitioner transitioner;
 
-    public SceneView(ThemedReactContext context) {
+    public SceneView(Context context) {
         super(context);
     }
 

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneView.java
@@ -11,7 +11,6 @@ import java.util.HashSet;
 
 public class SceneView extends ViewGroup {
     protected String sceneKey;
-    public int orientation;
     public HashSet<View> sharedElements = new HashSet<>();
     public SharedElementTransitioner transitioner;
 

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
@@ -41,8 +41,8 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
             @Override
             public boolean onPreDraw() {
                 view.getViewTreeObserver().removeOnPreDrawListener(this);
-                View rootView = view.getRootView();
-                SharedElementTransitioner transitioner = (SharedElementTransitioner) rootView.getTag(R.id.sharedElementTransitioner);
+                View sceneView = ((SceneActivity) reactContext.getCurrentActivity()).scene;
+                SharedElementTransitioner transitioner = (SharedElementTransitioner) sceneView.getTag(R.id.sharedElementTransitioner);
                 if (transitioner != null)
                     transitioner.load(view.name, view.enterTransition);
                 return true;
@@ -95,10 +95,9 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
     
     @SuppressWarnings("unchecked")
     public static HashSet<View> getSharedElements(Activity activity) {
-        String key = activity.getIntent().getStringExtra(SceneActivity.KEY);
-        if (key == null)
+        if (!(activity instanceof  SceneActivity))
             return null;
-        final View sceneView = NavigationStackView.scenes.get(key);
+        final View sceneView = ((SceneActivity) activity).scene;
         HashSet<View> sharedElements = (HashSet<View>) sceneView.getTag(R.id.sharedElements);
         if (sharedElements == null) {
             sharedElements = new HashSet<>();

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
@@ -1,15 +1,8 @@
 package com.navigation.reactnative;
 
-import android.app.Activity;
-import android.os.Build;
-import android.view.View;
-import android.view.ViewTreeObserver;
-
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
-
-import java.util.HashSet;
 
 public class SharedElementManager extends ViewGroupManager<SharedElementView> {
 
@@ -19,68 +12,13 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
     }
 
     @Override
-    protected SharedElementView createViewInstance(final ThemedReactContext reactContext) {
-        final SharedElementView view = new SharedElementView(reactContext);
-        view.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
-            @Override
-            public void onViewAttachedToWindow(View v) {
-                view.removeOnAttachStateChangeListener(this);
-                HashSet<View> sharedElements = getSharedElements(reactContext.getCurrentActivity());
-                View sharedElement = view.getChildAt(0);
-                if (sharedElements != null && !sharedElements.contains(sharedElement)) {
-                    setTransitionName(sharedElement, view.name);
-                    sharedElements.add(sharedElement);
-                }
-            }
-
-            @Override
-            public void onViewDetachedFromWindow(View v) {
-            }
-        });
-        view.getViewTreeObserver().addOnPreDrawListener(new ViewTreeObserver.OnPreDrawListener() {
-            @Override
-            public boolean onPreDraw() {
-                view.getViewTreeObserver().removeOnPreDrawListener(this);
-                View sceneView = ((SceneActivity) reactContext.getCurrentActivity()).scene;
-                SharedElementTransitioner transitioner = (SharedElementTransitioner) sceneView.getTag(R.id.sharedElementTransitioner);
-                if (transitioner != null)
-                    transitioner.load(view.name, view.enterTransition);
-                return true;
-            }
-        });
-        return view;
-    }
-
-    @Override
-    public void addView(SharedElementView parent, View child, int index) {
-        super.addView(parent, child, index);
-        Activity currentActivity = ((ThemedReactContext) parent.getContext()).getCurrentActivity();
-        HashSet<View> sharedElements = getSharedElements(currentActivity);
-        if (sharedElements != null && !sharedElements.contains(child))
-            sharedElements.add(child);
-    }
-
-    @Override
-    public void removeViewAt(SharedElementView parent, int index) {
-        Activity currentActivity = ((ThemedReactContext) parent.getContext()).getCurrentActivity();
-        HashSet<View> sharedElements = getSharedElements(currentActivity);
-        View sharedElement = parent.getChildAt(0);
-        if (sharedElements != null && sharedElements.contains(sharedElement)) {
-            setTransitionName(sharedElement, null);
-            sharedElements.remove(sharedElement);
-        }
-        super.removeViewAt(parent, index);
+    protected SharedElementView createViewInstance(ThemedReactContext reactContext) {
+        return new SharedElementView(reactContext);
     }
 
     @ReactProp(name = "name")
     public void setName(SharedElementView view, String name) {
-        view.name = name;
-        setTransitionName(view.getChildAt(0), name);
-    }
-
-    private void setTransitionName(View sharedElement, String name) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && sharedElement != null)
-            sharedElement.setTransitionName(name);
+        view.setName(name);
     }
 
     @ReactProp(name = "enterTransition")
@@ -91,18 +29,5 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
     @ReactProp(name = "exitTransition")
     public void setExitTransition(SharedElementView view, String exitTransition) {
         view.exitTransition = exitTransition;
-    }
-    
-    @SuppressWarnings("unchecked")
-    public static HashSet<View> getSharedElements(Activity activity) {
-        if (!(activity instanceof  SceneActivity))
-            return null;
-        final View sceneView = ((SceneActivity) activity).scene;
-        HashSet<View> sharedElements = (HashSet<View>) sceneView.getTag(R.id.sharedElements);
-        if (sharedElements == null) {
-            sharedElements = new HashSet<>();
-            sceneView.setTag(R.id.sharedElements, sharedElements);
-        }
-        return sharedElements;
     }
 }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
@@ -85,6 +85,11 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
             sharedElement.setTransitionName(name);
     }
 
+    @ReactProp(name = "crumb")
+    public void setCrumn(SharedElementView view, int crumb) {
+        view.crumb = crumb;
+    }
+
     @ReactProp(name = "enterTransition")
     public void setEnterTransition(SharedElementView view, String enterTransition) {
         view.enterTransition = enterTransition;

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementManager.java
@@ -85,11 +85,6 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
             sharedElement.setTransitionName(name);
     }
 
-    @ReactProp(name = "crumb")
-    public void setCrumn(SharedElementView view, int crumb) {
-        view.crumb = crumb;
-    }
-
     @ReactProp(name = "enterTransition")
     public void setEnterTransition(SharedElementView view, String enterTransition) {
         view.enterTransition = enterTransition;

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
@@ -45,7 +45,7 @@ class SharedElementTransitioner {
             }
             activity.getWindow().setSharedElementEnterTransition(transitionSet);
             activity.startPostponedEnterTransition();
-            if (activity instanceof  SceneActivity)
+            if (activity instanceof SceneActivity)
                 ((SceneActivity) activity).scene.transitioner = null;
             activity = null;
         }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
@@ -10,18 +10,18 @@ import android.view.View;
 import java.util.HashMap;
 import java.util.HashSet;
 
-public class SharedElementTransitioner {
+class SharedElementTransitioner {
     private Activity activity;
     private HashSet<String> sharedElements;
     private HashSet<String> loadedSharedElements = new HashSet<>();
     private HashMap<String, Transition> transitions = new HashMap<>();
 
-    public SharedElementTransitioner(Activity activity, HashSet<String> sharedElements) {
+    SharedElementTransitioner(Activity activity, HashSet<String> sharedElements) {
         this.activity = activity;
         this.sharedElements = sharedElements;
     }
 
-    public void load(String sharedElement, String transitionKey) {
+    void load(String sharedElement, String transitionKey) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP)
             return;
         if (sharedElements.contains(sharedElement) && !loadedSharedElements.contains(sharedElement)) {

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
@@ -5,7 +5,6 @@ import android.os.Build;
 import android.transition.Transition;
 import android.transition.TransitionInflater;
 import android.transition.TransitionSet;
-import android.view.View;
 
 import java.util.HashMap;
 import java.util.HashSet;

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
@@ -47,6 +47,7 @@ class SharedElementTransitioner {
             activity.startPostponedEnterTransition();
             if (activity instanceof  SceneActivity)
                 ((SceneActivity) activity).scene.transitioner = null;
+            activity = null;
         }
     }
 }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
@@ -46,8 +46,8 @@ class SharedElementTransitioner {
             }
             activity.getWindow().setSharedElementEnterTransition(transitionSet);
             activity.startPostponedEnterTransition();
-            View contentView = activity.findViewById(android.R.id.content);
-            contentView.getRootView().setTag(R.id.sharedElementTransitioner, null);
+            if (activity instanceof  SceneActivity)
+                ((SceneActivity) activity).scene.transitioner = null;
         }
     }
 }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -1,14 +1,11 @@
 package com.navigation.reactnative;
 
-import android.app.Activity;
 import android.content.Context;
 import android.os.Build;
 import android.view.View;
 import android.view.ViewParent;
 import android.view.ViewTreeObserver;
 import android.widget.FrameLayout;
-
-import com.facebook.react.uimanager.ThemedReactContext;
 
 public class SharedElementView extends FrameLayout {
     private String name;

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -1,14 +1,82 @@
 package com.navigation.reactnative;
 
 import android.content.Context;
+import android.os.Build;
+import android.view.View;
+import android.view.ViewTreeObserver;
 import android.widget.FrameLayout;
 
+import com.facebook.react.uimanager.ThemedReactContext;
+
+import java.util.HashSet;
+
 public class SharedElementView extends FrameLayout {
-    protected String name;
+    private String name;
     protected String enterTransition;
     protected String exitTransition;
+    private SceneView scene;
 
     public SharedElementView(Context context) {
         super(context);
+    }
+
+    public void setName(String name) {
+        this.name = name;
+        setTransitionName(getChildAt(0), name);
+    }
+
+    @Override
+    public void addView(View child, int index) {
+        super.addView(child, index);
+        setTransitionName(child, name);
+        if (scene != null) {
+            HashSet<View> sharedElements = (HashSet<View>) scene.getTag(R.id.sharedElements);
+            if (!sharedElements.contains(child))
+                sharedElements.add(child);
+        }
+    }
+
+    @Override
+    public void removeViewAt(int index) {
+        View sharedElement = getChildAt(index);
+        if (scene != null) {
+            HashSet<View> sharedElements = (HashSet<View>) scene.getTag(R.id.sharedElements);
+            if (sharedElements.contains(sharedElement)) {
+                setTransitionName(sharedElement, null);
+                sharedElements.remove(sharedElement);
+            }
+            super.removeViewAt(index);
+        }
+    }
+
+    protected void setTransitionName(View sharedElement, String name) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && sharedElement != null)
+            sharedElement.setTransitionName(name);
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        scene = ((SceneActivity) ((ThemedReactContext) getContext()).getCurrentActivity()).scene;
+        HashSet<View> sharedElements = (HashSet<View>) scene.getTag(R.id.sharedElements);
+        View sharedElement = getChildAt(0);
+        if (sharedElements == null) {
+            sharedElements = new HashSet<>();
+            scene.setTag(R.id.sharedElements, sharedElements);
+        }
+        if (!sharedElements.contains(sharedElement)) {
+            setTransitionName(sharedElement, name);
+            sharedElements.add(sharedElement);
+        }
+        getViewTreeObserver().addOnPreDrawListener(new ViewTreeObserver.OnPreDrawListener() {
+            @Override
+            public boolean onPreDraw() {
+                getViewTreeObserver().removeOnPreDrawListener(this);
+                SharedElementTransitioner transitioner = (SharedElementTransitioner) scene.getTag(R.id.sharedElementTransitioner);
+                if (transitioner != null)
+                    transitioner.load(name, enterTransition);
+                return true;
+            }
+        });
     }
 }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -5,7 +5,6 @@ import android.widget.FrameLayout;
 
 public class SharedElementView extends FrameLayout {
     protected String name;
-    protected int crumb;
     protected String enterTransition;
     protected String exitTransition;
 

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -74,4 +74,10 @@ public class SharedElementView extends FrameLayout {
             }
         });
     }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        scene = null;
+    }
 }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -1,5 +1,6 @@
 package com.navigation.reactnative;
 
+import android.app.Activity;
 import android.content.Context;
 import android.os.Build;
 import android.view.View;
@@ -54,7 +55,10 @@ public class SharedElementView extends FrameLayout {
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
-        scene = ((SceneActivity) ((ThemedReactContext) getContext()).getCurrentActivity()).scene;
+        Activity activity = ((ThemedReactContext) getContext()).getCurrentActivity();
+        if (!(activity instanceof SceneActivity))
+            return;
+        scene = ((SceneActivity) activity).scene;
         View sharedElement = getChildAt(0);
         if (!scene.sharedElements.contains(sharedElement)) {
             setTransitionName(sharedElement, name);

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -5,6 +5,7 @@ import android.widget.FrameLayout;
 
 public class SharedElementView extends FrameLayout {
     protected String name;
+    protected int crumb;
     protected String enterTransition;
     protected String exitTransition;
 

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.os.Build;
 import android.view.View;
+import android.view.ViewParent;
 import android.view.ViewTreeObserver;
 import android.widget.FrameLayout;
 
@@ -55,10 +56,12 @@ public class SharedElementView extends FrameLayout {
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
-        Activity activity = ((ThemedReactContext) getContext()).getCurrentActivity();
-        if (!(activity instanceof SceneActivity))
+        ViewParent ancestor = getParent();
+        while (ancestor != null && !(ancestor instanceof SceneView))
+            ancestor = ancestor.getParent();
+        if (ancestor == null)
             return;
-        scene = ((SceneActivity) activity).scene;
+        scene = (SceneView) ancestor;
         View sharedElement = getChildAt(0);
         if (!scene.sharedElements.contains(sharedElement)) {
             setTransitionName(sharedElement, name);

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -38,7 +38,7 @@ public class SharedElementView extends FrameLayout {
 
     @Override
     public void removeViewAt(int index) {
-        View sharedElement = getChildAt(index);
+        View sharedElement = getChildAt(0);
         if (scene != null) {
             HashSet<View> sharedElements = (HashSet<View>) scene.getTag(R.id.sharedElements);
             if (sharedElements.contains(sharedElement)) {

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -64,9 +64,8 @@ public class SharedElementView extends FrameLayout {
             @Override
             public boolean onPreDraw() {
                 getViewTreeObserver().removeOnPreDrawListener(this);
-                SharedElementTransitioner transitioner = (SharedElementTransitioner) scene.getTag(R.id.sharedElementTransitioner);
-                if (transitioner != null)
-                    transitioner.load(name, enterTransition);
+                if (scene.transitioner != null)
+                    scene.transitioner.load(name, enterTransition);
                 return true;
             }
         });

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -38,7 +38,7 @@ public class SharedElementView extends FrameLayout {
 
     @Override
     public void removeViewAt(int index) {
-        View sharedElement = getChildAt(0);
+        View sharedElement = getChildAt(index);
         if (scene != null) {
             HashSet<View> sharedElements = (HashSet<View>) scene.getTag(R.id.sharedElements);
             if (sharedElements.contains(sharedElement)) {

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -8,8 +8,6 @@ import android.widget.FrameLayout;
 
 import com.facebook.react.uimanager.ThemedReactContext;
 
-import java.util.HashSet;
-
 public class SharedElementView extends FrameLayout {
     private String name;
     protected String enterTransition;
@@ -28,11 +26,11 @@ public class SharedElementView extends FrameLayout {
     @Override
     public void addView(View child, int index) {
         super.addView(child, index);
-        setTransitionName(child, name);
         if (scene != null) {
-            HashSet<View> sharedElements = (HashSet<View>) scene.getTag(R.id.sharedElements);
-            if (!sharedElements.contains(child))
-                sharedElements.add(child);
+            if (!scene.sharedElements.contains(child)) {
+                setTransitionName(child, name);
+                scene.sharedElements.add(child);
+            }
         }
     }
 
@@ -40,10 +38,9 @@ public class SharedElementView extends FrameLayout {
     public void removeViewAt(int index) {
         View sharedElement = getChildAt(index);
         if (scene != null) {
-            HashSet<View> sharedElements = (HashSet<View>) scene.getTag(R.id.sharedElements);
-            if (sharedElements.contains(sharedElement)) {
+            if (scene.sharedElements.contains(sharedElement)) {
                 setTransitionName(sharedElement, null);
-                sharedElements.remove(sharedElement);
+                scene.sharedElements.remove(sharedElement);
             }
             super.removeViewAt(index);
         }
@@ -58,15 +55,10 @@ public class SharedElementView extends FrameLayout {
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
         scene = ((SceneActivity) ((ThemedReactContext) getContext()).getCurrentActivity()).scene;
-        HashSet<View> sharedElements = (HashSet<View>) scene.getTag(R.id.sharedElements);
         View sharedElement = getChildAt(0);
-        if (sharedElements == null) {
-            sharedElements = new HashSet<>();
-            scene.setTag(R.id.sharedElements, sharedElements);
-        }
-        if (!sharedElements.contains(sharedElement)) {
+        if (!scene.sharedElements.contains(sharedElement)) {
             setTransitionName(sharedElement, name);
-            sharedElements.add(sharedElement);
+            scene.sharedElements.add(sharedElement);
         }
         getViewTreeObserver().addOnPreDrawListener(new ViewTreeObserver.OnPreDrawListener() {
             @Override

--- a/NavigationReactNative/src/android/app/src/main/res/values/strings.xml
+++ b/NavigationReactNative/src/android/app/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <item type="id" name="sharedElements" />
     <item type="id" name="sharedElementTransitioner" />
 </resources>

--- a/NavigationReactNative/src/android/app/src/main/res/values/strings.xml
+++ b/NavigationReactNative/src/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <item type="id" name="sharedElementTransitioner" />
 </resources>


### PR DESCRIPTION
Android restarts the Activity on orientation change. This creates a new root view and clears the shared element cache. Think [that removing the onAttachStateChangeListener](https://github.com/grahammendick/navigation/commit/696df8199cf6b79dc772000f79bade5908632b49#diff-3d7ac409e0766be7beae709c4c967b5b) meant the cached wasn’t recreated when scene added to new Activity. 

Moved the code from the `SceneManager` into the `SceneView` so that it’s not so fragile. Also,
used the `SceneView` to cache the shared elements because don’t need the messy logic of finding the content view. 

There’s a React Native bug that means can’t share elements after an orientation change. Start portrait and navigate A → B. Change to landscape and navigate back. React Native throws an error saying can’t pause Activity B when Activity A is current. For now, disabled sharing elements when orientation changed.
