### PR TITLE
Added TabBar badges on Android

### DIFF
--- a/NavigationReactNative/sample/twitter/Tabs.js
+++ b/NavigationReactNative/sample/twitter/Tabs.js
@@ -1,15 +1,22 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {TabBar, TabBarItem} from 'navigation-react-native';
 import Home from './Home';
 import Notifications from './Notifications';
 
-export default ({tweets, notifications}) => (
-  <TabBar primary={true} selectedTintColor="#1da1f2">
-    <TabBarItem title="Home" image={require('./home.png')}>
-      <Home tweets={tweets} notifications={notifications} />
-    </TabBarItem>
-    <TabBarItem title="Notifications" image={require('./notifications.png')}>
-      <Notifications notifications={notifications} />
-    </TabBarItem>
-  </TabBar>
-);
+export default ({tweets, notifications}) => {
+  const [notified, setNotified] = useState(false);
+  return (
+    <TabBar primary={true} selectedTintColor="#1da1f2">
+      <TabBarItem title="Home" image={require('./home.png')}>
+        <Home tweets={tweets} notifications={notifications} />
+      </TabBarItem>
+      <TabBarItem
+        title="Notifications"
+        image={require('./notifications.png')}
+        badge={!notified ? notifications.length : null} 
+        onPress={() => {setNotified(true)}}>
+        <Notifications notifications={notifications} />
+      </TabBarItem>
+    </TabBar>
+  );
+}

--- a/NavigationReactNative/sample/twitter/android/app/build.gradle
+++ b/NavigationReactNative/sample/twitter/android/app/build.gradle
@@ -205,6 +205,7 @@ dependencies {
     debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${FLIPPER_VERSION}") {
         exclude group:'com.facebook.flipper'
     }
