### PR TITLE
Prevented postponing back navigation when no shared elements

### DIFF
--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -15,20 +15,18 @@ import java.util.HashSet;
 
 public class SceneFragment extends Fragment implements SharedElementContainer {
     private SceneView scene;
-    private HashSet<String> sharedElementNames;
 
     SceneFragment(SceneView scene, HashSet<String> sharedElements) {
         super();
         this.scene = scene;
         scene.fragment = this;
-        sharedElementNames = sharedElements;
+        if (sharedElements != null )
+            scene.transitioner = new SharedElementTransitioner(this, sharedElements);
     }
 
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        if (sharedElementNames != null )
-            scene.transitioner = new SharedElementTransitioner(this, sharedElementNames);
         if (scene.transitioner != null)
             postponeEnterTransition();
         return scene;


### PR DESCRIPTION
### Scenario
Change the zoom example so that clicking the 'X' calls ```navigate('grid')``` and set `trackCrumbTrail` to true on the 'grid' State. Then pick 'red' from grid, change to 'orange' on details, click the 'X' to go to new grid. Then press the android back button and the transition postpones incorrectly and doesn't run.
### Problem
The problem is that the `onCreateView` of the `SceneFragment` is called when navigating back. This creates the Shared Element Transitioner because the details scene had a shared element when first created. This postpones the navigation. It doesn't start again because the shared element when created is red but it only loads the color orange.
### Fix
Don't want to recreate the transitioner inside the `SceneFragment`. The `FragmentNavigator` does this if it detects the shared element needs to run. So moved the creation of the transitioner into the `SceneFragment` constructor so it only runs once.