### PR TITLE
Made SearchBar content tappable when inside a Modal (iOS)

### DIFF
--- a/NavigationReactNative/src/ios/NVSearchBarView.m
+++ b/NavigationReactNative/src/ios/NVSearchBarView.m
@@ -4,13 +4,11 @@
 #import <UIKit/UIKit.h>
 #import <React/RCTBridge.h>
 #import <React/RCTUIManager.h>
-#import <React/RCTTouchHandler.h>
 #import <React/UIView+React.h>
 
 @implementation NVSearchBarView
 {
     __weak RCTBridge *_bridge;
-    RCTTouchHandler *_touchHandler;
     UIView *_reactSubview;
     NSInteger _nativeEventCount;
 }
@@ -23,7 +21,6 @@
         NVSearchResultsController *viewController = [[NVSearchResultsController alloc] init];
         self.searchController = [[UISearchController alloc] initWithSearchResultsController:viewController];
         self.searchController.searchResultsUpdater = self;
-        _touchHandler = [[RCTTouchHandler alloc] initWithBridge:bridge];
         __weak typeof(self) weakSelf = self;
         viewController.boundsDidChangeBlock = ^(CGRect newBounds) {
             [weakSelf notifyForBoundsChange:newBounds];
@@ -78,14 +75,12 @@
 {
     [super insertReactSubview:subview atIndex:atIndex];
     self.searchController.searchResultsController.view = subview;
-    [_touchHandler attachToView:subview];
     _reactSubview = subview;
 }
 
 - (void)removeReactSubview:(UIView *)subview
 {
     [super removeReactSubview:subview];
-    [_touchHandler detachFromView:subview];
     _reactSubview = nil;
 }
 


### PR DESCRIPTION
Fixes #386

Removed the touch handler from the `NVSearchBarView`. Not sure why this was ever needed. Possibly dates back to when each scene was a separate React root?