+    implementation 'com.google.android.material:material:1.1.0'
 
     if (enableHermes) {
         def hermesPath = "../../node_modules/hermes-engine/android/";

--- a/NavigationReactNative/sample/twitter/android/app/src/main/res/values/styles.xml
+++ b/NavigationReactNative/sample/twitter/android/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
         <!-- Customize your theme here. -->
         <item name="android:textColor">#000000</item>
     </style>

--- a/NavigationReactNative/src/TabBarItem.tsx
+++ b/NavigationReactNative/src/TabBarItem.tsx
@@ -21,7 +21,7 @@ class TabBarItem extends React.Component<any> {
         return (
             <NVTabBarItem
                 {...props}
-                badge={badge != null ? '' + badge : undefined}
+                badge={badge != null ? (Platform.OS === 'ios' ? '' + badge : +badge) : undefined}
                 image={Platform.OS === 'ios' ? image : Image.resolveAssetSource(image)}
                 style={styles.tabBarItem}
                 onPress={event => {

--- a/NavigationReactNative/src/android/build.gradle
+++ b/NavigationReactNative/src/android/build.gradle
@@ -38,6 +38,6 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.google.android.material:material:1.0.0'
+    implementation 'com.google.android.material:material:1.1.0'
 }
   

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemManager.java
@@ -32,6 +32,16 @@ public class TabBarItemManager extends ViewGroupManager<TabBarItemView> {
         view.setIconSource(icon);
     }
 
+    @ReactProp(name = "badge")
+    public void setBadge(TabBarItemView view, @Nullable Integer badge) {
+        view.setBadge(badge);
+    }
+
+    @ReactProp(name = "badgeColor", customType = "Color")
+    public void setBadgeColor(TabBarItemView view, @Nullable Integer badgeColor) {
+        view.setBadgeColor(badgeColor);
+    }
+
     @Nonnull
     @Override
     protected TabBarItemView createViewInstance(@Nonnull ThemedReactContext reactContext) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemView.java
@@ -50,10 +50,13 @@ public class TabBarItemView extends ViewGroup {
         this.badge = badge;
         if (tabView == null)
             return;
-        if (badge != null)
-            tabView.getBadgeIcon(index).setNumber(badge);
-        else
-            tabView.removeBadgeIcon(index);
+        try {
+            if (badge != null)
+                tabView.getBadgeIcon(index).setNumber(badge);
+            else
+                tabView.removeBadgeIcon(index);
+        } catch(IllegalArgumentException ignored) {
+        }
         setBadgeColor(badgeColor);
     }
 
@@ -61,12 +64,15 @@ public class TabBarItemView extends ViewGroup {
         this.badgeColor = badgeColor;
         if (tabView == null || badge == null)
             return;
-        if (defaultBadgeColor == null)
-            defaultBadgeColor = tabView.getBadgeIcon(index).getBackgroundColor();
-        if (badgeColor != null)
-            tabView.getBadgeIcon(index).setBackgroundColor(badgeColor);
-        else
-            tabView.getBadgeIcon(index).setBackgroundColor(defaultBadgeColor);
+        try {
+            if (defaultBadgeColor == null)
+                defaultBadgeColor = tabView.getBadgeIcon(index).getBackgroundColor();
+            if (badgeColor != null)
+                tabView.getBadgeIcon(index).setBackgroundColor(badgeColor);
+            else
+                tabView.getBadgeIcon(index).setBackgroundColor(defaultBadgeColor);
+        } catch(IllegalArgumentException ignored) {
+        }
     }
 
     void setTabView(TabView tabView, int index) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemView.java
@@ -19,6 +19,9 @@ public class TabBarItemView extends ViewGroup {
     protected String title;
     private Drawable icon;
     private TabView tabView;
+    private Integer badge;
+    private Integer badgeColor;
+    private Integer defaultBadgeColor;
     List<View> content = new ArrayList<>();
     private IconResolver.IconResolverListener tabIconResolverListener;
 
@@ -43,12 +46,35 @@ public class TabBarItemView extends ViewGroup {
     void setIconSource(@Nullable ReadableMap source) {
         IconResolver.setIconSource(source, tabIconResolverListener, getContext());
     }
+    void setBadge(@Nullable Integer badge) {
+        this.badge = badge;
+        if (tabView == null)
+            return;
+        if (badge != null)
+            tabView.getBadgeIcon(index).setNumber(badge);
+        else
+            tabView.removeBadgeIcon(index);
+        setBadgeColor(badgeColor);
+    }
+
+    void setBadgeColor(@Nullable Integer badgeColor) {
+        this.badgeColor = badgeColor;
+        if (tabView == null || badge == null)
+            return;
+        if (defaultBadgeColor == null)
+            defaultBadgeColor = tabView.getBadgeIcon(index).getBackgroundColor();
+        if (badgeColor != null)
+            tabView.getBadgeIcon(index).setBackgroundColor(badgeColor);
+        else
+            tabView.getBadgeIcon(index).setBackgroundColor(defaultBadgeColor);
+    }
 
     void setTabView(TabView tabView, int index) {
         this.tabView = tabView;
         this.index = index;
         if (icon != null)
             tabView.setIcon(index, icon);
+        setBadge(badge);
     }
 
     protected void pressed() {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemView.java
@@ -46,6 +46,7 @@ public class TabBarItemView extends ViewGroup {
     void setIconSource(@Nullable ReadableMap source) {
         IconResolver.setIconSource(source, tabIconResolverListener, getContext());
     }
+
     void setBadge(@Nullable Integer badge) {
         this.badge = badge;
         if (tabView == null)

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutView.java
@@ -9,6 +9,7 @@ import androidx.annotation.Nullable;
 import androidx.viewpager.widget.ViewPager;
 
 import com.google.android.material.appbar.AppBarLayout;
+import com.google.android.material.badge.BadgeDrawable;
 import com.google.android.material.tabs.TabLayout;
 
 public class TabLayoutView extends TabLayout implements TabView {
@@ -106,5 +107,18 @@ public class TabLayoutView extends TabLayout implements TabView {
         TabLayout.Tab tab = getTabAt(index);
         if (tab != null)
             tab.setIcon(icon);
+    }
+
+    @Override
+    public BadgeDrawable getBadgeIcon(int index) {
+        TabLayout.Tab tab = getTabAt(index);
+        return tab != null ? tab.getOrCreateBadge() : null;
+    }
+
+    @Override
+    public void removeBadgeIcon(int index) {
+        TabLayout.Tab tab = getTabAt(index);
+        if (tab != null)
+            tab.removeBadge();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
@@ -3,6 +3,7 @@ package com.navigation.reactnative;
 import android.content.Context;
 import android.database.DataSetObserver;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -10,10 +11,12 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import androidx.viewpager.widget.PagerAdapter;
 import androidx.viewpager.widget.ViewPager;
 
 import com.google.android.material.badge.BadgeDrawable;
+import com.google.android.material.bottomnavigation.BottomNavigationItemView;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 
 public class TabNavigationView extends BottomNavigationView implements TabView {
@@ -150,5 +153,9 @@ public class TabNavigationView extends BottomNavigationView implements TabView {
     @Override
     public void removeBadgeIcon(int index) {
         removeBadge(index);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            BottomNavigationItemView itemView = (BottomNavigationItemView) getTouchables().get(index);
+            itemView.getChildAt(0).getOverlay().clear();
+        }
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
@@ -28,6 +28,7 @@ public class TabNavigationView extends BottomNavigationView implements TabView {
 
     public TabNavigationView(Context context) {
         super(context);
+        setBackground(null);
         TabLayoutView tabLayout = new TabLayoutView(context);
         selectedTintColor = unselectedTintColor = defaultTextColor = tabLayout.defaultTextColor;
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
@@ -11,7 +11,6 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 import androidx.viewpager.widget.PagerAdapter;
 import androidx.viewpager.widget.ViewPager;
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
@@ -13,6 +13,7 @@ import androidx.annotation.Nullable;
 import androidx.viewpager.widget.PagerAdapter;
 import androidx.viewpager.widget.ViewPager;
 
+import com.google.android.material.badge.BadgeDrawable;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 
 public class TabNavigationView extends BottomNavigationView implements TabView {
@@ -138,5 +139,15 @@ public class TabNavigationView extends BottomNavigationView implements TabView {
 
     public void setIcon(int index, Drawable icon) {
         getMenu().getItem(index).setIcon(icon);
+    }
+
+    @Override
+    public BadgeDrawable getBadgeIcon(int index) {
+        return getOrCreateBadge(index);
+    }
+
+    @Override
+    public void removeBadgeIcon(int index) {
+        removeBadge(index);
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabView.java
@@ -5,6 +5,8 @@ import android.graphics.drawable.Drawable;
 import androidx.annotation.Nullable;
 import androidx.viewpager.widget.ViewPager;
 
+import com.google.android.material.badge.BadgeDrawable;
+
 public interface TabView {
     void setupWithViewPager(@Nullable ViewPager viewPager);
 
@@ -13,4 +15,8 @@ public interface TabView {
     void setTitle(int index, String title);
 
     void setIcon(int index, Drawable icon);
+
+    BadgeDrawable getBadgeIcon(int index);
+
+    void removeBadgeIcon(int index);
 }


### PR DESCRIPTION
Second go at this PR after finding that [badges sometimes aren’t removed properly](https://github.com/material-components/material-components-android/issues/1002#issuecomment-615178290) (see #370 for first go). Cleared the image overlay to workaround the issue. Didn’t need the workaround for `TabLayout`, only needed for `BottomNavigationView`.

Upgraded the google material component library to v1.1.0 to bring in the native badge support. Updated the twitter sample to use the badge. Had to switch from AppCompat Theme to a MaterialComponents Theme. Used the Bridge theme to avoid other style changes.
