### PR TITLE
Allowed TabBar to be either controlled or uncontrolled

### DIFF
--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -6,11 +6,12 @@ class TabBar extends React.Component<any, any> {
     private ref: React.RefObject<View>;
     constructor(props) {
         super(props);
-        this.state = {selectedTab: props.tab || 0};
+        this.state = {selectedTab: props.tab || props.defaultTab};
         this.ref = React.createRef<View>();
         this.onTabSelected = this.onTabSelected.bind(this);
     }
     static defaultProps = {
+        defaultTab: 0,
         scrollable: false,
         primary: Platform.OS === 'ios',
     }

--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -3,9 +3,12 @@ import { requireNativeComponent, Platform, StyleSheet, View } from 'react-native
 import BackButton from './BackButton';
 
 class TabBar extends React.Component<any, any> {
+    private ref: React.RefObject<View>;
     constructor(props) {
         super(props);
         this.state = {selectedTab: props.selectedTab || 0};
+        this.ref = React.createRef<View>();
+        this.onTabSelected = this.onTabSelected.bind(this);
     }
     static defaultProps = {
         scrollable: false,
@@ -15,6 +18,11 @@ class TabBar extends React.Component<any, any> {
         if (selectedTab != null && selectedTab !== state.selectedTab)
             return {selectedTab};
         return null;
+    }
+    onTabSelected({nativeEvent}) {
+        var {eventCount: mostRecentEventCount, tab} = nativeEvent;
+        this.ref.current.setNativeProps({mostRecentEventCount});
+        this.changeTab(tab);
     }
     changeTab(tab) {
         var {selectedTab, onTabChange} = this.props;
@@ -55,8 +63,9 @@ class TabBar extends React.Component<any, any> {
             <>
                 {!bottomTabs && tabLayout}
                 {!!tabBarItems.length && <TabBar
+                    ref={this.ref}
                     tabCount={tabBarItems.length}
-                    onTabSelected={({nativeEvent: {tab}}) => this.changeTab(tab)}
+                    onTabSelected={this.onTabSelected}
                     selectedTab={this.state.selectedTab}
                     barTintColor={barTintColor}
                     selectedTintColor={selectedTintColor}

--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -48,6 +48,7 @@ class TabBar extends React.Component<any, any> {
         TabView = Platform.OS === 'android' ? TabView : NVSegmentedTab;
         var tabLayout = (Platform.OS === 'android' || !primary) && (
             <TabView
+                ref={Platform.OS === 'ios' ? this.ref : undefined}
                 bottomTabs={bottomTabs}
                 onTabSelected={this.onTabSelected}
                 selectedTab={this.state.selectedTab}
@@ -65,7 +66,7 @@ class TabBar extends React.Component<any, any> {
             <>
                 {!bottomTabs && tabLayout}
                 {!!tabBarItems.length && <TabBar
-                    ref={this.ref}
+                    ref={(Platform.OS === 'android' || primary) ? this.ref : undefined}
                     tabCount={tabBarItems.length}
                     onTabSelected={this.onTabSelected}
                     selectedTab={this.state.selectedTab}

--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -5,12 +5,26 @@ import BackButton from './BackButton';
 class TabBar extends React.Component<any, any> {
     constructor(props) {
         super(props);
-        this.state = {selectedTab: 0};
+        this.state = {selectedTab: props.selectedTab || 0};
+        this.selectTab = this.selectTab.bind(this);
         this.handleBack = this.handleBack.bind(this);
     }
     static defaultProps = {
         scrollable: false,
         primary: Platform.OS === 'ios',
+    }
+    static getDerivedStateFromProps({selectedTab}, state) {
+        if (selectedTab != null && selectedTab !== state.selectedTab)
+            return {selectedTab};
+        return null;
+    }
+    selectTab({nativeEvent: {tab}}) {
+        var {selectedTab, onTabChange} = this.props;
+        if (this.state.selectedTab !== tab) {
+            if (selectedTab == null)
+                this.setState({selectedTab: tab})
+            onTabChange(tab);
+        }
     }
     handleBack() {
         var {selectedTab} = this.state;
@@ -47,10 +61,7 @@ class TabBar extends React.Component<any, any> {
                 {!bottomTabs && tabLayout}
                 {!!tabBarItems.length && <TabBar
                     tabCount={tabBarItems.length}
-                    onTabSelected={({nativeEvent}) => {
-                        if (this.state.selectedTab !== nativeEvent.tab)
-                            this.setState({selectedTab: nativeEvent.tab})
-                    }}
+                    onTabSelected={this.selectTab}
                     selectedTab={this.state.selectedTab}
                     barTintColor={barTintColor}
                     selectedTintColor={selectedTintColor}

--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -6,7 +6,7 @@ class TabBar extends React.Component<any, any> {
     private ref: React.RefObject<View>;
     constructor(props) {
         super(props);
-        this.state = {selectedTab: props.selectedTab || 0};
+        this.state = {selectedTab: props.tab || 0};
         this.ref = React.createRef<View>();
         this.onTabSelected = this.onTabSelected.bind(this);
     }
@@ -14,9 +14,9 @@ class TabBar extends React.Component<any, any> {
         scrollable: false,
         primary: Platform.OS === 'ios',
     }
-    static getDerivedStateFromProps({selectedTab}, state) {
-        if (selectedTab != null && selectedTab !== state.selectedTab)
-            return {selectedTab};
+    static getDerivedStateFromProps({tab}, {selectedTab}) {
+        if (tab != null && tab !== selectedTab)
+            return {selectedTab: tab};
         return null;
     }
     onTabSelected({nativeEvent}) {
@@ -24,13 +24,13 @@ class TabBar extends React.Component<any, any> {
         this.ref.current.setNativeProps({mostRecentEventCount});
         this.changeTab(tab);
     }
-    changeTab(tab) {
-        var {selectedTab, onChangeTab} = this.props;
-        if (this.state.selectedTab !== tab) {
-            if (selectedTab == null)
-                this.setState({selectedTab: tab});
+    changeTab(selectedTab) {
+        var {tab, onChangeTab} = this.props;
+        if (this.state.selectedTab !== selectedTab) {
+            if (tab == null)
+                this.setState({selectedTab});
             if (!!onChangeTab)
-                onChangeTab(tab);
+                onChangeTab(selectedTab);
             return true;
         }
         return false;

--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -6,7 +6,7 @@ class TabBar extends React.Component<any, any> {
     constructor(props) {
         super(props);
         this.state = {selectedTab: props.selectedTab || 0};
-        this.selectTab = this.selectTab.bind(this);
+        this.handleTabChange = this.handleTabChange.bind(this);
         this.handleBack = this.handleBack.bind(this);
     }
     static defaultProps = {
@@ -18,7 +18,7 @@ class TabBar extends React.Component<any, any> {
             return {selectedTab};
         return null;
     }
-    selectTab({nativeEvent: {tab}}) {
+    handleTabChange({nativeEvent: {tab}}) {
         var {selectedTab, onTabChange} = this.props;
         if (this.state.selectedTab !== tab) {
             if (selectedTab == null)
@@ -61,7 +61,7 @@ class TabBar extends React.Component<any, any> {
                 {!bottomTabs && tabLayout}
                 {!!tabBarItems.length && <TabBar
                     tabCount={tabBarItems.length}
-                    onTabSelected={this.selectTab}
+                    onTabSelected={this.handleTabChange}
                     selectedTab={this.state.selectedTab}
                     barTintColor={barTintColor}
                     selectedTintColor={selectedTintColor}

--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -6,8 +6,6 @@ class TabBar extends React.Component<any, any> {
     constructor(props) {
         super(props);
         this.state = {selectedTab: props.selectedTab || 0};
-        this.handleTabChange = this.handleTabChange.bind(this);
-        this.handleBack = this.handleBack.bind(this);
     }
     static defaultProps = {
         scrollable: false,
@@ -18,20 +16,16 @@ class TabBar extends React.Component<any, any> {
             return {selectedTab};
         return null;
     }
-    handleTabChange({nativeEvent: {tab}}) {
+    changeTab(tab) {
         var {selectedTab, onTabChange} = this.props;
         if (this.state.selectedTab !== tab) {
             if (selectedTab == null)
                 this.setState({selectedTab: tab});
             if (!!onTabChange)
                 onTabChange(tab);
+            return true;
         }
-    }
-    handleBack() {
-        var {selectedTab} = this.state;
-        if (selectedTab)
-            this.setState({selectedTab: 0});
-        return !!selectedTab;
+        return false;
     }
     render() {
         var {children, barTintColor, selectedTintColor, unselectedTintColor, bottomTabs, scrollable, primary, swipeable} = this.props;
@@ -62,14 +56,14 @@ class TabBar extends React.Component<any, any> {
                 {!bottomTabs && tabLayout}
                 {!!tabBarItems.length && <TabBar
                     tabCount={tabBarItems.length}
-                    onTabSelected={this.handleTabChange}
+                    onTabSelected={({nativeEvent: {tab}}) => this.changeTab(tab)}
                     selectedTab={this.state.selectedTab}
                     barTintColor={barTintColor}
                     selectedTintColor={selectedTintColor}
                     unselectedTintColor={unselectedTintColor}
                     swipeable={!primary}
                     style={styles.tabBar}>
-                        <BackButton onPress={this.handleBack} />
+                        <BackButton onPress={() => this.changeTab(0)} />
                         {tabBarItems
                             .filter(child => !!child)
                             .map((child: any, index) => {

--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -25,12 +25,12 @@ class TabBar extends React.Component<any, any> {
         this.changeTab(tab);
     }
     changeTab(tab) {
-        var {selectedTab, onTabChange} = this.props;
+        var {selectedTab, onChangeTab} = this.props;
         if (this.state.selectedTab !== tab) {
             if (selectedTab == null)
                 this.setState({selectedTab: tab});
-            if (!!onTabChange)
-                onTabChange(tab);
+            if (!!onChangeTab)
+                onChangeTab(tab);
             return true;
         }
         return false;

--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -22,8 +22,9 @@ class TabBar extends React.Component<any, any> {
         var {selectedTab, onTabChange} = this.props;
         if (this.state.selectedTab !== tab) {
             if (selectedTab == null)
-                this.setState({selectedTab: tab})
-            onTabChange(tab);
+                this.setState({selectedTab: tab});
+            if (!!onTabChange)
+                onTabChange(tab);
         }
     }
     handleBack() {

--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -49,6 +49,8 @@ class TabBar extends React.Component<any, any> {
         var tabLayout = (Platform.OS === 'android' || !primary) && (
             <TabView
                 bottomTabs={bottomTabs}
+                onTabSelected={this.onTabSelected}
+                selectedTab={this.state.selectedTab}
                 selectedTintColor={selectedTintColor}
                 unselectedTintColor={unselectedTintColor}
                 selectedIndicatorAtTop={bottomTabs}

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarManager.java
@@ -2,7 +2,6 @@ package com.navigation.reactnative;
 
 import android.view.View;
 
-import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
@@ -29,7 +28,9 @@ public class TabBarManager extends ViewGroupManager<TabBarView> {
     @ReactProp(name = "selectedTab")
     public void setSelectedTab(TabBarView view, int selectedTab) {
         if (view.getCurrentItem() != selectedTab) {
-            view.setCurrentItem(selectedTab, false);
+            view.selectedTab = selectedTab;
+            if (view.getTabsCount() > selectedTab)
+                view.setCurrentItem(selectedTab, false);
         }
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarManager.java
@@ -27,11 +27,17 @@ public class TabBarManager extends ViewGroupManager<TabBarView> {
 
     @ReactProp(name = "selectedTab")
     public void setSelectedTab(TabBarView view, int selectedTab) {
-        if (view.getCurrentItem() != selectedTab) {
+        int eventLag = view.nativeEventCount - view.mostRecentEventCount;
+        if (eventLag == 0 && view.getCurrentItem() != selectedTab) {
             view.selectedTab = selectedTab;
             if (view.getTabsCount() > selectedTab)
                 view.setCurrentItem(selectedTab, false);
         }
+    }
+
+    @ReactProp(name = "mostRecentEventCount")
+    public void setMostRecentEventCount(TabBarView view, int mostRecentEventCount) {
+        view.mostRecentEventCount = mostRecentEventCount;
     }
 
     @ReactProp(name = "tabCount")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -202,6 +202,7 @@ public class TabBarView extends ViewPager {
 
         @Override
         public void onPageSelected(int position) {
+            selectedTab = position;
             WritableMap event = Arguments.createMap();
             event.putInt("tab", position);
             ReactContext reactContext = (ReactContext) getContext();

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -1,6 +1,7 @@
 package com.navigation.reactnative;
 
 import android.content.Context;
+import android.database.DataSetObserver;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -21,8 +22,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class TabBarView extends ViewPager {
+    int selectedTab = 0;
     boolean swipeable = true;
     private boolean layoutRequested = false;
+    private DataSetObserver dataSetObserver;
 
     public TabBarView(Context context) {
         super(context);
@@ -37,6 +40,18 @@ public class TabBarView extends ViewPager {
         if (getTabView() != null)
             getTabView().setupWithViewPager(this);
         populateTabs();
+        if (dataSetObserver == null && getAdapter() != null) {
+            if (getCurrentItem() != selectedTab && getTabsCount() > selectedTab)
+                setCurrentItem(selectedTab, false);
+            dataSetObserver = new DataSetObserver() {
+                @Override
+                public void onChanged() {
+                    if (getCurrentItem() != selectedTab && getTabsCount() > selectedTab)
+                        setCurrentItem(selectedTab, false);
+                }
+            };
+            getAdapter().registerDataSetObserver(dataSetObserver);
+        }
     }
 
     void populateTabs() {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -25,12 +25,18 @@ public class TabBarView extends ViewPager {
     int selectedTab = 0;
     boolean swipeable = true;
     private boolean layoutRequested = false;
-    private DataSetObserver dataSetObserver;
 
     public TabBarView(Context context) {
         super(context);
         addOnPageChangeListener(new TabChangeListener());
         setAdapter(new Adapter());
+        getAdapter().registerDataSetObserver(new DataSetObserver() {
+            @Override
+            public void onChanged() {
+                if (getCurrentItem() != selectedTab && getTabsCount() > selectedTab)
+                    setCurrentItem(selectedTab, false);
+            }
+        });
     }
 
     @Override
@@ -40,18 +46,6 @@ public class TabBarView extends ViewPager {
         if (getTabView() != null)
             getTabView().setupWithViewPager(this);
         populateTabs();
-        if (dataSetObserver == null && getAdapter() != null) {
-            if (getCurrentItem() != selectedTab && getTabsCount() > selectedTab)
-                setCurrentItem(selectedTab, false);
-            dataSetObserver = new DataSetObserver() {
-                @Override
-                public void onChanged() {
-                    if (getCurrentItem() != selectedTab && getTabsCount() > selectedTab)
-                        setCurrentItem(selectedTab, false);
-                }
-            };
-            getAdapter().registerDataSetObserver(dataSetObserver);
-        }
     }
 
     void populateTabs() {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -27,6 +27,7 @@ public class TabBarView extends ViewPager {
     private boolean layoutRequested = false;
     int nativeEventCount;
     int mostRecentEventCount;
+    private boolean dataSetChanged = false;
 
     public TabBarView(Context context) {
         super(context);
@@ -143,17 +144,21 @@ public class TabBarView extends ViewPager {
         return false;
     }
 
-    private static class Adapter extends PagerAdapter {
+    private class Adapter extends PagerAdapter {
         private List<TabBarItemView> tabs = new ArrayList<>();
 
         void addTab(TabBarItemView tab, int index) {
             tabs.add(index, tab);
+            dataSetChanged = true;
             notifyDataSetChanged();
+            dataSetChanged = false;
         }
 
         void removeTab(int index) {
             tabs.remove(index);
+            dataSetChanged = true;
             notifyDataSetChanged();
+            dataSetChanged = false;
         }
 
         @Override
@@ -204,7 +209,8 @@ public class TabBarView extends ViewPager {
 
         @Override
         public void onPageSelected(int position) {
-            nativeEventCount++;
+            if (!dataSetChanged)
+                nativeEventCount++;
             selectedTab = position;
             WritableMap event = Arguments.createMap();
             event.putInt("tab", position);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -29,14 +29,15 @@ public class TabBarView extends ViewPager {
     public TabBarView(Context context) {
         super(context);
         addOnPageChangeListener(new TabChangeListener());
-        setAdapter(new Adapter());
-        getAdapter().registerDataSetObserver(new DataSetObserver() {
+        Adapter adapter = new Adapter();
+        adapter.registerDataSetObserver(new DataSetObserver() {
             @Override
             public void onChanged() {
                 if (getCurrentItem() != selectedTab && getTabsCount() > selectedTab)
                     setCurrentItem(selectedTab, false);
             }
         });
+        setAdapter(adapter);
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -25,6 +25,8 @@ public class TabBarView extends ViewPager {
     int selectedTab = 0;
     boolean swipeable = true;
     private boolean layoutRequested = false;
+    int nativeEventCount;
+    int mostRecentEventCount;
 
     public TabBarView(Context context) {
         super(context);
@@ -202,9 +204,11 @@ public class TabBarView extends ViewPager {
 
         @Override
         public void onPageSelected(int position) {
+            nativeEventCount++;
             selectedTab = position;
             WritableMap event = Arguments.createMap();
             event.putInt("tab", position);
+            event.putInt("eventCount", nativeEventCount);
             ReactContext reactContext = (ReactContext) getContext();
             reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onTabSelected", event);
             if (getAdapter() != null)

--- a/NavigationReactNative/src/ios/NVSearchBarView.m
+++ b/NavigationReactNative/src/ios/NVSearchBarView.m
@@ -31,7 +31,9 @@
 
 - (void)setObscureBackground:(BOOL)obscureBackground
 {
-    [self.searchController setObscuresBackgroundDuringPresentation:obscureBackground];
+    if (@available(iOS 9.1, *)) {
+        [self.searchController setObscuresBackgroundDuringPresentation:obscureBackground];
+    }
 }
 
 - (void)setHideNavigationBar:(BOOL)hideNavigationBar

--- a/NavigationReactNative/src/ios/NVSegmentedTabManager.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabManager.m
@@ -16,6 +16,7 @@ RCT_EXPORT_VIEW_PROPERTY(backgroundColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(selectedTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(unselectedTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(titles, NSArray<NSString *>)
+RCT_EXPORT_VIEW_PROPERTY(mostRecentEventCount, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(onTabSelected, RCTDirectEventBlock)
 
 @end

--- a/NavigationReactNative/src/ios/NVSegmentedTabManager.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabManager.m
@@ -11,9 +11,11 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_EXPORT_VIEW_PROPERTY(bottomTabs, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(selectedTab, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(backgroundColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(selectedTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(unselectedTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(titles, NSArray<NSString *>)
+RCT_EXPORT_VIEW_PROPERTY(onTabSelected, RCTDirectEventBlock)
 
 @end

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.h
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.h
@@ -4,6 +4,7 @@
 @interface NVSegmentedTabView : UISegmentedControl
 
 @property (nonatomic, assign) BOOL bottomTabs;
+@property (nonatomic, assign) NSInteger mostRecentEventCount;
 @property (nonatomic, copy) RCTDirectEventBlock onTabSelected;
 
 @end

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.h
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.h
@@ -1,7 +1,9 @@
 #import <UIKit/UIKit.h>
+#import <React/RCTComponent.h>
 
 @interface NVSegmentedTabView : UISegmentedControl
 
 @property (nonatomic, assign) BOOL bottomTabs;
+@property (nonatomic, copy) RCTDirectEventBlock onTabSelected;
 
 @end

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.m
@@ -7,6 +7,7 @@
 {
     NSInteger _selectedTab;
     NVTabBarItemView *_selectedTabBarItem;
+    NSInteger _nativeEventCount;
 }
 
 - (id)init
@@ -72,7 +73,8 @@
 - (void)didSetProps:(NSArray<NSString *> *)changedProps
 {
     BOOL press = NO;
-    if (self.selectedSegmentIndex != _selectedTab) {
+    NSInteger eventLag = _nativeEventCount - _mostRecentEventCount;
+    if (eventLag == 0 && self.selectedSegmentIndex != _selectedTab) {
         self.selectedSegmentIndex = _selectedTab;
         press = YES;
     }
@@ -102,7 +104,13 @@
             self.selectedSegmentIndex = 0;
         tabChanged = _selectedTab != self.selectedSegmentIndex;
     }
-    self.onTabSelected(@{ @"tab": @(self.selectedSegmentIndex) });
+    if (tabChanged) {
+        _nativeEventCount++;
+        self.onTabSelected(@{
+            @"tab": @(self.selectedSegmentIndex),
+            @"eventCount": @(_nativeEventCount),
+        });
+    }
     for(NSInteger i = 0; i < [tabBar.reactSubviews count]; i++) {
         NVTabBarItemView *tabBarItem = (NVTabBarItemView *) [tabBar.reactSubviews objectAtIndex:i];
         tabBarItem.alpha = (i == self.selectedSegmentIndex ? 1 : 0);

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.m
@@ -85,8 +85,9 @@
 - (void)didMoveToWindow
 {
     [super didMoveToWindow];
-    if (!!self.window)
+    if (!!self.window) {
         [self selectTab:_selectedTabBarItem == nil && self.selectedSegmentIndex > 0];
+    }
 }
 
 - (void)tabPressed
@@ -100,8 +101,11 @@
     NSInteger tabBarIndex = [self.superview.subviews indexOfObject:self] + (self.bottomTabs ? -1 : 1);
     UIView* tabBar = [self.superview.subviews objectAtIndex:tabBarIndex];
     if (!press) {
-        BOOL tabFound = [tabBar.reactSubviews indexOfObject:_selectedTabBarItem] != NSNotFound;
-        self.selectedSegmentIndex = (tabFound || [tabBar.reactSubviews count] > self.selectedSegmentIndex) ? MAX(self.selectedSegmentIndex, 0) : 0;
+        NSInteger previousSelectionIndex = [tabBar.reactSubviews indexOfObject:_selectedTabBarItem];
+        if (previousSelectionIndex != NSNotFound)
+            self.selectedSegmentIndex = previousSelectionIndex;
+        if (previousSelectionIndex == NSNotFound)
+            self.selectedSegmentIndex = ([tabBar.reactSubviews count] > self.selectedSegmentIndex) ? self.selectedSegmentIndex : 0;
         tabChanged = _selectedTab != self.selectedSegmentIndex;
     }
     if (tabChanged) {

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.m
@@ -86,7 +86,7 @@
 {
     [super didMoveToWindow];
     if (!!self.window)
-        [self selectTab:NO];
+        [self selectTab:_selectedTabBarItem == nil && self.selectedSegmentIndex > 0];
 }
 
 - (void)tabPressed

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.m
@@ -29,12 +29,11 @@
 
 - (void)setTitles:(NSArray<NSString *> *)titles
 {
-    NSInteger selectedIndex = self.selectedSegmentIndex;
     [self removeAllSegments];
     for (NSString *title in titles) {
         [self insertSegmentWithTitle:title atIndex:self.numberOfSegments animated:NO];
     }
-    self.selectedSegmentIndex = selectedIndex;
+    self.selectedSegmentIndex = _selectedTab;
 }
 
 - (void)setBackgroundColor:(UIColor *)backgroundColor

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.m
@@ -101,11 +101,7 @@
     UIView* tabBar = [self.superview.subviews objectAtIndex:tabBarIndex];
     if (!press) {
         NSInteger previousSelectionIndex = [tabBar.reactSubviews indexOfObject:_selectedTabBarItem];
-        if (previousSelectionIndex != NSNotFound) {
-            self.selectedSegmentIndex = previousSelectionIndex;
-        } else {
-            self.selectedSegmentIndex = MAX(self.selectedSegmentIndex, 0);
-        }
+        self.selectedSegmentIndex = previousSelectionIndex != NSNotFound ? previousSelectionIndex : MAX(self.selectedSegmentIndex, 0);
         tabChanged = _selectedTab != self.selectedSegmentIndex;
     }
     if (tabChanged) {

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.m
@@ -5,17 +5,22 @@
 
 @implementation NVSegmentedTabView
 {
-    NSInteger _selectedTabIndex;
-    NVTabBarItemView *_selectedTab;
+    NSInteger _selectedTab;
+    NVTabBarItemView *_selectedTabBarItem;
 }
 
 - (id)init
 {
     if (self = [super init]) {
-        _selectedTabIndex = 0;
+        _selectedTab = 0;
         [self addTarget:self action:@selector(tabPressed) forControlEvents:UIControlEventValueChanged];
     }
     return self;
+}
+
+- (void)setSelectedTab:(NSInteger)selectedTab
+{
+    _selectedTab = selectedTab;
 }
 
 - (void)setTitles:(NSArray<NSString *> *)titles
@@ -66,7 +71,15 @@
 
 - (void)didSetProps:(NSArray<NSString *> *)changedProps
 {
-    [self selectTab:NO];
+    BOOL press = NO;
+    if (self.selectedSegmentIndex == NSNotFound) {
+        self.selectedSegmentIndex = 0;
+    }
+    if (self.selectedSegmentIndex != _selectedTab) {
+        self.selectedSegmentIndex = _selectedTab;
+        press = YES;
+    }
+    [self selectTab:press];
 }
 
 - (void)didMoveToWindow
@@ -87,17 +100,18 @@
     NSInteger tabBarIndex = [self.superview.subviews indexOfObject:self] + (self.bottomTabs ? -1 : 1);
     UIView* tabBar = [self.superview.subviews objectAtIndex:tabBarIndex];
     if (!press) {
-        self.selectedSegmentIndex = [tabBar.reactSubviews indexOfObject:_selectedTab];
+        self.selectedSegmentIndex = [tabBar.reactSubviews indexOfObject:_selectedTabBarItem];
         if (self.selectedSegmentIndex == -1)
             self.selectedSegmentIndex = 0;
-        tabChanged = _selectedTabIndex != self.selectedSegmentIndex;
+        tabChanged = _selectedTab != self.selectedSegmentIndex;
     }
+    self.onTabSelected(@{ @"tab": @(self.selectedSegmentIndex) });
     for(NSInteger i = 0; i < [tabBar.reactSubviews count]; i++) {
         NVTabBarItemView *tabBarItem = (NVTabBarItemView *) [tabBar.reactSubviews objectAtIndex:i];
         tabBarItem.alpha = (i == self.selectedSegmentIndex ? 1 : 0);
         if (i == self.selectedSegmentIndex) {
-            _selectedTabIndex = i;
-            _selectedTab = tabBarItem;
+            _selectedTab = i;
+            _selectedTabBarItem = tabBarItem;
             if (tabChanged && !!tabBarItem.onPress)
                 tabBarItem.onPress(nil);
         }

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.m
@@ -29,10 +29,12 @@
 
 - (void)setTitles:(NSArray<NSString *> *)titles
 {
+    NSInteger selectedIndex = self.selectedSegmentIndex;
     [self removeAllSegments];
     for (NSString *title in titles) {
         [self insertSegmentWithTitle:title atIndex:self.numberOfSegments animated:NO];
     }
+    self.selectedSegmentIndex = selectedIndex;
 }
 
 - (void)setBackgroundColor:(UIColor *)backgroundColor
@@ -98,9 +100,8 @@
     NSInteger tabBarIndex = [self.superview.subviews indexOfObject:self] + (self.bottomTabs ? -1 : 1);
     UIView* tabBar = [self.superview.subviews objectAtIndex:tabBarIndex];
     if (!press) {
-        self.selectedSegmentIndex = [tabBar.reactSubviews indexOfObject:_selectedTabBarItem];
-        if (self.selectedSegmentIndex == -1)
-            self.selectedSegmentIndex = 0;
+        BOOL tabFound = [tabBar.reactSubviews indexOfObject:_selectedTabBarItem] != NSNotFound;
+        self.selectedSegmentIndex = (tabFound || [tabBar.reactSubviews count] > self.selectedSegmentIndex) ? MAX(self.selectedSegmentIndex, 0) : 0;
         tabChanged = _selectedTab != self.selectedSegmentIndex;
     }
     if (tabChanged) {

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.m
@@ -100,8 +100,8 @@
     NSInteger tabBarIndex = [self.superview.subviews indexOfObject:self] + (self.bottomTabs ? -1 : 1);
     UIView* tabBar = [self.superview.subviews objectAtIndex:tabBarIndex];
     if (!press) {
-        NSInteger previousSelectionIndex = [tabBar.reactSubviews indexOfObject:_selectedTabBarItem];
-        self.selectedSegmentIndex = previousSelectionIndex != NSNotFound ? previousSelectionIndex : MAX(self.selectedSegmentIndex, 0);
+        NSInteger reselectedTab = [tabBar.reactSubviews indexOfObject:_selectedTabBarItem];
+        self.selectedSegmentIndex = reselectedTab != NSNotFound ? reselectedTab : MAX(self.selectedSegmentIndex, 0);
         tabChanged = _selectedTab != self.selectedSegmentIndex;
     }
     if (tabChanged) {

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.m
@@ -75,11 +75,8 @@
 
 - (void)didSetProps:(NSArray<NSString *> *)changedProps
 {
-    BOOL press = NO;
-    if (self.selectedSegmentIndex != _selectedTab) {
-        self.selectedSegmentIndex = _selectedTab;
-        press = YES;
-    }
+    BOOL press = self.selectedSegmentIndex != _selectedTab;
+    self.selectedSegmentIndex = _selectedTab;
     [self selectTab:press];
 }
 

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.m
@@ -21,7 +21,10 @@
 
 - (void)setSelectedTab:(NSInteger)selectedTab
 {
-    _selectedTab = selectedTab;
+    NSInteger eventLag = _nativeEventCount - _mostRecentEventCount;
+    if (eventLag == 0) {
+        _selectedTab = selectedTab;
+    }
 }
 
 - (void)setTitles:(NSArray<NSString *> *)titles
@@ -73,8 +76,7 @@
 - (void)didSetProps:(NSArray<NSString *> *)changedProps
 {
     BOOL press = NO;
-    NSInteger eventLag = _nativeEventCount - _mostRecentEventCount;
-    if (eventLag == 0 && self.selectedSegmentIndex != _selectedTab) {
+    if (self.selectedSegmentIndex != _selectedTab) {
         self.selectedSegmentIndex = _selectedTab;
         press = YES;
     }

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.m
@@ -102,10 +102,11 @@
     UIView* tabBar = [self.superview.subviews objectAtIndex:tabBarIndex];
     if (!press) {
         NSInteger previousSelectionIndex = [tabBar.reactSubviews indexOfObject:_selectedTabBarItem];
-        if (previousSelectionIndex != NSNotFound)
+        if (previousSelectionIndex != NSNotFound) {
             self.selectedSegmentIndex = previousSelectionIndex;
-        if (previousSelectionIndex == NSNotFound)
-            self.selectedSegmentIndex = ([tabBar.reactSubviews count] > self.selectedSegmentIndex) ? self.selectedSegmentIndex : 0;
+        } else {
+            self.selectedSegmentIndex = MAX(self.selectedSegmentIndex, 0);
+        }
         tabChanged = _selectedTab != self.selectedSegmentIndex;
     }
     if (tabChanged) {

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.m
@@ -72,9 +72,6 @@
 - (void)didSetProps:(NSArray<NSString *> *)changedProps
 {
     BOOL press = NO;
-    if (self.selectedSegmentIndex == NSNotFound) {
-        self.selectedSegmentIndex = 0;
-    }
     if (self.selectedSegmentIndex != _selectedTab) {
         self.selectedSegmentIndex = _selectedTab;
         press = YES;

--- a/NavigationReactNative/src/ios/NVTabBarItemView.m
+++ b/NavigationReactNative/src/ios/NVTabBarItemView.m
@@ -25,7 +25,9 @@
 
 - (void)setBadgeColor:(UIColor *)badgeColor
 {
-    self.tab.badgeColor = badgeColor;
+    if (@available(iOS 10.0, *)) {
+        self.tab.badgeColor = badgeColor;
+    }
 }
 
 - (void)setImage:(UIImage *)image

--- a/NavigationReactNative/src/ios/NVTabBarManager.m
+++ b/NavigationReactNative/src/ios/NVTabBarManager.m
@@ -14,6 +14,7 @@ RCT_EXPORT_VIEW_PROPERTY(selectedTab, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(barTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(selectedTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(unselectedTintColor, UIColor)
+RCT_EXPORT_VIEW_PROPERTY(mostRecentEventCount, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(onTabSelected, RCTDirectEventBlock)
 
 @end

--- a/NavigationReactNative/src/ios/NVTabBarManager.m
+++ b/NavigationReactNative/src/ios/NVTabBarManager.m
@@ -10,6 +10,7 @@ RCT_EXPORT_MODULE()
     return [[NVTabBarView alloc] init];
 }
 
+RCT_EXPORT_VIEW_PROPERTY(selectedTab, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(barTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(selectedTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(unselectedTintColor, UIColor)

--- a/NavigationReactNative/src/ios/NVTabBarManager.m
+++ b/NavigationReactNative/src/ios/NVTabBarManager.m
@@ -10,6 +10,7 @@ RCT_EXPORT_MODULE()
     return [[NVTabBarView alloc] init];
 }
 
+RCT_EXPORT_VIEW_PROPERTY(tabCount, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(selectedTab, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(barTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(selectedTintColor, UIColor)

--- a/NavigationReactNative/src/ios/NVTabBarManager.m
+++ b/NavigationReactNative/src/ios/NVTabBarManager.m
@@ -13,5 +13,6 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_VIEW_PROPERTY(barTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(selectedTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(unselectedTintColor, UIColor)
+RCT_EXPORT_VIEW_PROPERTY(onTabSelected, RCTDirectEventBlock)
 
 @end

--- a/NavigationReactNative/src/ios/NVTabBarView.h
+++ b/NavigationReactNative/src/ios/NVTabBarView.h
@@ -3,6 +3,7 @@
 
 @interface NVTabBarView : UIView <UITabBarControllerDelegate>
 
+@property (nonatomic, assign) NSInteger tabCount;
 @property (nonatomic, assign) NSInteger mostRecentEventCount;
 @property (nonatomic, copy) RCTDirectEventBlock onTabSelected;
 

--- a/NavigationReactNative/src/ios/NVTabBarView.h
+++ b/NavigationReactNative/src/ios/NVTabBarView.h
@@ -3,6 +3,7 @@
 
 @interface NVTabBarView : UIView <UITabBarControllerDelegate>
 
+@property (nonatomic, assign) NSInteger mostRecentEventCount;
 @property (nonatomic, copy) RCTDirectEventBlock onTabSelected;
 
 @end

--- a/NavigationReactNative/src/ios/NVTabBarView.h
+++ b/NavigationReactNative/src/ios/NVTabBarView.h
@@ -1,5 +1,8 @@
 #import <UIKit/UIKit.h>
+#import <React/RCTComponent.h>
 
 @interface NVTabBarView : UIView <UITabBarControllerDelegate>
+
+@property (nonatomic, copy) RCTDirectEventBlock onTabSelected;
 
 @end

--- a/NavigationReactNative/src/ios/NVTabBarView.m
+++ b/NavigationReactNative/src/ios/NVTabBarView.m
@@ -7,6 +7,7 @@
 @implementation NVTabBarView
 {
     UITabBarController *_tabBarController;
+    NSInteger _selectedTab;
 }
 
 - (id)init
@@ -17,6 +18,11 @@
         _tabBarController.delegate = self;
     }
     return self;
+}
+
+- (void)setSelectedTab:(NSInteger)selectedTab
+{
+    _selectedTab = selectedTab;
 }
 
 - (void)setBarTintColor:(UIColor *)barTintColor
@@ -47,6 +53,11 @@
     NSMutableArray *controllers = [NSMutableArray arrayWithArray:[_tabBarController viewControllers]];
     [controllers removeObjectAtIndex:tab];
     [_tabBarController setViewControllers:controllers];
+}
+
+- (void)didSetProps:(NSArray<NSString *> *)changedProps
+{
+    _tabBarController.selectedIndex = _selectedTab;
 }
 
 - (void)didUpdateReactSubviews

--- a/NavigationReactNative/src/ios/NVTabBarView.m
+++ b/NavigationReactNative/src/ios/NVTabBarView.m
@@ -89,8 +89,11 @@
 
 - (void)tabBarController:(UITabBarController *)tabBarController didSelectViewController:(nonnull UIViewController *)viewController
 {
-    _selectedTab = [tabBarController.viewControllers indexOfObject:viewController];
-    [self selectTab];
+    NSInteger selectedIndex = [tabBarController.viewControllers indexOfObject:viewController];
+    if (_selectedTab != selectedIndex) {
+        _selectedTab = selectedIndex;
+        [self selectTab];
+    }
 }
 
 -(void) selectTab

--- a/NavigationReactNative/src/ios/NVTabBarView.m
+++ b/NavigationReactNative/src/ios/NVTabBarView.m
@@ -8,6 +8,7 @@
 {
     UITabBarController *_tabBarController;
     NSInteger _selectedTab;
+    NSInteger _nativeEventCount;
 }
 
 - (id)init
@@ -60,7 +61,8 @@
     if (_tabBarController.selectedIndex == NSNotFound) {
         _tabBarController.selectedIndex = 0;
     }
-    if (_tabBarController.selectedIndex != _selectedTab) {
+    NSInteger eventLag = _nativeEventCount - _mostRecentEventCount;
+    if (eventLag == 0 && _tabBarController.selectedIndex != _selectedTab) {
         _tabBarController.selectedIndex = _selectedTab;
         [self selectTab];
     }
@@ -89,8 +91,12 @@
 
 -(void) selectTab
 {
+    _nativeEventCount++;
     NVTabBarItemView *tabBarItem = (NVTabBarItemView *)self.reactSubviews[_selectedTab];
-    self.onTabSelected(@{ @"tab": @(_selectedTab) });
+    self.onTabSelected(@{
+        @"tab": @(_selectedTab),
+        @"eventCount": @(_nativeEventCount),
+    });
     if (!!tabBarItem.onPress) {
         tabBarItem.onPress(nil);
     }

--- a/NavigationReactNative/src/ios/NVTabBarView.m
+++ b/NavigationReactNative/src/ios/NVTabBarView.m
@@ -57,7 +57,13 @@
 
 - (void)didSetProps:(NSArray<NSString *> *)changedProps
 {
-    _tabBarController.selectedIndex = _selectedTab;
+    if (_tabBarController.selectedIndex == NSNotFound) {
+        _tabBarController.selectedIndex = 0;
+    }
+    if (_tabBarController.selectedIndex != _selectedTab) {
+        _tabBarController.selectedIndex = _selectedTab;
+        [self selectTab];
+    }
 }
 
 - (void)didUpdateReactSubviews
@@ -78,6 +84,11 @@
 - (void)tabBarController:(UITabBarController *)tabBarController didSelectViewController:(nonnull UIViewController *)viewController
 {
     _selectedTab = [tabBarController.viewControllers indexOfObject:viewController];
+    [self selectTab];
+}
+
+-(void) selectTab
+{
     NVTabBarItemView *tabBarItem = (NVTabBarItemView *)self.reactSubviews[_selectedTab];
     self.onTabSelected(@{ @"tab": @(_selectedTab) });
     if (!!tabBarItem.onPress) {

--- a/NavigationReactNative/src/ios/NVTabBarView.m
+++ b/NavigationReactNative/src/ios/NVTabBarView.m
@@ -49,7 +49,9 @@
 - (void)insertReactSubview:(UIView *)subview atIndex:(NSInteger)atIndex
 {
     [super insertReactSubview:subview atIndex:atIndex];
-    [_tabBarController addChildViewController:[(NVTabBarItemView *) subview navigationController]];
+    NSMutableArray *controllers = [NSMutableArray arrayWithArray:[_tabBarController viewControllers]];
+    [controllers insertObject:[(NVTabBarItemView *) subview navigationController] atIndex:atIndex];
+    [_tabBarController setViewControllers:controllers];
 }
 
 - (void)removeReactSubview:(UIView *)subview

--- a/NavigationReactNative/src/ios/NVTabBarView.m
+++ b/NavigationReactNative/src/ios/NVTabBarView.m
@@ -68,6 +68,7 @@
 {
     NSUInteger tab = [tabBarController.viewControllers indexOfObject:viewController];
     NVTabBarItemView *tabBarItem = (NVTabBarItemView *)self.reactSubviews[tab];
+    self.onTabSelected(@{ @"tab": @(tab) });
     if (!!tabBarItem.onPress) {
         tabBarItem.onPress(nil);
     }

--- a/NavigationReactNative/src/ios/NVTabBarView.m
+++ b/NavigationReactNative/src/ios/NVTabBarView.m
@@ -23,7 +23,10 @@
 
 - (void)setSelectedTab:(NSInteger)selectedTab
 {
-    _selectedTab = selectedTab;
+    NSInteger eventLag = _nativeEventCount - _mostRecentEventCount;
+    if (eventLag == 0) {
+        _selectedTab = selectedTab;
+    }
 }
 
 - (void)setBarTintColor:(UIColor *)barTintColor
@@ -61,8 +64,7 @@
     if (_tabBarController.selectedIndex == NSNotFound) {
         _tabBarController.selectedIndex = 0;
     }
-    NSInteger eventLag = _nativeEventCount - _mostRecentEventCount;
-    if (eventLag == 0 && _tabBarController.selectedIndex != _selectedTab) {
+    if (_tabBarController.selectedIndex != _selectedTab) {
         _tabBarController.selectedIndex = _selectedTab;
         [self selectTab];
     }

--- a/NavigationReactNative/src/ios/NVTabBarView.m
+++ b/NavigationReactNative/src/ios/NVTabBarView.m
@@ -69,7 +69,11 @@
         _tabBarController.selectedIndex = 0;
     }
     if (_tabBarController.selectedIndex != _selectedTab) {
-        _tabBarController.selectedIndex = _selectedTab;
+        if ([changedProps containsObject:@"selectedTab"]) {
+            _tabBarController.selectedIndex = _selectedTab;
+        } else {
+            _selectedTab = _tabBarController.selectedIndex;
+        }
         [self selectTab];
     }
 }

--- a/NavigationReactNative/src/ios/NVTabBarView.m
+++ b/NavigationReactNative/src/ios/NVTabBarView.m
@@ -77,9 +77,9 @@
 
 - (void)tabBarController:(UITabBarController *)tabBarController didSelectViewController:(nonnull UIViewController *)viewController
 {
-    NSUInteger tab = [tabBarController.viewControllers indexOfObject:viewController];
-    NVTabBarItemView *tabBarItem = (NVTabBarItemView *)self.reactSubviews[tab];
-    self.onTabSelected(@{ @"tab": @(tab) });
+    _selectedTab = [tabBarController.viewControllers indexOfObject:viewController];
+    NVTabBarItemView *tabBarItem = (NVTabBarItemView *)self.reactSubviews[_selectedTab];
+    self.onTabSelected(@{ @"tab": @(_selectedTab) });
     if (!!tabBarItem.onPress) {
         tabBarItem.onPress(nil);
     }

--- a/NavigationReactNative/src/ios/NVTabBarView.m
+++ b/NavigationReactNative/src/ios/NVTabBarView.m
@@ -41,7 +41,9 @@
 
 - (void)setUnselectedTintColor:(UIColor *)unselectedTintColor
 {
-    [_tabBarController.tabBar setUnselectedItemTintColor: unselectedTintColor];
+    if (@available(iOS 10.0, *)) {
+        [_tabBarController.tabBar setUnselectedItemTintColor: unselectedTintColor];
+    }
 }
 
 - (void)insertReactSubview:(UIView *)subview atIndex:(NSInteger)atIndex

--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -355,6 +355,18 @@ export interface TabBarProps {
      * Indicates whether the selected tab can be changed by swiping 
      */
     swipeable?: boolean;
+    /**
+     * The default selected tab index
+     */
+    defaultTab?: number;
+    /**
+     * The selected tab index
+     */
+    tab?: number;
+    /**
+     * Handles tab change events
+     */
+    onChangeTab?: (tab: number) => void;
 }
 
 /**

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -355,6 +355,18 @@ export interface TabBarProps {
      * Indicates whether the selected tab can be changed by swiping 
      */
     swipeable?: boolean;
+    /**
+     * The default selected tab index
+     */
+    defaultTab?: number;
+    /**
+     * The selected tab index
+     */
+    tab?: number;
+    /**
+     * Handles tab change events
+     */
+    onChangeTab?: (tab: number) => void;
 }
 
 /**


### PR DESCRIPTION
If the `tab` prop isn’t set then it’s uncontrolled. If the `tab` prop is set then it’s controlled and expects the `onChangeTab` prop to be set too. Just like the `value` and `onChange` props for the React input component.
```jsx
  const [tab, setTab] = useState(0);
  <TabBar
    tab={tab}
    onChangeTab={tab => setTab(tab)}>
    ...
  </TabBar>
```
Added a `defaultTab` prop so the start tab can be set when uncontrolled.
