### PR TITLE
Worked out the primary NavigationStack automatically

### DIFF
--- a/NavigationReactNative/src/PrimaryStackContext.ts
+++ b/NavigationReactNative/src/PrimaryStackContext.ts
@@ -1,0 +1,3 @@
+import * as React from 'react';
+
+export default React.createContext(true);

--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -55,7 +55,7 @@ class TabBar extends React.Component<any, any> {
                             .filter(child => !!child)
                             .map((child: any, index) => {
                                 var selected = index === this.state.selectedTab;
-                                return React.cloneElement(child, {...child.props, selected})
+                                return React.cloneElement(child, {...child.props, index, selected})
                             })}
                 </NVTabBar>}
                 {bottomTabs && tabLayout}

--- a/NavigationReactNative/src/TabBarItem.tsx
+++ b/NavigationReactNative/src/TabBarItem.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { requireNativeComponent, Image, Platform, StyleSheet } from 'react-native';
 import BackButton from './BackButton';
 import BackHandlerContext from './BackHandlerContext';
+import PrimaryStackContext from './PrimaryStackContext';
 
 var createBackHandler = () => {
     var listeners = [];
@@ -35,7 +36,7 @@ class TabBarItem extends React.Component<any> {
         return false;
     }
     render() {
-        var {onPress, children, image, ...props} = this.props;
+        var {onPress, children, image, index, primary, ...props} = this.props;
         image = typeof image === 'string' ? (Platform.OS === 'ios' ? null : {uri: image}) : image;
         return (
             <NVTabBarItem
@@ -48,9 +49,11 @@ class TabBarItem extends React.Component<any> {
                         onPress(event);
                 }}>
                 <BackButton onPress={this.handleBack} />
-                <BackHandlerContext.Provider value={this.backHandler}>
-                    {children}
-                </BackHandlerContext.Provider>
+                <PrimaryStackContext.Provider value={primary && index === 0}>
+                    <BackHandlerContext.Provider value={this.backHandler}>
+                        {children}
+                    </BackHandlerContext.Provider>
+                </PrimaryStackContext.Provider>
             </NVTabBarItem>
         );
     }
@@ -66,4 +69,8 @@ const styles = StyleSheet.create({
     },
 });
 
-export default TabBarItem;
+export default (props) => (
+    <PrimaryStackContext.Consumer>
+        {(primary) => <TabBarItem {...props} primary={primary} />}
+    </PrimaryStackContext.Consumer>    
+);


### PR DESCRIPTION
It's the primary stack if it's not contained within any NavigationStacks and, if it's inside a TabBar, it must be the first tab.

Need to know the primary stack so that can finish the Activity when navigating back from its first scene. Otherwise the FragmentManager handles the back (the default) and goes to a blank screen with just an empty `NavigationStack`.

Won't remove the 'primary' prop from typings yet because that's a breaking change. Will deprecate it and remove in next major
