### PR TITLE
Prevented committing Fragments when state saved

### DIFF
--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/FragmentNavigator.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/FragmentNavigator.java
@@ -18,6 +18,11 @@ import java.util.Map;
 class FragmentNavigator extends SceneNavigator {
 
     @Override
+    boolean canNavigate(Activity activity, NavigationStackView stack) {
+        return !getFragmentManager(stack, activity).isStateSaved();
+    }
+
+    @Override
     void navigateBack(int currentCrumb, int crumb, Activity activity, NavigationStackView stack) {
         FragmentManager fragmentManager = getFragmentManager(stack, activity);
         SceneFragment fragment = (SceneFragment) fragmentManager.findFragmentByTag(oldKey);

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -29,7 +29,6 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
     protected ReadableArray oldSharedElementNames;
     protected boolean primary = true;
     protected boolean finish = false;
-    private boolean canNavigate = true;
     SceneNavigator navigator;
 
     public NavigationStackView(Context context) {
@@ -38,7 +37,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
 
     protected void onAfterUpdateTransaction() {
         Activity currentActivity = ((ThemedReactContext) getContext()).getCurrentActivity();
-        if (currentActivity == null || !canNavigate)
+        if (currentActivity == null)
             return;
         if (mainActivity == null) {
             mainActivity = currentActivity;
@@ -53,7 +52,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
             currentActivity.finishAffinity();
             return;
         }
-        if (scenes.size() == 0)
+        if (scenes.size() == 0 || !navigator.canNavigate(currentActivity, this))
             return;
         int crumb = keys.size() - 1;
         int currentCrumb = navigator.oldCrumb;
@@ -97,13 +96,11 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
 
     @Override
     public void onHostResume() {
-        canNavigate = true;
         onAfterUpdateTransaction();
     }
 
     @Override
     public void onHostPause() {
-        canNavigate = false;
     }
 
     @Override

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneNavigator.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/SceneNavigator.java
@@ -19,6 +19,10 @@ abstract class SceneNavigator {
     String oldKey;
     private SparseIntArray defaultAnimation;
 
+    boolean canNavigate(Activity activity, NavigationStackView stack) {
+        return true;
+    }
+
     abstract void navigateBack(int currentCrumb, int crumb, Activity activity, NavigationStackView stack);
 
     abstract void navigate(int currentCrumb, int crumb, Activity activity, NavigationStackView stack);


### PR DESCRIPTION
Fixes #353

If navigate from A to B but press the Android Home button before the navigation takes place in Java then get an exception. Can't commit Fragments after `onSaveInstanceState` is called.
## Fix
Checked if the `FragmentManager` has `SavedState`. If it has then don't run the navigation because it will throw the error. Then listened for the `onResume` of the `Activity` and re-ran the navigation to catch up

