### PR TITLE
Applied tint and title colors with UINavigationBarAppearance on iOS 13

### DIFF
--- a/NavigationReactNative/sample/zoom/App.js
+++ b/NavigationReactNative/sample/zoom/App.js
@@ -22,9 +22,9 @@ detail.renderScene = (data) => <Detail colors={colors} {...data}/>;
 
 stateNavigator.navigate('grid');
 
-detail.truncateCrumbTrail = (state, data, crumbs) => (
+/*detail.truncateCrumbTrail = (state, data, crumbs) => (
   crumbs.slice(-1)[0].state === detail ? crumbs.slice(0, -1) : crumbs
-);
+);*/
 
 const openLink = (url) => {
   if (url) {

--- a/NavigationReactNative/sample/zoom/App.js
+++ b/NavigationReactNative/sample/zoom/App.js
@@ -22,9 +22,9 @@ detail.renderScene = (data) => <Detail colors={colors} {...data}/>;
 
 stateNavigator.navigate('grid');
 
-/*detail.truncateCrumbTrail = (state, data, crumbs) => (
+detail.truncateCrumbTrail = (state, data, crumbs) => (
   crumbs.slice(-1)[0].state === detail ? crumbs.slice(0, -1) : crumbs
-);*/
+);
 
 const openLink = (url) => {
   if (url) {

--- a/NavigationReactNative/src/ios/NVNavigationBarView.m
+++ b/NavigationReactNative/src/ios/NVNavigationBarView.m
@@ -60,7 +60,7 @@ API_AVAILABLE(ios(13.0))
     UINavigationBarAppearance *appearanceCopy = [appearance copy];
     if (self.barTintColor != nil)
         [appearanceCopy setBackgroundColor:self.barTintColor];
-    [appearanceCopy.buttonAppearance.normal setTitleTextAttributes:[self setForeground:self.tintColor :appearanceCopy.backButtonAppearance.normal.titleTextAttributes]];
+    [appearanceCopy.buttonAppearance.normal setTitleTextAttributes:[self setForeground:self.tintColor :appearanceCopy.buttonAppearance.normal.titleTextAttributes]];
     [appearanceCopy.doneButtonAppearance.normal setTitleTextAttributes:[self setForeground:self.tintColor :appearanceCopy.doneButtonAppearance.normal.titleTextAttributes]];
     [appearanceCopy setTitleTextAttributes:[self setForeground:self.titleColor :appearanceCopy.titleTextAttributes]];
     [appearanceCopy setLargeTitleTextAttributes:[self setForeground:self.titleColor :appearanceCopy.largeTitleTextAttributes]];

--- a/NavigationReactNative/src/ios/NVNavigationBarView.m
+++ b/NavigationReactNative/src/ios/NVNavigationBarView.m
@@ -58,7 +58,8 @@
 API_AVAILABLE(ios(13.0))
 {
     UINavigationBarAppearance *appearanceCopy = [appearance copy];
-    [appearanceCopy setBackgroundColor:self.barTintColor];
+    if (self.barTintColor != nil)
+        [appearanceCopy setBackgroundColor:self.barTintColor];
     [appearanceCopy.buttonAppearance.normal setTitleTextAttributes:[self setForeground:self.tintColor :appearanceCopy.backButtonAppearance.normal.titleTextAttributes]];
     [appearanceCopy.doneButtonAppearance.normal setTitleTextAttributes:[self setForeground:self.tintColor :appearanceCopy.doneButtonAppearance.normal.titleTextAttributes]];
     [appearanceCopy setTitleTextAttributes:[self setForeground:self.titleColor :appearanceCopy.titleTextAttributes]];
@@ -69,7 +70,6 @@ API_AVAILABLE(ios(13.0))
 -(NSDictionary *)setForeground:(UIColor *)color :(NSDictionary *)attributes
 {
     NSMutableDictionary *attributesCopy = attributes != nil ? [attributes mutableCopy] : @{}.mutableCopy;
-    [attributesCopy removeObjectForKey:NSForegroundColorAttributeName];
     if (color != nil)
         attributesCopy[NSForegroundColorAttributeName] = color;
     return attributesCopy;

--- a/NavigationReactNative/src/ios/NVNavigationBarView.m
+++ b/NavigationReactNative/src/ios/NVNavigationBarView.m
@@ -58,7 +58,7 @@
 -(UINavigationBarAppearance *)updateColors:(UINavigationBarAppearance *)appearance
 API_AVAILABLE(ios(13.0))
 {
-    UINavigationBarAppearance *appearanceCopy = [appearance copy];
+    UINavigationBarAppearance *appearanceCopy = appearance != nil ? [appearance copy] : [UINavigationBarAppearance new];
     [appearanceCopy setBackgroundColor:self.barTintColor];
     [appearanceCopy.buttonAppearance.normal setTitleTextAttributes:[self setForeground:self.tintColor :appearanceCopy.buttonAppearance.normal.titleTextAttributes]];
     [appearanceCopy.doneButtonAppearance.normal setTitleTextAttributes:[self setForeground:self.tintColor :appearanceCopy.doneButtonAppearance.normal.titleTextAttributes]];

--- a/NavigationReactNative/src/ios/NVNavigationBarView.m
+++ b/NavigationReactNative/src/ios/NVNavigationBarView.m
@@ -68,7 +68,7 @@ API_AVAILABLE(ios(13.0))
 
 -(NSDictionary *)setForeground:(UIColor *)color :(NSDictionary *)attributes
 {
-    NSMutableDictionary *attributesCopy = attributes != nil ? [attributes mutableCopy] : @{}.mutableCopy;
+    NSMutableDictionary *attributesCopy = [attributes != nil ? attributes : @{} mutableCopy];
     [attributesCopy removeObjectForKey:NSForegroundColorAttributeName];
     if (color != nil) {
         attributesCopy[NSForegroundColorAttributeName] = color;

--- a/NavigationReactNative/src/ios/NVNavigationBarView.m
+++ b/NavigationReactNative/src/ios/NVNavigationBarView.m
@@ -27,7 +27,6 @@
             previousController.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:self.backTitle style:UIBarButtonItemStylePlain target:nil action:nil];
         }
     }
-    
     [self updateColors];
 }
 
@@ -40,30 +39,22 @@
 }
 
 -(void)updateColors {
-    [self.reactViewController.navigationController.navigationBar setBarTintColor:self.barTintColor];
-    [self.reactViewController.navigationController.navigationBar setTintColor: self.tintColor];
-
-    NSMutableDictionary *titleAttributes = [self.reactViewController.navigationController.navigationBar.titleTextAttributes mutableCopy];
-    if (titleAttributes == nil) {
-        titleAttributes = @{}.mutableCopy;
-    }
-    [titleAttributes removeObjectForKey:NSForegroundColorAttributeName];
-    if (self.titleColor != nil) {
-        titleAttributes[NSForegroundColorAttributeName] = self.titleColor;
-    }
-    [self.reactViewController.navigationController.navigationBar setTitleTextAttributes:titleAttributes];
-    
+    UINavigationBar *navigationBar = self.reactViewController.navigationController.navigationBar;
+    [navigationBar setBarTintColor:self.barTintColor];
+    [navigationBar setTintColor: self.tintColor];
+    [navigationBar setTitleTextAttributes:[self setForegroundColor:navigationBar.titleTextAttributes :self.titleColor]];
     if (@available(iOS 11.0, *)) {
-        NSMutableDictionary *largeTitleTextAttributes = [self.reactViewController.navigationController.navigationBar.largeTitleTextAttributes mutableCopy];
-        if (largeTitleTextAttributes == nil) {
-            largeTitleTextAttributes = @{}.mutableCopy;
-        }
-        [largeTitleTextAttributes removeObjectForKey:NSForegroundColorAttributeName];
-        if (self.titleColor != nil) {
-            largeTitleTextAttributes[NSForegroundColorAttributeName] = self.titleColor;
-        }
-        [self.reactViewController.navigationController.navigationBar setLargeTitleTextAttributes:largeTitleTextAttributes];
+        [navigationBar setLargeTitleTextAttributes:[self setForegroundColor:navigationBar.largeTitleTextAttributes :self.titleColor]];
     }
+}
+
+-(NSDictionary *)setForegroundColor:(NSDictionary *)attributes :(UIColor *)color
+{
+    NSMutableDictionary *attributesCopy = attributes != nil ? [attributes mutableCopy] : @{}.mutableCopy;
+    [attributesCopy removeObjectForKey:NSForegroundColorAttributeName];
+    if (color != nil)
+        attributesCopy[NSForegroundColorAttributeName] = color;
+    return attributesCopy;
 }
 
 @end

--- a/NavigationReactNative/src/ios/NVNavigationBarView.m
+++ b/NavigationReactNative/src/ios/NVNavigationBarView.m
@@ -58,8 +58,7 @@
 API_AVAILABLE(ios(13.0))
 {
     UINavigationBarAppearance *appearanceCopy = [appearance copy];
-    if (self.barTintColor != nil)
-        [appearanceCopy setBackgroundColor:self.barTintColor];
+    [appearanceCopy setBackgroundColor:self.barTintColor];
     [appearanceCopy.buttonAppearance.normal setTitleTextAttributes:[self setForeground:self.tintColor :appearanceCopy.backButtonAppearance.normal.titleTextAttributes]];
     [appearanceCopy.doneButtonAppearance.normal setTitleTextAttributes:[self setForeground:self.tintColor :appearanceCopy.doneButtonAppearance.normal.titleTextAttributes]];
     [appearanceCopy setTitleTextAttributes:[self setForeground:self.titleColor :appearanceCopy.titleTextAttributes]];
@@ -70,6 +69,7 @@ API_AVAILABLE(ios(13.0))
 -(NSDictionary *)setForeground:(UIColor *)color :(NSDictionary *)attributes
 {
     NSMutableDictionary *attributesCopy = attributes != nil ? [attributes mutableCopy] : @{}.mutableCopy;
+    [attributesCopy removeObjectForKey:NSForegroundColorAttributeName];
     if (color != nil)
         attributesCopy[NSForegroundColorAttributeName] = color;
     return attributesCopy;

--- a/NavigationReactNative/src/ios/NVNavigationBarView.m
+++ b/NavigationReactNative/src/ios/NVNavigationBarView.m
@@ -58,9 +58,7 @@
 API_AVAILABLE(ios(13.0))
 {
     UINavigationBarAppearance *appearanceCopy = [appearance copy];
-    if (self.barTintColor != nil) {
-        [appearanceCopy setBackgroundColor:self.barTintColor];
-    }
+    [appearanceCopy setBackgroundColor:self.barTintColor];
     [appearanceCopy.buttonAppearance.normal setTitleTextAttributes:[self setForeground:self.tintColor :appearanceCopy.buttonAppearance.normal.titleTextAttributes]];
     [appearanceCopy.doneButtonAppearance.normal setTitleTextAttributes:[self setForeground:self.tintColor :appearanceCopy.doneButtonAppearance.normal.titleTextAttributes]];
     [appearanceCopy setTitleTextAttributes:[self setForeground:self.titleColor :appearanceCopy.titleTextAttributes]];
@@ -71,9 +69,7 @@ API_AVAILABLE(ios(13.0))
 -(NSDictionary *)setForeground:(UIColor *)color :(NSDictionary *)attributes
 {
     NSMutableDictionary *attributesCopy = attributes != nil ? [attributes mutableCopy] : @{}.mutableCopy;
-    if (@available(iOS 13.0, *)) {} else {
-        [attributesCopy removeObjectForKey:NSForegroundColorAttributeName];
-    }
+    [attributesCopy removeObjectForKey:NSForegroundColorAttributeName];
     if (color != nil) {
         attributesCopy[NSForegroundColorAttributeName] = color;
     }

--- a/NavigationReactNative/src/ios/NVNavigationBarView.m
+++ b/NavigationReactNative/src/ios/NVNavigationBarView.m
@@ -58,7 +58,8 @@
 API_AVAILABLE(ios(13.0))
 {
     UINavigationBarAppearance *appearanceCopy = [appearance copy];
-    [appearanceCopy setBackgroundColor:self.barTintColor];
+    if (self.barTintColor != nil)
+        [appearanceCopy setBackgroundColor:self.barTintColor];
     [appearanceCopy.buttonAppearance.normal setTitleTextAttributes:[self setForeground:self.tintColor :appearanceCopy.backButtonAppearance.normal.titleTextAttributes]];
     [appearanceCopy.doneButtonAppearance.normal setTitleTextAttributes:[self setForeground:self.tintColor :appearanceCopy.doneButtonAppearance.normal.titleTextAttributes]];
     [appearanceCopy setTitleTextAttributes:[self setForeground:self.titleColor :appearanceCopy.titleTextAttributes]];
@@ -69,7 +70,8 @@ API_AVAILABLE(ios(13.0))
 -(NSDictionary *)setForeground:(UIColor *)color :(NSDictionary *)attributes
 {
     NSMutableDictionary *attributesCopy = attributes != nil ? [attributes mutableCopy] : @{}.mutableCopy;
-    [attributesCopy removeObjectForKey:NSForegroundColorAttributeName];
+    if (@available(iOS 13.0, *)) {} else
+        [attributesCopy removeObjectForKey:NSForegroundColorAttributeName];
     if (color != nil)
         attributesCopy[NSForegroundColorAttributeName] = color;
     return attributesCopy;

--- a/NavigationReactNative/src/ios/NVNavigationBarView.m
+++ b/NavigationReactNative/src/ios/NVNavigationBarView.m
@@ -70,10 +70,12 @@ API_AVAILABLE(ios(13.0))
 -(NSDictionary *)setForeground:(UIColor *)color :(NSDictionary *)attributes
 {
     NSMutableDictionary *attributesCopy = attributes != nil ? [attributes mutableCopy] : @{}.mutableCopy;
-    if (@available(iOS 13.0, *)) {} else
+    if (@available(iOS 13.0, *)) {} else {
         [attributesCopy removeObjectForKey:NSForegroundColorAttributeName];
-    if (color != nil)
+    }
+    if (color != nil) {
         attributesCopy[NSForegroundColorAttributeName] = color;
+    }
     return attributesCopy;
 }
 

--- a/NavigationReactNative/src/ios/NVNavigationBarView.m
+++ b/NavigationReactNative/src/ios/NVNavigationBarView.m
@@ -40,15 +40,18 @@
 
 -(void)updateColors {
     UINavigationBar *navigationBar = self.reactViewController.navigationController.navigationBar;
-    [navigationBar setBarTintColor:self.barTintColor];
-    [navigationBar setTintColor: self.tintColor];
-    [navigationBar setTitleTextAttributes:[self setForegroundColor:navigationBar.titleTextAttributes :self.titleColor]];
-    if (@available(iOS 11.0, *)) {
-        [navigationBar setLargeTitleTextAttributes:[self setForegroundColor:navigationBar.largeTitleTextAttributes :self.titleColor]];
+    if (@available(iOS 13.0, *)) {
+    } else {
+        [navigationBar setBarTintColor:self.barTintColor];
+        [navigationBar setTintColor: self.tintColor];
+        [navigationBar setTitleTextAttributes:[self setForeground:self.titleColor :navigationBar.titleTextAttributes]];
+        if (@available(iOS 11.0, *)) {
+            [navigationBar setLargeTitleTextAttributes:[self setForeground:self.titleColor :navigationBar.largeTitleTextAttributes]];
+        }
     }
 }
 
--(NSDictionary *)setForegroundColor:(NSDictionary *)attributes :(UIColor *)color
+-(NSDictionary *)setForeground:(UIColor *)color :(NSDictionary *)attributes
 {
     NSMutableDictionary *attributesCopy = attributes != nil ? [attributes mutableCopy] : @{}.mutableCopy;
     [attributesCopy removeObjectForKey:NSForegroundColorAttributeName];

--- a/NavigationReactNative/src/ios/NVNavigationBarView.m
+++ b/NavigationReactNative/src/ios/NVNavigationBarView.m
@@ -58,8 +58,9 @@
 API_AVAILABLE(ios(13.0))
 {
     UINavigationBarAppearance *appearanceCopy = [appearance copy];
-    if (self.barTintColor != nil)
+    if (self.barTintColor != nil) {
         [appearanceCopy setBackgroundColor:self.barTintColor];
+    }
     [appearanceCopy.buttonAppearance.normal setTitleTextAttributes:[self setForeground:self.tintColor :appearanceCopy.buttonAppearance.normal.titleTextAttributes]];
     [appearanceCopy.doneButtonAppearance.normal setTitleTextAttributes:[self setForeground:self.tintColor :appearanceCopy.doneButtonAppearance.normal.titleTextAttributes]];
     [appearanceCopy setTitleTextAttributes:[self setForeground:self.titleColor :appearanceCopy.titleTextAttributes]];

--- a/NavigationReactNative/src/ios/NVNavigationBarView.m
+++ b/NavigationReactNative/src/ios/NVNavigationBarView.m
@@ -41,6 +41,9 @@
 -(void)updateColors {
     UINavigationBar *navigationBar = self.reactViewController.navigationController.navigationBar;
     if (@available(iOS 13.0, *)) {
+        self.reactViewController.navigationItem.standardAppearance = [self updateColors:navigationBar.standardAppearance];
+        self.reactViewController.navigationItem.scrollEdgeAppearance = [self updateColors:navigationBar.scrollEdgeAppearance];
+        self.reactViewController.navigationItem.compactAppearance = [self updateColors:navigationBar.compactAppearance];
     } else {
         [navigationBar setBarTintColor:self.barTintColor];
         [navigationBar setTintColor: self.tintColor];
@@ -49,6 +52,18 @@
             [navigationBar setLargeTitleTextAttributes:[self setForeground:self.titleColor :navigationBar.largeTitleTextAttributes]];
         }
     }
+}
+
+-(UINavigationBarAppearance *)updateColors:(UINavigationBarAppearance *)appearance
+API_AVAILABLE(ios(13.0))
+{
+    UINavigationBarAppearance *appearanceCopy = [appearance copy];
+    [appearanceCopy setBackgroundColor:self.barTintColor];
+    [appearanceCopy.buttonAppearance.normal setTitleTextAttributes:[self setForeground:self.tintColor :appearanceCopy.backButtonAppearance.normal.titleTextAttributes]];
+    [appearanceCopy.doneButtonAppearance.normal setTitleTextAttributes:[self setForeground:self.tintColor :appearanceCopy.doneButtonAppearance.normal.titleTextAttributes]];
+    [appearanceCopy setTitleTextAttributes:[self setForeground:self.titleColor :appearanceCopy.titleTextAttributes]];
+    [appearanceCopy setLargeTitleTextAttributes:[self setForeground:self.titleColor :appearanceCopy.largeTitleTextAttributes]];
+    return appearanceCopy;
 }
 
 -(NSDictionary *)setForeground:(UIColor *)color :(NSDictionary *)attributes

--- a/NavigationReactNative/src/ios/NVNavigationBarView.m
+++ b/NavigationReactNative/src/ios/NVNavigationBarView.m
@@ -41,6 +41,7 @@
 -(void)updateColors {
     UINavigationBar *navigationBar = self.reactViewController.navigationController.navigationBar;
     if (@available(iOS 13.0, *)) {
+        [navigationBar setTintColor: self.tintColor];
         self.reactViewController.navigationItem.standardAppearance = [self updateColors:navigationBar.standardAppearance];
         self.reactViewController.navigationItem.scrollEdgeAppearance = [self updateColors:navigationBar.scrollEdgeAppearance];
         self.reactViewController.navigationItem.compactAppearance = [self updateColors:navigationBar.compactAppearance];

--- a/NavigationReactNative/src/ios/NVSceneController.m
+++ b/NavigationReactNative/src/ios/NVSceneController.m
@@ -46,16 +46,13 @@
     if (navigationBar.title.length != 0) {
         [self.navigationItem setTitle:navigationBar.title];
     }
-
     [navigationBar updateColors];
-
     NSInteger crumb = [self.navigationController.viewControllers indexOfObject:self];
     UIViewController *previousController = crumb > 0 ? [self.navigationController.viewControllers objectAtIndex:crumb - 1] : nil;
     previousController.navigationItem.backBarButtonItem = nil;
     if (navigationBar.backTitle != nil) {
         previousController.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:navigationBar.backTitle style:UIBarButtonItemStylePlain target:nil action:nil];
     }
-
     if (@available(iOS 11.0, *)) {
         self.navigationController.navigationBar.prefersLargeTitles = true;
         [self.navigationItem setLargeTitleDisplayMode:navigationBar.largeTitle ? UINavigationItemLargeTitleDisplayModeAlways : UINavigationItemLargeTitleDisplayModeNever];
@@ -65,10 +62,10 @@
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
-    
     NVNavigationBarView *navigationBar = (NVNavigationBarView *) [self.view viewWithTag:NAVIGATION_BAR];
-    [navigationBar updateColors];
-
+    if (@available(iOS 13.0, *)) {} else {
+        [navigationBar updateColors];
+    }
 }
 
 - (void)viewDidLayoutSubviews

--- a/NavigationReactNative/src/ios/NVSceneController.m
+++ b/NavigationReactNative/src/ios/NVSceneController.m
@@ -63,9 +63,7 @@
 {
     [super viewDidAppear:animated];
     NVNavigationBarView *navigationBar = (NVNavigationBarView *) [self.view viewWithTag:NAVIGATION_BAR];
-    if (@available(iOS 13.0, *)) {} else {
-        [navigationBar updateColors];
-    }
+    [navigationBar updateColors];
 }
 
 - (void)viewDidLayoutSubviews


### PR DESCRIPTION
@mpiannucci This fixes the problems we had when the navigation bar has different `barTint` colors between scenes. Remember them? The color change animations are smooth now