### PR TITLE
Allowed scene transition animation to be disabled

### DIFF
--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneNavigator.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneNavigator.java
@@ -48,6 +48,8 @@ abstract class SceneNavigator {
         }
         if (animationName == null)
             return defaultAnimation.get(defaultId);
+        if (animationName.equals(""))
+            return 0;
         String packageName = context.getPackageName();
         return context.getResources().getIdentifier(animationName, "anim", packageName);
     }

--- a/NavigationReactNative/src/ios/NVNavigationStackManager.m
+++ b/NavigationReactNative/src/ios/NVNavigationStackManager.m
@@ -11,6 +11,7 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_EXPORT_VIEW_PROPERTY(keys, NSArray)
+RCT_EXPORT_VIEW_PROPERTY(enterAnim, NSString)
 RCT_EXPORT_VIEW_PROPERTY(mostRecentEventCount, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(onDidNavigateBack, RCTDirectEventBlock)
 

--- a/NavigationReactNative/src/ios/NVNavigationStackView.h
+++ b/NavigationReactNative/src/ios/NVNavigationStackView.h
@@ -6,6 +6,7 @@
 
 @property (nonatomic, strong) UINavigationController *navigationController;
 @property (nonatomic, copy) NSArray *keys;
+@property (nonatomic, copy) NSString *enterAnim;
 @property (nonatomic, assign) NSInteger mostRecentEventCount;
 @property (nonatomic, copy) RCTDirectEventBlock onDidNavigateBack;
 

--- a/NavigationReactNative/src/ios/NVNavigationStackView.m
+++ b/NavigationReactNative/src/ios/NVNavigationStackView.m
@@ -53,6 +53,7 @@
     if (crumb < currentCrumb) {
         [_navigationController popToViewController:_navigationController.viewControllers[crumb] animated:true];
     }
+    BOOL animate = ![self.enterAnim isEqualToString:@""];
     if (crumb > currentCrumb) {
         NSMutableArray *controllers = [[NSMutableArray alloc] init];
         for(NSInteger i = 0; i < crumb - currentCrumb; i++) {
@@ -70,10 +71,10 @@
         }
         
         if (crumb - currentCrumb == 1) {
-            [_navigationController pushViewController:controllers[0] animated:true];
+            [_navigationController pushViewController:controllers[0] animated:animate];
         } else {
             NSArray *allControllers = [_navigationController.viewControllers arrayByAddingObjectsFromArray:controllers];
-            [_navigationController setViewControllers:allControllers animated:true];
+            [_navigationController setViewControllers:allControllers animated:animate];
         }
     }
     if (crumb == currentCrumb) {
@@ -83,7 +84,7 @@
         NVSceneController *controller = [[NVSceneController alloc] initWithScene:scene];
         NSMutableArray *controllers = [NSMutableArray arrayWithArray:_navigationController.viewControllers];
         [controllers replaceObjectAtIndex:crumb withObject:controller];
-        [_navigationController setViewControllers:controllers animated:true];
+        [_navigationController setViewControllers:controllers animated:animate];
     }
 }
 


### PR DESCRIPTION
Returning an empty string disables the animation that runs when a scene transitions. On Android there are four different animations that can be disabled - enter, to crumb, from crumb and exit  On iOS, only the enter animation can be disabled because iOS automatically runs the other three.
```jsx
    <NavigationStack crumbStyle={() => ''} unmountStyle={() => '' />
```
On Android, could already disable animations by returning any string that doesn’t match a resource file name. This functionality is still there although the official way is to return an empty string.
