### PR TITLE
Moved scene children out of NavigationStackView into Manager

### DIFF
--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -1,5 +1,8 @@
 package com.navigation.reactnative;
 
+import android.os.Build;
+import android.view.View;
+
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
@@ -59,6 +62,41 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
     @Override
     protected NavigationStackView createViewInstance(@Nonnull ThemedReactContext reactContext) {
         return new NavigationStackView(reactContext);
+    }
+
+    @Override
+    public void addView(NavigationStackView parent, View child, int index) {
+        if (child instanceof FragmentContainerView) {
+            parent.addView(child, index);
+            return;
+        }
+        SceneView scene = (SceneView) child;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+            scene.setElevation(getChildAt(parent, index - 1).getElevation() + 1);
+        parent.sceneKeys.add(index - 1, scene.sceneKey);
+        parent.scenes.put(scene.sceneKey, scene);
+    }
+
+    @Override
+    public void removeViewAt(NavigationStackView parent, int index) {
+        if (index == 0) {
+            parent.removeViewAt(index);
+            return;
+        }
+        String sceneKey = parent.sceneKeys.remove(index - 1);
+        parent.scenes.remove(sceneKey);
+    }
+
+    @Override
+    public int getChildCount(NavigationStackView parent) {
+        return parent.scenes.size() + 1;
+    }
+
+    @Override
+    public View getChildAt(NavigationStackView parent, int index) {
+        if (index == 0)
+            return parent.getChildAt(index);
+        return parent.scenes.get(parent.sceneKeys.get(index - 1));
     }
 
     @Override

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -3,8 +3,6 @@ package com.navigation.reactnative;
 import android.app.Activity;
 import android.content.Context;
 import android.net.Uri;
-import android.os.Build;
-import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.fragment.app.Fragment;
@@ -20,7 +18,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 
 public class NavigationStackView extends ViewGroup {
-    private ArrayList<String> sceneKeys = new ArrayList<>();
+    protected ArrayList<String> sceneKeys = new ArrayList<>();
     protected HashMap<String, SceneView> scenes = new HashMap<>();
     protected ReadableArray keys;
     private Activity mainActivity;
@@ -34,29 +32,6 @@ public class NavigationStackView extends ViewGroup {
 
     public NavigationStackView(Context context) {
         super(context);
-    }
-
-    @Override
-    public void addView(View child, int index) {
-        if (child instanceof FragmentContainerView) {
-            super.addView(child, index);
-            return;
-        }
-        SceneView scene = (SceneView) child;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            scene.setElevation(getChildAt(index - 1).getElevation() + 1);
-        sceneKeys.add(index - 1, scene.sceneKey);
-        scenes.put(scene.sceneKey, scene);
-    }
-
-    @Override
-    public void removeViewAt(int index) {
-        if (index == 0) {
-            super.removeViewAt(index);
-            return;
-        }
-        String sceneKey = sceneKeys.remove(index - 1);
-        scenes.remove(sceneKey);
     }
 
     protected void onAfterUpdateTransaction() {
@@ -91,18 +66,6 @@ public class NavigationStackView extends ViewGroup {
         }
         navigator.oldCrumb = keys.size() - 1;
         navigator.oldKey = keys.getString(navigator.oldCrumb);
-    }
-
-    @Override
-    public int getChildCount() {
-        return scenes.size() + 1;
-    }
-
-    @Override
-    public View getChildAt(int index) {
-        if (index == 0)
-            return super.getChildAt(index);
-        return scenes.get(sceneKeys.get(index - 1));
     }
 
     @Override


### PR DESCRIPTION
Finally worked out the difference between the View children and the Manager children. The View children should be View hierarchy and the Manger children should be the component hierarchy. So the scenes shouldn't be returned from the children of the NavigationStackView. Not directly anyway because they're actually children of the FragmentContainer. The scenes must be returned from the children of the NavigationStackManager so that React Native destroys them (clears them from its cache).
