### PR TITLE
Primed browser history when fluently navigating

### DIFF
--- a/Navigation/src/StateNavigator.ts
+++ b/Navigation/src/StateNavigator.ts
@@ -158,7 +158,7 @@ class StateNavigator {
         }
         if (url === this.stateContext.url) {
             if (historyAction !== 'none')
-                this.historyManager.addHistory(url, historyAction === 'replace', stateContext);
+                this.historyManager.addHistory(url, historyAction === 'replace', this.stateContext);
             if (this.stateContext.title && (typeof document !== 'undefined'))
                 document.title = this.stateContext.title;
         }

--- a/Navigation/src/StateNavigator.ts
+++ b/Navigation/src/StateNavigator.ts
@@ -158,7 +158,7 @@ class StateNavigator {
         }
         if (url === this.stateContext.url) {
             if (historyAction !== 'none')
-                this.historyManager.addHistory(url, historyAction === 'replace');
+                this.historyManager.addHistory(url, historyAction === 'replace', stateContext);
             if (this.stateContext.title && (typeof document !== 'undefined'))
                 document.title = this.stateContext.title;
         }

--- a/Navigation/src/history/HistoryManager.ts
+++ b/Navigation/src/history/HistoryManager.ts
@@ -1,7 +1,9 @@
-﻿interface HistoryManager {
+﻿import StateContext from "../StateContext";
+
+interface HistoryManager {
     disabled: boolean;
     init(navigateHistory: (url?: string) => void): void;
-    addHistory(url: string, replace: boolean): void;
+    addHistory(url: string, replace: boolean, stateContext: StateContext): void;
     getCurrentUrl(): string;
     getHref(url: string): string;
     getUrl(hrefElement: HTMLAnchorElement | Location): string;

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -3967,12 +3967,15 @@ describe('Navigation', function () {
 
     describe('History Add', function () {
         var replaceHistory;
+        var historyContext: StateContext;
         var stateNavigator: StateNavigator;
         beforeEach(function() {
             var historyManager = new HashHistoryManager();
             replaceHistory = undefined;
-            historyManager.addHistory = (_url: string, replace: boolean) => {
+            historyContext = undefined;
+            historyManager.addHistory = (_url: string, replace: boolean, stateContext?: StateContext) => {
                 replaceHistory = replace;
+                historyContext = stateContext;
             }
             stateNavigator = new StateNavigator([
                     { key: 's', route: 'r' }
@@ -3999,18 +4002,23 @@ describe('Navigation', function () {
         function test() {
             it('should pass replace false to history manager', function() {
                 assert.strictEqual(replaceHistory, false);
+                assert.strictEqual(historyContext.url, '/r');
+                assert.strictEqual(historyContext.state, stateNavigator.states.s);
             });
         }
     });
 
     describe('History Replace', function () {
         var replaceHistory;
+        var historyContext: StateContext;
         var stateNavigator: StateNavigator;
         beforeEach(function() {
             var historyManager = new HashHistoryManager();
             replaceHistory = undefined;
-            historyManager.addHistory = (_url: string, replace: boolean) => {
+            historyContext = undefined;
+            historyManager.addHistory = (_url: string, replace: boolean, stateContext?: StateContext) => {
                 replaceHistory = replace;
+                historyContext = stateContext;
             }
             stateNavigator = new StateNavigator([
                     { key: 's', route: 'r' }
@@ -4037,6 +4045,8 @@ describe('Navigation', function () {
         function test() {
             it('should pass replace true to history manager', function() {
                 assert.strictEqual(replaceHistory, true);
+                assert.strictEqual(historyContext.url, '/r');
+                assert.strictEqual(historyContext.state, stateNavigator.states.s);
             });
         }
     });

--- a/Navigation/test/node_modules/@types/navigation.d.ts
+++ b/Navigation/test/node_modules/@types/navigation.d.ts
@@ -165,9 +165,10 @@ export interface HistoryManager {
      * Adds browser history
      * @param url The current url
      * @param replace A value indicating whether to replace the current
+     * @param stateContext The current StateContext
      * browser history entry
      */
-    addHistory(url: string, replace: boolean): void;
+    addHistory(url: string, replace: boolean, stateContext: StateContext): void;
     /**
      * Gets the current location
      */

--- a/NavigationReact/src/node_modules/@types/navigation.d.ts
+++ b/NavigationReact/src/node_modules/@types/navigation.d.ts
@@ -165,9 +165,10 @@ export interface HistoryManager {
      * Adds browser history
      * @param url The current url
      * @param replace A value indicating whether to replace the current
+     * @param stateContext The current StateContext
      * browser history entry
      */
-    addHistory(url: string, replace: boolean): void;
+    addHistory(url: string, replace: boolean, stateContext: StateContext): void;
     /**
      * Gets the current location
      */

--- a/NavigationReact/test/node_modules/@types/navigation.d.ts
+++ b/NavigationReact/test/node_modules/@types/navigation.d.ts
@@ -165,9 +165,10 @@ export interface HistoryManager {
      * Adds browser history
      * @param url The current url
      * @param replace A value indicating whether to replace the current
+     * @param stateContext The current StateContext
      * browser history entry
      */
-    addHistory(url: string, replace: boolean): void;
+    addHistory(url: string, replace: boolean, stateContext: StateContext): void;
     /**
      * Gets the current location
      */
@@ -282,7 +283,7 @@ export class HTML5HistoryManager implements HistoryManager {
 }
 
 /**
- * Represents one piece of the crumb trail and holds the information need
+ * Represents one piece of the crumb trail and holds the information needed
  * to return to and recreate the State as previously visited
  */
 export class Crumb {
@@ -553,9 +554,11 @@ export class StateNavigator {
      * @param historyAction A value determining the effect on browser history
      * @param history A value indicating whether browser history was used
      * @param suspendNavigation Called before the navigation completes
+     * @param currentContext The current StateContext
      */
     navigateLink(url: string, historyAction?: 'add' | 'replace' | 'none', history?: boolean,
-        suspendNavigation?: (stateContext: StateContext, resumeNavigation: () => void) => void);
+        suspendNavigation?: (stateContext: StateContext, resumeNavigation: () => void) => void,
+        currentContext?: StateContext): void;
     /**
      * Parses the url out into State and Navigation Data
      * @param url The url to parse

--- a/NavigationReactMobile/sample/app.html
+++ b/NavigationReactMobile/sample/app.html
@@ -153,9 +153,9 @@
 
         var buildStartUrl = url => {
             var { state, data } = stateNavigator.parseLink(url);
-            var fluent = stateNavigator.fluent().navigate('people');
-            stateNavigator.historyManager.addHistory(fluent.url, true);
-            return fluent.navigate(state.key, data).url;
+            return stateNavigator.fluent()
+                .navigate('people')
+                .navigate(state.key, data).url;
         }
 
         var stateNavigator = new Navigation.StateNavigator([

--- a/NavigationReactMobile/src/MobileHistoryManager.ts
+++ b/NavigationReactMobile/src/MobileHistoryManager.ts
@@ -12,7 +12,7 @@ class MobileHistoryManager extends HTML5HistoryManager {
 
     addHistory(url: string, replace: boolean, stateContext?: StateContext) {
         var title = typeof document !== 'undefined' && document.title;
-        if (!!stateContext) {
+        if (!!stateContext && !stateContext.history) {
             var {oldUrl, crumbs} = stateContext;
             var start = !oldUrl ? 0 : oldUrl.split('crumb=').length;
             for(var i = start; i < crumbs.length; i++) {

--- a/NavigationReactMobile/src/MobileHistoryManager.ts
+++ b/NavigationReactMobile/src/MobileHistoryManager.ts
@@ -13,7 +13,7 @@ class MobileHistoryManager extends HTML5HistoryManager {
     addHistory(url: string, replace: boolean, stateContext?: StateContext) {
         if (!!stateContext) {
             var {oldUrl, crumbs} = stateContext;
-            if (!!oldUrl) {
+            if (!oldUrl) {
                 for(var i = 0; i < crumbs.length; i++) {
                     super.addHistory(crumbs[i].url, true);                    
                 }

--- a/NavigationReactMobile/src/MobileHistoryManager.ts
+++ b/NavigationReactMobile/src/MobileHistoryManager.ts
@@ -1,4 +1,4 @@
-import { HTML5HistoryManager } from 'navigation';
+import { HTML5HistoryManager, StateContext } from 'navigation';
 
 class MobileHistoryManager extends HTML5HistoryManager {
     private hash = false;
@@ -8,6 +8,25 @@ class MobileHistoryManager extends HTML5HistoryManager {
         super(applicationPath || '');
         this.buildCurrentUrl = buildCurrentUrl;
         this.hash = applicationPath === undefined;
+    }
+
+    addHistory(url: string, replace: boolean, stateContext?: StateContext) {
+        if (!!stateContext) {
+            var {oldUrl, crumbs} = stateContext;
+            if (!!oldUrl) {
+                for(var i = 0; i < crumbs.length; i++) {
+                    super.addHistory(crumbs[i].url, true);                    
+                }
+            } else {
+                var oldScenes = oldUrl.split('crumb=').length;
+                if (crumbs.length > oldScenes) {
+                    for(var i = oldScenes + 1; i < crumbs.length; i++) {
+                        super.addHistory(crumbs[i].url, false);                    
+                    }    
+                }
+            }
+        }
+        super.addHistory(url, replace);
     }
 
     getHref(url: string): string {

--- a/NavigationReactMobile/src/MobileHistoryManager.ts
+++ b/NavigationReactMobile/src/MobileHistoryManager.ts
@@ -19,10 +19,13 @@ class MobileHistoryManager extends HTML5HistoryManager {
                 }
             } else {
                 var oldScenes = oldUrl.split('crumb=').length - 1;
-                if (crumbs.length > oldScenes) {
+                if (crumbs.length > oldScenes + 1) {
                     for(var i = oldScenes + 1; i < crumbs.length; i++) {
-                        super.addHistory(crumbs[i].url, false);                    
-                    }    
+                        var crumb = crumbs[i];
+                        super.addHistory(crumb.url, false);                    
+                        if (typeof document !== 'undefined' && crumb.state.title)
+                            document.title = crumb.state.title;
+                    }
                 }
             }
         }

--- a/NavigationReactMobile/src/MobileHistoryManager.ts
+++ b/NavigationReactMobile/src/MobileHistoryManager.ts
@@ -16,10 +16,10 @@ class MobileHistoryManager extends HTML5HistoryManager {
             var {oldUrl, crumbs} = stateContext;
             var start = !oldUrl ? 0 : oldUrl.split('crumb=').length;
             for(var i = start; i < crumbs.length; i++) {
-                var crumb = crumbs[i];
-                super.addHistory(crumb.url, i === 0);
-                if (typeof document !== 'undefined' && crumb.state.title)
-                    document.title = crumb.state.title;
+                let {url, state} = crumbs[i];
+                super.addHistory(url, i === 0);
+                if (typeof document !== 'undefined' && state.title)
+                    document.title = state.title;
             }
         }
         super.addHistory(url, replace);

--- a/NavigationReactMobile/src/MobileHistoryManager.ts
+++ b/NavigationReactMobile/src/MobileHistoryManager.ts
@@ -11,6 +11,7 @@ class MobileHistoryManager extends HTML5HistoryManager {
     }
 
     addHistory(url: string, replace: boolean, stateContext?: StateContext) {
+        var title = typeof document !== 'undefined' && document.title;
         if (!!stateContext) {
             var {oldUrl, crumbs} = stateContext;
             var start = !oldUrl ? 0 : oldUrl.split('crumb=').length;
@@ -22,7 +23,9 @@ class MobileHistoryManager extends HTML5HistoryManager {
             }
         }
         super.addHistory(url, replace);
-    }
+        if (title)
+            document.title = title;
+}
 
     getHref(url: string): string {
         var queryIndex = url.indexOf('?');

--- a/NavigationReactMobile/src/MobileHistoryManager.ts
+++ b/NavigationReactMobile/src/MobileHistoryManager.ts
@@ -15,7 +15,7 @@ class MobileHistoryManager extends HTML5HistoryManager {
             var {oldUrl, crumbs} = stateContext;
             if (!oldUrl) {
                 for(var i = 0; i < crumbs.length; i++) {
-                    super.addHistory(crumbs[i].url, true);                    
+                    super.addHistory(crumbs[i].url, i === 0);
                 }
             } else {
                 var oldScenes = oldUrl.split('crumb=').length - 1;

--- a/NavigationReactMobile/src/MobileHistoryManager.ts
+++ b/NavigationReactMobile/src/MobileHistoryManager.ts
@@ -18,7 +18,7 @@ class MobileHistoryManager extends HTML5HistoryManager {
                     super.addHistory(crumbs[i].url, true);                    
                 }
             } else {
-                var oldScenes = oldUrl.split('crumb=').length;
+                var oldScenes = oldUrl.split('crumb=').length - 1;
                 if (crumbs.length > oldScenes) {
                     for(var i = oldScenes + 1; i < crumbs.length; i++) {
                         super.addHistory(crumbs[i].url, false);                    

--- a/NavigationReactMobile/src/MobileHistoryManager.ts
+++ b/NavigationReactMobile/src/MobileHistoryManager.ts
@@ -25,7 +25,7 @@ class MobileHistoryManager extends HTML5HistoryManager {
         super.addHistory(url, replace);
         if (title)
             document.title = title;
-}
+    }
 
     getHref(url: string): string {
         var queryIndex = url.indexOf('?');

--- a/NavigationReactMobile/src/MobileHistoryManager.ts
+++ b/NavigationReactMobile/src/MobileHistoryManager.ts
@@ -13,23 +13,12 @@ class MobileHistoryManager extends HTML5HistoryManager {
     addHistory(url: string, replace: boolean, stateContext?: StateContext) {
         if (!!stateContext) {
             var {oldUrl, crumbs} = stateContext;
-            if (!oldUrl) {
-                for(var i = 0; i < crumbs.length; i++) {
-                    var crumb = crumbs[i];
-                    super.addHistory(crumb.url, i === 0);
-                    if (typeof document !== 'undefined' && crumb.state.title)
-                        document.title = crumb.state.title;
-                }
-            } else {
-                var oldScenes = oldUrl.split('crumb=').length - 1;
-                if (crumbs.length > oldScenes + 1) {
-                    for(var i = oldScenes + 1; i < crumbs.length; i++) {
-                        var crumb = crumbs[i];
-                        super.addHistory(crumb.url, false);                    
-                        if (typeof document !== 'undefined' && crumb.state.title)
-                            document.title = crumb.state.title;
-                    }
-                }
+            var start = !oldUrl ? 0 : oldUrl.split('crumb=').length;
+            for(var i = start; i < crumbs.length; i++) {
+                var crumb = crumbs[i];
+                super.addHistory(crumb.url, i === 0);
+                if (typeof document !== 'undefined' && crumb.state.title)
+                    document.title = crumb.state.title;
             }
         }
         super.addHistory(url, replace);

--- a/NavigationReactMobile/src/MobileHistoryManager.ts
+++ b/NavigationReactMobile/src/MobileHistoryManager.ts
@@ -15,7 +15,10 @@ class MobileHistoryManager extends HTML5HistoryManager {
             var {oldUrl, crumbs} = stateContext;
             if (!oldUrl) {
                 for(var i = 0; i < crumbs.length; i++) {
-                    super.addHistory(crumbs[i].url, i === 0);
+                    var crumb = crumbs[i];
+                    super.addHistory(crumb.url, i === 0);
+                    if (typeof document !== 'undefined' && crumb.state.title)
+                        document.title = crumb.state.title;
                 }
             } else {
                 var oldScenes = oldUrl.split('crumb=').length - 1;

--- a/NavigationReactMobile/src/node_modules/@types/navigation.d.ts
+++ b/NavigationReactMobile/src/node_modules/@types/navigation.d.ts
@@ -165,9 +165,10 @@ export interface HistoryManager {
      * Adds browser history
      * @param url The current url
      * @param replace A value indicating whether to replace the current
+     * @param stateContext The current StateContext
      * browser history entry
      */
-    addHistory(url: string, replace: boolean): void;
+    addHistory(url: string, replace: boolean, stateContext: StateContext): void;
     /**
      * Gets the current location
      */

--- a/NavigationReactMobile/test/node_modules/@types/navigation.d.ts
+++ b/NavigationReactMobile/test/node_modules/@types/navigation.d.ts
@@ -165,9 +165,10 @@ export interface HistoryManager {
      * Adds browser history
      * @param url The current url
      * @param replace A value indicating whether to replace the current
+     * @param stateContext The current StateContext
      * browser history entry
      */
-    addHistory(url: string, replace: boolean): void;
+    addHistory(url: string, replace: boolean, stateContext: StateContext): void;
     /**
      * Gets the current location
      */

--- a/NavigationReactNative/src/node_modules/@types/navigation.d.ts
+++ b/NavigationReactNative/src/node_modules/@types/navigation.d.ts
@@ -165,9 +165,10 @@ export interface HistoryManager {
      * Adds browser history
      * @param url The current url
      * @param replace A value indicating whether to replace the current
+     * @param stateContext The current StateContext
      * browser history entry
      */
-    addHistory(url: string, replace: boolean): void;
+    addHistory(url: string, replace: boolean, stateContext: StateContext): void;
     /**
      * Gets the current location
      */

--- a/NavigationReactNative/test/node_modules/@types/navigation.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation.d.ts
@@ -165,9 +165,10 @@ export interface HistoryManager {
      * Adds browser history
      * @param url The current url
      * @param replace A value indicating whether to replace the current
+     * @param stateContext The current StateContext
      * browser history entry
      */
-    addHistory(url: string, replace: boolean): void;
+    addHistory(url: string, replace: boolean, stateContext: StateContext): void;
     /**
      * Gets the current location
      */

--- a/build/npm/navigation/navigation.d.ts
+++ b/build/npm/navigation/navigation.d.ts
@@ -165,9 +165,10 @@ export interface HistoryManager {
      * Adds browser history
      * @param url The current url
      * @param replace A value indicating whether to replace the current
+     * @param stateContext The current StateContext
      * browser history entry
      */
-    addHistory(url: string, replace: boolean): void;
+    addHistory(url: string, replace: boolean, stateContext: StateContext): void;
     /**
      * Gets the current location
      */


### PR DESCRIPTION
Fluently navigate A → B → C then history back should go to B. History back must match the actual stack. Changed `MobileHistoryManager` to add in the browser history entries if it detects a fluent navigation. This fix also primes history for the fluent navigation in `buildCurrentUrl`.