### PR TITLE
Update IconResolver to handle image sources that do not have width or height

### DIFF
--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/IconResolver.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/IconResolver.java
@@ -31,11 +31,9 @@ class IconResolver {
 
         DrawableWithIntrinsicSize(Resources resources, Bitmap bitmap, ReadableMap source) {
             super(resources, bitmap);
-
             width = source.hasKey(PROP_ICON_WIDTH)
                     ? Math.round(PixelUtil.toPixelFromDIP(source.getInt(PROP_ICON_WIDTH)))
                     : bitmap.getWidth();
-
             height = source.hasKey(PROP_ICON_HEIGHT)
                     ? Math.round(PixelUtil.toPixelFromDIP(source.getInt(PROP_ICON_HEIGHT)))
                     : bitmap.getHeight();

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/IconResolver.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/IconResolver.java
@@ -31,18 +31,14 @@ class IconResolver {
 
         DrawableWithIntrinsicSize(Resources resources, Bitmap bitmap, ReadableMap source) {
             super(resources, bitmap);
-            
-            if (source.hasKey(PROP_ICON_WIDTH)) {
-                width = Math.round(PixelUtil.toPixelFromDIP(source.getInt(PROP_ICON_WIDTH)));
-            } else {
-                width = bitmap.getWidth();
-            }
 
-            if (source.hasKey(PROP_ICON_HEIGHT)) {
-                height = Math.round(PixelUtil.toPixelFromDIP(source.getInt(PROP_ICON_HEIGHT)));
-            } else {
-                height = bitmap.getHeight();
-            }
+            width = source.hasKey(PROP_ICON_WIDTH)
+                    ? Math.round(PixelUtil.toPixelFromDIP(source.getInt(PROP_ICON_WIDTH)))
+                    : bitmap.getWidth();
+
+            height = source.hasKey(PROP_ICON_HEIGHT)
+                    ? Math.round(PixelUtil.toPixelFromDIP(source.getInt(PROP_ICON_HEIGHT)))
+                    : bitmap.getHeight();
         }
 
         @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/IconResolver.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/IconResolver.java
@@ -31,8 +31,18 @@ class IconResolver {
 
         DrawableWithIntrinsicSize(Resources resources, Bitmap bitmap, ReadableMap source) {
             super(resources, bitmap);
-            width = Math.round(PixelUtil.toPixelFromDIP(source.getInt(PROP_ICON_WIDTH)));
-            height = Math.round(PixelUtil.toPixelFromDIP(source.getInt(PROP_ICON_HEIGHT)));
+            
+            if (source.hasKey(PROP_ICON_WIDTH)) {
+                width = Math.round(PixelUtil.toPixelFromDIP(source.getInt(PROP_ICON_WIDTH)));
+            } else {
+                width = bitmap.getWidth();
+            }
+
+            if (source.hasKey(PROP_ICON_HEIGHT)) {
+                height = Math.round(PixelUtil.toPixelFromDIP(source.getInt(PROP_ICON_HEIGHT)));
+            } else {
+                height = bitmap.getHeight();
+            }
         }
 
         @Override


### PR DESCRIPTION
Fixes #381 

This fixes a crash due to `source.getInt` throwing if the `source` is missing the `width` or `height` props.

What I found is that the react-native-vector-icons' images have their width/height embedded in the bitmap, and do not pass a height/width prop. They pass a scale prop, but it is not needed.

If the props are not present in the source, we can just fallback to the bitmap's own height and width.