### PR TITLE
Supported separate transition per shared element

### DIFF
--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FragmentNavigator.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FragmentNavigator.java
@@ -23,7 +23,7 @@ class FragmentNavigator extends SceneNavigator {
     void navigateBack(int currentCrumb, int crumb, Activity activity, NavigationStackView stack) {
         FragmentManager fragmentManager = stack.fragment.getChildFragmentManager();
         SceneFragment fragment = (SceneFragment) fragmentManager.findFragmentByTag(oldKey);
-        Pair[] sharedElements = fragment != null ? getOldSharedElements(currentCrumb, crumb, fragment, stack) : null;
+        Pair[] sharedElements = fragment != null ? getOldSharedElements(currentCrumb, crumb, fragment, stack, activity) : null;
         SceneFragment prevFragment = (SceneFragment) fragmentManager.findFragmentByTag(stack.keys.getString(crumb));
         if (sharedElements != null && prevFragment != null && prevFragment.getScene() != null)
             prevFragment.getScene().transitioner = new SharedElementTransitioner(prevFragment, getSharedElementSet(stack.oldSharedElementNames));
@@ -84,10 +84,19 @@ class FragmentNavigator extends SceneNavigator {
         fragmentTransaction.commit();
     }
 
-    private Pair[] getOldSharedElements(int currentCrumb, int crumb, SharedElementContainer sharedElementContainer, final NavigationStackView stack) {
+    private Pair[] getOldSharedElements(int currentCrumb, int crumb, SharedElementContainer sharedElementContainer, final NavigationStackView stack, final Activity activity) {
         final HashMap<String, View> oldSharedElementsMap = getSharedElementMap(sharedElementContainer.getScene());
         final Pair[] oldSharedElements = currentCrumb - crumb == 1 ? getSharedElements(oldSharedElementsMap, stack.oldSharedElementNames) : null;
         if (oldSharedElements != null && oldSharedElements.length != 0) {
+            final SharedElementTransitioner transitioner = new SharedElementTransitioner(sharedElementContainer, getSharedElementSet(stack.oldSharedElementNames));
+            for(int i = 0; i < stack.oldSharedElementNames.size(); i++) {
+                String name = stack.oldSharedElementNames.getString(i);
+                if (oldSharedElementsMap.containsKey(name)) {
+                    View oldSharedElement = oldSharedElementsMap.get(name);
+                    SharedElementView oldSharedElementView = (SharedElementView) oldSharedElement.getParent();
+                    transitioner.load(name, oldSharedElementView.exitTransition, activity);
+                }
+            }
             sharedElementContainer.setEnterCallback(new SharedElementCallback() {
                 @Override
                 public void onMapSharedElements(List<String> names, Map<String, View> elements) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -81,6 +81,10 @@ public class SceneActivity extends ReactActivity implements DefaultHardwareBackB
     }
 
     @Override
+    public void setReturnTransition(Transition transition) {
+    }
+
+    @Override
     public void setExitCallback(SharedElementCallback sharedElementCallback) {
         setExitSharedElementCallback(sharedElementCallback);
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneActivity.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneActivity.java
@@ -70,11 +70,6 @@ public class SceneActivity extends ReactActivity implements DefaultHardwareBackB
     }
 
     @Override
-    public boolean canAddTarget() {
-        return true;
-    }
-
-    @Override
     public void setEnterTransition(Transition transition) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
             getWindow().setSharedElementEnterTransition(transition);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -47,11 +47,6 @@ public class SceneFragment extends Fragment implements SharedElementContainer {
     }
 
     @Override
-    public boolean canAddTarget() {
-        return true;
-    }
-
-    @Override
     public void setEnterTransition(Transition transition) {
         setSharedElementEnterTransition(transition);
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -48,12 +48,17 @@ public class SceneFragment extends Fragment implements SharedElementContainer {
 
     @Override
     public boolean canAddTarget() {
-        return false;
+        return true;
     }
 
     @Override
     public void setEnterTransition(Transition transition) {
         setSharedElementEnterTransition(transition);
+    }
+
+    @Override
+    public void setReturnTransition(Transition transition) {
+        setSharedElementReturnTransition(transition);
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementContainer.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementContainer.java
@@ -7,8 +7,6 @@ import androidx.core.app.SharedElementCallback;
 interface SharedElementContainer {
     SceneView getScene();
 
-    boolean canAddTarget();
-
     void setEnterTransition(Transition transition);
 
     void setReturnTransition(Transition transition);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementContainer.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementContainer.java
@@ -11,6 +11,8 @@ interface SharedElementContainer {
 
     void setEnterTransition(Transition transition);
 
+    void setReturnTransition(Transition transition);
+
     void setExitCallback(SharedElementCallback sharedElementCallback);
 
     void setEnterCallback(SharedElementCallback sharedElementCallback);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
@@ -38,8 +38,7 @@ class SharedElementTransitioner {
                 transition = TransitionInflater.from(context).inflateTransition(transitionId);
                 transitions.put(transitionKey, transition);
             }
-            if (sharedElementContainer.canAddTarget())
-                transition.addTarget(sharedElement);
+            transition.addTarget(sharedElement);
         }
         if(sharedElements.size() == loadedSharedElements.size()) {
             TransitionSet transitionSet = new TransitionSet();

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
@@ -47,6 +47,7 @@ class SharedElementTransitioner {
                 transitionSet.addTransition(transitions.get(key));
             }
             sharedElementContainer.setEnterTransition(transitionSet);
+            sharedElementContainer.setReturnTransition(transitionSet);
             sharedElementContainer.startPostponedEnterTransition();
             sharedElementContainer.getScene().transitioner = null;
         }


### PR DESCRIPTION
Targeting the transition worked when going A -> B but not when going back if the shared element had been remapped (name change). Had to call `setSharedElementReturnTransition` on B