### PR TITLE
Raised onBeforeNavigate event when swipe back starts on iOS

### DIFF
--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -16,6 +16,7 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
         this.state = {stateNavigator: null, keys: [], finish: false};
         this.ref = React.createRef<View>();
         this.handleBack = this.handleBack.bind(this);
+        this.onWillNavigateBack = this.onWillNavigateBack.bind(this);
         this.onDidNavigateBack = this.onDidNavigateBack.bind(this);
     }
     static defaultProps = {
@@ -35,6 +36,8 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
         if (prevKeys.length === keys.length && prevState !== state)
             keys[keys.length - 1] += '+';
         return {keys, stateNavigator};
+    }
+    onWillNavigateBack({nativeEvent}) {
     }
     onDidNavigateBack({nativeEvent}) {
         var {stateNavigator} = this.props;
@@ -88,6 +91,7 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
                 fragmentMode={fragmentMode}
                 style={[styles.stack, fragmentMode ? {backgroundColor: '#000'} : null]}
                 {...this.getAnimation()}
+                onWillNavigateBack={this.onWillNavigateBack}
                 onDidNavigateBack={this.onDidNavigateBack}>
                 <BackButton onPress={this.handleBack} />
                 {Platform.OS === 'android' && <NVFragmentContainer style={styles.stack} />}

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -40,8 +40,7 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
     }
     onWillNavigateBack({nativeEvent}) {
         var {stateNavigator} = this.props;
-        var {crumb} = nativeEvent;
-        var distance = stateNavigator.stateContext.crumbs.length - crumb;
+        var distance = stateNavigator.stateContext.crumbs.length - nativeEvent.crumb;
         if (stateNavigator.canNavigateBack(distance)) {
             var url = stateNavigator.getNavigationBackLink(distance);
             stateNavigator.navigateLink(url, undefined, true, (_stateContext, resumeNavigation) => {
@@ -50,7 +49,7 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
         }
     }
     onDidNavigateBack({nativeEvent}) {
-        var {eventCount: mostRecentEventCount} = nativeEvent;
+        var mostRecentEventCount = nativeEvent.eventCount;
         this.ref.current.setNativeProps({mostRecentEventCount});
         this.resumeNavigation();
     }

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -41,6 +41,7 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
     onWillNavigateBack({nativeEvent}) {
         var {stateNavigator} = this.props;
         var distance = stateNavigator.stateContext.crumbs.length - nativeEvent.crumb;
+        this.resumeNavigation = null;
         if (stateNavigator.canNavigateBack(distance)) {
             var url = stateNavigator.getNavigationBackLink(distance);
             stateNavigator.navigateLink(url, undefined, true, (_stateContext, resumeNavigation) => {
@@ -51,7 +52,8 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
     onDidNavigateBack({nativeEvent}) {
         var mostRecentEventCount = nativeEvent.eventCount;
         this.ref.current.setNativeProps({mostRecentEventCount});
-        this.resumeNavigation();
+        if (this.resumeNavigation)
+            this.resumeNavigation();
     }
     handleBack() {
         var {primary, fragmentMode} = this.props;

--- a/NavigationReactNative/src/ios/NVNavigationStackManager.m
+++ b/NavigationReactNative/src/ios/NVNavigationStackManager.m
@@ -13,6 +13,7 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_VIEW_PROPERTY(keys, NSArray)
 RCT_EXPORT_VIEW_PROPERTY(enterAnim, NSString)
 RCT_EXPORT_VIEW_PROPERTY(mostRecentEventCount, NSInteger)
+RCT_EXPORT_VIEW_PROPERTY(onWillNavigateBack, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onDidNavigateBack, RCTDirectEventBlock)
 
 @end

--- a/NavigationReactNative/src/ios/NVNavigationStackView.h
+++ b/NavigationReactNative/src/ios/NVNavigationStackView.h
@@ -8,6 +8,7 @@
 @property (nonatomic, copy) NSArray *keys;
 @property (nonatomic, copy) NSString *enterAnim;
 @property (nonatomic, assign) NSInteger mostRecentEventCount;
+@property (nonatomic, copy) RCTDirectEventBlock onWillNavigateBack;
 @property (nonatomic, copy) RCTDirectEventBlock onDidNavigateBack;
 
 -(id)initWithBridge: (RCTBridge *)bridge;

--- a/NavigationReactNative/src/ios/NVNavigationStackView.m
+++ b/NavigationReactNative/src/ios/NVNavigationStackView.m
@@ -107,7 +107,7 @@
 - (void)navigationController:(UINavigationController *)navigationController didShowViewController:(UIViewController *)viewController animated:(BOOL)animated
 {
     NSInteger crumb = [navigationController.viewControllers indexOfObject:viewController];
-    if (crumb < [self.reactSubviews count] - 1) {
+    if (crumb < [self.keys count] - 1) {
         _nativeEventCount++;
         self.onDidNavigateBack(@{
             @"crumb": @(crumb),
@@ -119,8 +119,13 @@
 - (void)navigationController:(UINavigationController *)navigationController willShowViewController:(UIViewController *)viewController animated:(BOOL)animated
 {
     NSInteger crumb = [navigationController.viewControllers indexOfObject:viewController];
-    NVSceneView *scene = (NVSceneView *) [_scenes objectForKey:[self.keys objectAtIndex:crumb]];
-    [scene willAppear];
+    if (crumb < [self.keys count] - 1) {
+        _nativeEventCount++;
+        self.onWillNavigateBack(@{
+            @"crumb": @(crumb),
+            @"eventCount": @(_nativeEventCount),
+        });
+    }
 }
 
 @end

--- a/NavigationReactNative/src/ios/NVNavigationStackView.m
+++ b/NavigationReactNative/src/ios/NVNavigationStackView.m
@@ -104,18 +104,6 @@
     _navigationController.delegate = nil;
 }
 
-- (void)navigationController:(UINavigationController *)navigationController didShowViewController:(UIViewController *)viewController animated:(BOOL)animated
-{
-    NSInteger crumb = [navigationController.viewControllers indexOfObject:viewController];
-    if (crumb < [self.keys count] - 1) {
-        _nativeEventCount++;
-        self.onDidNavigateBack(@{
-            @"crumb": @(crumb),
-            @"eventCount": @(_nativeEventCount),
-        });
-    }
-}
-
 - (void)navigationController:(UINavigationController *)navigationController willShowViewController:(UIViewController *)viewController animated:(BOOL)animated
 {
     NSInteger crumb = [navigationController.viewControllers indexOfObject:viewController];
@@ -123,6 +111,16 @@
         _nativeEventCount++;
         self.onWillNavigateBack(@{
             @"crumb": @(crumb),
+        });
+    }
+}
+
+- (void)navigationController:(UINavigationController *)navigationController didShowViewController:(UIViewController *)viewController animated:(BOOL)animated
+{
+    NSInteger crumb = [navigationController.viewControllers indexOfObject:viewController];
+    if (crumb < [self.keys count] - 1) {
+        _nativeEventCount++;
+        self.onDidNavigateBack(@{
             @"eventCount": @(_nativeEventCount),
         });
     }

--- a/NavigationReactNative/src/ios/NVNavigationStackView.m
+++ b/NavigationReactNative/src/ios/NVNavigationStackView.m
@@ -108,9 +108,7 @@
 {
     NSInteger crumb = [navigationController.viewControllers indexOfObject:viewController];
     if (crumb < [self.keys count] - 1) {
-        self.onWillNavigateBack(@{
-            @"crumb": @(crumb),
-        });
+        self.onWillNavigateBack(@{ @"crumb": @(crumb) });
     }
 }
 
@@ -119,9 +117,7 @@
     NSInteger crumb = [navigationController.viewControllers indexOfObject:viewController];
     if (crumb < [self.keys count] - 1) {
         _nativeEventCount++;
-        self.onDidNavigateBack(@{
-            @"eventCount": @(_nativeEventCount),
-        });
+        self.onDidNavigateBack(@{ @"eventCount": @(_nativeEventCount) });
     }
 }
 

--- a/NavigationReactNative/src/ios/NVNavigationStackView.m
+++ b/NavigationReactNative/src/ios/NVNavigationStackView.m
@@ -108,7 +108,6 @@
 {
     NSInteger crumb = [navigationController.viewControllers indexOfObject:viewController];
     if (crumb < [self.keys count] - 1) {
-        _nativeEventCount++;
         self.onWillNavigateBack(@{
             @"crumb": @(crumb),
         });

--- a/NavigationReactNative/src/ios/NVSceneManager.m
+++ b/NavigationReactNative/src/ios/NVSceneManager.m
@@ -12,7 +12,6 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_VIEW_PROPERTY(sceneKey, NSString)
 RCT_EXPORT_VIEW_PROPERTY(title, NSString)
-RCT_EXPORT_VIEW_PROPERTY(onWillAppear, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPopped, RCTDirectEventBlock)
 
 @end

--- a/NavigationReactNative/src/ios/NVSceneView.h
+++ b/NavigationReactNative/src/ios/NVSceneView.h
@@ -5,7 +5,6 @@
 
 @property (nonatomic, copy) NSString *sceneKey;
 @property (nonatomic, copy) NSString *title;
-@property (nonatomic, copy) RCTDirectEventBlock onWillAppear;
 @property (nonatomic, copy) RCTDirectEventBlock onPopped;
 
 -(void)willAppear;

--- a/NavigationReactNative/src/ios/NVSceneView.m
+++ b/NavigationReactNative/src/ios/NVSceneView.m
@@ -9,11 +9,6 @@
     return self;
 }
 
--(void)willAppear
-{
-    self.onWillAppear(nil);
-}
-
 -(void)didPop
 {
     self.onPopped(nil);


### PR DESCRIPTION
When swiping back on iOS, the JavaScript navigation didn’t start until the swipe completed. In the case where the user peeks at the previous screen and doesn’t complete the swipe, then nothing happened in the Navigation router.

But there are use-cases that need to know when the swipe begins. For example, when fluently navigating from A → B → C, scene B isn’t rendered until it’s visited. So swiping back would show a blank screen until swipe completes. The Scene had to bypass the Navigation router and manually listen for the swipe start. 

Changed so that the JavaScript navigation back begins as soon as the swipe starts. It’s suspended and only resumes when the swipe completes. This means the `onBeforeNavigate` event fires immediately. The `onNavigate` event is delayed until the swipe finishes.

Changed the Scene to listen to the `onBeforeNavigate` event and removed the manual swipe-start listener.
