### PR TITLE
Ensured primary tabs that contain stacks are populated

### DIFF
--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutManager.java
@@ -17,6 +17,11 @@ public class TabLayoutManager extends ViewGroupManager<TabLayoutView> {
         return "NVTabLayout";
     }
 
+    @ReactProp(name = "bottomTabs")
+    public void setBottomTabs(TabLayoutView view, boolean bottomTabs) {
+        view.bottomTabs = bottomTabs;
+    }
+
     @ReactProp(name = "selectedTintColor", customType = "Color")
     public void setSelectedTintColor(TabLayoutView view, @Nullable Integer selectedTintColor) {
         view.selectedTintColor = selectedTintColor != null ? selectedTintColor : view.defaultTextColor;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutView.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.database.DataSetObserver;
 import android.graphics.drawable.Drawable;
 import android.view.View;
+import android.view.ViewGroup;
 
 import androidx.annotation.Nullable;
 import androidx.viewpager.widget.ViewPager;
@@ -12,6 +13,7 @@ import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.tabs.TabLayout;
 
 public class TabLayoutView extends TabLayout implements TabView {
+    boolean bottomTabs;
     int defaultTextColor;
     int selectedTintColor;
     int unselectedTintColor;
@@ -38,6 +40,25 @@ public class TabLayoutView extends TabLayout implements TabView {
     public void setScrollable(boolean scrollable) {
         setTabMode(scrollable ? TabLayout.MODE_SCROLLABLE : TabLayout.MODE_FIXED);
         post(measureAndLayout);
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        TabBarView tabBar = getTabBar();
+        if (bottomTabs && tabBar != null) {
+            setupWithViewPager(tabBar);
+            tabBar.populateTabs();
+        }
+    }
+
+    private TabBarView getTabBar() {
+        for(int i = 0; getParent() != null && i < ((ViewGroup) getParent()).getChildCount(); i++) {
+            View child = ((ViewGroup) getParent()).getChildAt(i);
+            if (child instanceof TabBarView)
+                return (TabBarView) child;
+        }
+        return null;
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationManager.java
@@ -18,6 +18,11 @@ public class TabNavigationManager extends ViewGroupManager<TabNavigationView> {
         return "NVTabNavigation";
     }
 
+    @ReactProp(name = "bottomTabs")
+    public void setBottomTabs(TabNavigationView view, boolean bottomTabs) {
+        view.bottomTabs = bottomTabs;
+    }
+
     @ReactProp(name = "selectedTintColor", customType = "Color")
     public void setSelectedTintColor(TabNavigationView view, @Nullable Integer selectedTintColor) {
         view.selectedTintColor = selectedTintColor != null ? selectedTintColor : view.defaultTextColor;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
@@ -5,6 +5,8 @@ import android.database.DataSetObserver;
 import android.graphics.drawable.Drawable;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -14,6 +16,7 @@ import androidx.viewpager.widget.ViewPager;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 
 public class TabNavigationView extends BottomNavigationView implements TabView {
+    boolean bottomTabs;
     int defaultTextColor;
     int selectedTintColor;
     int unselectedTintColor;
@@ -24,6 +27,25 @@ public class TabNavigationView extends BottomNavigationView implements TabView {
         super(context);
         TabLayoutView tabLayout = new TabLayoutView(context);
         selectedTintColor = unselectedTintColor = defaultTextColor = tabLayout.defaultTextColor;
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        TabBarView tabBar = getTabBar();
+        if (bottomTabs && tabBar != null) {
+            setupWithViewPager(tabBar);
+            tabBar.populateTabs();
+        }
+    }
+
+    private TabBarView getTabBar() {
+        for(int i = 0; getParent() != null && i < ((ViewGroup) getParent()).getChildCount(); i++) {
+            View child = ((ViewGroup) getParent()).getChildAt(i);
+            if (child instanceof TabBarView)
+                return (TabBarView) child;
+        }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Ran the Twitter sample with the main navigation tabs on Android (so, ran the ios tabs in App on android) and the titles and images of the tabs weren't populated. The onAttachedToWindow of the TabBarView can run before the TabView has been added as.a child. Thought this wasn't possible. Anyway, added back in the code deleted before. It just runs the setup from the TabView for belts and braces.
Only did this when bottom tabs. Sure the problem can't happen if top tabs because TabView must be added as the first child. Also, if run it for top tabs then the tabs get added twice when using the duplicated TabBar in the NavigationBar