### PR TITLE
Change IconResolver to use Fresco ImagePipeline directly

### DIFF
--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationBarView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationBarView.java
@@ -13,11 +13,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewOutlineProvider;
 
-import com.facebook.drawee.drawable.ScalingUtils;
-import com.facebook.drawee.generic.GenericDraweeHierarchy;
-import com.facebook.drawee.generic.GenericDraweeHierarchyBuilder;
-import com.facebook.drawee.view.DraweeHolder;
-import com.facebook.drawee.view.MultiDraweeHolder;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
@@ -43,13 +38,9 @@ public class NavigationBarView extends AppBarLayout {
     ViewOutlineProvider defaultOutlineProvider;
     Drawable defaultBackground;
     Drawable defaultOverflowIcon;
-    private final DraweeHolder logoHolder = DraweeHolder.create(createDraweeHierarchy(), getContext());
-    private final DraweeHolder navIconHolder = DraweeHolder.create(createDraweeHierarchy(), getContext());
-    private final DraweeHolder overflowIconHolder = DraweeHolder.create(createDraweeHierarchy(), getContext());
-    private IconResolver.IconControllerListener logoControllerListener;
-    private IconResolver.IconControllerListener navIconControllerListener;
-    private IconResolver.IconControllerListener overflowIconControllerListener;
-    private final MultiDraweeHolder<GenericDraweeHierarchy> actionsHolder = new MultiDraweeHolder<>();
+    private IconResolver.IconResolverListener logoControllerListener;
+    private IconResolver.IconResolverListener navIconControllerListener;
+    private IconResolver.IconResolverListener overflowIconControllerListener;
 
     public NavigationBarView(Context context) {
         super(context);
@@ -65,25 +56,25 @@ public class NavigationBarView extends AppBarLayout {
         defaultBackground = getBackground();
 
         iconResolver = new IconResolver(context);
-        logoControllerListener = new IconResolver.IconControllerListener(logoHolder) {
+        logoControllerListener = new IconResolver.IconResolverListener() {
             @Override
-            protected void setDrawable(Drawable d) {
+            public void setDrawable(Drawable d) {
                 toolbar.setLogo(d);
                 setTintColor(toolbar.getLogo());
                 post(measureAndLayout);
             }
         };
-        navIconControllerListener = new IconResolver.IconControllerListener(navIconHolder) {
+        navIconControllerListener = new IconResolver.IconResolverListener() {
             @Override
-            protected void setDrawable(Drawable d) {
+            public void setDrawable(Drawable d) {
                 toolbar.setNavigationIcon(d);
                 setTintColor(toolbar.getNavigationIcon());
                 post(measureAndLayout);
             }
         };
-        overflowIconControllerListener = new IconResolver.IconControllerListener(overflowIconHolder) {
+        overflowIconControllerListener = new IconResolver.IconResolverListener() {
             @Override
-            protected void setDrawable(Drawable d) {
+            public void setDrawable(Drawable d) {
                 toolbar.setOverflowIcon(d);
                 setTintColor(toolbar.getOverflowIcon());
             }
@@ -107,57 +98,19 @@ public class NavigationBarView extends AppBarLayout {
         });
     }
 
-    @Override
-    public void onDetachedFromWindow() {
-        super.onDetachedFromWindow();
-        detachDraweeHolders();
-    }
-
-    @Override
-    public void onStartTemporaryDetach() {
-        super.onStartTemporaryDetach();
-        detachDraweeHolders();
-    }
-
-    @Override
-    protected void onAttachedToWindow() {
-        super.onAttachedToWindow();
-        attachDraweeHolders();
-    }
-
-    @Override
-    public void onFinishTemporaryDetach() {
-        super.onFinishTemporaryDetach();
-        attachDraweeHolders();
-    }
-
     void setLogoSource(@Nullable ReadableMap source) {
-        iconResolver.setIconSource(source, logoControllerListener, logoHolder);
+        iconResolver.setIconSource(source, logoControllerListener);
     }
 
     void setNavIconSource(@Nullable ReadableMap source) {
-        iconResolver.setIconSource(source, navIconControllerListener, navIconHolder);
+        iconResolver.setIconSource(source, navIconControllerListener);
     }
 
     void setOverflowIconSource(@Nullable ReadableMap source) {
         if (source != null)
-            iconResolver.setIconSource(source, overflowIconControllerListener, overflowIconHolder);
+            iconResolver.setIconSource(source, overflowIconControllerListener);
         else
             toolbar.setOverflowIcon(defaultOverflowIcon);
-    }
-
-    private void detachDraweeHolders() {
-        logoHolder.onDetach();
-        navIconHolder.onDetach();
-        overflowIconHolder.onDetach();
-        actionsHolder.onDetach();
-    }
-
-    private void attachDraweeHolders() {
-        logoHolder.onAttach();
-        navIconHolder.onAttach();
-        overflowIconHolder.onAttach();
-        actionsHolder.onAttach();
     }
 
     void setTintColor(Integer tintColor) {
@@ -181,7 +134,6 @@ public class NavigationBarView extends AppBarLayout {
 
     void setMenuItems(@Nullable ReadableArray menuItems) {
         toolbar.getMenu().clear();
-        actionsHolder.clear();
         post(measureAndLayout);
         for (int i = 0; menuItems != null && i < menuItems.size(); i++) {
             ReadableMap menuItemProps = menuItems.getMap(i);
@@ -220,11 +172,8 @@ public class NavigationBarView extends AppBarLayout {
     }
 
     private void setMenuItemIcon(final MenuItem item, ReadableMap iconSource) {
-        DraweeHolder<GenericDraweeHierarchy> holder = DraweeHolder.create(createDraweeHierarchy(), getContext());
-        ActionIconControllerListener controllerListener = new ActionIconControllerListener(item, holder);
-        controllerListener.setIconImageInfo(iconResolver.getIconImageInfo(iconSource));
-        iconResolver.setIconSource(iconSource, controllerListener, holder);
-        actionsHolder.add(holder);
+        ActionIconControllerListener controllerListener = new ActionIconControllerListener(item);
+        iconResolver.setIconSource(iconSource, controllerListener);
     }
 
     void setOnSearchListener(OnSearchListener onSearchListener) {
@@ -232,13 +181,6 @@ public class NavigationBarView extends AppBarLayout {
         if (searchMenuItem != null)
             this.onSearchAddedListener.onSearchAdd(searchMenuItem);
 
-    }
-
-    private GenericDraweeHierarchy createDraweeHierarchy() {
-        return new GenericDraweeHierarchyBuilder(getContext().getResources())
-            .setActualImageScaleType(ScalingUtils.ScaleType.FIT_CENTER)
-            .setFadeDuration(0)
-            .build();
     }
 
     private final Runnable measureAndLayout = new Runnable() {
@@ -269,16 +211,15 @@ public class NavigationBarView extends AppBarLayout {
         return context.getResources().getIdentifier(name, "attr", context.getPackageName());
     }
 
-    class ActionIconControllerListener extends IconResolver.IconControllerListener {
+    class ActionIconControllerListener implements IconResolver.IconResolverListener {
         private final MenuItem item;
 
-        ActionIconControllerListener(MenuItem item, DraweeHolder holder) {
-            super(holder);
+        ActionIconControllerListener(MenuItem item) {
             this.item = item;
         }
 
         @Override
-        protected void setDrawable(Drawable d) {
+        public void setDrawable(Drawable d) {
             item.setIcon(d);
             setTintColor(item.getIcon());
             post(measureAndLayout);

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/TabBarItemView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/TabBarItemView.java
@@ -4,13 +4,10 @@ import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
-import com.facebook.drawee.drawable.ScalingUtils;
-import com.facebook.drawee.generic.GenericDraweeHierarchy;
-import com.facebook.drawee.generic.GenericDraweeHierarchyBuilder;
-import com.facebook.drawee.view.DraweeHolder;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
@@ -21,47 +18,23 @@ public class TabBarItemView extends ViewGroup implements NavigationBoundary {
     private Drawable icon;
     private OnIconListener onIconListener;
     private IconResolver iconResolver;
-    private final DraweeHolder tabIconHolder = DraweeHolder.create(createDraweeHierarchy(), getContext());
-    private IconResolver.IconControllerListener tabIconControllerListener;
+    private IconResolver.IconResolverListener tabIconControllerListener;
 
     public TabBarItemView(Context context) {
         super(context);
         iconResolver = new IconResolver(context);
-        tabIconControllerListener = new IconResolver.IconControllerListener(tabIconHolder) {
+        tabIconControllerListener = new IconResolver.IconResolverListener() {
             @Override
-            protected void setDrawable(Drawable d) {
+            public void setDrawable(Drawable d) {
                 icon = d;
                 if (onIconListener != null)
                     onIconListener.onIconResolve(icon);
             }
         };
     }
-    @Override
-    public void onDetachedFromWindow() {
-        super.onDetachedFromWindow();
-        tabIconHolder.onDetach();
-    }
-
-    @Override
-    public void onStartTemporaryDetach() {
-        super.onStartTemporaryDetach();
-        tabIconHolder.onDetach();
-    }
-
-    @Override
-    protected void onAttachedToWindow() {
-        super.onAttachedToWindow();
-        tabIconHolder.onAttach();
-    }
-
-    @Override
-    public void onFinishTemporaryDetach() {
-        super.onFinishTemporaryDetach();
-        tabIconHolder.onAttach();
-    }
 
     void setIconSource(@Nullable ReadableMap source) {
-        iconResolver.setIconSource(source, tabIconControllerListener, tabIconHolder);
+        iconResolver.setIconSource(source, tabIconControllerListener);
     }
 
     void setOnIconListener(OnIconListener onIconListener) {
@@ -69,13 +42,6 @@ public class TabBarItemView extends ViewGroup implements NavigationBoundary {
         if (icon!= null)
             this.onIconListener.onIconResolve(icon);
 
-    }
-
-    private GenericDraweeHierarchy createDraweeHierarchy() {
-        return new GenericDraweeHierarchyBuilder(getContext().getResources())
-            .setActualImageScaleType(ScalingUtils.ScaleType.FIT_CENTER)
-            .setFadeDuration(0)
-            .build();
     }
 
     protected void pressed() {


### PR DESCRIPTION
Allows for tinting icons in BottomNavigationView menus and TabLayout tabs 