### PR TITLE
feat(NavigationReactNative): added show/hide tab bar on ios

### DIFF
--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { requireNativeComponent, Platform, StyleSheet, View } from 'react-native';
+import { requireNativeComponent, Platform, StyleSheet, View, UIManager, findNodeHandle } from 'react-native';
 import BackButton from './BackButton';
 
 class TabBar extends React.Component<any, any> {
@@ -36,6 +36,37 @@ class TabBar extends React.Component<any, any> {
         }
         return false;
     }
+    
+    public hide() {
+        switch(Platform.OS) {
+            case 'ios':
+                (UIManager as any).dispatchViewManagerCommand(
+                    findNodeHandle(this),
+                    'hideTabBar',
+                    []
+                );
+                break        
+            default:
+                console.warn(`Hide TabBar is not supported on ${Platform.OS}`);
+                break;
+            }
+    }
+    
+    public show() {
+        switch(Platform.OS) {
+            case 'ios':
+                (UIManager as any).dispatchViewManagerCommand(
+                    findNodeHandle(this),
+                    'showTabBar',
+                    []
+                );
+                break;
+            default:
+                console.warn(`Show TabBar is not supported on ${Platform.OS}`);
+                break;
+        }
+    }
+
     render() {
         var {children, barTintColor, selectedTintColor, unselectedTintColor, bottomTabs, scrollable, primary, swipeable} = this.props;
         bottomTabs = bottomTabs != null ? bottomTabs : primary;

--- a/NavigationReactNative/src/ios/NVTabBarManager.m
+++ b/NavigationReactNative/src/ios/NVTabBarManager.m
@@ -1,5 +1,8 @@
 #import "NVTabBarManager.h"
 #import "NVTabBarView.h"
+#import <React/RCTViewManager.h>
+#import <React/RCTUIManager.h>
+#import <React/RCTLog.h>
 
 @implementation NVTabBarManager
 
@@ -17,5 +20,29 @@ RCT_EXPORT_VIEW_PROPERTY(selectedTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(unselectedTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(mostRecentEventCount, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(onTabSelected, RCTDirectEventBlock)
+
+RCT_EXPORT_METHOD(hideTabBar:(nonnull NSNumber*) reactTag) {
+    [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *,UIView *> *viewRegistry) {
+        NVTabBarView *view = viewRegistry[reactTag];
+        if (!view || ![view isKindOfClass:[NVTabBarView class]]) {
+            RCTLogError(@"Cannot find NVTabBarView with tag #%@", reactTag);
+            return;
+        }
+        [view hideTabBar];
+    }];
+
+}
+
+RCT_EXPORT_METHOD(showTabBar:(nonnull NSNumber*) reactTag) {
+    [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *,UIView *> *viewRegistry) {
+        NVTabBarView *view = viewRegistry[reactTag];
+        if (!view || ![view isKindOfClass:[NVTabBarView class]]) {
+            RCTLogError(@"Cannot find NVTabBarView with tag #%@", reactTag);
+            return;
+        }
+        [view showTabBar];
+    }];
+
+}
 
 @end

--- a/NavigationReactNative/src/ios/NVTabBarView.h
+++ b/NavigationReactNative/src/ios/NVTabBarView.h
@@ -7,4 +7,7 @@
 @property (nonatomic, assign) NSInteger mostRecentEventCount;
 @property (nonatomic, copy) RCTDirectEventBlock onTabSelected;
 
+-(void)hideTabBar;
+-(void)showTabBar;
+
 @end

--- a/NavigationReactNative/src/ios/NVTabBarView.m
+++ b/NavigationReactNative/src/ios/NVTabBarView.m
@@ -115,4 +115,61 @@
     }
 }
 
+- (void) hideTabBar
+{
+    CGRect screenRect = [[UIScreen mainScreen] bounds];
+
+    [UIView beginAnimations:nil context:NULL];
+    [UIView setAnimationDuration:0.25];
+    [UIView setAnimationCurve:UIViewAnimationCurveEaseOut];
+    float fHeight = screenRect.size.height;
+    if(  UIDeviceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation) )
+    {
+        fHeight = screenRect.size.width;
+    }
+
+    for(UIView *view in _tabBarController.view.subviews)
+    {
+        if([view isKindOfClass:[UITabBar class]])
+        {
+            [view setFrame:CGRectMake(view.frame.origin.x, fHeight, view.frame.size.width, view.frame.size.height)];
+        }
+        else
+        {
+            [view setFrame:CGRectMake(view.frame.origin.x, view.frame.origin.y, view.frame.size.width, fHeight)];
+            view.backgroundColor = [UIColor blackColor];
+        }
+    }
+    [UIView commitAnimations];
+}
+
+
+
+- (void) showTabBar
+{
+    CGRect screenRect = [[UIScreen mainScreen] bounds];
+    float fHeight = screenRect.size.height - _tabBarController.tabBar.frame.size.height;
+
+    if(  UIDeviceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation) )
+    {
+        fHeight = screenRect.size.width - _tabBarController.tabBar.frame.size.height;
+    }
+
+    [UIView beginAnimations:nil context:NULL];
+    [UIView setAnimationDuration:0.25];
+    [UIView setAnimationCurve:UIViewAnimationCurveEaseOut];
+    for(UIView *view in _tabBarController.view.subviews)
+    {
+        if([view isKindOfClass:[UITabBar class]])
+        {
+            [view setFrame:CGRectMake(view.frame.origin.x, fHeight, view.frame.size.width, view.frame.size.height)];
+        }
+        else
+        {
+            [view setFrame:CGRectMake(view.frame.origin.x, view.frame.origin.y, view.frame.size.width, fHeight)];
+        }
+    }
+    [UIView commitAnimations];
+}
+
 @end

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -381,7 +381,16 @@ export class TabBarIOS extends Component<TabBarProps> {}
 /**
  * Renders a tab bar
  */
-export class TabBar extends Component<TabBarProps> {}
+export class TabBar extends Component<TabBarProps> {
+    /**
+     * Hides the tab bar
+     */
+    show: () => void;
+    /**
+     * Hides the tab bar
+     */
+    hide: () => void;
+}
 
 /**
  * Defines the Modal Back Handler Props contract


### PR DESCRIPTION
On iOS, it is sometimes important to show/hide the tab bar, for instance, navigating to a chat screen, the chat screen will have no tab bar to allow for the message bar to be there instead.