### PR TITLE
Fix a bug when another library push fragments in the middle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules
 .DS_Store
 .project
 org.eclipse.buildship.core.prefs
+.classpath

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ node_modules
 !Navigation*/src/node_modules
 !Navigation*/test/node_modules
 .DS_Store
-
+.project
+org.eclipse.buildship.core.prefs

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,3 @@ node_modules
 !Navigation*/src/node_modules
 !Navigation*/test/node_modules
 .DS_Store
-.project
-org.eclipse.buildship.core.prefs
-.classpath

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/FragmentNavigator.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/FragmentNavigator.java
@@ -17,10 +17,24 @@ import java.util.Map;
 
 class FragmentNavigator extends SceneNavigator {
 
+    private SceneFragment getLastSceneFragment(FragmentManager fragmentManager){
+        int from = fragmentManager.getFragments().size() - 1;
+
+        for (int i = from; i >= 0; i--) {
+            Fragment current = fragmentManager.getFragments().get(i);
+
+            if (current instanceof  SceneFragment) {
+                return (SceneFragment) current;
+            }
+        }
+
+        return null;
+    }
+
     @Override
     void navigateBack(int currentCrumb, int crumb, Activity activity, NavigationStackView stack) {
         FragmentManager fragmentManager = getFragmentManager(stack, activity);;
-        SceneFragment fragment = (SceneFragment) fragmentManager.getFragments().get(fragmentManager.getFragments().size() - 1);
+        SceneFragment fragment = getLastSceneFragment(fragmentManager);
         Pair[] sharedElements = getOldSharedElements(currentCrumb, crumb, fragment, stack);
         SceneFragment prevFragment = (SceneFragment) fragmentManager.findFragmentByTag(stack.keys.getString(crumb));
         if (sharedElements != null && prevFragment != null && prevFragment.getScene() != null)

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/FragmentNavigator.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/FragmentNavigator.java
@@ -17,24 +17,10 @@ import java.util.Map;
 
 class FragmentNavigator extends SceneNavigator {
 
-    private SceneFragment getLastSceneFragment(FragmentManager fragmentManager){
-        int from = fragmentManager.getFragments().size() - 1;
-
-        for (int i = from; i >= 0; i--) {
-            Fragment current = fragmentManager.getFragments().get(i);
-
-            if (current instanceof  SceneFragment) {
-                return (SceneFragment) current;
-            }
-        }
-
-        return null;
-    }
-
     @Override
     void navigateBack(int currentCrumb, int crumb, Activity activity, NavigationStackView stack) {
         FragmentManager fragmentManager = getFragmentManager(stack, activity);;
-        SceneFragment fragment = getLastSceneFragment(fragmentManager);
+        SceneFragment fragment = (SceneFragment) fragmentManager.findFragmentByTag(oldKey);
         Pair[] sharedElements = getOldSharedElements(currentCrumb, crumb, fragment, stack);
         SceneFragment prevFragment = (SceneFragment) fragmentManager.findFragmentByTag(stack.keys.getString(crumb));
         if (sharedElements != null && prevFragment != null && prevFragment.getScene() != null)


### PR DESCRIPTION
For example, when using react-native-fast-image, it uses another fragment to load the images. so when getting the last fragment we get their instance which is another type from SceneFragment and we get an exception. 

This fix simply traverses from the end and finds the last SceneFragment.