### PR TITLE
Tinted menu items on the navigation bar

### DIFF
--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
@@ -33,7 +33,7 @@ public class ToolbarView extends Toolbar {
     private static final String PROP_ACTION_SEARCH = "search";
     int defaultTitleTextColor;
     Drawable defaultOverflowIcon;
-    private Integer defaultMenuItemColor;
+    private Integer defaultMenuTintColor;
     private IconResolver.IconResolverListener logoResolverListener;
     private IconResolver.IconResolverListener navIconResolverListener;
     private IconResolver.IconResolverListener overflowIconResolverListener;
@@ -181,9 +181,9 @@ public class ToolbarView extends Toolbar {
                 for(int j = 0; j < menu.getChildCount(); j++) {
                     if (menu.getChildAt(j) instanceof ActionMenuItemView) {
                         ActionMenuItemView menuItem = (ActionMenuItemView) menu.getChildAt(j);
-                        if (defaultMenuItemColor == null)
-                            defaultMenuItemColor = menuItem.getCurrentTextColor();
-                        menuItem.setTextColor(tintColor != null ? tintColor : defaultMenuItemColor);
+                        if (defaultMenuTintColor == null)
+                            defaultMenuTintColor = menuItem.getCurrentTextColor();
+                        menuItem.setTextColor(tintColor != null ? tintColor : defaultMenuTintColor);
                     }
                 }
             }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
@@ -11,6 +11,8 @@ import android.view.MenuItem;
 import android.view.View;
 
 import androidx.annotation.Nullable;
+import androidx.appcompat.view.menu.ActionMenuItemView;
+import androidx.appcompat.widget.ActionMenuView;
 import androidx.appcompat.widget.Toolbar;
 
 import com.facebook.react.bridge.Arguments;
@@ -31,6 +33,7 @@ public class ToolbarView extends Toolbar {
     private static final String PROP_ACTION_SEARCH = "search";
     int defaultTitleTextColor;
     Drawable defaultOverflowIcon;
+    private Integer defaultMenuItemColor;
     private IconResolver.IconResolverListener logoResolverListener;
     private IconResolver.IconResolverListener navIconResolverListener;
     private IconResolver.IconResolverListener overflowIconResolverListener;
@@ -119,6 +122,7 @@ public class ToolbarView extends Toolbar {
         setTintColor(getNavigationIcon());
         setTintColor(getLogo());
         setTintColor(getOverflowIcon());
+        setMenuTintColor();
         for(int i = 0; i < getMenu().size(); i++) {
             setTintColor(getMenu().getItem(i).getIcon());
         }
@@ -166,6 +170,23 @@ public class ToolbarView extends Toolbar {
                 });
             }
             menuItem.setShowAsAction(showAsAction);
+        }
+        setMenuTintColor();
+    }
+
+    private void setMenuTintColor()  {
+        for (int i = 0; i < getChildCount(); i++) {
+            if (getChildAt(i) instanceof ActionMenuView) {
+                ActionMenuView menu = (ActionMenuView) getChildAt(i);
+                for(int j = 0; j < menu.getChildCount(); j++) {
+                    if (menu.getChildAt(j) instanceof ActionMenuItemView) {
+                        ActionMenuItemView menuItem = (ActionMenuItemView) menu.getChildAt(j);
+                        if (defaultMenuItemColor == null)
+                            defaultMenuItemColor = menuItem.getCurrentTextColor();
+                        menuItem.setTextColor(tintColor != null ? tintColor : defaultMenuItemColor);
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Fixes part of #396

Treated the menu items on the navigation bar differently to the menu items in the overflow menu. Tinted the onees on the navigation bar using the `tintColor` prop of the `NavigationBar`. 
