### PR TITLE
Guaranteed NavigationStacks inside TabBarItems work independently

### DIFF
--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabFragment.java
@@ -24,9 +24,9 @@ public class TabFragment extends Fragment {
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         boolean nestedScrollView = false;
-        ScrollView scrollView = (ScrollView) tabBarItem.getChildAt(0);
+        View child = tabBarItem.getChildAt(0);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            nestedScrollView = scrollView != null && scrollView.isNestedScrollingEnabled();
+            nestedScrollView = child instanceof ScrollView && child.isNestedScrollingEnabled();
         return nestedScrollView ? tabBarItem.getChildAt(0) : tabBarItem;
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabFragment.java
@@ -1,9 +1,11 @@
 package com.navigation.reactnative;
 
+import android.os.Build;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ScrollView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -21,6 +23,10 @@ public class TabFragment extends Fragment {
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        return tabBarItem.getChildCount() == 1 ? tabBarItem.getChildAt(0) : tabBarItem;
+        boolean nestedScrollView = false;
+        ScrollView scrollView = (ScrollView) tabBarItem.getChildAt(0);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+            nestedScrollView = scrollView != null && scrollView.isNestedScrollingEnabled();
+        return nestedScrollView ? tabBarItem.getChildAt(0) : tabBarItem;
     }
 }


### PR DESCRIPTION
Introduced a regression when doing the `CoordinatorLayout` work.

Need the `NavigationStackView` to render inside the `TabBarItemView`. Otherwise each stack doesn't have its own `FragmentManager` and pollution occurs. For example, pressing android back in tab A can go back in tab B.

Checked if the `TabBarItem` child is a nested `ScrollView` to keep the `CoordinatorLayout` working