### PR TITLE
Prevented unmount of an unpopped scene when orientation changed on Android

### DIFF
--- a/NavigationReactNative/src/PopSync.tsx
+++ b/NavigationReactNative/src/PopSync.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Platform } from 'react-native';
 type PopSyncProps<T> = {data: T[], getKey: any, children: (items: {key: string, data: T}[], popNative: (key: string) => void) => React.ReactElement<any>[]};
 
 class PopSync<T> extends React.Component<PopSyncProps<T>, any> {
@@ -16,7 +17,7 @@ class PopSync<T> extends React.Component<PopSyncProps<T>, any> {
         var items = prevItems
             .map(item => {
                 var matchedItem = dataByKey[item.key];
-                var nextItem: any = {key: item.key, data: matchedItem || item.data};
+                var nextItem: any = {key: item.key, data: matchedItem || item.data, reactPop: !matchedItem};
                 nextItem.index = !matchedItem ? item.index : matchedItem.index;
                 return nextItem;
             })
@@ -24,7 +25,7 @@ class PopSync<T> extends React.Component<PopSyncProps<T>, any> {
                 .filter(item => !itemsByKey[getKey(item)])
                 .map(item => {
                     var index = dataByKey[getKey(item)].index;
-                    return {key: getKey(item), data: item, index};
+                    return {key: getKey(item), data: item, index, reactPop: false};
                 })
             )
             .sort((a, b) => a.index !== b.index ? a.index - b.index : a.key.length - b.key.length);
@@ -32,6 +33,9 @@ class PopSync<T> extends React.Component<PopSyncProps<T>, any> {
     }
     popNative(key: string) {
         this.setState(({items: prevItems}) => {
+            var poppedItem = prevItems.filter(item => item.key === key)[0];
+            if (Platform.OS === 'android' && !poppedItem.reactPop)
+                return null;
             var items = prevItems.filter(item => item.key !== key);
             return {items};            
         });


### PR DESCRIPTION
On Android, when the orientation changes, for example, then the Activity is destroyed and recreated. Destroying the Activity raised the `onPopped` event which unmounted the scene so the screen went blank. Only want a destroy to unmount if the scene has been popped.

On Android, pops are always triggered from React first and then on Native. So marked popped items in PopSync and only unmounted them if they've been marked. Orientation change won't unmount because the scene hasn't been popped from React. 

On iOS, the pop can happen on Native first and then in React. So, in the case of clicking a tab and popping multiple scenes at once, need to unmount even though they haven't been popped in React. So wrapped the code in an 'android'  platform check