### PR TITLE
Made the Navigation Bar collapsible on Android

### DIFF
--- a/NavigationReactNative/sample/twitter/Home.js
+++ b/NavigationReactNative/sample/twitter/Home.js
@@ -1,15 +1,18 @@
 import React from 'react';
 import {Platform, StyleSheet, ScrollView} from 'react-native';
-import {NavigationBar} from 'navigation-react-native';
+import {NavigationBar, CoordinatorLayout} from 'navigation-react-native';
 import Tweets from './Tweets';
 
 export default ({tweets}) => (
-  <>
+  <CoordinatorLayout>
     <NavigationBar title="Home" barTintColor={Platform.OS === 'android' ? '#fff' : null} />
-    <ScrollView contentInsetAdjustmentBehavior="automatic" style={styles.view}>
+    <ScrollView
+      nestedScrollEnabled={true}
+      contentInsetAdjustmentBehavior="automatic"
+      style={styles.view}>
       <Tweets tweets={tweets} />
     </ScrollView>
-  </>
+  </CoordinatorLayout>
 );
 
 const styles = StyleSheet.create({

--- a/NavigationReactNative/sample/twitter/Timeline.js
+++ b/NavigationReactNative/sample/twitter/Timeline.js
@@ -1,28 +1,34 @@
 import React, {useContext} from 'react';
 import {StyleSheet, Text, Image, Platform, ScrollView, View} from 'react-native';
 import {NavigationContext} from 'navigation-react';
-import {NavigationBar} from 'navigation-react-native';
+import {NavigationBar, CoordinatorLayout, CollapsingBar} from 'navigation-react-native';
 import Tweets from './Tweets';
 
 export default ({timeline: {id, name, username, logo, bio, 
   followers, following, tweets}}) => {
   const {stateNavigator} = useContext(NavigationContext);
   return (
-    <>
+    <CoordinatorLayout>
       <NavigationBar
         title={name}
         navigationImage={require('./arrow.png')}
         barTintColor={Platform.OS === 'android' ? '#fff' : null}
         tintColor={Platform.OS === 'android' ? "deepskyblue" : null}
+        style={{height: 200}}
         onNavigationPress={() => {
           stateNavigator.navigateBack(1)
-        }} />
-      <ScrollView 
+        }}>
+        <CollapsingBar>
+          <View collapsable={false}>
+            <Image style={styles.logo} source={logo} />
+          </View>
+        </CollapsingBar>
+      </NavigationBar>
+      <ScrollView
+        nestedScrollEnabled={true}
         contentInsetAdjustmentBehavior="automatic"
         style={styles.view}>
         <View>
-          <Image style={styles.logo} source={logo} />
-          <Text style={styles.name}>{name}</Text>
           <Text>{username}</Text>
           <Text style={styles.bio}>{bio}</Text>
         </View>
@@ -34,7 +40,7 @@ export default ({timeline: {id, name, username, logo, bio,
         </View>
         <Tweets tweets={tweets} onTimeline={accountId => accountId !== id} />
       </ScrollView>
-    </>
+    </CoordinatorLayout>
   );
 };
 
@@ -45,11 +51,11 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   logo: {
-    width: 100,
-    height: 100,
-    marginTop: 20,
+    width: 75,
+    height: 75,
     borderRadius: 50,
-    marginRight: 12,
+    marginTop: 60,
+    marginLeft: 15,
   },
   name: {
     fontWeight: 'bold',

--- a/NavigationReactNative/sample/twitter/Timeline.js
+++ b/NavigationReactNative/sample/twitter/Timeline.js
@@ -12,16 +12,14 @@ export default ({timeline: {id, name, username, logo, bio,
       <NavigationBar
         title={name}
         navigationImage={require('./arrow.png')}
+        barTintColor={Platform.OS === 'android' ? "#008d4a" : null}
         tintColor={Platform.OS === 'android' ? "#fff" : null}
         titleColor={Platform.OS === 'android' ? "#fff" : null}
         style={{height: 120}}
         onNavigationPress={() => {
           stateNavigator.navigateBack(1)
         }}>
-        <CollapsingBar
-          titleEnabled={false}
-          contentScrimColor="#008d4a"
-          style={{backgroundColor: '#006c37'}} />
+        <CollapsingBar style={{backgroundColor: '#006c37'}} />
       </NavigationBar>
       <ScrollView
         nestedScrollEnabled={true}

--- a/NavigationReactNative/sample/twitter/Timeline.js
+++ b/NavigationReactNative/sample/twitter/Timeline.js
@@ -19,7 +19,9 @@ export default ({timeline: {id, name, username, logo, bio,
         onNavigationPress={() => {
           stateNavigator.navigateBack(1)
         }}>
-        <CollapsingBar style={{backgroundColor: '#006c37'}} />
+        <CollapsingBar>
+          <View  style={{backgroundColor: '#006c37'}} />
+        </CollapsingBar>
       </NavigationBar>
       <ScrollView
         nestedScrollEnabled={true}

--- a/NavigationReactNative/sample/twitter/Timeline.js
+++ b/NavigationReactNative/sample/twitter/Timeline.js
@@ -18,7 +18,7 @@ export default ({timeline: {id, name, username, logo, bio,
         onNavigationPress={() => {
           stateNavigator.navigateBack(1)
         }}>
-        <CollapsingBar style={{backgroundColor: '#006c37'}} />
+        <CollapsingBar titleEnabled={false} style={{backgroundColor: '#006c37'}} />
       </NavigationBar>
       <ScrollView
         nestedScrollEnabled={true}

--- a/NavigationReactNative/sample/twitter/Timeline.js
+++ b/NavigationReactNative/sample/twitter/Timeline.js
@@ -8,7 +8,7 @@ export default ({timeline: {id, name, username, logo, bio,
   followers, following, tweets}}) => {
   const {stateNavigator} = useContext(NavigationContext);
   return (
-    <CoordinatorLayout overlapTop={100}>
+    <CoordinatorLayout overlapTop={110}>
       <NavigationBar
         title={name}
         navigationImage={require('./arrow.png')}

--- a/NavigationReactNative/sample/twitter/Timeline.js
+++ b/NavigationReactNative/sample/twitter/Timeline.js
@@ -20,7 +20,7 @@ export default ({timeline: {id, name, username, logo, bio,
           stateNavigator.navigateBack(1)
         }}>
         <CollapsingBar>
-          <View  style={{backgroundColor: '#006c37'}} />
+          <View style={{backgroundColor: '#006c37'}} />
         </CollapsingBar>
       </NavigationBar>
       <ScrollView

--- a/NavigationReactNative/sample/twitter/Timeline.js
+++ b/NavigationReactNative/sample/twitter/Timeline.js
@@ -8,27 +8,25 @@ export default ({timeline: {id, name, username, logo, bio,
   followers, following, tweets}}) => {
   const {stateNavigator} = useContext(NavigationContext);
   return (
-    <CoordinatorLayout>
+    <CoordinatorLayout overlayTop={100}>
       <NavigationBar
         title={name}
         navigationImage={require('./arrow.png')}
-        barTintColor={Platform.OS === 'android' ? '#fff' : null}
-        tintColor={Platform.OS === 'android' ? "deepskyblue" : null}
-        style={{height: 200}}
+        tintColor={Platform.OS === 'android' ? "#fff" : null}
+        titleColor={Platform.OS === 'android' ? "#fff" : null}
+        style={{height: 120}}
         onNavigationPress={() => {
           stateNavigator.navigateBack(1)
         }}>
-        <CollapsingBar>
-          <View collapsable={false}>
-            <Image style={styles.logo} source={logo} />
-          </View>
-        </CollapsingBar>
+        <CollapsingBar style={{backgroundColor: '#006c37'}} />
       </NavigationBar>
       <ScrollView
         nestedScrollEnabled={true}
         contentInsetAdjustmentBehavior="automatic"
         style={styles.view}>
         <View>
+          <Image style={styles.logo} source={logo} />
+          <Text style={styles.name}>{name}</Text>
           <Text>{username}</Text>
           <Text style={styles.bio}>{bio}</Text>
         </View>
@@ -51,15 +49,15 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   logo: {
-    width: 75,
-    height: 75,
+    width: 80,
+    height: 80,
     borderRadius: 50,
-    marginTop: 60,
-    marginLeft: 15,
+    borderWidth: 4,
+    borderColor: 'white',
   },
   name: {
     fontWeight: 'bold',
-    fontSize: 18, 
+    fontSize: 24, 
     marginTop: 5,
     marginBottom: 2,
   },

--- a/NavigationReactNative/sample/twitter/Timeline.js
+++ b/NavigationReactNative/sample/twitter/Timeline.js
@@ -5,14 +5,14 @@ import {NavigationBar, CoordinatorLayout, CollapsingBar} from 'navigation-react-
 import Tweets from './Tweets';
 
 export default ({timeline: {id, name, username, logo, bio, 
-  followers, following, tweets}}) => {
+  colors, followers, following, tweets}}) => {
   const {stateNavigator} = useContext(NavigationContext);
   return (
     <CoordinatorLayout overlap={110}>
       <NavigationBar
         title={name}
         navigationImage={require('./arrow.png')}
-        barTintColor={Platform.OS === 'android' ? "#008d4a" : null}
+        barTintColor={Platform.OS === 'android' ? colors[0] : null}
         tintColor={Platform.OS === 'android' ? "#fff" : null}
         titleColor={Platform.OS === 'android' ? "#fff" : null}
         style={{height: 120}}
@@ -20,7 +20,7 @@ export default ({timeline: {id, name, username, logo, bio,
           stateNavigator.navigateBack(1)
         }}>
         <CollapsingBar>
-          <View style={{backgroundColor: '#006c37'}} />
+          <View style={{backgroundColor: colors[1]}} />
         </CollapsingBar>
       </NavigationBar>
       <ScrollView

--- a/NavigationReactNative/sample/twitter/Timeline.js
+++ b/NavigationReactNative/sample/twitter/Timeline.js
@@ -8,7 +8,7 @@ export default ({timeline: {id, name, username, logo, bio,
   followers, following, tweets}}) => {
   const {stateNavigator} = useContext(NavigationContext);
   return (
-    <CoordinatorLayout overlayTop={100}>
+    <CoordinatorLayout overlapTop={100}>
       <NavigationBar
         title={name}
         navigationImage={require('./arrow.png')}

--- a/NavigationReactNative/sample/twitter/Timeline.js
+++ b/NavigationReactNative/sample/twitter/Timeline.js
@@ -8,7 +8,7 @@ export default ({timeline: {id, name, username, logo, bio,
   followers, following, tweets}}) => {
   const {stateNavigator} = useContext(NavigationContext);
   return (
-    <CoordinatorLayout overlapTop={110}>
+    <CoordinatorLayout overlap={110}>
       <NavigationBar
         title={name}
         navigationImage={require('./arrow.png')}

--- a/NavigationReactNative/sample/twitter/Timeline.js
+++ b/NavigationReactNative/sample/twitter/Timeline.js
@@ -18,7 +18,10 @@ export default ({timeline: {id, name, username, logo, bio,
         onNavigationPress={() => {
           stateNavigator.navigateBack(1)
         }}>
-        <CollapsingBar titleEnabled={false} style={{backgroundColor: '#006c37'}} />
+        <CollapsingBar
+          titleEnabled={false}
+          contentScrimColor="#008d4a"
+          style={{backgroundColor: '#006c37'}} />
       </NavigationBar>
       <ScrollView
         nestedScrollEnabled={true}

--- a/NavigationReactNative/sample/twitter/Timeline.js
+++ b/NavigationReactNative/sample/twitter/Timeline.js
@@ -8,10 +8,14 @@ export default ({timeline: {id, name, username, logo, bio,
   colors, followers, following, tweets}}) => {
   const {stateNavigator} = useContext(NavigationContext);
   const [offset] = useState(new Animated.Value(0));
-  const diameter = offset.interpolate({
+  const width = offset.interpolate({
     inputRange:  [-64, 0],
     outputRange: [60, 80],
-  })
+  });
+  const marginLeft = offset.interpolate({
+    inputRange:  [-64, 0],
+    outputRange: [10, 0],
+  });
   return (
     <CoordinatorLayout overlap={110}>
       <NavigationBar
@@ -36,7 +40,7 @@ export default ({timeline: {id, name, username, logo, bio,
         <View>
           <Animated.Image
             source={logo}
-            style={[styles.logo, {width: diameter, height: diameter}]} />
+            style={[styles.logo, {width, height: width, marginLeft}]} />
           <Text style={styles.name}>{name}</Text>
           <Text>{username}</Text>
           <Text style={styles.bio}>{bio}</Text>

--- a/NavigationReactNative/sample/twitter/Timeline.js
+++ b/NavigationReactNative/sample/twitter/Timeline.js
@@ -8,13 +8,9 @@ export default ({timeline: {id, name, username, logo, bio,
   colors, followers, following, tweets}}) => {
   const {stateNavigator} = useContext(NavigationContext);
   const [offset] = useState(new Animated.Value(0));
-  const width = offset.interpolate({
+  const scale = offset.interpolate({
     inputRange:  [-64, 0],
-    outputRange: [60, 80],
-  });
-  const marginLeft = offset.interpolate({
-    inputRange:  [-64, 0],
-    outputRange: [10, 0],
+    outputRange: [.8, 1],
   });
   return (
     <CoordinatorLayout overlap={110}>
@@ -40,7 +36,7 @@ export default ({timeline: {id, name, username, logo, bio,
         <View>
           <Animated.Image
             source={logo}
-            style={[styles.logo, {width, height: width, marginLeft}]} />
+            style={[styles.logo, {transform: [{scale}]}]} />
           <Text style={styles.name}>{name}</Text>
           <Text>{username}</Text>
           <Text style={styles.bio}>{bio}</Text>
@@ -64,6 +60,8 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   logo: {
+    width: 80,
+    height: 80,
     borderRadius: 50,
     borderWidth: 4,
     borderColor: 'white',

--- a/NavigationReactNative/sample/twitter/Timeline.js
+++ b/NavigationReactNative/sample/twitter/Timeline.js
@@ -1,5 +1,5 @@
-import React, {useContext} from 'react';
-import {StyleSheet, Text, Image, Platform, ScrollView, View} from 'react-native';
+import React, {useContext, useState} from 'react';
+import {StyleSheet, Text, Image, Platform, ScrollView, View, Animated} from 'react-native';
 import {NavigationContext} from 'navigation-react';
 import {NavigationBar, CoordinatorLayout, CollapsingBar} from 'navigation-react-native';
 import Tweets from './Tweets';
@@ -7,10 +7,16 @@ import Tweets from './Tweets';
 export default ({timeline: {id, name, username, logo, bio, 
   colors, followers, following, tweets}}) => {
   const {stateNavigator} = useContext(NavigationContext);
+  const [offset] = useState(new Animated.Value(0));
+  const diameter = offset.interpolate({
+    inputRange:  [-64, 0],
+    outputRange: [60, 80],
+  })
   return (
     <CoordinatorLayout overlap={110}>
       <NavigationBar
         title={name}
+        onOffsetChanged={Animated.event([{nativeEvent:{offset}}])}
         navigationImage={require('./arrow.png')}
         barTintColor={Platform.OS === 'android' ? colors[0] : null}
         tintColor={Platform.OS === 'android' ? "#fff" : null}
@@ -28,7 +34,9 @@ export default ({timeline: {id, name, username, logo, bio,
         contentInsetAdjustmentBehavior="automatic"
         style={styles.view}>
         <View>
-          <Image style={styles.logo} source={logo} />
+          <Animated.Image
+            source={logo}
+            style={[styles.logo, {width: diameter, height: diameter}]} />
           <Text style={styles.name}>{name}</Text>
           <Text>{username}</Text>
           <Text style={styles.bio}>{bio}</Text>
@@ -52,8 +60,6 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   logo: {
-    width: 80,
-    height: 80,
     borderRadius: 50,
     borderWidth: 4,
     borderColor: 'white',

--- a/NavigationReactNative/sample/twitter/Timeline.js
+++ b/NavigationReactNative/sample/twitter/Timeline.js
@@ -1,5 +1,5 @@
 import React, {useContext, useState} from 'react';
-import {StyleSheet, Text, Image, Platform, ScrollView, View, Animated} from 'react-native';
+import {StyleSheet, Text, Platform, ScrollView, View, Animated} from 'react-native';
 import {NavigationContext} from 'navigation-react';
 import {NavigationBar, CoordinatorLayout, CollapsingBar} from 'navigation-react-native';
 import Tweets from './Tweets';

--- a/NavigationReactNative/sample/twitter/Timeline.js
+++ b/NavigationReactNative/sample/twitter/Timeline.js
@@ -60,8 +60,8 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   logo: {
-    width: 80,
-    height: 80,
+    width: 85,
+    height: 85,
     borderRadius: 50,
     borderWidth: 4,
     borderColor: 'white',

--- a/NavigationReactNative/sample/twitter/Timeline.js
+++ b/NavigationReactNative/sample/twitter/Timeline.js
@@ -26,7 +26,7 @@ export default ({timeline: {id, name, username, logo, bio,
           stateNavigator.navigateBack(1)
         }}>
         <CollapsingBar>
-          <View style={{backgroundColor: colors[1]}} />
+          <View style={{backgroundColor: colors[1], flex: 1}} />
         </CollapsingBar>
       </NavigationBar>
       <ScrollView

--- a/NavigationReactNative/sample/twitter/data.js
+++ b/NavigationReactNative/sample/twitter/data.js
@@ -4,7 +4,7 @@ const accounts = {
     username: '@iam_preethi',
     logo: require('./iam_preethi.jpeg'),
     bio: 'Software Engineer @coinbase. Previously @a16z & @GoldmanSachs. Besides doing nerdy things, I love running & reading. I believe in the magic of thinking big :)',
-    colors: ['#008d4a', '#006c37'],
+    colors: ['#3b00d9', '#009df7'],
     following: 763,
     followers: 6722,
     tweets: [1, 2, 5, 3, 4, 10]

--- a/NavigationReactNative/sample/twitter/data.js
+++ b/NavigationReactNative/sample/twitter/data.js
@@ -137,7 +137,7 @@ const fetchTweet = id => ({
 });
 
 const getHome = () => {
-  const homeTweets = [1, 5, 9, 2, 6, 10];
+  const homeTweets = [1, 5, 9, 2, 6, 10, 3, 7, 11];
   return homeTweets.map(id => fetchTweet(id));
 };
 

--- a/NavigationReactNative/sample/twitter/data.js
+++ b/NavigationReactNative/sample/twitter/data.js
@@ -6,7 +6,7 @@ const accounts = {
     bio: 'Software Engineer @coinbase. Previously @a16z & @GoldmanSachs. Besides doing nerdy things, I love running & reading. I believe in the magic of thinking big :)',
     following: 763,
     followers: 6722,
-    tweets: [1, 2, 5, 3, 4]
+    tweets: [1, 2, 5, 3, 4, 10]
   },
   2: {
     name: 'Sebastian Markbåge',
@@ -15,7 +15,7 @@ const accounts = {
     bio: 'React JS · TC39 · The Facebook · Tweets are personal',
     following: 354,
     followers: 14319,
-    tweets: [5, 6, 9, 7, 8]
+    tweets: [5, 6, 9, 7, 8, 2]
   },
   3: {
     name: 'Dan Abramov',
@@ -24,7 +24,7 @@ const accounts = {
     bio: 'Co-authored Redux, Create React App, React Hot Loader, React DnD. Helping improve @reactjs. Personal opinions. #juniordevforlife',
     following: 1576,
     followers: 52822,
-    tweets: [9, 10, 1, 11, 12]
+    tweets: [9, 10, 1, 11, 12, 6]
   }
 };
 

--- a/NavigationReactNative/sample/twitter/data.js
+++ b/NavigationReactNative/sample/twitter/data.js
@@ -4,6 +4,7 @@ const accounts = {
     username: '@iam_preethi',
     logo: require('./iam_preethi.jpeg'),
     bio: 'Software Engineer @coinbase. Previously @a16z & @GoldmanSachs. Besides doing nerdy things, I love running & reading. I believe in the magic of thinking big :)',
+    colors: ['#008d4a', '#006c37'],
     following: 763,
     followers: 6722,
     tweets: [1, 2, 5, 3, 4, 10]
@@ -13,6 +14,7 @@ const accounts = {
     username: '@sebmarkbage',
     logo: require('./sebmarkbage.jpg'),
     bio: 'React JS · TC39 · The Facebook · Tweets are personal',
+    colors: ['#008d4a', '#006c37'],
     following: 354,
     followers: 14319,
     tweets: [5, 6, 9, 7, 8, 2]
@@ -22,6 +24,7 @@ const accounts = {
     username: '@dan_abramov',
     logo: require('./dan_abramov.jpeg'),
     bio: 'Co-authored Redux, Create React App, React Hot Loader, React DnD. Helping improve @reactjs. Personal opinions. #juniordevforlife',
+    colors: ['#008d4a', '#006c37'],
     following: 1576,
     followers: 52822,
     tweets: [9, 10, 1, 11, 12, 6]

--- a/NavigationReactNative/sample/twitter/data.js
+++ b/NavigationReactNative/sample/twitter/data.js
@@ -24,7 +24,7 @@ const accounts = {
     username: '@dan_abramov',
     logo: require('./dan_abramov.jpeg'),
     bio: 'Co-authored Redux, Create React App, React Hot Loader, React DnD. Helping improve @reactjs. Personal opinions. #juniordevforlife',
-    colors: ['#008d4a', '#006c37'],
+    colors: ['#9e6144', '#ff80a4'],
     following: 1576,
     followers: 52822,
     tweets: [9, 10, 1, 11, 12, 6]

--- a/NavigationReactNative/sample/zoom/Grid.js
+++ b/NavigationReactNative/sample/zoom/Grid.js
@@ -52,7 +52,7 @@ export default class Grid extends React.Component {
     const {colors} = this.props;
     return (
       <CoordinatorLayout>
-        <NavigationBar height={200} title="Colors" scrollFlags={['scroll', 'exitUntilCollapsed']}>
+        <NavigationBar height={200} title="Colors">
           <CollapsingBar>
           </CollapsingBar>
         </NavigationBar>

--- a/NavigationReactNative/sample/zoom/Grid.js
+++ b/NavigationReactNative/sample/zoom/Grid.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Platform, StyleSheet, ScrollView, View, TouchableHighlight} from 'react-native';
 import {NavigationContext} from 'navigation-react';
-import {SharedElement, NavigationBar, CoordinatorLayout, CollapsingBar, SearchBar, RightBar, BarButton} from 'navigation-react-native';
+import {SharedElement, NavigationBar, SearchBar, RightBar, BarButton} from 'navigation-react-native';
 
 const Colors = ({colors, children, filter}) => {
   const suffix = filter != null ? '_search' : '';
@@ -13,7 +13,6 @@ const Colors = ({colors, children, filter}) => {
       {({stateNavigator}) => (
         <ScrollView
           style={styles.scene}
-          nestedScrollEnabled={true}
           contentInsetAdjustmentBehavior="automatic">
           <View style={styles.colors}>
             {matchedColors.map(color => (
@@ -50,14 +49,29 @@ export default class Grid extends React.Component {
   }
   render() {
     const {colors} = this.props;
+    const {text} = this.state;
     return (
-      <CoordinatorLayout>
-        <NavigationBar height={200} title="Colors">
-          <CollapsingBar>
-          </CollapsingBar>
+      <Container
+        style={styles.scene}
+        collapsable={false}
+        contentInsetAdjustmentBehavior="automatic">
+        <NavigationBar
+          largeTitle={true}
+          title="Colors"
+          barTintColor={Platform.OS === 'android' ? '#fff' : null}>
+          <SearchBar
+            text={text}
+            autoCapitalize="none"
+            obscureBackground={false}
+            onChangeText={text => this.setState({text})}>
+            <Colors colors={colors} filter={text} />
+          </SearchBar>
+          <RightBar>
+            <BarButton title="search" show="always" search={true} />
+          </RightBar>
         </NavigationBar>
         <Colors colors={colors} />
-      </CoordinatorLayout>
+      </Container>
     );
   }
 }

--- a/NavigationReactNative/src/CollapsingBar.ts
+++ b/NavigationReactNative/src/CollapsingBar.ts
@@ -1,3 +1,0 @@
-import { requireNativeComponent, Platform } from 'react-native';
-
-export default Platform.OS === "android" ? requireNativeComponent<any>('NVCollapsingBar', null) : () => null;

--- a/NavigationReactNative/src/CollapsingBar.tsx
+++ b/NavigationReactNative/src/CollapsingBar.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { requireNativeComponent, Platform } from 'react-native';
 
-var CollapsingBar: any = ({largeTitle = false, barTintColor, style = {}, ...props}) => (
+var CollapsingBar: any = ({largeTitle = false, barTintColor, titleColor, largeTitleColor, style = {}, ...props}) => (
     <NVCollapsingBar
         titleEnabled={largeTitle}
         contentScrimColor={barTintColor}
+        collapsedTitleColor={titleColor}
+        expandedTitleColor={largeTitleColor}
         style={{backgroundColor: style.backgroundColor}}
         {...props} />
 )

--- a/NavigationReactNative/src/CollapsingBar.tsx
+++ b/NavigationReactNative/src/CollapsingBar.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { requireNativeComponent, Platform } from 'react-native';
 
-var CollapsingBar: any = ({largeTitle = false, barTintColor, titleColor, largeTitleColor, style = {}, ...props}) => (
+var CollapsingBar: any = ({largeTitle = false, barTintColor, titleColor, largeTitleColor, ...props}) => (
     <NVCollapsingBar
         titleEnabled={largeTitle}
         contentScrimColor={barTintColor}
         collapsedTitleColor={titleColor}
         expandedTitleColor={largeTitleColor}
-        style={{backgroundColor: style.backgroundColor}}
         {...props} />
 )
 

--- a/NavigationReactNative/src/CollapsingBar.tsx
+++ b/NavigationReactNative/src/CollapsingBar.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { requireNativeComponent, Platform } from 'react-native';
 
-var CollapsingBar: any = ({titleEnabled = true, style = {}, ...props}) => (
+var CollapsingBar: any = ({largeTitle = false, barTintColor, style = {}, ...props}) => (
     <NVCollapsingBar
-        titleEnabled={titleEnabled}
+        titleEnabled={largeTitle}
+        contentScrimColor={barTintColor}
         style={{backgroundColor: style.backgroundColor}}
         {...props} />
 )

--- a/NavigationReactNative/src/CollapsingBar.tsx
+++ b/NavigationReactNative/src/CollapsingBar.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { requireNativeComponent, Platform } from 'react-native';
+
+var CollapsingBar: any = ({titleEnabled = true, style = {}, ...props}) => (
+    <NVCollapsingBar
+        titleEnabled={titleEnabled}
+        style={{backgroundColor: style.backgroundColor}}
+        {...props} />
+)
+
+var NVCollapsingBar = requireNativeComponent<any>('NVCollapsingBar', null);
+
+export default Platform.OS === "android" ? CollapsingBar : () => null;

--- a/NavigationReactNative/src/CollapsingBar.tsx
+++ b/NavigationReactNative/src/CollapsingBar.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { requireNativeComponent, Platform } from 'react-native';
 
-var CollapsingBar: any = ({largeTitle = false, barTintColor, titleColor, largeTitleColor, ...props}) => (
+var CollapsingBar: any = ({largeTitle = false, barTintColor, titleColor, style, ...props}) => (
     <NVCollapsingBar
         titleEnabled={largeTitle}
         contentScrimColor={barTintColor}
         collapsedTitleColor={titleColor}
-        expandedTitleColor={largeTitleColor}
+        expandedTitleColor={titleColor}
         {...props} />
 )
 

--- a/NavigationReactNative/src/CoordinatorLayout.tsx
+++ b/NavigationReactNative/src/CoordinatorLayout.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
 import { requireNativeComponent, Platform } from 'react-native';
 
-const CoordinatorLayout = ({children}) => (
-    <NVCoordinatorLayout style={{flex: 1}}>{children}</NVCoordinatorLayout>
-);
+const CoordinatorLayout = (props) => <NVCoordinatorLayout {...props} style={{flex: 1}} />;
 
 const NVCoordinatorLayout = requireNativeComponent<any>('NVCoordinatorLayout', null)
 

--- a/NavigationReactNative/src/CoordinatorLayout.tsx
+++ b/NavigationReactNative/src/CoordinatorLayout.tsx
@@ -1,8 +1,26 @@
 import React from 'react'
 import { requireNativeComponent, Platform } from 'react-native';
+import NavigationBar from './NavigationBar';
+import SearchBar from './SearchBar';
 
-const CoordinatorLayout = (props) => <NVCoordinatorLayout {...props} style={{flex: 1}} />;
-
+const CoordinatorLayout = ({overlap, children}) => {
+    var {clonedChildren, searchBar} = React.Children.toArray(children)
+        .reduce((val, child: any) => {
+            if (child.type === NavigationBar) {
+                var barChildren = React.Children.toArray(child.props.children);
+                val.searchBar = barChildren.find(({type}: any) => type === SearchBar);
+                child = React.cloneElement(child, child.props, barChildren.filter(c => c !== val.searchBar))
+            }
+            val.clonedChildren.push(child);
+            return val;
+        }, {clonedChildren: [], searchBar: null});
+    return (
+        <>
+            <NVCoordinatorLayout overlap={overlap} style={{flex: 1}}>{clonedChildren}</NVCoordinatorLayout>
+            {searchBar}
+        </>
+    );
+};
 const NVCoordinatorLayout = requireNativeComponent<any>('NVCoordinatorLayout', null)
 
 export default Platform.OS === 'android' ? CoordinatorLayout : ({children}) => children;

--- a/NavigationReactNative/src/NavigationBar.tsx
+++ b/NavigationReactNative/src/NavigationBar.tsx
@@ -6,7 +6,7 @@ import SearchBar from './SearchBar';
 import TitleBar from './TitleBar';
 import CollapsingBar from './CollapsingBar';
 
-var NavigationBar = ({hidden, logo, navigationImage, overflowImage, height, children, style, ...otherProps}) => {
+var NavigationBar: any = ({hidden, logo, navigationImage, overflowImage, children, style = {}, ...otherProps}) => {
     if (Platform.OS === 'android' && hidden)
         return null
     var constants = (UIManager as any).getViewManagerConfig('NVNavigationBar').Constants;
@@ -26,7 +26,7 @@ var NavigationBar = ({hidden, logo, navigationImage, overflowImage, height, chil
     var collapsingBar = childrenArray.find(({type}) => type === CollapsingBar);
     return (
         <>
-            <NVNavigationBar hidden={hidden} style={{height}} {...otherProps}>
+            <NVNavigationBar hidden={hidden} style={{height: style.height}} {...otherProps}>
                 {Platform.OS === 'ios' ? children :
                     <Container collapse={!!collapsingBar} {...otherProps}>
                         {collapsingBar && collapsingBar.props.children}

--- a/NavigationReactNative/src/NavigationBar.tsx
+++ b/NavigationReactNative/src/NavigationBar.tsx
@@ -28,7 +28,7 @@ var NavigationBar = ({hidden, logo, navigationImage, overflowImage, height, chil
         <>
             <NVNavigationBar hidden={hidden} style={{height}} {...otherProps}>
                 {Platform.OS === 'ios' ? children :
-                    <Container collapse={!!collapsingBar} title={otherProps.title}>
+                    <Container collapse={!!collapsingBar} {...otherProps}>
                         {collapsingBar && collapsingBar.props.children}
                         <NVToolbar
                             menuItems={menuItems}
@@ -51,8 +51,9 @@ var NavigationBar = ({hidden, logo, navigationImage, overflowImage, height, chil
     )
 }
 
-var Container = ({collapse, ...props}) => (
-    !collapse ? props.children : <CollapsingBar {...props} />
+var Container = ({collapse, title, barTintColor, children}) => (
+    !collapse ? children : 
+        <CollapsingBar title={title} barTintColor={barTintColor}>{children}</CollapsingBar>
 )
 
 var NVNavigationBar = requireNativeComponent<any>('NVNavigationBar', null);

--- a/NavigationReactNative/src/NavigationBar.tsx
+++ b/NavigationReactNative/src/NavigationBar.tsx
@@ -6,7 +6,7 @@ import SearchBar from './SearchBar';
 import TitleBar from './TitleBar';
 import CollapsingBar from './CollapsingBar';
 
-var NavigationBar = ({hidden, logo, navigationImage, overflowImage, height = 56, scrollFlags = [], children, style, ...otherProps}) => {
+var NavigationBar = ({hidden, logo, navigationImage, overflowImage, height = 56, children, style, ...otherProps}) => {
     if (Platform.OS === 'android' && hidden)
         return null
     var constants = (UIManager as any).getViewManagerConfig('NVNavigationBar').Constants;
@@ -23,21 +23,18 @@ var NavigationBar = ({hidden, logo, navigationImage, overflowImage, height = 56,
                 })
             ))
         ), []);
-    var flags = (typeof scrollFlags === 'string' ? [scrollFlags] : scrollFlags)
-        .reduce((flags, flag) => flags | constants.ScrollFlag[flag], 0);
     var collapsingBar = childrenArray.find(({type}) => type === CollapsingBar);
     return (
         <>
             <NVNavigationBar hidden={hidden} style={{height}} {...otherProps}>
                 {Platform.OS === 'ios' ? children :
-                    <Container collapse={!!collapsingBar} scrollFlags={flags} title={otherProps.title}>
+                    <Container collapse={!!collapsingBar} title={otherProps.title}>
                         {collapsingBar && collapsingBar.props.children}
                         <NVToolbar
                             menuItems={menuItems}
                             logo={Image.resolveAssetSource(logo)}
                             navigationImage={Image.resolveAssetSource(navigationImage)}
                             overflowImage={Image.resolveAssetSource(overflowImage)}
-                            scrollFlags={flags}
                             {...otherProps}
                             style={{height: 56}}
                             onActionSelected={({nativeEvent}) => {

--- a/NavigationReactNative/src/NavigationBar.tsx
+++ b/NavigationReactNative/src/NavigationBar.tsx
@@ -51,7 +51,7 @@ var NavigationBar = ({hidden, logo, navigationImage, overflowImage, height, chil
     )
 }
 
-var Container = ({collapse, title, barTintColor, children}) => (
+var Container: any = ({collapse, title, barTintColor, children}) => (
     !collapse ? children : 
         <CollapsingBar title={title} barTintColor={barTintColor}>{children}</CollapsingBar>
 )

--- a/NavigationReactNative/src/NavigationBar.tsx
+++ b/NavigationReactNative/src/NavigationBar.tsx
@@ -6,7 +6,7 @@ import SearchBar from './SearchBar';
 import TitleBar from './TitleBar';
 import CollapsingBar from './CollapsingBar';
 
-var NavigationBar = ({hidden, logo, navigationImage, overflowImage, height = 56, children, style, ...otherProps}) => {
+var NavigationBar = ({hidden, logo, navigationImage, overflowImage, height, children, style, ...otherProps}) => {
     if (Platform.OS === 'android' && hidden)
         return null
     var constants = (UIManager as any).getViewManagerConfig('NVNavigationBar').Constants;

--- a/NavigationReactNative/src/NavigationBar.tsx
+++ b/NavigationReactNative/src/NavigationBar.tsx
@@ -24,11 +24,15 @@ var NavigationBar: any = ({hidden, logo, navigationImage, overflowImage, childre
             ))
         ), []);
     var collapsingBar = childrenArray.find(({type}) => type === CollapsingBar);
+    var collapsingStyle = collapsingBar && collapsingBar.props.style;
     return (
         <>
             <NVNavigationBar hidden={hidden} style={{height: style.height}} {...otherProps}>
                 {Platform.OS === 'ios' ? children :
-                    <Container collapse={!!collapsingBar} {...otherProps}>
+                    <Container
+                        collapse={!!collapsingBar}
+                        title={otherProps.title}
+                        backgroundColor={collapsingStyle && collapsingStyle.backgroundColor}>
                         {collapsingBar && collapsingBar.props.children}
                         <NVToolbar
                             menuItems={menuItems}
@@ -52,9 +56,9 @@ var NavigationBar: any = ({hidden, logo, navigationImage, overflowImage, childre
     )
 }
 
-var Container: any = ({collapse, title, barTintColor, children}) => (
+var Container: any = ({collapse, title, backgroundColor, children}) => (
     !collapse ? children : 
-        <CollapsingBar title={title} barTintColor={barTintColor}>{children}</CollapsingBar>
+        <CollapsingBar title={title} style={{backgroundColor}}>{children}</CollapsingBar>
 )
 
 var NVNavigationBar = requireNativeComponent<any>('NVNavigationBar', null);

--- a/NavigationReactNative/src/NavigationBar.tsx
+++ b/NavigationReactNative/src/NavigationBar.tsx
@@ -35,6 +35,7 @@ var NavigationBar: any = ({hidden, logo, navigationImage, overflowImage, childre
                             logo={Image.resolveAssetSource(logo)}
                             navigationImage={Image.resolveAssetSource(navigationImage)}
                             overflowImage={Image.resolveAssetSource(overflowImage)}
+                            pin={!!collapsingBar}
                             {...otherProps}
                             style={{height: 56}}
                             onActionSelected={({nativeEvent}) => {

--- a/NavigationReactNative/src/NavigationBar.tsx
+++ b/NavigationReactNative/src/NavigationBar.tsx
@@ -55,9 +55,8 @@ var NavigationBar: any = ({hidden, logo, navigationImage, overflowImage, childre
     )
 }
 
-var Container: any = ({collapse, title, children, ...props}) => (
-    !collapse ? children : 
-        <CollapsingBar title={title} {...props}>{children}</CollapsingBar>
+var Container: any = ({collapse, children, ...props}) => (
+    !collapse ? children : <CollapsingBar {...props}>{children}</CollapsingBar>
 )
 
 var NVNavigationBar = requireNativeComponent<any>('NVNavigationBar', null);

--- a/NavigationReactNative/src/NavigationBar.tsx
+++ b/NavigationReactNative/src/NavigationBar.tsx
@@ -30,7 +30,7 @@ var NavigationBar: any = ({hidden, logo, navigationImage, overflowImage, childre
                 {Platform.OS === 'ios' ? children :
                     <Container
                         collapse={!!collapsingBar}
-                        title={otherProps.title}
+                        {...otherProps}
                         {...(collapsingBar && collapsingBar.props)}>
                         {collapsingBar && collapsingBar.props.children}
                         <NVToolbar
@@ -40,6 +40,7 @@ var NavigationBar: any = ({hidden, logo, navigationImage, overflowImage, childre
                             overflowImage={Image.resolveAssetSource(overflowImage)}
                             pin={!!collapsingBar}
                             {...otherProps}
+                            barTintColor={!collapsingBar ? otherProps.barTintColor : null}
                             style={{height: 56}}
                             onActionSelected={({nativeEvent}) => {
                                 var onPress = menuItems[nativeEvent.position].onPress;

--- a/NavigationReactNative/src/NavigationBar.tsx
+++ b/NavigationReactNative/src/NavigationBar.tsx
@@ -24,7 +24,6 @@ var NavigationBar: any = ({hidden, logo, navigationImage, overflowImage, childre
             ))
         ), []);
     var collapsingBar = childrenArray.find(({type}) => type === CollapsingBar);
-    var collapsingStyle = collapsingBar && collapsingBar.props.style;
     return (
         <>
             <NVNavigationBar hidden={hidden} style={{height: style.height}} {...otherProps}>
@@ -32,7 +31,7 @@ var NavigationBar: any = ({hidden, logo, navigationImage, overflowImage, childre
                     <Container
                         collapse={!!collapsingBar}
                         title={otherProps.title}
-                        backgroundColor={collapsingStyle && collapsingStyle.backgroundColor}>
+                        {...(collapsingBar && collapsingBar.props)}>
                         {collapsingBar && collapsingBar.props.children}
                         <NVToolbar
                             menuItems={menuItems}
@@ -56,9 +55,9 @@ var NavigationBar: any = ({hidden, logo, navigationImage, overflowImage, childre
     )
 }
 
-var Container: any = ({collapse, title, backgroundColor, children}) => (
+var Container: any = ({collapse, title, children, ...props}) => (
     !collapse ? children : 
-        <CollapsingBar title={title} style={{backgroundColor}}>{children}</CollapsingBar>
+        <CollapsingBar title={title} {...props}>{children}</CollapsingBar>
 )
 
 var NVNavigationBar = requireNativeComponent<any>('NVNavigationBar', null);

--- a/NavigationReactNative/src/NavigationBar.tsx
+++ b/NavigationReactNative/src/NavigationBar.tsx
@@ -26,7 +26,10 @@ var NavigationBar: any = ({hidden, logo, navigationImage, overflowImage, childre
     var collapsingBar = childrenArray.find(({type}) => type === CollapsingBar);
     return (
         <>
-            <NVNavigationBar hidden={hidden} style={{height: style.height}} {...otherProps}>
+            <NVNavigationBar
+                hidden={hidden}
+                style={{height: Platform.OS === 'android' && collapsingBar ? style.height : null}}
+                {...otherProps}>
                 {Platform.OS === 'ios' ? children :
                     <Container
                         collapse={!!collapsingBar}

--- a/NavigationReactNative/src/SearchBar.tsx
+++ b/NavigationReactNative/src/SearchBar.tsx
@@ -35,7 +35,7 @@ class SearchBar extends React.Component<any, any> {
                 onChangeText={this.onChangeText}
                 onExpand={() => this.setState({show: true})}
                 onCollapse={() => this.setState({show: false})}
-                style={[styles.searchBar, {zIndex: Platform.OS === 'android' && this.state.show ? 58 : -58}]}>
+                style={[this.state.show && styles.searchBar, {position: 'absolute'}]}>
                 {Platform.OS === 'ios' || this.state.show ? children : null}
             </NVSearchBar>
         );
@@ -45,15 +45,12 @@ class SearchBar extends React.Component<any, any> {
 var NVSearchBar = requireNativeComponent<any>('NVSearchBar', null);
 
 var styles = StyleSheet.create({
-    searchBar: {
-        position: 'absolute',
-        ...Platform.select({
-            android: {
-                top: 56, right: 0,
-                bottom: 0, left: 0,
-            },
-        })
-    },
+    searchBar: Platform.select({
+        android: {
+            top: 56, right: 0,
+            bottom: 0, left: 0,
+        },
+    })
 });
 
 export default SearchBar;

--- a/NavigationReactNative/src/SearchBar.tsx
+++ b/NavigationReactNative/src/SearchBar.tsx
@@ -28,6 +28,7 @@ class SearchBar extends React.Component<any, any> {
         var {autoCapitalize, children, ...props} = this.props;
         var constants = (UIManager as any).getViewManagerConfig('NVSearchBar').Constants;
         autoCapitalize = Platform.OS === 'android' ? constants.AutoCapitalize[autoCapitalize] : autoCapitalize;
+        var showStyle = Platform.OS == 'android' && show && {top, right: 0, bottom: 0, left: 0, zIndex: 58}
         return (
             <NVSearchBar
                 {...props}
@@ -36,7 +37,7 @@ class SearchBar extends React.Component<any, any> {
                 onChangeText={this.onChangeText}
                 onExpand={({nativeEvent: {top}}) => this.setState({show: true, top})}
                 onCollapse={() => this.setState({show: false})}
-                style={[show && styles.searchBar, {position: 'absolute', top}]}>
+                style={[styles.searchBar, showStyle]}>
                 {Platform.OS === 'ios' || this.state.show ? children : null}
             </NVSearchBar>
         );
@@ -46,12 +47,15 @@ class SearchBar extends React.Component<any, any> {
 var NVSearchBar = requireNativeComponent<any>('NVSearchBar', null);
 
 var styles = StyleSheet.create({
-    searchBar: Platform.select({
-        android: {
-            right: 0,
-            bottom: 0, left: 0,
-        },
-    })
+    searchBar: {
+        position: 'absolute',
+        ...Platform.select({
+            android: {
+                zIndex: -58,
+                position: 'absolute',
+            },
+        })
+    },
 });
 
 export default SearchBar;

--- a/NavigationReactNative/src/SearchBar.tsx
+++ b/NavigationReactNative/src/SearchBar.tsx
@@ -52,7 +52,6 @@ var styles = StyleSheet.create({
         ...Platform.select({
             android: {
                 zIndex: -58,
-                position: 'absolute',
             },
         })
     },

--- a/NavigationReactNative/src/SearchBar.tsx
+++ b/NavigationReactNative/src/SearchBar.tsx
@@ -5,7 +5,7 @@ class SearchBar extends React.Component<any, any> {
     private ref: React.RefObject<View>;
     constructor(props) {
         super(props);
-        this.state = {show: false};
+        this.state = {show: false, top: 56};
         this.ref = React.createRef<View>();
         this.onChangeText = this.onChangeText.bind(this);
     }
@@ -24,6 +24,7 @@ class SearchBar extends React.Component<any, any> {
 
     }
     render() {
+        var {show, top} = this.state;
         var {autoCapitalize, children, ...props} = this.props;
         var constants = (UIManager as any).getViewManagerConfig('NVSearchBar').Constants;
         autoCapitalize = Platform.OS === 'android' ? constants.AutoCapitalize[autoCapitalize] : autoCapitalize;
@@ -33,9 +34,9 @@ class SearchBar extends React.Component<any, any> {
                 ref={this.ref}
                 autoCapitalize={autoCapitalize}
                 onChangeText={this.onChangeText}
-                onExpand={() => this.setState({show: true})}
+                onExpand={({nativeEvent: {top}}) => this.setState({show: true, top})}
                 onCollapse={() => this.setState({show: false})}
-                style={[this.state.show && styles.searchBar, {position: 'absolute'}]}>
+                style={[show && styles.searchBar, {position: 'absolute', top}]}>
                 {Platform.OS === 'ios' || this.state.show ? children : null}
             </NVSearchBar>
         );
@@ -47,7 +48,7 @@ var NVSearchBar = requireNativeComponent<any>('NVSearchBar', null);
 var styles = StyleSheet.create({
     searchBar: Platform.select({
         android: {
-            top: 56, right: 0,
+            right: 0,
             bottom: 0, left: 0,
         },
     })

--- a/NavigationReactNative/src/SearchBar.tsx
+++ b/NavigationReactNative/src/SearchBar.tsx
@@ -28,7 +28,7 @@ class SearchBar extends React.Component<any, any> {
         var {autoCapitalize, children, ...props} = this.props;
         var constants = (UIManager as any).getViewManagerConfig('NVSearchBar').Constants;
         autoCapitalize = Platform.OS === 'android' ? constants.AutoCapitalize[autoCapitalize] : autoCapitalize;
-        var showStyle = Platform.OS == 'android' && show && {top, right: 0, bottom: 0, left: 0, zIndex: 58}
+        var showStyle = Platform.OS == 'android' && {top, right: 0, bottom: 0, left: 0, zIndex: 58}
         return (
             <NVSearchBar
                 {...props}
@@ -37,7 +37,7 @@ class SearchBar extends React.Component<any, any> {
                 onChangeText={this.onChangeText}
                 onExpand={({nativeEvent: {top}}) => this.setState({show: true, top})}
                 onCollapse={() => this.setState({show: false})}
-                style={[styles.searchBar, showStyle]}>
+                style={[styles.searchBar, show && showStyle]}>
                 {Platform.OS === 'ios' || this.state.show ? children : null}
             </NVSearchBar>
         );

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
@@ -27,14 +27,6 @@ public class CollapsingBarManager extends ViewGroupManager<CollapsingBarView> {
         view.setTitle(title);
     }
 
-    @ReactProp(name = "barTintColor", customType = "Color")
-    public void setBarTintColor(CollapsingBarView view, @Nullable Integer barTintColor) {
-        if (barTintColor != null)
-            view.setBackgroundColor(barTintColor);
-        else
-            view.setBackground(null);
-    }
-
     @Override
     public boolean needsCustomLayoutForChildren() {
         return true;

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
@@ -28,11 +28,6 @@ public class CollapsingBarManager extends ViewGroupManager<CollapsingBarView> {
         view.setTitle(title);
     }
 
-    @ReactProp(name = "scrollFlags")
-    public void setScrollFlags(CollapsingBarView view, int scrollFlags) {
-        ((AppBarLayout.LayoutParams) view.getLayoutParams()).setScrollFlags(scrollFlags);
-    }
-
     @Override
     public boolean needsCustomLayoutForChildren() {
         return true;

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
@@ -27,6 +27,11 @@ public class CollapsingBarManager extends ViewGroupManager<CollapsingBarView> {
         view.setTitle(title);
     }
 
+    @ReactProp(name = "titleEnabled")
+    public void setTitleEnabled(CollapsingBarView view, boolean titleEnabled) {
+        view.setTitleEnabled(titleEnabled);
+    }
+
     @Override
     public boolean needsCustomLayoutForChildren() {
         return true;

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
@@ -7,6 +7,7 @@ import androidx.annotation.Nullable;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.google.android.material.internal.CollapsingTextHelper;
 
 import javax.annotation.Nonnull;
 
@@ -37,6 +38,16 @@ public class CollapsingBarManager extends ViewGroupManager<CollapsingBarView> {
     @ReactProp(name = "contentScrimColor", customType = "Color")
     public void setContentScrimColor(CollapsingBarView view, @Nullable Integer contentScrimColor) {
         view.setContentScrim(contentScrimColor != null ? new ColorDrawable(contentScrimColor) : view.defaultContentScrim);
+    }
+
+    @ReactProp(name = "collapsedTitleColor", customType = "Color")
+    public void setCollapsedTitleColor(CollapsingBarView view, @Nullable Integer collapsedTitleColor) {
+        view.setCollapsedTitleTextColor(collapsedTitleColor != null ? collapsedTitleColor : view.defaultTitleTextColor);
+    }
+
+    @ReactProp(name = "expandedTitleColor", customType = "Color")
+    public void setExpandedTitleColor(CollapsingBarView view, @Nullable Integer expandedTitleColor) {
+        view.setExpandedTitleColor(expandedTitleColor != null ? expandedTitleColor : view.defaultTitleTextColor);
     }
 
     @Override

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
@@ -27,6 +27,14 @@ public class CollapsingBarManager extends ViewGroupManager<CollapsingBarView> {
         view.setTitle(title);
     }
 
+    @ReactProp(name = "barTintColor", customType = "Color")
+    public void setBarTintColor(CollapsingBarView view, @Nullable Integer barTintColor) {
+        if (barTintColor != null)
+            view.setBackgroundColor(barTintColor);
+        else
+            view.setBackground(null);
+    }
+
     @Override
     public boolean needsCustomLayoutForChildren() {
         return true;

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
@@ -5,7 +5,6 @@ import androidx.annotation.Nullable;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
-import com.google.android.material.appbar.AppBarLayout;
 
 import javax.annotation.Nonnull;
 

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
@@ -1,5 +1,7 @@
 package com.navigation.reactnative;
 
+import android.graphics.drawable.ColorDrawable;
+
 import androidx.annotation.Nullable;
 
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -30,6 +32,11 @@ public class CollapsingBarManager extends ViewGroupManager<CollapsingBarView> {
     @ReactProp(name = "titleEnabled")
     public void setTitleEnabled(CollapsingBarView view, boolean titleEnabled) {
         view.setTitleEnabled(titleEnabled);
+    }
+
+    @ReactProp(name = "contentScrimColor", customType = "Color")
+    public void setContentScrimColor(CollapsingBarView view, @Nullable Integer contentScrimColor) {
+        view.setContentScrim(contentScrimColor != null ? new ColorDrawable(contentScrimColor) : view.defaultContentScrim);
     }
 
     @Override

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
@@ -40,6 +40,7 @@ public class CollapsingBarManager extends ViewGroupManager<CollapsingBarView> {
     @ReactProp(name = "contentScrimColor", customType = "Color")
     public void setContentScrimColor(CollapsingBarView view, @Nullable Integer contentScrimColor) {
         view.setContentScrim(contentScrimColor != null ? new ColorDrawable(contentScrimColor) : view.defaultContentScrim);
+        view.measureAndLayoutCoordinator();
     }
 
     @ReactProp(name = "collapsedTitleColor", customType = "Color")

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
@@ -28,6 +28,7 @@ public class CollapsingBarManager extends ViewGroupManager<CollapsingBarView> {
     @ReactProp(name = "title")
     public void setTitle(CollapsingBarView view, @Nullable String title) {
         view.setTitle(title);
+        view.measureAndLayoutCoordinator();
     }
 
     @ReactProp(name = "titleEnabled")

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
@@ -34,6 +34,7 @@ public class CollapsingBarManager extends ViewGroupManager<CollapsingBarView> {
     @ReactProp(name = "titleEnabled")
     public void setTitleEnabled(CollapsingBarView view, boolean titleEnabled) {
         view.setTitleEnabled(titleEnabled);
+        view.measureAndLayoutCoordinator();
     }
 
     @ReactProp(name = "contentScrimColor", customType = "Color")

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarView.java
@@ -1,17 +1,20 @@
 package com.navigation.reactnative;
 
 import android.content.Context;
+import android.graphics.drawable.Drawable;
 
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.CollapsingToolbarLayout;
 
 public class CollapsingBarView extends CollapsingToolbarLayout {
+    Drawable defaultContentScrim;
 
     public CollapsingBarView(Context context) {
         super(context);
         AppBarLayout.LayoutParams params = new AppBarLayout.LayoutParams(AppBarLayout.LayoutParams.MATCH_PARENT, AppBarLayout.LayoutParams.MATCH_PARENT);
         params.setScrollFlags(AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL | AppBarLayout.LayoutParams.SCROLL_FLAG_EXIT_UNTIL_COLLAPSED);
         setLayoutParams(params);
+        defaultContentScrim = getContentScrim();
     }
 
     @Override

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarView.java
@@ -8,6 +8,7 @@ import com.google.android.material.appbar.CollapsingToolbarLayout;
 
 public class CollapsingBarView extends CollapsingToolbarLayout {
     Drawable defaultContentScrim;
+    int defaultTitleTextColor;
 
     public CollapsingBarView(Context context) {
         super(context);
@@ -15,6 +16,7 @@ public class CollapsingBarView extends CollapsingToolbarLayout {
         params.setScrollFlags(AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL | AppBarLayout.LayoutParams.SCROLL_FLAG_EXIT_UNTIL_COLLAPSED);
         setLayoutParams(params);
         defaultContentScrim = getContentScrim();
+        defaultTitleTextColor = new ToolbarView(context).defaultTitleTextColor;
     }
 
     @Override

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarView.java
@@ -9,7 +9,9 @@ public class CollapsingBarView extends CollapsingToolbarLayout {
 
     public CollapsingBarView(Context context) {
         super(context);
-        setLayoutParams(new AppBarLayout.LayoutParams(AppBarLayout.LayoutParams.MATCH_PARENT, AppBarLayout.LayoutParams.MATCH_PARENT));
+        AppBarLayout.LayoutParams params = new AppBarLayout.LayoutParams(AppBarLayout.LayoutParams.MATCH_PARENT, AppBarLayout.LayoutParams.MATCH_PARENT);
+        params.setScrollFlags(AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL | AppBarLayout.LayoutParams.SCROLL_FLAG_EXIT_UNTIL_COLLAPSED);
+        setLayoutParams(params);
     }
 
     @Override

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarView.java
@@ -21,10 +21,7 @@ public class CollapsingBarView extends CollapsingToolbarLayout {
         addOnLayoutChangeListener(new OnLayoutChangeListener() {
             @Override
             public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
-                if (getParent() != null && getParent().getParent() instanceof CoordinatorLayoutView) {
-                    CoordinatorLayoutView coordinatorLayoutView = (CoordinatorLayoutView) getParent().getParent();
-                    coordinatorLayoutView.post(coordinatorLayoutView.measureAndLayout);
-                }
+                measureAndLayoutCoordinator();
             }
         });
     }
@@ -45,4 +42,11 @@ public class CollapsingBarView extends CollapsingToolbarLayout {
             layout(getLeft(), getTop(), getRight(), getBottom());
         }
     };
+
+    void measureAndLayoutCoordinator() {
+        if (getParent() != null && getParent().getParent() instanceof CoordinatorLayoutView) {
+            CoordinatorLayoutView coordinatorLayoutView = (CoordinatorLayoutView) getParent().getParent();
+            coordinatorLayoutView.post(coordinatorLayoutView.measureAndLayout);
+        }
+    }
 }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarView.java
@@ -25,7 +25,6 @@ public class CollapsingBarView extends CollapsingToolbarLayout {
                     CoordinatorLayoutView coordinatorLayoutView = (CoordinatorLayoutView) getParent().getParent();
                     coordinatorLayoutView.post(coordinatorLayoutView.measureAndLayout);
                 }
-
             }
         });
     }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CollapsingBarView.java
@@ -2,6 +2,7 @@ package com.navigation.reactnative;
 
 import android.content.Context;
 import android.graphics.drawable.Drawable;
+import android.view.View;
 
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.CollapsingToolbarLayout;
@@ -17,6 +18,16 @@ public class CollapsingBarView extends CollapsingToolbarLayout {
         setLayoutParams(params);
         defaultContentScrim = getContentScrim();
         defaultTitleTextColor = new ToolbarView(context).defaultTitleTextColor;
+        addOnLayoutChangeListener(new OnLayoutChangeListener() {
+            @Override
+            public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
+                if (getParent() != null && getParent().getParent() instanceof CoordinatorLayoutView) {
+                    CoordinatorLayoutView coordinatorLayoutView = (CoordinatorLayoutView) getParent().getParent();
+                    coordinatorLayoutView.post(coordinatorLayoutView.measureAndLayout);
+                }
+
+            }
+        });
     }
 
     @Override

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CoordinatorLayoutManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CoordinatorLayoutManager.java
@@ -26,13 +26,13 @@ public class CoordinatorLayoutManager extends ViewGroupManager<CoordinatorLayout
         return new CoordinatorLayoutView(reactContext);
     }
 
-    @ReactProp(name = "overlayTop")
-    public void setOverlayTop(CoordinatorLayoutView view, int overlayTop) {
-        view.overlayTop = overlayTop;
+    @ReactProp(name = "overlapTop")
+    public void setOverlapTop(CoordinatorLayoutView view, int overlapTop) {
+        view.overlapTop = overlapTop;
         if (view.getChildAt(1) != null) {
             CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) view.getChildAt(1).getLayoutParams();
             if (params.getBehavior() != null)
-                ((AppBarLayout.ScrollingViewBehavior) params.getBehavior()).setOverlayTop(overlayTop);
+                ((AppBarLayout.ScrollingViewBehavior) params.getBehavior()).setOverlayTop(overlapTop);
         }
     }
 
@@ -42,7 +42,7 @@ public class CoordinatorLayoutManager extends ViewGroupManager<CoordinatorLayout
         if (child instanceof ScrollView) {
             CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) child.getLayoutParams();
             AppBarLayout.ScrollingViewBehavior behavior = new AppBarLayout.ScrollingViewBehavior();
-            behavior.setOverlayTop(parent.overlayTop);
+            behavior.setOverlayTop(parent.overlapTop);
             params.setBehavior(behavior);
         }
     }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CoordinatorLayoutManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CoordinatorLayoutManager.java
@@ -31,7 +31,8 @@ public class CoordinatorLayoutManager extends ViewGroupManager<CoordinatorLayout
         view.overlayTop = overlayTop;
         if (view.getChildAt(1) != null) {
             CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) view.getChildAt(1).getLayoutParams();
-            ((AppBarLayout.ScrollingViewBehavior) params.getBehavior()).setOverlayTop(overlayTop);
+            if (params.getBehavior() != null)
+                ((AppBarLayout.ScrollingViewBehavior) params.getBehavior()).setOverlayTop(overlayTop);
         }
     }
 

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CoordinatorLayoutManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CoordinatorLayoutManager.java
@@ -29,8 +29,8 @@ public class CoordinatorLayoutManager extends ViewGroupManager<CoordinatorLayout
     @ReactProp(name = "overlap")
     public void setOverlap(CoordinatorLayoutView view, int overlap) {
         view.overlap = overlap;
-        if (view.getChildAt(1) != null) {
-            CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) view.getChildAt(1).getLayoutParams();
+        if (view.getScrollView() != null) {
+            CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) view.getScrollView().getLayoutParams();
             if (params.getBehavior() != null)
                 ((AppBarLayout.ScrollingViewBehavior) params.getBehavior()).setOverlayTop(overlap);
         }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CoordinatorLayoutManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CoordinatorLayoutManager.java
@@ -26,13 +26,13 @@ public class CoordinatorLayoutManager extends ViewGroupManager<CoordinatorLayout
         return new CoordinatorLayoutView(reactContext);
     }
 
-    @ReactProp(name = "overlapTop")
-    public void setOverlapTop(CoordinatorLayoutView view, int overlapTop) {
-        view.overlapTop = overlapTop;
+    @ReactProp(name = "overlap")
+    public void setOverlap(CoordinatorLayoutView view, int overlap) {
+        view.overlap = overlap;
         if (view.getChildAt(1) != null) {
             CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) view.getChildAt(1).getLayoutParams();
             if (params.getBehavior() != null)
-                ((AppBarLayout.ScrollingViewBehavior) params.getBehavior()).setOverlayTop(overlapTop);
+                ((AppBarLayout.ScrollingViewBehavior) params.getBehavior()).setOverlayTop(overlap);
         }
     }
 
@@ -42,7 +42,7 @@ public class CoordinatorLayoutManager extends ViewGroupManager<CoordinatorLayout
         if (child instanceof ScrollView) {
             CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) child.getLayoutParams();
             AppBarLayout.ScrollingViewBehavior behavior = new AppBarLayout.ScrollingViewBehavior();
-            behavior.setOverlayTop(parent.overlapTop);
+            behavior.setOverlayTop(parent.overlap);
             params.setBehavior(behavior);
         }
     }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CoordinatorLayoutManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CoordinatorLayoutManager.java
@@ -7,6 +7,7 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.annotations.ReactProp;
 import com.google.android.material.appbar.AppBarLayout;
 
 import javax.annotation.Nonnull;
@@ -25,12 +26,23 @@ public class CoordinatorLayoutManager extends ViewGroupManager<CoordinatorLayout
         return new CoordinatorLayoutView(reactContext);
     }
 
+    @ReactProp(name = "overlayTop")
+    public void setOverlayTop(CoordinatorLayoutView view, int overlayTop) {
+        view.overlayTop = overlayTop;
+        if (view.getChildAt(1) != null) {
+            CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) view.getChildAt(1).getLayoutParams();
+            ((AppBarLayout.ScrollingViewBehavior) params.getBehavior()).setOverlayTop(overlayTop);
+        }
+    }
+
     @Override
     public void addView(CoordinatorLayoutView parent, View child, int index) {
         super.addView(parent, child, index);
         if (child instanceof ScrollView) {
             CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) child.getLayoutParams();
-            params.setBehavior(new AppBarLayout.ScrollingViewBehavior());
+            AppBarLayout.ScrollingViewBehavior behavior = new AppBarLayout.ScrollingViewBehavior();
+            behavior.setOverlayTop(parent.overlayTop);
+            params.setBehavior(behavior);
         }
     }
 

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CoordinatorLayoutManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CoordinatorLayoutManager.java
@@ -31,8 +31,11 @@ public class CoordinatorLayoutManager extends ViewGroupManager<CoordinatorLayout
         view.overlap = overlap;
         if (view.getScrollView() != null) {
             CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) view.getScrollView().getLayoutParams();
-            if (params.getBehavior() != null)
+            if (params.getBehavior() != null) {
                 ((AppBarLayout.ScrollingViewBehavior) params.getBehavior()).setOverlayTop(overlap);
+                view.requestLayout();
+                view.post(view.measureAndLayout);
+            }
         }
     }
 

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CoordinatorLayoutView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CoordinatorLayoutView.java
@@ -8,6 +8,7 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import com.facebook.react.uimanager.PixelUtil;
 
 public class CoordinatorLayoutView extends CoordinatorLayout {
+    int overlayTop = 0;
 
     public CoordinatorLayoutView(Context context){
         super(context);

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CoordinatorLayoutView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CoordinatorLayoutView.java
@@ -8,7 +8,7 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import com.facebook.react.uimanager.PixelUtil;
 
 public class CoordinatorLayoutView extends CoordinatorLayout {
-    int overlapTop = 0;
+    int overlap = 0;
 
     public CoordinatorLayoutView(Context context){
         super(context);

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CoordinatorLayoutView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CoordinatorLayoutView.java
@@ -1,8 +1,11 @@
 package com.navigation.reactnative;
 
 import android.content.Context;
+import android.widget.ScrollView;
 
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
+
+import com.facebook.react.uimanager.PixelUtil;
 
 public class CoordinatorLayoutView extends CoordinatorLayout {
 
@@ -26,4 +29,16 @@ public class CoordinatorLayoutView extends CoordinatorLayout {
             layout(getLeft(), getTop(), getRight(), getBottom());
         }
     };
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        int height = MeasureSpec.getSize(heightMeasureSpec);
+        int contentHeight = ((ScrollView) getChildAt(1)).getChildAt(0).getHeight();
+        boolean collapsingBar = ((NavigationBarView) getChildAt(0)).getChildAt(0) instanceof CollapsingBarView;
+        int navigationBarHeight = collapsingBar ? (int) PixelUtil.toPixelFromDIP(56) : 0;
+        int collapsedGap = height + 2 - contentHeight - navigationBarHeight;
+        if (collapsedGap > 0)
+            heightMeasureSpec = MeasureSpec.makeMeasureSpec(MeasureSpec.getSize(heightMeasureSpec) - collapsedGap, MeasureSpec.EXACTLY);
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+    }
 }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CoordinatorLayoutView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CoordinatorLayoutView.java
@@ -8,7 +8,7 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import com.facebook.react.uimanager.PixelUtil;
 
 public class CoordinatorLayoutView extends CoordinatorLayout {
-    int overlayTop = 0;
+    int overlapTop = 0;
 
     public CoordinatorLayoutView(Context context){
         super(context);

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CoordinatorLayoutView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CoordinatorLayoutView.java
@@ -31,11 +31,27 @@ public class CoordinatorLayoutView extends CoordinatorLayout {
         }
     };
 
+    private NavigationBarView getNavigationBarView() {
+        for(int i = 0; i < getChildCount(); i++) {
+            if (getChildAt(i) instanceof NavigationBarView)
+                return (NavigationBarView) getChildAt(i);
+        }
+        return null;
+    }
+
+    ScrollView getScrollView() {
+        for(int i = 0; i < getChildCount(); i++) {
+            if (getChildAt(i) instanceof ScrollView)
+                return (ScrollView) getChildAt(i);
+        }
+        return null;
+    }
+
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         int height = MeasureSpec.getSize(heightMeasureSpec);
-        int contentHeight = ((ScrollView) getChildAt(1)).getChildAt(0).getHeight();
-        boolean collapsingBar = ((NavigationBarView) getChildAt(0)).getChildAt(0) instanceof CollapsingBarView;
+        int contentHeight = getScrollView() != null ? getScrollView().getChildAt(0).getHeight() : 0;
+        boolean collapsingBar = getNavigationBarView() != null && getNavigationBarView().getChildAt(0) instanceof CollapsingBarView;
         int navigationBarHeight = collapsingBar ? (int) PixelUtil.toPixelFromDIP(56) : 0;
         int collapsedGap = height + 2 - contentHeight - navigationBarHeight;
         if (collapsedGap > 0)

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CoordinatorLayoutView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/CoordinatorLayoutView.java
@@ -21,7 +21,7 @@ public class CoordinatorLayoutView extends CoordinatorLayout {
         post(measureAndLayout);
     }
 
-    private final Runnable measureAndLayout = new Runnable() {
+    final Runnable measureAndLayout = new Runnable() {
         @Override
         public void run() {
             measure(

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationBarManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationBarManager.java
@@ -9,7 +9,6 @@ import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
-import com.google.android.material.appbar.AppBarLayout;
 
 import java.util.Map;
 
@@ -67,13 +66,6 @@ public class NavigationBarManager extends ViewGroupManager<NavigationBarView> {
             MapBuilder.of(
                 "never", MenuItem.SHOW_AS_ACTION_NEVER,
                 "always", MenuItem.SHOW_AS_ACTION_ALWAYS,
-                "ifRoom", MenuItem.SHOW_AS_ACTION_IF_ROOM),
-            "ScrollFlag",
-            MapBuilder.of(
-                "snap", AppBarLayout.LayoutParams.SCROLL_FLAG_SNAP,
-                "scroll", AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL,
-                "enterAlways", AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS,
-                "exitUntilCollapsed", AppBarLayout.LayoutParams.SCROLL_FLAG_EXIT_UNTIL_COLLAPSED,
-                "enterAlwaysCollapsed", AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS_COLLAPSED));
+                "ifRoom", MenuItem.SHOW_AS_ACTION_IF_ROOM));
     }
 }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationBarManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationBarManager.java
@@ -9,6 +9,7 @@ import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.google.android.material.appbar.AppBarLayout;
 
 import java.util.Map;
 
@@ -48,7 +49,7 @@ public class NavigationBarManager extends ViewGroupManager<NavigationBarView> {
 
     @ReactProp(name = "height")
     public void setHeight(NavigationBarView view, double height) {
-        view.getLayoutParams().height = (int) PixelUtil.toPixelFromDIP(height);
+        view.getLayoutParams().height = height != 0 ? (int) PixelUtil.toPixelFromDIP(height) : AppBarLayout.LayoutParams.WRAP_CONTENT;
     }
 
     @Override

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationBarManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationBarManager.java
@@ -56,6 +56,7 @@ public class NavigationBarManager extends ViewGroupManager<NavigationBarView> {
         return MapBuilder.<String, Object>builder()
             .put("onNavigationPress", MapBuilder.of("registrationName", "onNavigationPress"))
             .put("onActionSelected", MapBuilder.of("registrationName", "onActionSelected"))
+            .put("onOffsetChanged", MapBuilder.of("registrationName", "onOffsetChanged"))
             .build();
     }
 

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationBarManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationBarManager.java
@@ -3,6 +3,7 @@ package com.navigation.reactnative;
 import android.graphics.Color;
 import android.os.Build;
 import android.view.MenuItem;
+import android.view.ViewParent;
 
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.PixelUtil;
@@ -16,6 +17,7 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 
 import androidx.annotation.Nullable;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
 public class NavigationBarManager extends ViewGroupManager<NavigationBarView> {
     @Nonnull
@@ -50,6 +52,11 @@ public class NavigationBarManager extends ViewGroupManager<NavigationBarView> {
     @ReactProp(name = "height")
     public void setHeight(NavigationBarView view, double height) {
         view.getLayoutParams().height = height != 0 ? (int) PixelUtil.toPixelFromDIP(height) : AppBarLayout.LayoutParams.WRAP_CONTENT;
+        if (view.getParent() instanceof CoordinatorLayoutView) {
+            CoordinatorLayoutView coordinatorLayoutView = (CoordinatorLayoutView) view.getParent();
+            coordinatorLayoutView.requestLayout();
+            coordinatorLayoutView.post(coordinatorLayoutView.measureAndLayout);
+        }
     }
 
     @Override

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationBarManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationBarManager.java
@@ -54,8 +54,6 @@ public class NavigationBarManager extends ViewGroupManager<NavigationBarView> {
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("onNavigationPress", MapBuilder.of("registrationName", "onNavigationPress"))
-            .put("onActionSelected", MapBuilder.of("registrationName", "onActionSelected"))
             .put("onOffsetChanged", MapBuilder.of("registrationName", "onOffsetChanged"))
             .build();
     }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationBarView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationBarView.java
@@ -5,6 +5,11 @@ import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.view.ViewOutlineProvider;
 
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.PixelUtil;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.google.android.material.appbar.AppBarLayout;
 
 public class NavigationBarView extends AppBarLayout {
@@ -18,5 +23,14 @@ public class NavigationBarView extends AppBarLayout {
             defaultOutlineProvider = getOutlineProvider();
         }
         defaultBackground = getBackground();
+        addOnOffsetChangedListener(new OnOffsetChangedListener() {
+            @Override
+            public void onOffsetChanged(AppBarLayout appBarLayout, int offset) {
+                WritableMap event = Arguments.createMap();
+                event.putInt("offset", (int) PixelUtil.toDIPFromPixel(offset));
+                ReactContext reactContext = (ReactContext) getContext();
+                reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onOffsetChanged", event);
+            }
+        });
     }
 }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SearchBarView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SearchBarView.java
@@ -3,6 +3,7 @@ package com.navigation.reactnative;
 import android.content.Context;
 import android.view.MenuItem;
 import android.view.ViewGroup;
+import android.view.inputmethod.InputMethodManager;
 
 import androidx.appcompat.widget.SearchView;
 
@@ -50,6 +51,14 @@ public class SearchBarView extends ReactViewGroup {
         super.onAttachedToWindow();
         ViewGroup view = (ViewGroup) getParent();
         ToolbarView toolbarView = null;
+        if (searchView.requestFocusFromTouch()) {
+            InputMethodManager inputMethodManager = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+            inputMethodManager.showSoftInput(searchView.findFocus(), 0);
+        }
+        for(int i = 0; i < view.getChildCount(); i++) {
+            if (view.getChildAt(i) instanceof  CoordinatorLayoutView)
+                view = (CoordinatorLayoutView) view.getChildAt(i);
+        }
         for(int i = 0; i < view.getChildCount(); i++) {
             if (view.getChildAt(i) instanceof NavigationBarView) {
                 NavigationBarView navigationBarView = (NavigationBarView) view.getChildAt(i);

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SearchBarView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SearchBarView.java
@@ -83,11 +83,8 @@ public class SearchBarView extends ReactViewGroup {
                 @Override
                 public void onSearchExpand() {
                     ReactContext reactContext = (ReactContext) getContext();
-                    int top = 56;
-                    if (!(navigationBarView.getChildAt(0) instanceof CollapsingBarView))
-                        top += PixelUtil.toDIPFromPixel(barOffset);
                     WritableMap event = Arguments.createMap();
-                    event.putInt("top", top);
+                    event.putInt("top", 56 + (int) PixelUtil.toDIPFromPixel(barOffset));
                     reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onExpand", event);
                 }
 

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SearchBarView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SearchBarView.java
@@ -53,7 +53,8 @@ public class SearchBarView extends ReactViewGroup {
         ToolbarView toolbarView = null;
         if (searchView.requestFocusFromTouch()) {
             InputMethodManager inputMethodManager = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
-            inputMethodManager.showSoftInput(searchView.findFocus(), 0);
+            if (inputMethodManager != null)
+                inputMethodManager.showSoftInput(searchView.findFocus(), 0);
         }
         for(int i = 0; i < view.getChildCount(); i++) {
             if (view.getChildAt(i) instanceof  CoordinatorLayoutView)

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SearchBarView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SearchBarView.java
@@ -10,11 +10,15 @@ import androidx.appcompat.widget.SearchView;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.facebook.react.views.view.ReactViewGroup;
+import com.google.android.material.appbar.AppBarLayout;
 
 public class SearchBarView extends ReactViewGroup {
     SearchView searchView;
+    AppBarLayout.OnOffsetChangedListener onOffsetChangedListener;
+    private int barOffset = 0;
     int nativeEventCount;
     int mostRecentEventCount;
 
@@ -38,6 +42,12 @@ public class SearchBarView extends ReactViewGroup {
                 return false;
             }
         });
+        onOffsetChangedListener = new AppBarLayout.OnOffsetChangedListener() {
+            @Override
+            public void onOffsetChanged(AppBarLayout appBarLayout, int offset) {
+                barOffset = offset;
+            }
+        };
     }
 
     void setQuery(String query) {
@@ -49,25 +59,19 @@ public class SearchBarView extends ReactViewGroup {
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
-        ViewGroup view = (ViewGroup) getParent();
-        ToolbarView toolbarView = null;
         if (searchView.requestFocusFromTouch()) {
             InputMethodManager inputMethodManager = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
             if (inputMethodManager != null)
                 inputMethodManager.showSoftInput(searchView.findFocus(), 0);
         }
-        for(int i = 0; i < view.getChildCount(); i++) {
-            if (view.getChildAt(i) instanceof  CoordinatorLayoutView)
-                view = (CoordinatorLayoutView) view.getChildAt(i);
-        }
-        for(int i = 0; i < view.getChildCount(); i++) {
-            if (view.getChildAt(i) instanceof NavigationBarView) {
-                NavigationBarView navigationBarView = (NavigationBarView) view.getChildAt(i);
-                for (int j = 0; j < navigationBarView.getChildCount(); j++) {
-                    if (navigationBarView.getChildAt(j) instanceof ToolbarView)
-                        toolbarView = (ToolbarView) navigationBarView.getChildAt(j);
-                }
+        ToolbarView toolbarView = null;
+        final NavigationBarView navigationBarView = getNavigationBarView();
+        if (navigationBarView != null) {
+            for (int i = 0; i < navigationBarView.getChildCount(); i++) {
+                if (navigationBarView.getChildAt(i) instanceof ToolbarView)
+                    toolbarView = (ToolbarView) navigationBarView.getChildAt(i);
             }
+            navigationBarView.addOnOffsetChangedListener(onOffsetChangedListener);
         }
         if (toolbarView != null) {
             toolbarView.setOnSearchListener(new ToolbarView.OnSearchListener() {
@@ -79,7 +83,12 @@ public class SearchBarView extends ReactViewGroup {
                 @Override
                 public void onSearchExpand() {
                     ReactContext reactContext = (ReactContext) getContext();
-                    reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onExpand", null);
+                    int top = 56;
+                    if (!(navigationBarView.getChildAt(0) instanceof CollapsingBarView))
+                        top += PixelUtil.toDIPFromPixel(barOffset);
+                    WritableMap event = Arguments.createMap();
+                    event.putInt("top", top);
+                    reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onExpand", event);
                 }
 
                 @Override
@@ -89,6 +98,28 @@ public class SearchBarView extends ReactViewGroup {
                 }
             });
         }
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        NavigationBarView navigationBarView = getNavigationBarView();
+        if (navigationBarView != null)
+            navigationBarView.removeOnOffsetChangedListener(onOffsetChangedListener);
+    }
+
+    private NavigationBarView getNavigationBarView() {
+        ViewGroup view = (ViewGroup) getParent();
+        for(int i = 0; i < view.getChildCount(); i++) {
+            if (view.getChildAt(i) instanceof  CoordinatorLayoutView)
+                view = (CoordinatorLayoutView) view.getChildAt(i);
+        }
+        for(int i = 0; i < view.getChildCount(); i++) {
+            if (view.getChildAt(i) instanceof NavigationBarView) {
+                return (NavigationBarView) view.getChildAt(i);
+            }
+        }
+        return null;
     }
 
     @Override

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/ToolbarManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/ToolbarManager.java
@@ -69,11 +69,6 @@ public class ToolbarManager extends ViewGroupManager<ToolbarView> {
         view.setTitleTextColor(textColor != null ? textColor : view.defaultTitleTextColor);
     }
 
-    @ReactProp(name = "scrollFlags")
-    public void setScrollFlags(ToolbarView view, int scrollFlags) {
-        ((AppBarLayout.LayoutParams) view.getLayoutParams()).setScrollFlags(scrollFlags);
-    }
-
     @ReactProp(name = "height")
     public void setHeight(ToolbarView view, double height) {
         view.getLayoutParams().height = (int) PixelUtil.toPixelFromDIP(height);

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/ToolbarManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/ToolbarManager.java
@@ -8,7 +8,6 @@ import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
-import com.google.android.material.appbar.AppBarLayout;
 
 import javax.annotation.Nonnull;
 

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/ToolbarManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/ToolbarManager.java
@@ -8,6 +8,8 @@ import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.google.android.material.appbar.AppBarLayout;
+import com.google.android.material.appbar.CollapsingToolbarLayout;
 
 import javax.annotation.Nonnull;
 
@@ -71,5 +73,18 @@ public class ToolbarManager extends ViewGroupManager<ToolbarView> {
     @ReactProp(name = "height")
     public void setHeight(ToolbarView view, double height) {
         view.getLayoutParams().height = (int) PixelUtil.toPixelFromDIP(height);
+    }
+
+    @ReactProp(name = "pin")
+    public void setPin(ToolbarView view, boolean pin) {
+        if (pin) {
+            CollapsingToolbarLayout.LayoutParams params = new CollapsingToolbarLayout.LayoutParams(view.getLayoutParams().width, view.getLayoutParams().height);
+            params.setCollapseMode(CollapsingToolbarLayout.LayoutParams.COLLAPSE_MODE_PIN);
+            view.setLayoutParams(params);
+        } else {
+            AppBarLayout.LayoutParams params = new AppBarLayout.LayoutParams(view.getLayoutParams().width, view.getLayoutParams().height);
+            params.setScrollFlags(AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL | AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS);
+            view.setLayoutParams(params);
+        }
     }
 }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/ToolbarManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/ToolbarManager.java
@@ -4,12 +4,15 @@ import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.CollapsingToolbarLayout;
+
+import java.util.Map;
 
 import javax.annotation.Nonnull;
 
@@ -87,4 +90,13 @@ public class ToolbarManager extends ViewGroupManager<ToolbarView> {
             view.setLayoutParams(params);
         }
     }
+
+    @Override
+    public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
+        return MapBuilder.<String, Object>builder()
+                .put("onNavigationPress", MapBuilder.of("registrationName", "onNavigationPress"))
+                .put("onActionSelected", MapBuilder.of("registrationName", "onActionSelected"))
+                .build();
+    }
+
 }

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/ToolbarView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/ToolbarView.java
@@ -37,9 +37,7 @@ public class ToolbarView extends Toolbar {
 
     public ToolbarView(Context context) {
         super(context);
-        AppBarLayout.LayoutParams params = new AppBarLayout.LayoutParams(AppBarLayout.LayoutParams.MATCH_PARENT, AppBarLayout.LayoutParams.MATCH_PARENT);
-        params.setScrollFlags(AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL | AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS);
-        setLayoutParams(params);
+        setLayoutParams(new AppBarLayout.LayoutParams(AppBarLayout.LayoutParams.MATCH_PARENT, AppBarLayout.LayoutParams.MATCH_PARENT));
         defaultTitleTextColor = getDefaultTitleTextColor();
         defaultOverflowIcon = getOverflowIcon();
         logoResolverListener = new IconResolver.IconResolverListener() {

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/ToolbarView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/ToolbarView.java
@@ -37,7 +37,9 @@ public class ToolbarView extends Toolbar {
 
     public ToolbarView(Context context) {
         super(context);
-        setLayoutParams(new AppBarLayout.LayoutParams(AppBarLayout.LayoutParams.MATCH_PARENT, AppBarLayout.LayoutParams.MATCH_PARENT));
+        AppBarLayout.LayoutParams params = new AppBarLayout.LayoutParams(AppBarLayout.LayoutParams.MATCH_PARENT, AppBarLayout.LayoutParams.MATCH_PARENT);
+        params.setScrollFlags(AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL | AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS);
+        setLayoutParams(params);
         defaultTitleTextColor = getDefaultTitleTextColor();
         defaultOverflowIcon = getOverflowIcon();
         logoResolverListener = new IconResolver.IconResolverListener() {

--- a/NavigationReactNative/test/navigation-react-native-tests.tsx
+++ b/NavigationReactNative/test/navigation-react-native-tests.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { View, Text, TouchableHighlight } from 'react-native';
 import { StateNavigator } from 'navigation';
 import { NavigationContext, NavigationHandler } from 'navigation-react';
-import { NavigationStack, NavigationBar, RightBar, BarButton, SearchBar, SharedElement, TabBar, TabBarItem } from 'navigation-react-native';
+import { NavigationStack, NavigationBar, CoordinatorLayout, RightBar, BarButton, SearchBar, SharedElement, TabBar, TabBarItem } from 'navigation-react-native';
 
 const stateNavigator: StateNavigator = new StateNavigator([
     { key: 'people' },
@@ -12,7 +12,7 @@ const stateNavigator: StateNavigator = new StateNavigator([
 var List = ({people, children}: any) => (
     <NavigationContext.Consumer>
         {({stateNavigator}) => (
-            <>
+            <CoordinatorLayout>
                 <NavigationBar title="People" />
                 <View>
                     {people.map(name => (
@@ -27,7 +27,7 @@ var List = ({people, children}: any) => (
                     ))}
                     {children}
                 </View>
-            </>
+            </CoordinatorLayout>
         )}
     </NavigationContext.Consumer>
 );

--- a/NavigationReactNative/test/navigation-react-native-tests.tsx
+++ b/NavigationReactNative/test/navigation-react-native-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, Text, TouchableHighlight } from 'react-native';
+import { View, Text, ScrollView, TouchableHighlight } from 'react-native';
 import { StateNavigator } from 'navigation';
 import { NavigationContext, NavigationHandler } from 'navigation-react';
 import { NavigationStack, NavigationBar, CoordinatorLayout, RightBar, BarButton, SearchBar, SharedElement, TabBar, TabBarItem } from 'navigation-react-native';
@@ -12,22 +12,19 @@ const stateNavigator: StateNavigator = new StateNavigator([
 var List = ({people, children}: any) => (
     <NavigationContext.Consumer>
         {({stateNavigator}) => (
-            <CoordinatorLayout>
-                <NavigationBar title="People" />
-                <View>
-                    {people.map(name => (
-                        <TouchableHighlight
-                            onPress={() => {
-                                stateNavigator.navigate('person', {name});
-                        }}>
-                            <SharedElement name={name}>
-                                <Text>{name}</Text>
-                            </SharedElement>
-                        </TouchableHighlight>
-                    ))}
-                    {children}
-                </View>
-            </CoordinatorLayout>
+            <ScrollView>
+                {people.map(name => (
+                    <TouchableHighlight
+                        onPress={() => {
+                            stateNavigator.navigate('person', {name});
+                    }}>
+                        <SharedElement name={name}>
+                            <Text>{name}</Text>
+                        </SharedElement>
+                    </TouchableHighlight>
+                ))}
+                {children}
+            </ScrollView>
         )}
     </NavigationContext.Consumer>
 );
@@ -44,8 +41,8 @@ class People extends React.Component<any, any> {
             person.indexOf(text.toLowerCase()) !== -1
         ));
         return (
-            <>
-                <NavigationBar largeTitle={true} title="Person">
+            <CoordinatorLayout>
+                <NavigationBar largeTitle={true} title="People">
                     <SearchBar
                         text={text}
                         autoCapitalize="none"
@@ -58,7 +55,7 @@ class People extends React.Component<any, any> {
                     </RightBar>
                 </NavigationBar>
                 <List people={people} />
-            </>
+            </CoordinatorLayout>
         );
     }    
 }

--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -224,6 +224,26 @@ export class SearchBarIOS extends Component<SearchBarProps> { }
 export class SearchBar extends Component<SearchBarProps> { }
 
 /**
+ * Defines the Coordinator Layout Props contract
+ */
+export interface CoordinatorLayoutProps {
+    /**
+     * The distance the scrolled content overlaps the navigation bar
+     */
+    overlap?: number;   
+}
+
+/**
+ * Container that supports collapsing the navigation bar
+ */
+export class CoordinatorLayout<CoordinatorLayoutProps> {}
+
+/**
+ * Renders collapsing content inside the navigation bar
+ */
+export class CollapsingBar {}
+
+/**
  * Defines the Shared Element Props contract
  */
 export interface SharedElementProps {

--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -236,7 +236,7 @@ export interface CoordinatorLayoutProps {
 /**
  * Container that supports collapsing the navigation bar
  */
-export class CoordinatorLayout<CoordinatorLayoutProps> {}
+export class CoordinatorLayout extends Component<CoordinatorLayoutProps> {}
 
 /**
  * Renders collapsing content inside the navigation bar

--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -241,7 +241,7 @@ export class CoordinatorLayout extends Component<CoordinatorLayoutProps> {}
 /**
  * Renders collapsing content inside the navigation bar
  */
-export class CollapsingBar {}
+export class CollapsingBar extends Component {}
 
 /**
  * Defines the Shared Element Props contract

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -224,6 +224,26 @@ export class SearchBarIOS extends Component<SearchBarProps> { }
 export class SearchBar extends Component<SearchBarProps> { }
 
 /**
+ * Defines the Coordinator Layout Props contract
+ */
+export interface CoordinatorLayoutProps {
+    /**
+     * The distance the scrolled content overlaps the navigation bar
+     */
+    overlap?: number;   
+}
+
+/**
+ * Container that supports collapsing the navigation bar
+ */
+export class CoordinatorLayout extends Component<CoordinatorLayoutProps> {}
+
+/**
+ * Renders collapsing content inside the navigation bar
+ */
+export class CollapsingBar extends Component {}
+
+/**
  * Defines the Shared Element Props contract
  */
 export interface SharedElementProps {


### PR DESCRIPTION
Part-fixes #342

Wrapped the native Android collapsing toolbar functionality (`CoordinatorLayout` and `CollapsingBarLayout`).

Here's what the jsx looks like to get a toolbar that collapses off screen as the user scrolls.
```jsx
<CoordinatorLayout>
  <NavigationBar />
  <ScrollView nestedScrollEnabled={true} />
</CoordinatorLayout> 
```
And here’s what the jsx looks like to get the large title collapsing up into the fixed toolbar as the user scrolls.

```jsx
<CoordinatorLayout>
  <NavigationBar largeTitle={true} style={{height: 120}}>
    <CollpasingBar>
      <View style={{flex: 1}} />
    </CollpasingBar>
  </NavigationBar>
  <ScrollView nestedScrollEnabled={true} />
</CoordinatorLayout> 
```
I've updated the Twitter sample to demonstrate these two use-cases.

It relies on Android API level 21+ because the `CoordinatorLayout` java code needs nested scrolling enabled on the `ScrollView`.

Any other content, like an absolutely positioned popup, must be rendered either inside the ScrollView or outside of the `CoordinatorLayout`. Android has a restriction on the direct children of the `CoordinatorLayout`.

It’s only a part fix for #342 because it doesn’t support the TabBar. This can be added in a future release.
 
Wrapping the native `CoordinatorLayout` implementation opens up possibilities for third party libraries to hook into. For example, could have a FAB (floating action button) component that wraps the native Android one. Then it could scroll up anchored to the navigation bar.

@arunmenon1975 Please have a look through and get back to me with any questions or suggestions
