### PR TITLE
Used the same class for all Activities and prevented scene reuse across Activities

### DIFF
--- a/NavigationReactNative/src/PopSync.tsx
+++ b/NavigationReactNative/src/PopSync.tsx
@@ -4,12 +4,14 @@ type PopSyncProps<T> = {data: T[], getKey: any, children: (items: {key: string, 
 class PopSync<T> extends React.Component<PopSyncProps<T>, any> {
     constructor(props) {
         super(props);
-        this.state = {items: []};
+        this.state = {items: [], data: null};
         this.popNative = this.popNative.bind(this);
     }
-    static getDerivedStateFromProps(props, {items: prevItems}) {
+    static getDerivedStateFromProps(props, {items: prevItems, data: currentData}) {
         var tick = Date.now();
         var {data, getKey} = props;
+        if (data === currentData)
+            return null;
         var dataByKey = data.reduce((acc, item, index) => ({...acc, [getKey(item)]: {...item, index}}), {});
         var itemsByKey = prevItems.reduce((acc, item) => ({...acc, [item.key]: item}), {});
         var items = prevItems
@@ -28,16 +30,11 @@ class PopSync<T> extends React.Component<PopSyncProps<T>, any> {
                 })
             )
             .sort((a, b) => a.index !== b.index ? a.index - b.index : a.key.length - b.key.length);
-        return {items};
+        return {items, data};
     }
     popNative(key: string) {
         this.setState(({items: prevItems}) => {
-            var poppedItem = prevItems.filter(item => item.key === key)[0];
-            if (!poppedItem || !poppedItem.reactPop)
-                return null;
-            var items = prevItems.filter(({reactPop, index}) => (
-                reactPop !== poppedItem.reactPop || index > poppedItem.index 
-            ));
+            var items = prevItems.filter(item => item.key !== key);
             return {items};            
         });
     }

--- a/NavigationReactNative/src/PopSync.tsx
+++ b/NavigationReactNative/src/PopSync.tsx
@@ -8,7 +8,6 @@ class PopSync<T> extends React.Component<PopSyncProps<T>, any> {
         this.popNative = this.popNative.bind(this);
     }
     static getDerivedStateFromProps(props, {items: prevItems, data: prevData}) {
-        var tick = Date.now();
         var {data, getKey} = props;
         if (data === prevData)
             return null;
@@ -19,14 +18,13 @@ class PopSync<T> extends React.Component<PopSyncProps<T>, any> {
                 var matchedItem = dataByKey[item.key];
                 var nextItem: any = {key: item.key, data: matchedItem || item.data};
                 nextItem.index = !matchedItem ? item.index : matchedItem.index;
-                nextItem.reactPop = !matchedItem ? (item.reactPop || tick) : 0;
                 return nextItem;
             })
             .concat(data
                 .filter(item => !itemsByKey[getKey(item)])
                 .map(item => {
                     var index = dataByKey[getKey(item)].index;
-                    return {key: getKey(item), data: item, index, reactPop: 0};
+                    return {key: getKey(item), data: item, index};
                 })
             )
             .sort((a, b) => a.index !== b.index ? a.index - b.index : a.key.length - b.key.length);

--- a/NavigationReactNative/src/PopSync.tsx
+++ b/NavigationReactNative/src/PopSync.tsx
@@ -7,10 +7,10 @@ class PopSync<T> extends React.Component<PopSyncProps<T>, any> {
         this.state = {items: [], data: null};
         this.popNative = this.popNative.bind(this);
     }
-    static getDerivedStateFromProps(props, {items: prevItems, data: currentData}) {
+    static getDerivedStateFromProps(props, {items: prevItems, data: prevData}) {
         var tick = Date.now();
         var {data, getKey} = props;
-        if (data === currentData)
+        if (data === prevData)
             return null;
         var dataByKey = data.reduce((acc, item, index) => ({...acc, [getKey(item)]: {...item, index}}), {});
         var itemsByKey = prevItems.reduce((acc, item) => ({...acc, [item.key]: item}), {});

--- a/NavigationReactNative/src/android/app/src/main/AndroidManifest.xml
+++ b/NavigationReactNative/src/android/app/src/main/AndroidManifest.xml
@@ -3,17 +3,6 @@
 
     <application>
         <activity android:name=".SceneActivity" />
-        <activity android:name=".SceneActivity$Crumb0" /> <activity android:name=".SceneActivity$Crumb1" />
-        <activity android:name=".SceneActivity$Crumb2" /> <activity android:name=".SceneActivity$Crumb3" />
-        <activity android:name=".SceneActivity$Crumb4" /> <activity android:name=".SceneActivity$Crumb5" />
-        <activity android:name=".SceneActivity$Crumb6" /> <activity android:name=".SceneActivity$Crumb7" />
-        <activity android:name=".SceneActivity$Crumb8" /> <activity android:name=".SceneActivity$Crumb9" />
-        <activity android:name=".SceneActivity$Crumb10" /> <activity android:name=".SceneActivity$Crumb11" />
-        <activity android:name=".SceneActivity$Crumb12" /> <activity android:name=".SceneActivity$Crumb13" />
-        <activity android:name=".SceneActivity$Crumb14" /> <activity android:name=".SceneActivity$Crumb15" />
-        <activity android:name=".SceneActivity$Crumb16" /> <activity android:name=".SceneActivity$Crumb17" />
-        <activity android:name=".SceneActivity$Crumb18" /> <activity android:name=".SceneActivity$Crumb19" />
-        <activity android:name=".SceneActivity$Crumb20" />
     </application>
 
 </manifest>

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 public class NavigationStackView extends ViewGroup {
+    private static final String ORIENTATION = "Navigation.ORIENTATION";
     private ArrayList<String> sceneKeys = new ArrayList<>();
     public static HashMap<String, SceneView> scenes = new HashMap<>();
     protected ReadableArray keys;
@@ -102,7 +103,7 @@ public class NavigationStackView extends ViewGroup {
             int enter = getAnimationResourceId(enterAnim, activityCloseEnterAnimationId);
             int exit = getAnimationResourceId(exitAnim, activityCloseExitAnimationId);
             final HashMap<String, View> oldSharedElementsMap = getSharedElementMap();
-            boolean orientationChanged = currentActivity.getIntent().getIntExtra(SceneActivity.ORIENTATION, 0) != currentActivity.getResources().getConfiguration().orientation;
+            boolean orientationChanged = currentActivity.getIntent().getIntExtra(ORIENTATION, 0) != currentActivity.getResources().getConfiguration().orientation;
             Pair[] oldSharedElements = (!orientationChanged && currentCrumb - crumb == 1) ? getSharedElements(oldSharedElementsMap, oldSharedElementNames) : null;
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && oldSharedElements != null && oldSharedElements.length != 0) {
                 final SharedElementTransitioner transitioner = new SharedElementTransitioner(currentActivity, getSharedElementSet(oldSharedElementNames));
@@ -137,7 +138,7 @@ public class NavigationStackView extends ViewGroup {
                 String key = keys.getString(nextCrumb);
                 intent.putExtra(SceneActivity.KEY, key);
                 intent.putExtra(SceneActivity.CRUMB, nextCrumb);
-                intent.putExtra(SceneActivity.ORIENTATION, currentActivity.getResources().getConfiguration().orientation);
+                intent.putExtra(ORIENTATION, currentActivity.getResources().getConfiguration().orientation);
                 intents[i] = intent;
             }
             int enter = getAnimationResourceId(enterAnim, activityOpenEnterAnimationId);

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -94,9 +94,10 @@ public class NavigationStackView extends ViewGroup {
         int crumb = keys.size() - 1;
         int currentCrumb = oldCrumb;
         if (crumb < currentCrumb) {
-            Intent intent = new Intent(getContext(), SceneActivity.getActivity(crumb));
+            Intent intent = new Intent(getContext(), SceneActivity.class);
             String key = keys.getString(crumb);
             intent.putExtra(SceneActivity.KEY, key);
+            intent.putExtra(SceneActivity.CRUMB, crumb);
             intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             int enter = getAnimationResourceId(enterAnim, activityCloseEnterAnimationId);
             int exit = getAnimationResourceId(exitAnim, activityCloseExitAnimationId);
@@ -132,9 +133,10 @@ public class NavigationStackView extends ViewGroup {
             Intent[] intents = new Intent[crumb - currentCrumb];
             for(int i = 0; i < crumb - currentCrumb; i++) {
                 int nextCrumb = currentCrumb + i + 1;
-                Intent intent = new Intent(getContext(), SceneActivity.getActivity(nextCrumb));
+                Intent intent = new Intent(getContext(), SceneActivity.class);
                 String key = keys.getString(nextCrumb);
                 intent.putExtra(SceneActivity.KEY, key);
+                intent.putExtra(SceneActivity.CRUMB, nextCrumb);
                 intent.putExtra(SceneActivity.ORIENTATION, currentActivity.getResources().getConfiguration().orientation);
                 intents[i] = intent;
             }
@@ -170,9 +172,10 @@ public class NavigationStackView extends ViewGroup {
             currentActivity.overridePendingTransition(enter, exit);
         }
         if (crumb == currentCrumb && !oldKey.equals(keys.getString(crumb))) {
-            Intent intent = new Intent(getContext(), SceneActivity.getActivity(crumb));
+            Intent intent = new Intent(getContext(), SceneActivity.class);
             String key = keys.getString(crumb);
             intent.putExtra(SceneActivity.KEY, key);
+            intent.putExtra(SceneActivity.CRUMB, crumb);
             int enter = getAnimationResourceId(enterAnim, activityOpenEnterAnimationId);
             int exit = getAnimationResourceId(exitAnim, activityOpenExitAnimationId);
             currentActivity.finish();

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -103,7 +103,7 @@ public class NavigationStackView extends ViewGroup {
             int exit = getAnimationResourceId(exitAnim, activityCloseExitAnimationId);
             final HashMap<String, View> oldSharedElementsMap = getSharedElementMap();
             boolean orientationChanged = currentActivity.getIntent().getIntExtra(SceneActivity.ORIENTATION, 0) != currentActivity.getResources().getConfiguration().orientation;
-            Pair[] oldSharedElements = (!orientationChanged && crumb < 20 && currentCrumb - crumb == 1) ? getSharedElements(oldSharedElementsMap, oldSharedElementNames) : null;
+            Pair[] oldSharedElements = (!orientationChanged && currentCrumb - crumb == 1) ? getSharedElements(oldSharedElementsMap, oldSharedElementNames) : null;
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && oldSharedElements != null && oldSharedElements.length != 0) {
                 final SharedElementTransitioner transitioner = new SharedElementTransitioner(currentActivity, getSharedElementSet(oldSharedElementNames));
                 currentActivity.setEnterSharedElementCallback(new SharedElementCallback() {

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -98,7 +98,6 @@ public class NavigationStackView extends ViewGroup {
             Intent intent = new Intent(getContext(), SceneActivity.class);
             String key = keys.getString(crumb);
             intent.putExtra(SceneActivity.KEY, key);
-            intent.putExtra(SceneActivity.CRUMB, crumb);
             intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             int enter = getAnimationResourceId(enterAnim, activityCloseEnterAnimationId);
             int exit = getAnimationResourceId(exitAnim, activityCloseExitAnimationId);
@@ -137,7 +136,6 @@ public class NavigationStackView extends ViewGroup {
                 Intent intent = new Intent(getContext(), SceneActivity.class);
                 String key = keys.getString(nextCrumb);
                 intent.putExtra(SceneActivity.KEY, key);
-                intent.putExtra(SceneActivity.CRUMB, nextCrumb);
                 intent.putExtra(ORIENTATION, currentActivity.getResources().getConfiguration().orientation);
                 intents[i] = intent;
             }
@@ -176,7 +174,6 @@ public class NavigationStackView extends ViewGroup {
             Intent intent = new Intent(getContext(), SceneActivity.class);
             String key = keys.getString(crumb);
             intent.putExtra(SceneActivity.KEY, key);
-            intent.putExtra(SceneActivity.CRUMB, crumb);
             int enter = getAnimationResourceId(enterAnim, activityOpenEnterAnimationId);
             int exit = getAnimationResourceId(exitAnim, activityOpenExitAnimationId);
             currentActivity.finish();

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -57,15 +57,6 @@ public class SceneActivity extends ReactActivity implements DefaultHardwareBackB
         }
         intent.putExtra(ORIENTATION, getIntent().getIntExtra(ORIENTATION, 0));
         setIntent(intent);
-        String key = intent.getStringExtra(KEY);
-        if (rootView.getChildCount() > 0)
-            rootView.removeViewAt(0);
-        if (NavigationStackView.scenes.containsKey(key)) {
-            scene = NavigationStackView.scenes.get(key);
-            if (scene.getParent() != null)
-                ((ViewGroup) scene.getParent()).removeView(scene);
-            rootView.addView(scene);
-        }
     }
 
     @Override

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -51,12 +51,8 @@ public class SceneActivity extends ReactActivity implements DefaultHardwareBackB
     @Override
     public void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
-        if (getIntent().getIntExtra(CRUMB, 0) == intent.getIntExtra(CRUMB, 0)) {
-            intent.putExtra(ORIENTATION, getIntent().getIntExtra(ORIENTATION, 0));
-            setIntent(intent);
-        } else {
+        if (getIntent().getIntExtra(CRUMB, 0) != intent.getIntExtra(CRUMB, 0))
             navigateUpTo(intent);
-        }
     }
 
     @Override

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -23,14 +23,13 @@ import java.util.HashSet;
 public class SceneActivity extends ReactActivity implements DefaultHardwareBackBtnHandler {
     public static final String KEY = "Navigation.KEY";
     public static final String SHARED_ELEMENTS = "Navigation.SHARED_ELEMENTS";
-    private SceneRootViewGroup rootView;
     public SceneView scene;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         String key = getIntent().getStringExtra(KEY);
-        rootView = new SceneRootViewGroup(getReactNativeHost().getReactInstanceManager().getCurrentReactContext());
+        SceneRootViewGroup rootView = new SceneRootViewGroup(getReactNativeHost().getReactInstanceManager().getCurrentReactContext());
         if (NavigationStackView.scenes.containsKey(key)) {
             scene = NavigationStackView.scenes.get(key);
             if (scene.getParent() != null)

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -51,12 +51,12 @@ public class SceneActivity extends ReactActivity implements DefaultHardwareBackB
     @Override
     public void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
-        if (getIntent().getIntExtra(CRUMB, 0) != intent.getIntExtra(CRUMB, 0)) {
+        if (getIntent().getIntExtra(CRUMB, 0) == intent.getIntExtra(CRUMB, 0)) {
+            intent.putExtra(ORIENTATION, getIntent().getIntExtra(ORIENTATION, 0));
+            setIntent(intent);
+        } else {
             navigateUpTo(intent);
-            return;
         }
-        intent.putExtra(ORIENTATION, getIntent().getIntExtra(ORIENTATION, 0));
-        setIntent(intent);
     }
 
     @Override

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 
 public class SceneActivity extends ReactActivity implements DefaultHardwareBackBtnHandler {
     public static final String KEY = "Navigation.KEY";
+    public static final String CRUMB = "Navigation.CRUMB";
     public static final String SHARED_ELEMENTS = "Navigation.SHARED_ELEMENTS";
     public static final String ORIENTATION = "Navigation.ORIENTATION";
     private SceneRootViewGroup rootView;
@@ -50,6 +51,10 @@ public class SceneActivity extends ReactActivity implements DefaultHardwareBackB
     @Override
     public void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
+        if (getIntent().getIntExtra(CRUMB, 0) != intent.getIntExtra(CRUMB, 0)) {
+            navigateUpTo(intent);
+            return;
+        }
         intent.putExtra(ORIENTATION, getIntent().getIntExtra(ORIENTATION, 0));
         setIntent(intent);
         String key = intent.getStringExtra(KEY);
@@ -66,7 +71,7 @@ public class SceneActivity extends ReactActivity implements DefaultHardwareBackB
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        if (scene.getParent() != null && scene.getParent() == rootView)
+        if (scene != null && scene.getParent() != null && scene.getParent() == rootView)
             scene.popped();
     }
 

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -24,7 +24,6 @@ public class SceneActivity extends ReactActivity implements DefaultHardwareBackB
     public static final String KEY = "Navigation.KEY";
     public static final String CRUMB = "Navigation.CRUMB";
     public static final String SHARED_ELEMENTS = "Navigation.SHARED_ELEMENTS";
-    public static final String ORIENTATION = "Navigation.ORIENTATION";
     private SceneRootViewGroup rootView;
     public SceneView scene;
 

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -62,7 +62,7 @@ public class SceneActivity extends ReactActivity implements DefaultHardwareBackB
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        if (scene != null && scene.getParent() != null && scene.getParent() == rootView)
+        if (scene != null)
             scene.popped();
     }
 

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -147,24 +147,4 @@ public class SceneActivity extends ReactActivity implements DefaultHardwareBackB
             return reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
         }
     }
-
-    public static class Crumb0 extends SceneActivity {} public static class Crumb1 extends SceneActivity {}
-    public static class Crumb2 extends SceneActivity {} public static class Crumb3 extends SceneActivity {}
-    public static class Crumb4 extends SceneActivity {} public static class Crumb5 extends SceneActivity {}
-    public static class Crumb6 extends SceneActivity {} public static class Crumb7 extends SceneActivity {}
-    public static class Crumb8 extends SceneActivity {} public static class Crumb9 extends SceneActivity {}
-    public static class Crumb10 extends SceneActivity {} public static class Crumb11 extends SceneActivity {}
-    public static class Crumb12 extends SceneActivity {} public static class Crumb13 extends SceneActivity {}
-    public static class Crumb14 extends SceneActivity {} public static class Crumb15 extends SceneActivity {}
-    public static class Crumb16 extends SceneActivity {} public static class Crumb17 extends SceneActivity {}
-    public static class Crumb18 extends SceneActivity {} public static class Crumb19 extends SceneActivity {}
-    public static class Crumb20 extends SceneActivity {}
-
-    public static Class getActivity(int crumb) {
-        try {
-            return Class.forName("com.navigation.reactnative.SceneActivity$Crumb" + crumb);
-        } catch (ClassNotFoundException e) {
-            return SceneActivity.class;
-        }
-    }
 }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -22,7 +22,6 @@ import java.util.HashSet;
 
 public class SceneActivity extends ReactActivity implements DefaultHardwareBackBtnHandler {
     public static final String KEY = "Navigation.KEY";
-    public static final String CRUMB = "Navigation.CRUMB";
     public static final String SHARED_ELEMENTS = "Navigation.SHARED_ELEMENTS";
     private SceneRootViewGroup rootView;
     public SceneView scene;
@@ -50,7 +49,7 @@ public class SceneActivity extends ReactActivity implements DefaultHardwareBackB
     @Override
     public void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
-        if (getIntent().getIntExtra(CRUMB, 0) != intent.getIntExtra(CRUMB, 0))
+        if (!getIntent().getStringExtra(KEY).equals(intent.getStringExtra(KEY)))
             navigateUpTo(intent);
     }
 


### PR DESCRIPTION
Navigate A → B -- C with A, B and C having the same Activity class. Then `navigateUpTo` passing A’s Intent will return to Activity B not A. That’s because Android goes back to most recent Activity with the same class. This stopped shared elements working. Navigate A → B → C → D with shared element animation when going from A to B. Then navigate back 2 to B. This will use Activity from C. Then when call `finishAfterTransition` to get shared element to run it actually goes back to B instead of A. The workaround was to create different Activity classes for each scene so that going back 2 from D will end up back at Activity B. But can’t create unlimited number of Activity classes so settled on 20 and had to avoid calling `finishAfterTransition` after scene 20. This put an artificial stack size limit on running the return leg of a shared element transition.

Look again at navigating A → B -- C with A, B and C having the same Activity class. When call `navigateUpTo` passing A’s Intent need this to finish Activity B and go to Activity A. Added `onNewIntent` to B that checks whether the new Intent matches its current Intent (by comparing scene keys) and if not it calls `navigateUpTo` with the new Intent. This finishes B and displays Activity A. The `navigateUpTo` passes the Intent back through the Activity stack until it reaches its original destination!

Now can guarantee that latest X Activities are destroyed when navigating back X, don’t need the `PopSync` workaround described in #282. Used to unmount scenes with same pop times but now each scene sends its own pop event.
