### PR TITLE
Started app from deep link on Android

### DIFF
--- a/NavigationReactNative/sample/zoom/android/app/src/main/java/com/zoom/MainActivity.java
+++ b/NavigationReactNative/sample/zoom/android/app/src/main/java/com/zoom/MainActivity.java
@@ -1,25 +1,8 @@
 package com.zoom;
 
-import android.net.Uri;
-import android.os.Bundle;
-
 import com.facebook.react.ReactActivity;
-import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 public class MainActivity extends ReactActivity {
-
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        Uri uri = getIntent().getData();
-        if (uri != null) {
-            ReactContext currentContext = getReactInstanceManager().getCurrentReactContext();
-            DeviceEventManagerModule deviceEventManagerModule =
-                currentContext.getNativeModule(DeviceEventManagerModule.class);
-            deviceEventManagerModule.emitNewIntentReceived(uri);
-        }
-    }
 
     /**
      * Returns the name of the main component registered from JavaScript.

--- a/NavigationReactNative/sample/zoom/ios/zoom/AppDelegate.m
+++ b/NavigationReactNative/sample/zoom/ios/zoom/AppDelegate.m
@@ -40,11 +40,11 @@
 #endif
 }
 
-- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url
-  sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
+- (BOOL)application:(UIApplication *)application
+            openURL:(NSURL *)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
 {
-  return [RCTLinkingManager application:application openURL:url
-             sourceApplication:sourceApplication annotation:annotation];
+  return [RCTLinkingManager application:application openURL:url options:options];
 }
 
 @end

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/LinkActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/LinkActivity.java
@@ -17,7 +17,7 @@ public class LinkActivity extends Activity {
         Intent intent = getIntent();
         Uri uri = intent.getData();
         ReactContext reactContext = ((ReactApplication) getApplication()).getReactNativeHost().getReactInstanceManager().getCurrentReactContext();
-        if (reactContext == null) {
+        if (reactContext == null || reactContext.getCurrentActivity() == null) {
             Intent mainIntent = getApplicationContext().getPackageManager().getLaunchIntentForPackage(getApplicationContext().getPackageName());
             if (mainIntent != null) {
                 mainIntent.setData(uri);

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/LinkActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/LinkActivity.java
@@ -14,23 +14,17 @@ public class LinkActivity extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        finish();
-    }
-    
-    @Override
-    protected void onDestroy() {
-        Activity currentActivity = getReactContext().getCurrentActivity();
         Intent intent = getIntent();
         Uri uri = intent.getData();
-        if (currentActivity == null) {
-            Intent mainIntent = getReactContext().getPackageManager().getLaunchIntentForPackage(getReactContext().getPackageName());
+        if (getReactContext() == null) {
+            Intent mainIntent = getApplicationContext().getPackageManager().getLaunchIntentForPackage(getApplicationContext().getPackageName());
             mainIntent.setData(uri);
             startActivity(mainIntent);
         } else {
             DeviceEventManagerModule deviceEventManagerModule = getReactContext().getNativeModule(DeviceEventManagerModule.class);
             deviceEventManagerModule.emitNewIntentReceived(uri);
         }
-        super.onDestroy();
+        finish();
     }
 
     private ReactContext getReactContext() {

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/LinkActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/LinkActivity.java
@@ -16,18 +16,19 @@ public class LinkActivity extends Activity {
         super.onCreate(savedInstanceState);
         Intent intent = getIntent();
         Uri uri = intent.getData();
-        if (getReactContext() == null) {
+        ReactContext reactContext = ((ReactApplication) getApplication()).getReactNativeHost().getReactInstanceManager().getCurrentReactContext();
+        if (reactContext == null) {
             Intent mainIntent = getApplicationContext().getPackageManager().getLaunchIntentForPackage(getApplicationContext().getPackageName());
-            mainIntent.setData(uri);
-            startActivity(mainIntent);
+            if (mainIntent != null) {
+                mainIntent.setData(uri);
+                startActivity(mainIntent);
+            }
         } else {
-            DeviceEventManagerModule deviceEventManagerModule = getReactContext().getNativeModule(DeviceEventManagerModule.class);
-            deviceEventManagerModule.emitNewIntentReceived(uri);
+            if (uri != null) {
+                DeviceEventManagerModule deviceEventManagerModule = reactContext.getNativeModule(DeviceEventManagerModule.class);
+                deviceEventManagerModule.emitNewIntentReceived(uri);
+            }
         }
         finish();
-    }
-
-    private ReactContext getReactContext() {
-        return ((ReactApplication) getApplication()).getReactNativeHost().getReactInstanceManager().getCurrentReactContext();
     }
 }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -80,6 +80,7 @@ public class NavigationStackView extends ViewGroup {
             mainActivity = currentActivity;
             Uri uri = mainActivity.getIntent().getData();
             if (uri != null) {
+                mainActivity.getIntent().setData(null);
                 DeviceEventManagerModule deviceEventManagerModule = ((ThemedReactContext) getContext()).getNativeModule(DeviceEventManagerModule.class);
                 deviceEventManagerModule.emitNewIntentReceived(uri);
             }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -6,6 +6,7 @@ import android.app.SharedElementCallback;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.TypedArray;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Pair;
@@ -13,6 +14,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.views.image.ReactImageView;
 
@@ -74,8 +76,14 @@ public class NavigationStackView extends ViewGroup {
         Activity currentActivity = ((ThemedReactContext) getContext()).getCurrentActivity();
         if (currentActivity == null)
             return;
-        if (mainActivity == null)
+        if (mainActivity == null) {
             mainActivity = currentActivity;
+            Uri uri = mainActivity.getIntent().getData();
+            if (uri != null) {
+                DeviceEventManagerModule deviceEventManagerModule = ((ThemedReactContext) getContext()).getNativeModule(DeviceEventManagerModule.class);
+                deviceEventManagerModule.emitNewIntentReceived(uri);
+            }
+        }
         if (finish) {
             mainActivity.finish();
             return;


### PR DESCRIPTION
The deep link couldn’t start a closed (not running in the background) Android app. The React Context was null so `LinkActivity` threw an error. It was still null in `MainActivity so that threw too.

Used `getApplciationContext` in `LinkActivity` and moved the `onCreate` of `MainActivity` into `NavigationStackView`.
