### PR TITLE
Ensured tabs reflect changes made to TabBarItems on Android

### DIFF
--- a/NavigationReactNative/src/TabBarItem.tsx
+++ b/NavigationReactNative/src/TabBarItem.tsx
@@ -21,7 +21,6 @@ class TabBarItem extends React.Component<any> {
         return (
             <NVTabBarItem
                 {...props}
-                index={index}
                 badge={badge != null ? '' + badge : undefined}
                 image={Platform.OS === 'ios' ? image : Image.resolveAssetSource(image)}
                 style={styles.tabBarItem}

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
@@ -37,7 +37,6 @@ public class CollapsingBarManager extends ViewGroupManager<CollapsingBarView> {
     @ReactProp(name = "contentScrimColor", customType = "Color")
     public void setContentScrimColor(CollapsingBarView view, @Nullable Integer contentScrimColor) {
         view.setContentScrim(contentScrimColor != null ? new ColorDrawable(contentScrimColor) : view.defaultContentScrim);
-        view.measureAndLayoutCoordinator();
     }
 
     @ReactProp(name = "collapsedTitleColor", customType = "Color")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
@@ -27,13 +27,11 @@ public class CollapsingBarManager extends ViewGroupManager<CollapsingBarView> {
     @ReactProp(name = "title")
     public void setTitle(CollapsingBarView view, @Nullable String title) {
         view.setTitle(title);
-        view.measureAndLayoutCoordinator();
     }
 
     @ReactProp(name = "titleEnabled")
     public void setTitleEnabled(CollapsingBarView view, boolean titleEnabled) {
         view.setTitleEnabled(titleEnabled);
-        view.measureAndLayoutCoordinator();
     }
 
     @ReactProp(name = "contentScrimColor", customType = "Color")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CollapsingBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CollapsingBarView.java
@@ -9,6 +9,7 @@ import com.google.android.material.appbar.CollapsingToolbarLayout;
 public class CollapsingBarView extends CollapsingToolbarLayout {
     Drawable defaultContentScrim;
     int defaultTitleTextColor;
+    private boolean layoutRequested = false;
 
     public CollapsingBarView(Context context) {
         super(context);
@@ -23,12 +24,21 @@ public class CollapsingBarView extends CollapsingToolbarLayout {
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
         requestLayout();
-        post(measureAndLayout);
+    }
+
+    @Override
+    public void requestLayout() {
+        super.requestLayout();
+        if (!layoutRequested) {
+            layoutRequested = true;
+            post(measureAndLayout);
+        }
     }
 
     private final Runnable measureAndLayout = new Runnable() {
         @Override
         public void run() {
+            layoutRequested = false;
             measure(
                 MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
                 MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CollapsingBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CollapsingBarView.java
@@ -31,8 +31,8 @@ public class CollapsingBarView extends CollapsingToolbarLayout {
         @Override
         public void run() {
             measure(
-                    MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
-                    MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
+                MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
+                MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
             layout(getLeft(), getTop(), getRight(), getBottom());
         }
     };

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CollapsingBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CollapsingBarView.java
@@ -18,12 +18,6 @@ public class CollapsingBarView extends CollapsingToolbarLayout {
         setLayoutParams(params);
         defaultContentScrim = getContentScrim();
         defaultTitleTextColor = new ToolbarView(context).defaultTitleTextColor;
-        addOnLayoutChangeListener(new OnLayoutChangeListener() {
-            @Override
-            public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
-                measureAndLayoutCoordinator();
-            }
-        });
     }
 
     @Override
@@ -42,11 +36,4 @@ public class CollapsingBarView extends CollapsingToolbarLayout {
             layout(getLeft(), getTop(), getRight(), getBottom());
         }
     };
-
-    void measureAndLayoutCoordinator() {
-        if (getParent() != null && getParent().getParent() instanceof CoordinatorLayoutView) {
-            CoordinatorLayoutView coordinatorLayoutView = (CoordinatorLayoutView) getParent().getParent();
-            //coordinatorLayoutView.post(coordinatorLayoutView.measureAndLayout);
-        }
-    }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CollapsingBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CollapsingBarView.java
@@ -46,7 +46,7 @@ public class CollapsingBarView extends CollapsingToolbarLayout {
     void measureAndLayoutCoordinator() {
         if (getParent() != null && getParent().getParent() instanceof CoordinatorLayoutView) {
             CoordinatorLayoutView coordinatorLayoutView = (CoordinatorLayoutView) getParent().getParent();
-            coordinatorLayoutView.post(coordinatorLayoutView.measureAndLayout);
+            //coordinatorLayoutView.post(coordinatorLayoutView.measureAndLayout);
         }
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CollapsingBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CollapsingBarView.java
@@ -2,7 +2,6 @@ package com.navigation.reactnative;
 
 import android.content.Context;
 import android.graphics.drawable.Drawable;
-import android.view.View;
 
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.CollapsingToolbarLayout;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CoordinatorLayoutManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CoordinatorLayoutManager.java
@@ -32,11 +32,8 @@ public class CoordinatorLayoutManager extends ViewGroupManager<CoordinatorLayout
         view.overlap = overlap;
         if (view.getScrollView() != null) {
             CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) view.getScrollView().getLayoutParams();
-            if (params.getBehavior() != null) {
+            if (params.getBehavior() != null)
                 ((AppBarLayout.ScrollingViewBehavior) params.getBehavior()).setOverlayTop(overlap);
-                view.requestLayout();
-                view.post(view.measureAndLayout);
-            }
         }
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CoordinatorLayoutView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CoordinatorLayoutView.java
@@ -9,8 +9,6 @@ import android.widget.ScrollView;
 
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
-import com.facebook.react.modules.core.ChoreographerCompat;
-import com.facebook.react.modules.core.ReactChoreographer;
 import com.facebook.react.uimanager.events.NativeGestureUtil;
 
 public class CoordinatorLayoutView extends CoordinatorLayout {
@@ -22,16 +20,6 @@ public class CoordinatorLayoutView extends CoordinatorLayout {
     private int[] scrollOffset = new int[2];
     private int[] scrollConsumed = new int[2];
     private boolean layoutRequested = false;
-    private final ChoreographerCompat.FrameCallback layoutCallback = new ChoreographerCompat.FrameCallback() {
-        @Override
-        public void doFrame(long frameTimeNanos) {
-            layoutRequested = false;
-            measure(
-                MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
-                MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
-            layout(getLeft(), getTop(), getRight(), getBottom());
-        }
-    };
 
     public CoordinatorLayoutView(Context context){
         super(context);
@@ -44,14 +32,26 @@ public class CoordinatorLayoutView extends CoordinatorLayout {
         requestLayout();
     }
 
+
     @Override
     public void requestLayout() {
         super.requestLayout();
-        if (!layoutRequested && layoutCallback != null) {
+        if (!layoutRequested) {
             layoutRequested = true;
-            ReactChoreographer.getInstance().postFrameCallback(ReactChoreographer.CallbackType.NATIVE_ANIMATED_MODULE, layoutCallback);
+            post(measureAndLayout);
         }
     }
+
+    private final Runnable measureAndLayout = new Runnable() {
+        @Override
+        public void run() {
+            layoutRequested = false;
+            measure(
+                    MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
+                    MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
+            layout(getLeft(), getTop(), getRight(), getBottom());
+        }
+    };
 
     ScrollView getScrollView() {
         for(int i = 0; i < getChildCount(); i++) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CoordinatorLayoutView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CoordinatorLayoutView.java
@@ -47,8 +47,8 @@ public class CoordinatorLayoutView extends CoordinatorLayout {
         public void run() {
             layoutRequested = false;
             measure(
-                    MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
-                    MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
+                MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
+                MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
             layout(getLeft(), getTop(), getRight(), getBottom());
         }
     };

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarManager.java
@@ -53,7 +53,6 @@ public class NavigationBarManager extends ViewGroupManager<NavigationBarView> {
         if (view.getParent() instanceof CoordinatorLayoutView) {
             CoordinatorLayoutView coordinatorLayoutView = (CoordinatorLayoutView) view.getParent();
             coordinatorLayoutView.requestLayout();
-            //coordinatorLayoutView.post(coordinatorLayoutView.measureAndLayout);
         }
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarManager.java
@@ -53,7 +53,7 @@ public class NavigationBarManager extends ViewGroupManager<NavigationBarView> {
         if (view.getParent() instanceof CoordinatorLayoutView) {
             CoordinatorLayoutView coordinatorLayoutView = (CoordinatorLayoutView) view.getParent();
             coordinatorLayoutView.requestLayout();
-            coordinatorLayoutView.post(coordinatorLayoutView.measureAndLayout);
+            //coordinatorLayoutView.post(coordinatorLayoutView.measureAndLayout);
         }
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemManager.java
@@ -22,11 +22,6 @@ public class TabBarItemManager extends ViewGroupManager<TabBarItemView> {
         return "NVTabBarItem";
     }
 
-    @ReactProp(name = "index")
-    public void setIndex(TabBarItemView view, int index) {
-        view.index = index;
-    }
-
     @ReactProp(name = "title")
     public void setTitle(TabBarItemView view, String title) {
         view.setTitle(title);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemView.java
@@ -44,8 +44,9 @@ public class TabBarItemView extends ViewGroup {
         IconResolver.setIconSource(source, tabIconResolverListener, getContext());
     }
 
-    void setTabView(TabView tabView) {
+    void setTabView(TabView tabView, int index) {
         this.tabView = tabView;
+        this.index = index;
         if (icon != null)
             tabView.setIcon(index, icon);
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarManager.java
@@ -31,10 +31,6 @@ public class TabBarManager extends ViewGroupManager<TabBarView> {
         if (view.getCurrentItem() != selectedTab) {
             view.setCurrentItem(selectedTab, false);
         }
-        if (view.getParent() instanceof CoordinatorLayoutView) {
-            CoordinatorLayoutView coordinatorLayoutView = (CoordinatorLayoutView) view.getParent();
-            coordinatorLayoutView.post(coordinatorLayoutView.measureAndLayout);
-        }
     }
 
     @ReactProp(name = "tabCount")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -127,7 +127,7 @@ public class TabBarView extends ViewPager {
         return false;
     }
 
-    private class Adapter extends PagerAdapter {
+    private static class Adapter extends PagerAdapter {
         private List<TabBarItemView> tabs = new ArrayList<>();
 
         void addTab(TabBarItemView tab, int index) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -131,7 +131,7 @@ public class TabBarView extends ViewPager {
         return false;
     }
 
-    private class Adapter extends PagerAdapter {
+    private static class Adapter extends PagerAdapter {
         private List<TabBarItemView> tabs = new ArrayList<>();
 
         void addTab(TabBarItemView tab, int index) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 public class TabBarView extends ViewPager {
     boolean swipeable = true;
+    private boolean layoutRequested = false;
 
     public TabBarView(Context context) {
         super(context);
@@ -33,7 +34,6 @@ public class TabBarView extends ViewPager {
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
         requestLayout();
-        post(measureAndLayout);
         if (getTabView() != null)
             getTabView().setupWithViewPager(this);
         populateTabs();
@@ -61,9 +61,19 @@ public class TabBarView extends ViewPager {
         return null;
     }
 
+    @Override
+    public void requestLayout() {
+        super.requestLayout();
+        if (!layoutRequested) {
+            layoutRequested = true;
+            post(measureAndLayout);
+        }
+    }
+
     private final Runnable measureAndLayout = new Runnable() {
         @Override
         public void run() {
+            layoutRequested = false;
             measure(
                 MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
                 MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
@@ -156,7 +166,6 @@ public class TabBarView extends ViewPager {
         public Object instantiateItem(@NonNull ViewGroup container, int position) {
             TabBarItemView tab = tabs.get(position);
             container.addView(tab.content.get(0), 0);
-            post(measureAndLayout);
             return tab.content.get(0);
         }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -43,7 +43,7 @@ public class TabBarView extends ViewPager {
         TabView tabView = getTabView();
         if (tabView != null && getAdapter() != null) {
             for(int i = 0; i < tabView.getTabCount(); i++) {
-                getAdapter().tabs.get(i).setTabView(tabView);
+                getAdapter().tabs.get(i).setTabView(tabView, i);
             }
         }
     }
@@ -96,13 +96,17 @@ public class TabBarView extends ViewPager {
     }
 
     void addTab(TabBarItemView tab, int index) {
-        if (getAdapter() != null)
+        if (getAdapter() != null) {
             getAdapter().addTab(tab, index);
+            populateTabs();
+        }
     }
 
     void removeTab(int index) {
-        if (getAdapter() != null)
+        if (getAdapter() != null) {
             getAdapter().removeTab(index);
+            populateTabs();
+        }
     }
 
     @Override
@@ -127,7 +131,7 @@ public class TabBarView extends ViewPager {
         return false;
     }
 
-    private static class Adapter extends PagerAdapter {
+    private class Adapter extends PagerAdapter {
         private List<TabBarItemView> tabs = new ArrayList<>();
 
         void addTab(TabBarItemView tab, int index) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutView.java
@@ -5,8 +5,6 @@ import android.graphics.drawable.Drawable;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.facebook.react.modules.core.ChoreographerCompat;
-import com.facebook.react.modules.core.ReactChoreographer;
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.tabs.TabLayout;
 
@@ -16,16 +14,6 @@ public class TabLayoutView extends TabLayout implements TabView {
     int selectedTintColor;
     int unselectedTintColor;
     private boolean layoutRequested = false;
-    private final ChoreographerCompat.FrameCallback layoutCallback = new ChoreographerCompat.FrameCallback() {
-        @Override
-        public void doFrame(long frameTimeNanos) {
-            layoutRequested = false;
-            measure(
-                MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
-                MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
-            layout(getLeft(), getTop(), getRight(), getBottom());
-        }
-    };
 
     public TabLayoutView(Context context) {
         super(context);
@@ -63,11 +51,22 @@ public class TabLayoutView extends TabLayout implements TabView {
     @Override
     public void requestLayout() {
         super.requestLayout();
-        if (!layoutRequested && layoutCallback != null) {
+        if (!layoutRequested) {
             layoutRequested = true;
-            ReactChoreographer.getInstance().postFrameCallback(ReactChoreographer.CallbackType.NATIVE_ANIMATED_MODULE, layoutCallback);
+            post(measureAndLayout);
         }
     }
+
+    private final Runnable measureAndLayout = new Runnable() {
+        @Override
+        public void run() {
+            layoutRequested = false;
+            measure(
+                MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
+                MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
+            layout(getLeft(), getTop(), getRight(), getBottom());
+        }
+    };
 
     @Override
     public void setTitle(int index, String title) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutView.java
@@ -39,15 +39,6 @@ public class TabLayoutView extends TabLayout implements TabView {
         if (getTabTextColors() != null)
             selectedTintColor = unselectedTintColor = defaultTextColor = getTabTextColors().getDefaultColor();
         setSelectedTabIndicatorColor(defaultTextColor);
-        addOnLayoutChangeListener(new OnLayoutChangeListener() {
-            @Override
-            public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
-                if (getParent() != null && getParent().getParent() instanceof CoordinatorLayoutView) {
-                    CoordinatorLayoutView coordinatorLayoutView = (CoordinatorLayoutView) getParent().getParent();
-                    post(coordinatorLayoutView.measureAndLayout);
-                }
-            }
-        });
     }
 
     public void setScrollable(boolean scrollable) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutView.java
@@ -1,13 +1,9 @@
 package com.navigation.reactnative;
 
 import android.content.Context;
-import android.database.DataSetObserver;
 import android.graphics.drawable.Drawable;
 import android.view.View;
 import android.view.ViewGroup;
-
-import androidx.annotation.Nullable;
-import androidx.viewpager.widget.ViewPager;
 
 import com.facebook.react.modules.core.ChoreographerCompat;
 import com.facebook.react.modules.core.ReactChoreographer;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
@@ -13,8 +13,6 @@ import androidx.annotation.Nullable;
 import androidx.viewpager.widget.PagerAdapter;
 import androidx.viewpager.widget.ViewPager;
 
-import com.facebook.react.modules.core.ChoreographerCompat;
-import com.facebook.react.modules.core.ReactChoreographer;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 
 public class TabNavigationView extends BottomNavigationView implements TabView {
@@ -25,16 +23,6 @@ public class TabNavigationView extends BottomNavigationView implements TabView {
     private ViewPager.OnPageChangeListener pageChangeListener;
     private DataSetObserver dataSetObserver;
     private boolean layoutRequested = false;
-    private final ChoreographerCompat.FrameCallback layoutCallback = new ChoreographerCompat.FrameCallback() {
-        @Override
-        public void doFrame(long frameTimeNanos) {
-            layoutRequested = false;
-            measure(
-                MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
-                MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
-            layout(getLeft(), getTop(), getRight(), getBottom());
-        }
-    };
 
     public TabNavigationView(Context context) {
         super(context);
@@ -114,11 +102,22 @@ public class TabNavigationView extends BottomNavigationView implements TabView {
     @Override
     public void requestLayout() {
         super.requestLayout();
-        if (!layoutRequested && layoutCallback != null) {
+        if (!layoutRequested) {
             layoutRequested = true;
-            ReactChoreographer.getInstance().postFrameCallback(ReactChoreographer.CallbackType.NATIVE_ANIMATED_MODULE, layoutCallback);
+            post(measureAndLayout);
         }
     }
+
+    private final Runnable measureAndLayout = new Runnable() {
+        @Override
+        public void run() {
+            layoutRequested = false;
+            measure(
+                MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
+                MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
+            layout(getLeft(), getTop(), getRight(), getBottom());
+        }
+    };
 
     @Override
     public int getTabCount() {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
@@ -155,14 +155,12 @@ public class ToolbarView extends Toolbar {
                     @Override
                     public boolean onMenuItemActionCollapse(MenuItem item) {
                         onSearchAddedListener.onSearchCollapse();
-                        post(measureAndLayout);
                         return true;
                     }
 
                     @Override
                     public boolean onMenuItemActionExpand(MenuItem item) {
                         onSearchAddedListener.onSearchExpand();
-                        post(measureAndLayout);
                         return true;
                     }
                 });

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
@@ -195,8 +195,8 @@ public class ToolbarView extends Toolbar {
         public void run() {
             layoutRequested = false;
             measure(
-                    MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
-                    MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
+                MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
+                MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
             layout(getLeft(), getTop(), getRight(), getBottom());
         }
     };

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
@@ -34,6 +34,7 @@ public class ToolbarView extends Toolbar {
     private IconResolver.IconResolverListener logoResolverListener;
     private IconResolver.IconResolverListener navIconResolverListener;
     private IconResolver.IconResolverListener overflowIconResolverListener;
+    private boolean layoutRequested = false;
 
     public ToolbarView(Context context) {
         super(context);
@@ -45,7 +46,6 @@ public class ToolbarView extends Toolbar {
             public void setDrawable(Drawable d) {
                 setLogo(d);
                 setTintColor(getLogo());
-                post(measureAndLayout);
             }
         };
         navIconResolverListener = new IconResolver.IconResolverListener() {
@@ -53,7 +53,6 @@ public class ToolbarView extends Toolbar {
             public void setDrawable(Drawable d) {
                 setNavigationIcon(d);
                 setTintColor(getNavigationIcon());
-                post(measureAndLayout);
             }
         };
         overflowIconResolverListener = new IconResolver.IconResolverListener() {
@@ -136,7 +135,6 @@ public class ToolbarView extends Toolbar {
 
     void setMenuItems(@Nullable ReadableArray menuItems) {
         getMenu().clear();
-        post(measureAndLayout);
         for (int i = 0; menuItems != null && i < menuItems.size(); i++) {
             ReadableMap menuItemProps = menuItems.getMap(i);
             if (menuItemProps == null)
@@ -185,9 +183,19 @@ public class ToolbarView extends Toolbar {
 
     }
 
+    @Override
+    public void requestLayout() {
+        super.requestLayout();
+        if (!layoutRequested) {
+            layoutRequested = true;
+            post(measureAndLayout);
+        }
+    }
+
     private final Runnable measureAndLayout = new Runnable() {
         @Override
         public void run() {
+            layoutRequested = false;
             measure(
                     MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
                     MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
@@ -206,7 +214,6 @@ public class ToolbarView extends Toolbar {
         public void setDrawable(Drawable d) {
             item.setIcon(d);
             setTintColor(item.getIcon());
-            post(measureAndLayout);
         }
     }
 


### PR DESCRIPTION
Create primary tab bar with two tabs and, after 2000ms, insert a tab between the two. If click on the second tab before 2000ms elapses the tabs don't update properly. Some images missing, partial title text.
Fixed by posting a measureAndLayout when requestLayout is called. Before, was manually sprinkling measureAndLayout calls but this didn't work. Let Android dictate by scheduling measure whenever layout requested. Made this change throughout for consistency. Also meant could get rid of LayoutChangeListeners because Android knows when to request a layout. 

Create tab bar with three tabs and, after 2000ms, remove middle tab and change image of third tab. Threw error because tries to update image of third tab but should be second because there is no third. Problem was that was setting the tab index prop from javascript and the image prop update ran before the index update. Changed to set the index on the native side whenever the tabs change. Luckily, the children updates run before the prop updates