### PR TITLE
fixed back button crash (#348)

### DIFF
--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -27,6 +27,8 @@ public class SceneFragment extends Fragment implements SharedElementContainer {
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        if (scene.getParent() != null)
+            ((ViewGroup) scene.getParent()).endViewTransition(scene);
         if (scene.transitioner != null)
             postponeEnterTransition();
         return scene;


### PR DESCRIPTION
Fixes one of the issues on #348

> java.lang.IllegalStateException The specified child already has a parent. You must call removeView() on the child's parent first.
