### PR TITLE
Add specific type to offset for onOffsetChanged

### DIFF
--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -92,7 +92,7 @@ export interface NavigationBarProps {
     /**
      * Handles offset change events
      */
-    onOffsetChanged?: (e: NativeSyntheticEvent<{offset}>) => void;
+    onOffsetChanged?: (e: NativeSyntheticEvent<{offset: number}>) => void;
 }
 
 /**

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -92,7 +92,7 @@ export interface NavigationBarProps {
     /**
      * Handles offset change events
      */
-    onOffsetChanged?: (e: NativeSyntheticEvent<{offset}>) => void;
+    onOffsetChanged?: (e: NativeSyntheticEvent<{offset: number}>) => void;
 }
 
 /**


### PR DESCRIPTION
With stricter type checking on, this `navigation-react-native` is throwing the following error:

```
node_modules/navigation-react-native/navigation.react.native.d.ts:95:49 - error TS7008: Member 'offset' implicitly has an 'any' type.

95     onOffsetChanged?: (e: NativeSyntheticEvent<{offset}>) => void;
```

This resolves this error by adding a type constraint to `onOffsetChanged`

Please let me know if the type is correct, or needs more work.

Thanks!