### PR TITLE
Tabbar pager

### DIFF
--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -50,7 +50,6 @@ class TabBar extends React.Component<any, any> {
         TabView = Platform.OS === 'android' ? TabView : NVSegmentedTab;
         var tabLayout = (Platform.OS === 'android' || !primary) && (
             <TabView
-                bottomTabs={bottomTabs}
                 selectedTintColor={selectedTintColor}
                 unselectedTintColor={unselectedTintColor}
                 selectedIndicatorAtTop={bottomTabs}

--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -50,10 +50,7 @@ class TabBar extends React.Component<any, any> {
         TabView = Platform.OS === 'android' ? TabView : NVSegmentedTab;
         var tabLayout = (Platform.OS === 'android' || !primary) && (
             <TabView
-                ref={Platform.OS === 'ios' ? this.ref : undefined}
                 bottomTabs={bottomTabs}
-                onTabSelected={this.onTabSelected}
-                selectedTab={this.state.selectedTab}
                 selectedTintColor={selectedTintColor}
                 unselectedTintColor={unselectedTintColor}
                 selectedIndicatorAtTop={bottomTabs}
@@ -69,7 +66,7 @@ class TabBar extends React.Component<any, any> {
             <>
                 {!bottomTabs && tabLayout}
                 {!!tabBarItems.length && <TabBar
-                    ref={(Platform.OS === 'android' || primary) ? this.ref : undefined}
+                    ref={this.ref}
                     tabCount={tabBarItems.length}
                     onTabSelected={this.onTabSelected}
                     selectedTab={this.state.selectedTab}

--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -45,7 +45,7 @@ class TabBar extends React.Component<any, any> {
         var titleOnly = !tabBarItems.find(({props}: any) => props.title && props.image);
         var tabViewHeight = !primary ? (titleOnly ? 48 : 72) : 56
         tabViewHeight = Platform.OS === 'android' ? tabViewHeight : 28;
-        var TabBar = (Platform.OS === 'android' || primary) ? NVTabBar : View;
+        var TabBar = (Platform.OS === 'android' || primary) ? NVTabBar : NVTabBarPager;
         var TabView = !primary ? NVTabLayout : NVTabNavigation;
         TabView = Platform.OS === 'android' ? TabView : NVSegmentedTab;
         var tabLayout = (Platform.OS === 'android' || !primary) && (
@@ -97,6 +97,7 @@ var NVTabLayout = requireNativeComponent<any>('NVTabLayout', null);
 var NVTabNavigation = requireNativeComponent<any>('NVTabNavigation', null);
 var NVSegmentedTab = requireNativeComponent<any>('NVSegmentedTab', null);
 var NVTabBar = requireNativeComponent<any>('NVTabBar', null);
+var NVTabBarPager = requireNativeComponent<any>('NVTabBarPager', null);
 
 const styles = StyleSheet.create({
     tabBar: {

--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -55,7 +55,6 @@ class TabBar extends React.Component<any, any> {
                 selectedIndicatorAtTop={bottomTabs}
                 titles={tabBarItems.map(({props}: any) => props.title)}
                 scrollable={scrollable}
-                scrollsToTop={scrollsToTop}
                 style={{
                     height: tabViewHeight,
                     backgroundColor: barTintColor

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -98,9 +98,9 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
     void removeFragment() {
         if (mainActivity != null && fragment != null) {
             FragmentManager fragmentManager = ((FragmentActivity) mainActivity).getSupportFragmentManager();
-            FragmentTransaction fragmentTransation = fragmentManager.beginTransaction();
-            fragmentTransation.remove(fragment);
-            fragmentTransation.commitAllowingStateLoss();
+            FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+            fragmentTransaction.remove(fragment);
+            fragmentTransaction.commitAllowingStateLoss();
         }
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -227,18 +227,20 @@ public class TabBarView extends ViewPager {
 
     public static class TabFragment extends Fragment {
         TabBarItemView tabBarItem;
+        View view;
 
         TabFragment(TabBarItemView tabBarItem) {
             super();
             this.tabBarItem = tabBarItem;
-            if (tabBarItem.content.get(0) instanceof NavigationStackView)
-                ((NavigationStackView) tabBarItem.content.get(0)).onAfterUpdateTransaction();
+            view = tabBarItem.content.get(0);
+            if (view instanceof NavigationStackView)
+                ((NavigationStackView) view).onAfterUpdateTransaction();
         }
 
         @Nullable
         @Override
         public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-            return tabBarItem.content.get(0);
+            return view;
         }
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -63,7 +63,7 @@ public class TabBarView extends ViewPager {
     void populateTabs() {
         TabView tabView = getTabView();
         if (tabView != null && getAdapter() != null) {
-            for(int i = 0; i < tabView.getTabCount(); i++) {
+            for(int i = 0; i < getAdapter().tabFragments.size(); i++) {
                 getAdapter().tabFragments.get(i).tabBarItem.setTabView(tabView, i);
             }
         }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -2,7 +2,6 @@ package com.navigation.reactnative;
 
 import android.content.Context;
 import android.database.DataSetObserver;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
@@ -41,7 +40,7 @@ public class TabBarView extends ViewPager {
         super(context);
         addOnPageChangeListener(new TabChangeListener());
         FragmentActivity activity = (FragmentActivity) ((ReactContext) context).getCurrentActivity();
-        Adapter adapter = new Adapter(activity.getSupportFragmentManager());
+        Adapter adapter = new Adapter(activity != null ? activity.getSupportFragmentManager() : null);
         adapter.registerDataSetObserver(new DataSetObserver() {
             @Override
             public void onChanged() {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
@@ -152,7 +152,7 @@ public class TabNavigationView extends BottomNavigationView implements TabView {
     @Override
     public void removeBadgeIcon(int index) {
         removeBadge(index);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2 && getTouchables().size() > index) {
             BottomNavigationItemView itemView = (BottomNavigationItemView) getTouchables().get(index);
             itemView.getChildAt(0).getOverlay().clear();
         }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
@@ -131,11 +131,6 @@ public class TabNavigationView extends BottomNavigationView implements TabView {
     };
 
     @Override
-    public int getTabCount() {
-        return getMenu().size();
-    }
-
-    @Override
     public void setTitle(int index, String title) {
         getMenu().getItem(index).setTitle(title);
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabView.java
@@ -10,8 +10,6 @@ import com.google.android.material.badge.BadgeDrawable;
 public interface TabView {
     void setupWithViewPager(@Nullable ViewPager viewPager);
 
-    int getTabCount();
-
     void setTitle(int index, String title);
 
     void setIcon(int index, Drawable icon);

--- a/NavigationReactNative/src/ios/NVSceneView.h
+++ b/NavigationReactNative/src/ios/NVSceneView.h
@@ -8,7 +8,6 @@
 @property (nonatomic, assign) BOOL hidesTabBar;
 @property (nonatomic, copy) RCTDirectEventBlock onPopped;
 
--(void)willAppear;
 -(void)didPop;
 
 @end

--- a/NavigationReactNative/src/ios/NVSegmentedTabManager.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabManager.m
@@ -11,13 +11,10 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_EXPORT_VIEW_PROPERTY(bottomTabs, BOOL)
-RCT_EXPORT_VIEW_PROPERTY(selectedTab, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(backgroundColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(selectedTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(unselectedTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(titles, NSArray<NSString *>)
 RCT_EXPORT_VIEW_PROPERTY(scrollsToTop, BOOL)
-RCT_EXPORT_VIEW_PROPERTY(mostRecentEventCount, NSInteger)
-RCT_EXPORT_VIEW_PROPERTY(onTabSelected, RCTDirectEventBlock)
 
 @end

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.h
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.h
@@ -1,15 +1,12 @@
 #import "NVTabBarPagerView.h"
 
 #import <UIKit/UIKit.h>
-#import <React/RCTComponent.h>
 
 @interface NVSegmentedTabView : UISegmentedControl
 
 @property (nonatomic, assign) BOOL bottomTabs;
 @property (nonatomic, assign) BOOL scrollsToTop;
 @property (nonatomic, weak) NVTabBarPagerView *tabBarPager;
-@property (nonatomic, assign) NSInteger mostRecentEventCount;
-@property (nonatomic, copy) RCTDirectEventBlock onTabSelected;
 
 -(void)scrollToTop;
 

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.h
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.h
@@ -1,3 +1,5 @@
+#import "NVTabBarPagerView.h"
+
 #import <UIKit/UIKit.h>
 #import <React/RCTComponent.h>
 
@@ -5,6 +7,7 @@
 
 @property (nonatomic, assign) BOOL bottomTabs;
 @property (nonatomic, assign) BOOL scrollsToTop;
+@property (nonatomic, weak) NVTabBarPagerView *tabBarPager;
 @property (nonatomic, assign) NSInteger mostRecentEventCount;
 @property (nonatomic, copy) RCTDirectEventBlock onTabSelected;
 

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.h
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.h
@@ -4,6 +4,6 @@
 
 @interface NVSegmentedTabView : UISegmentedControl
 
-@property (nonatomic, weak) NVTabBarPagerView *tabBarPager;
+-(void)setupWithPager:(NVTabBarPagerView *) pager;
 
 @end

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.h
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.h
@@ -4,9 +4,6 @@
 
 @interface NVSegmentedTabView : UISegmentedControl
 
-@property (nonatomic, assign) BOOL scrollsToTop;
 @property (nonatomic, weak) NVTabBarPagerView *tabBarPager;
-
--(void)scrollToTop;
 
 @end

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.h
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.h
@@ -4,7 +4,6 @@
 
 @interface NVSegmentedTabView : UISegmentedControl
 
-@property (nonatomic, assign) BOOL bottomTabs;
 @property (nonatomic, assign) BOOL scrollsToTop;
 @property (nonatomic, weak) NVTabBarPagerView *tabBarPager;
 

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.h
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.h
@@ -1,8 +1,9 @@
 #import "NVTabBarPagerView.h"
+#import "NVTabBarPagerView.h"
 
 #import <UIKit/UIKit.h>
 
-@interface NVSegmentedTabView : UISegmentedControl
+@interface NVSegmentedTabView : UISegmentedControl <TabChangeDelegate>
 
 -(void)setupWithPager:(NVTabBarPagerView *) pager;
 

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.m
@@ -2,7 +2,6 @@
 #import "NVTabBarItemView.h"
 
 #import <React/UIView+React.h>
-#import <React/RCTScrollView.h>
 
 @implementation NVSegmentedTabView
 
@@ -59,15 +58,6 @@
         }
         [self setTitleTextAttributes:titleAttributes forState:UIControlStateNormal];
     }
-}
-
-- (void)scrollToTop
-{
-    /*UIView *tabBarItem = _selectedTabBarItem.subviews[0];
-    if ([tabBarItem isKindOfClass:[RCTScrollView class]] && _scrollsToTop) {
-        UIScrollView *scrollView = ((RCTScrollView *) tabBarItem).scrollView;
-        [scrollView setContentOffset:CGPointMake(0, 0) animated:YES];
-    }*/
 }
 
 - (void)tabPressed

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.m
@@ -1,5 +1,6 @@
 #import "NVSegmentedTabView.h"
 #import "NVTabBarItemView.h"
+#import "NVTabBarPagerView.h"
 
 @implementation NVSegmentedTabView
 {
@@ -57,6 +58,16 @@
             titleAttributes[NSForegroundColorAttributeName] = unselectedTintColor;
         }
         [self setTitleTextAttributes:titleAttributes forState:UIControlStateNormal];
+    }
+}
+
+- (void)didMoveToWindow
+{
+    [super didMoveToWindow];
+    for(NSInteger i = 0; !!self.window && i < [self.superview subviews].count; i++) {
+        UIView *view = [self.superview subviews][i];
+        if ([view isKindOfClass:[NVTabBarPagerView class]])
+            [self setupWithPager:(NVTabBarPagerView *) view];
     }
 }
 

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.m
@@ -36,14 +36,7 @@
 - (void)setSelectedTintColor:(UIColor *)selectedTintColor
 {
     if (@available(iOS 13.0, *)) {
-        NSMutableDictionary *titleAttributes = [[self titleTextAttributesForState:UIControlStateSelected] mutableCopy];
-        if (titleAttributes == nil) {
-            titleAttributes = @{}.mutableCopy;
-        }
-        [titleAttributes removeObjectForKey:NSForegroundColorAttributeName];
-        if (selectedTintColor != nil) {
-            titleAttributes[NSForegroundColorAttributeName] = selectedTintColor;
-        }
+        NSDictionary *titleAttributes = [self setForeground:selectedTintColor :[self titleTextAttributesForState:UIControlStateSelected]];
         [self setTitleTextAttributes:titleAttributes forState:UIControlStateSelected];
     }
 }
@@ -51,16 +44,19 @@
 - (void)setUnselectedTintColor:(UIColor *)unselectedTintColor
 {
     if (@available(iOS 13.0, *)) {
-        NSMutableDictionary *titleAttributes = [[self titleTextAttributesForState:UIControlStateNormal] mutableCopy];
-        if (titleAttributes == nil) {
-            titleAttributes = @{}.mutableCopy;
-        }
-        [titleAttributes removeObjectForKey:NSForegroundColorAttributeName];
-        if (unselectedTintColor != nil) {
-            titleAttributes[NSForegroundColorAttributeName] = unselectedTintColor;
-        }
+        NSDictionary *titleAttributes = [self setForeground:unselectedTintColor :[self titleTextAttributesForState:UIControlStateNormal]];
         [self setTitleTextAttributes:titleAttributes forState:UIControlStateNormal];
     }
+}
+
+-(NSDictionary *)setForeground:(UIColor *)color :(NSDictionary *)attributes
+{
+    NSMutableDictionary *attributesCopy = [attributes != nil ? attributes : @{} mutableCopy];
+    [attributesCopy removeObjectForKey:NSForegroundColorAttributeName];
+    if (color != nil) {
+        attributesCopy[NSForegroundColorAttributeName] = color;
+    }
+    return attributesCopy;
 }
 
 - (void)didMoveToWindow

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.m
@@ -1,8 +1,6 @@
 #import "NVSegmentedTabView.h"
 #import "NVTabBarItemView.h"
 
-#import <React/UIView+React.h>
-
 @implementation NVSegmentedTabView
 
 - (id)init

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.m
@@ -5,16 +5,10 @@
 #import <React/RCTScrollView.h>
 
 @implementation NVSegmentedTabView
-{
-    NSInteger _selectedTab;
-    NVTabBarItemView *_selectedTabBarItem;
-    NSInteger _nativeEventCount;
-}
 
 - (id)init
 {
     if (self = [super init]) {
-        _selectedTab = 0;
         [self addTarget:self action:@selector(tabPressed) forControlEvents:UIControlEventValueChanged];
     }
     return self;
@@ -26,7 +20,7 @@
     for (NSString *title in titles) {
         [self insertSegmentWithTitle:title atIndex:self.numberOfSegments animated:NO];
     }
-    self.selectedSegmentIndex = _selectedTab;
+    self.selectedSegmentIndex = 0;
 }
 
 - (void)setBackgroundColor:(UIColor *)backgroundColor
@@ -67,63 +61,18 @@
     }
 }
 
-- (void)didSetProps:(NSArray<NSString *> *)changedProps
-{
-    BOOL press = self.selectedSegmentIndex != _selectedTab;
-    self.selectedSegmentIndex = _selectedTab;
-    [self selectTab:press];
-}
-
 - (void)scrollToTop
 {
-    UIView *tabBarItem = _selectedTabBarItem.subviews[0];
+    /*UIView *tabBarItem = _selectedTabBarItem.subviews[0];
     if ([tabBarItem isKindOfClass:[RCTScrollView class]] && _scrollsToTop) {
         UIScrollView *scrollView = ((RCTScrollView *) tabBarItem).scrollView;
         [scrollView setContentOffset:CGPointMake(0, 0) animated:YES];
-    }
-}
-
-- (void)didMoveToWindow
-{
-    [super didMoveToWindow];
-    if (!!self.window) {
-        [self selectTab:_selectedTabBarItem == nil && self.selectedSegmentIndex > 0];
-    }
+    }*/
 }
 
 - (void)tabPressed
 {
-    [self selectTab:YES];
-}
-
-- (void)selectTab:(BOOL) press
-{
-    BOOL tabChanged = press;
-    NSInteger tabBarIndex = [self.superview.subviews indexOfObject:self] + (self.bottomTabs ? -1 : 1);
-    UIView* tabBar = [self.superview.subviews objectAtIndex:tabBarIndex];
-    if (!press) {
-        NSInteger reselectedTab = [tabBar.reactSubviews indexOfObject:_selectedTabBarItem];
-        self.selectedSegmentIndex = reselectedTab != NSNotFound ? reselectedTab : MAX(self.selectedSegmentIndex, 0);
-        tabChanged = _selectedTab != self.selectedSegmentIndex;
-    }
-    if (tabChanged) {
-        /*_nativeEventCount++;
-        self.onTabSelected(@{
-            @"tab": @(self.selectedSegmentIndex),
-            @"eventCount": @(_nativeEventCount),
-        });*/
-        [self.tabBarPager setCurrentTab:self.selectedSegmentIndex];
-    }
-    /*for(NSInteger i = 0; i < [tabBar.reactSubviews count]; i++) {
-        NVTabBarItemView *tabBarItem = (NVTabBarItemView *) [tabBar.reactSubviews objectAtIndex:i];
-        tabBarItem.alpha = (i == self.selectedSegmentIndex ? 1 : 0);
-        if (i == self.selectedSegmentIndex) {
-            _selectedTab = i;
-            _selectedTabBarItem = tabBarItem;
-            if (tabChanged && !!tabBarItem.onPress)
-                tabBarItem.onPress(nil);
-        }
-    }*/
+    [self.tabBarPager setCurrentTab:self.selectedSegmentIndex];
 }
 
 @end

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.m
@@ -2,6 +2,9 @@
 #import "NVTabBarItemView.h"
 
 @implementation NVSegmentedTabView
+{
+    NVTabBarPagerView *_tabBarPager;
+}
 
 - (id)init
 {
@@ -17,7 +20,6 @@
     for (NSString *title in titles) {
         [self insertSegmentWithTitle:title atIndex:self.numberOfSegments animated:NO];
     }
-    self.selectedSegmentIndex = 0;
 }
 
 - (void)setBackgroundColor:(UIColor *)backgroundColor
@@ -58,9 +60,15 @@
     }
 }
 
+- (void)setupWithPager:(NVTabBarPagerView *)pager
+{
+    _tabBarPager = pager;
+    self.selectedSegmentIndex = pager.selectedTab;
+}
+
 - (void)tabPressed
 {
-    [self.tabBarPager setCurrentTab:self.selectedSegmentIndex];
+    [_tabBarPager setCurrentTab:self.selectedSegmentIndex];
 }
 
 @end

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.m
@@ -17,10 +17,12 @@
 
 - (void)setTitles:(NSArray<NSString *> *)titles
 {
+    NSInteger _selectedIndex = self.selectedSegmentIndex;
     [self removeAllSegments];
     for (NSString *title in titles) {
         [self insertSegmentWithTitle:title atIndex:self.numberOfSegments animated:NO];
     }
+    self.selectedSegmentIndex = _selectedIndex;
 }
 
 - (void)setBackgroundColor:(UIColor *)backgroundColor

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.m
@@ -74,12 +74,18 @@
 - (void)setupWithPager:(NVTabBarPagerView *)pager
 {
     _tabBarPager = pager;
+    _tabBarPager.tabChange = self;
     self.selectedSegmentIndex = pager.selectedTab;
 }
 
 - (void)tabPressed
 {
     [_tabBarPager setCurrentTab:self.selectedSegmentIndex];
+}
+
+- (void)tabSelected:(NSInteger)index
+{
+    self.selectedSegmentIndex = index;
 }
 
 @end

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.m
@@ -120,8 +120,9 @@
             @"tab": @(self.selectedSegmentIndex),
             @"eventCount": @(_nativeEventCount),
         });
+        [self.tabBarPager setCurrentTab:self.selectedSegmentIndex];
     }
-    for(NSInteger i = 0; i < [tabBar.reactSubviews count]; i++) {
+    /*for(NSInteger i = 0; i < [tabBar.reactSubviews count]; i++) {
         NVTabBarItemView *tabBarItem = (NVTabBarItemView *) [tabBar.reactSubviews objectAtIndex:i];
         tabBarItem.alpha = (i == self.selectedSegmentIndex ? 1 : 0);
         if (i == self.selectedSegmentIndex) {
@@ -130,7 +131,7 @@
             if (tabChanged && !!tabBarItem.onPress)
                 tabBarItem.onPress(nil);
         }
-    }
+    }*/
 }
 
 @end

--- a/NavigationReactNative/src/ios/NVSegmentedTabView.m
+++ b/NavigationReactNative/src/ios/NVSegmentedTabView.m
@@ -20,14 +20,6 @@
     return self;
 }
 
-- (void)setSelectedTab:(NSInteger)selectedTab
-{
-    NSInteger eventLag = _nativeEventCount - _mostRecentEventCount;
-    if (eventLag == 0) {
-        _selectedTab = selectedTab;
-    }
-}
-
 - (void)setTitles:(NSArray<NSString *> *)titles
 {
     [self removeAllSegments];
@@ -115,11 +107,11 @@
         tabChanged = _selectedTab != self.selectedSegmentIndex;
     }
     if (tabChanged) {
-        _nativeEventCount++;
+        /*_nativeEventCount++;
         self.onTabSelected(@{
             @"tab": @(self.selectedSegmentIndex),
             @"eventCount": @(_nativeEventCount),
-        });
+        });*/
         [self.tabBarPager setCurrentTab:self.selectedSegmentIndex];
     }
     /*for(NSInteger i = 0; i < [tabBar.reactSubviews count]; i++) {

--- a/NavigationReactNative/src/ios/NVTabBarPagerManager.h
+++ b/NavigationReactNative/src/ios/NVTabBarPagerManager.h
@@ -1,0 +1,13 @@
+//
+//  NVTabBarPagerManager.h
+//  NavigationReactNative
+//
+//  Created by Graham Mendick on 27/06/2020.
+//  Copyright © 2020 Graham Mendick. All rights reserved.
+//
+
+#ifndef NVTabBarPagerManager_h
+#define NVTabBarPagerManager_h
+
+
+#endif /* NVTabBarPagerManager_h */

--- a/NavigationReactNative/src/ios/NVTabBarPagerManager.h
+++ b/NavigationReactNative/src/ios/NVTabBarPagerManager.h
@@ -1,13 +1,4 @@
-//
-//  NVTabBarPagerManager.h
-//  NavigationReactNative
-//
-//  Created by Graham Mendick on 27/06/2020.
-//  Copyright © 2020 Graham Mendick. All rights reserved.
-//
+#import <React/RCTViewManager.h>
 
-#ifndef NVTabBarPagerManager_h
-#define NVTabBarPagerManager_h
-
-
-#endif /* NVTabBarPagerManager_h */
+@interface NVTabBarPagerManager : RCTViewManager
+@end

--- a/NavigationReactNative/src/ios/NVTabBarPagerManager.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerManager.m
@@ -1,9 +1,13 @@
-//
-//  NVTabBarPagerManager.m
-//  NavigationReactNative
-//
-//  Created by Graham Mendick on 27/06/2020.
-//  Copyright © 2020 Graham Mendick. All rights reserved.
-//
+#import "NVTabBarPagerManager.h"
+#import "NVTabBarPagerView.h"
 
-#import <Foundation/Foundation.h>
+@implementation NVTabBarPagerManager
+
+RCT_EXPORT_MODULE()
+
+- (UIView *)view
+{
+    return [[NVTabBarPagerView alloc] init];
+}
+
+@end

--- a/NavigationReactNative/src/ios/NVTabBarPagerManager.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerManager.m
@@ -10,4 +10,8 @@ RCT_EXPORT_MODULE()
     return [[NVTabBarPagerView alloc] init];
 }
 
+RCT_EXPORT_VIEW_PROPERTY(selectedTab, NSInteger)
+RCT_EXPORT_VIEW_PROPERTY(mostRecentEventCount, NSInteger)
+RCT_EXPORT_VIEW_PROPERTY(onTabSelected, RCTDirectEventBlock)
+
 @end

--- a/NavigationReactNative/src/ios/NVTabBarPagerManager.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerManager.m
@@ -10,6 +10,7 @@ RCT_EXPORT_MODULE()
     return [[NVTabBarPagerView alloc] init];
 }
 
+RCT_EXPORT_VIEW_PROPERTY(tabCount, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(selectedTab, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(scrollsToTop, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(mostRecentEventCount, NSInteger)

--- a/NavigationReactNative/src/ios/NVTabBarPagerManager.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerManager.m
@@ -11,6 +11,7 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_EXPORT_VIEW_PROPERTY(selectedTab, NSInteger)
+RCT_EXPORT_VIEW_PROPERTY(scrollsToTop, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(mostRecentEventCount, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(onTabSelected, RCTDirectEventBlock)
 

--- a/NavigationReactNative/src/ios/NVTabBarPagerManager.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerManager.m
@@ -1,0 +1,9 @@
+//
+//  NVTabBarPagerManager.m
+//  NavigationReactNative
+//
+//  Created by Graham Mendick on 27/06/2020.
+//  Copyright © 2020 Graham Mendick. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.h
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.h
@@ -1,8 +1,11 @@
 #import "NVTabBarPagerView.h"
 
 #import <UIKit/UIKit.h>
+#import <React/RCTComponent.h>
 
 @interface NVTabBarPagerView : UIView
+@property (nonatomic, assign) NSInteger mostRecentEventCount;
+@property (nonatomic, copy) RCTDirectEventBlock onTabSelected;
 
 -(void)setCurrentTab:(NSInteger) index;
 

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.h
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.h
@@ -3,12 +3,17 @@
 #import <UIKit/UIKit.h>
 #import <React/RCTComponent.h>
 
+@protocol TabChangeDelegate
+-(void) tabSelected:(NSInteger) index;
+@end
+
 @interface NVTabBarPagerView : UIView
 
 @property (nonatomic, assign) NSInteger selectedTab;
 @property (nonatomic, assign) BOOL scrollsToTop;
 @property (nonatomic, assign) NSInteger mostRecentEventCount;
 @property (nonatomic, copy) RCTDirectEventBlock onTabSelected;
+@property (nonatomic, weak) id<TabChangeDelegate> tabChange;
 
 -(void)setCurrentTab:(NSInteger) index;
 -(void)scrollToTop;

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.h
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.h
@@ -3,4 +3,7 @@
 #import <UIKit/UIKit.h>
 
 @interface NVTabBarPagerView : UIView
+
+-(void)setCurrentTab:(NSInteger) index;
+
 @end

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.h
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.h
@@ -5,6 +5,7 @@
 
 @interface NVTabBarPagerView : UIView
 
+@property (nonatomic, assign) NSInteger selectedTab;
 @property (nonatomic, assign) BOOL scrollsToTop;
 @property (nonatomic, assign) NSInteger mostRecentEventCount;
 @property (nonatomic, copy) RCTDirectEventBlock onTabSelected;

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.h
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.h
@@ -4,9 +4,12 @@
 #import <React/RCTComponent.h>
 
 @interface NVTabBarPagerView : UIView
+
+@property (nonatomic, assign) BOOL scrollsToTop;
 @property (nonatomic, assign) NSInteger mostRecentEventCount;
 @property (nonatomic, copy) RCTDirectEventBlock onTabSelected;
 
 -(void)setCurrentTab:(NSInteger) index;
+-(void)scrollToTop;
 
 @end

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.h
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.h
@@ -10,6 +10,7 @@
 @interface NVTabBarPagerView : UIView
 
 @property (nonatomic, assign) NSInteger selectedTab;
+@property (nonatomic, assign) NSInteger tabCount;
 @property (nonatomic, assign) BOOL scrollsToTop;
 @property (nonatomic, assign) NSInteger mostRecentEventCount;
 @property (nonatomic, copy) RCTDirectEventBlock onTabSelected;

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.h
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.h
@@ -1,0 +1,13 @@
+//
+//  NVTabBarPagerView.h
+//  NavigationReactNative
+//
+//  Created by Graham Mendick on 27/06/2020.
+//  Copyright © 2020 Graham Mendick. All rights reserved.
+//
+
+#ifndef NVTabBarPagerView_h
+#define NVTabBarPagerView_h
+
+
+#endif /* NVTabBarPagerView_h */

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.h
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.h
@@ -1,13 +1,6 @@
-//
-//  NVTabBarPagerView.h
-//  NavigationReactNative
-//
-//  Created by Graham Mendick on 27/06/2020.
-//  Copyright © 2020 Graham Mendick. All rights reserved.
-//
+#import "NVTabBarPagerView.h"
 
-#ifndef NVTabBarPagerView_h
-#define NVTabBarPagerView_h
+#import <UIKit/UIKit.h>
 
-
-#endif /* NVTabBarPagerView_h */
+@interface NVTabBarPagerView : UIView
+@end

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.m
@@ -1,4 +1,19 @@
 #import "NVTabBarPagerView.h"
 
 @implementation NVTabBarPagerView
+{
+    UIPageViewController *_pageViewController;
+    NSArray<UIViewController *> *_tabs;
+}
+
+- (id)init
+{
+    if (self = [super init]) {
+        _pageViewController = [[UIPageViewController alloc] init];
+        [self addSubview:_pageViewController.view];
+        _tabs = [[NSMutableArray alloc] init];
+    }
+    return self;
+}
+
 @end

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.m
@@ -11,6 +11,7 @@
     UIViewController *_selectedTabView;
     NSMutableArray<UIViewController *> *_tabs;
     NSInteger _nativeEventCount;
+    NSInteger _selectedIndex;
 }
 
 - (id)init
@@ -19,6 +20,7 @@
         _pageViewController = [[UIPageViewController alloc] init];
         [self addSubview:_pageViewController.view];
         _tabs = [[NSMutableArray alloc] init];
+        _selectedIndex = NSNotFound;
     }
     return self;
 }
@@ -76,7 +78,7 @@
 - (void)setCurrentTab:(NSInteger)index
 {
     _nativeEventCount++;
-    if (index != _selectedTab) {
+    if (index != _selectedIndex && _selectedIndex != NSNotFound) {
         self.onTabSelected(@{
             @"tab": @(index),
             @"eventCount": @(_nativeEventCount),
@@ -88,7 +90,7 @@
     }
     [self.tabChange tabSelected:index];
     [_pageViewController setViewControllers:@[_tabs[index]] direction:UIPageViewControllerNavigationDirectionForward animated:NO completion:nil];
-    _selectedTab = index;
+    _selectedTab = _selectedIndex = index;
     _selectedTabView = _tabs[index];
 }
 

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.m
@@ -1,9 +1,4 @@
-//
-//  NVTabBarPagerView.m
-//  NavigationReactNative
-//
-//  Created by Graham Mendick on 27/06/2020.
-//  Copyright © 2020 Graham Mendick. All rights reserved.
-//
+#import "NVTabBarPagerView.h"
 
-#import <Foundation/Foundation.h>
+@implementation NVTabBarPagerView
+@end

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.m
@@ -1,5 +1,6 @@
 #import "NVTabBarPagerView.h"
 #import "NVSegmentedTabView.h"
+#import "NVTabBarItemView.h"
 
 #import <React/UIView+React.h>
 
@@ -7,6 +8,7 @@
 {
     UIPageViewController *_pageViewController;
     NSMutableArray<UIViewController *> *_tabs;
+    NSInteger _nativeEventCount;
 }
 
 - (id)init
@@ -52,8 +54,25 @@
     }
 }
 
+- (void)setSelectedTab:(NSInteger)selectedTab
+{
+    NSInteger eventLag = _nativeEventCount - _mostRecentEventCount;
+    if (eventLag == 0 && _tabs.count > selectedTab) {
+        [self setCurrentTab:selectedTab];
+    }
+}
+
 - (void)setCurrentTab:(NSInteger)index
 {
+    _nativeEventCount++;
+    self.onTabSelected(@{
+        @"tab": @(index),
+        @"eventCount": @(_nativeEventCount),
+    });
+    NVTabBarItemView *tabBarItem = ((NVTabBarItemView *) _tabs[index].view);
+    if (!!tabBarItem.onPress) {
+        tabBarItem.onPress(nil);
+    }
     [_pageViewController setViewControllers:@[_tabs[index]] direction:UIPageViewControllerNavigationDirectionForward animated:NO completion:nil];
 }
 

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.m
@@ -7,7 +7,6 @@
 
 @implementation NVTabBarPagerView
 {
-    NSInteger _selectedTab;
     UIPageViewController *_pageViewController;
     NSMutableArray<UIViewController *> *_tabs;
     NSInteger _nativeEventCount;
@@ -43,16 +42,18 @@
 
 - (void)didUpdateReactSubviews
 {
-    [self setCurrentTab:0];
 }
 
 - (void)didMoveToWindow
 {
     [super didMoveToWindow];
-    for(NSInteger i = 0; !!self.window && i < [self.superview subviews].count; i++) {
-        UIView *view = [self.superview subviews][i];
-        if ([view isKindOfClass:[NVSegmentedTabView class]])
-            ((NVSegmentedTabView *) view).tabBarPager = self;
+    if (!!self.window) {
+        [self setCurrentTab:_selectedTab];
+        for(NSInteger i = 0; i < [self.superview subviews].count; i++) {
+            UIView *view = [self.superview subviews][i];
+            if ([view isKindOfClass:[NVSegmentedTabView class]])
+                [((NVSegmentedTabView *) view) setupWithPager:self];
+        }
     }
 }
 

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.m
@@ -54,16 +54,11 @@
 
 - (void)didUpdateReactSubviews
 {
-    BOOL tabChanged = !_selectedTabView;
     if (!!_selectedTabView) {
         NSInteger reselectedTab = [_tabs indexOfObject:_selectedTabView];
-        NSInteger selectedIndex = reselectedTab != NSNotFound ? reselectedTab : MIN(_selectedTab, _tabs.count - 1);
-        tabChanged = _selectedTab != selectedIndex;
-        _selectedTab = selectedIndex;
+        _selectedTab = reselectedTab != NSNotFound ? reselectedTab : MIN(_selectedTab, _tabs.count - 1);
     }
-    if (tabChanged) {
-        [self setCurrentTab:_selectedTab];
-    }
+    [self setCurrentTab:_selectedTab];
 }
 
 - (void)didMoveToWindow

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.m
@@ -1,0 +1,9 @@
+//
+//  NVTabBarPagerView.m
+//  NavigationReactNative
+//
+//  Created by Graham Mendick on 27/06/2020.
+//  Copyright © 2020 Graham Mendick. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.m
@@ -70,8 +70,11 @@
 - (void)setSelectedTab:(NSInteger)selectedTab
 {
     NSInteger eventLag = _nativeEventCount - _mostRecentEventCount;
-    if (eventLag == 0 && _selectedTab != selectedTab && _tabs.count > selectedTab) {
-        [self setCurrentTab:selectedTab];
+    if (eventLag == 0 && _selectedTab != selectedTab) {
+        _selectedTab = selectedTab;
+        if (_tabs.count > selectedTab) {
+            [self setCurrentTab:selectedTab];
+        }
     }
 }
 

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.m
@@ -76,15 +76,17 @@
 - (void)setCurrentTab:(NSInteger)index
 {
     _nativeEventCount++;
-    [self.tabChange tabSelected:index];
-    self.onTabSelected(@{
-        @"tab": @(index),
-        @"eventCount": @(_nativeEventCount),
-    });
-    NVTabBarItemView *tabBarItem = ((NVTabBarItemView *) _tabs[index].view);
-    if (!!tabBarItem.onPress) {
-        tabBarItem.onPress(nil);
+    if (index != _selectedTab) {
+        self.onTabSelected(@{
+            @"tab": @(index),
+            @"eventCount": @(_nativeEventCount),
+        });
+        NVTabBarItemView *tabBarItem = ((NVTabBarItemView *) _tabs[index].view);
+        if (!!tabBarItem.onPress) {
+            tabBarItem.onPress(nil);
+        }
     }
+    [self.tabChange tabSelected:index];
     [_pageViewController setViewControllers:@[_tabs[index]] direction:UIPageViewControllerNavigationDirectionForward animated:NO completion:nil];
     _selectedTab = index;
     _selectedTabView = _tabs[index];

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.m
@@ -28,7 +28,7 @@
     [super insertReactSubview:subview atIndex:atIndex];
     UIViewController *viewController = [[UIViewController alloc] init];
     viewController.view = subview;
-    [_tabs addObject:viewController];
+    [_tabs insertObject:viewController atIndex:atIndex];
 }
 
 - (void)removeReactSubview:(UIView *)subview

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.m
@@ -48,6 +48,7 @@
         NSInteger reselectedTab = [_tabs indexOfObject:_selectedTabView];
         NSInteger selectedIndex = reselectedTab != NSNotFound ? reselectedTab : MIN(_selectedTab, _tabs.count - 1);
         tabChanged = _selectedTab != selectedIndex;
+        _selectedTab = selectedIndex;
     }
     if (tabChanged) {
         [self setCurrentTab:_selectedTab];

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.m
@@ -3,9 +3,11 @@
 #import "NVTabBarItemView.h"
 
 #import <React/UIView+React.h>
+#import <React/RCTScrollView.h>
 
 @implementation NVTabBarPagerView
 {
+    NSInteger _selectedTab;
     UIPageViewController *_pageViewController;
     NSMutableArray<UIViewController *> *_tabs;
     NSInteger _nativeEventCount;
@@ -74,6 +76,16 @@
         tabBarItem.onPress(nil);
     }
     [_pageViewController setViewControllers:@[_tabs[index]] direction:UIPageViewControllerNavigationDirectionForward animated:NO completion:nil];
+    _selectedTab = index;
+}
+
+- (void)scrollToTop
+{
+    UIView *tabBarItem = _tabs[_selectedTab].view.subviews[0];
+    if ([tabBarItem isKindOfClass:[RCTScrollView class]] && _scrollsToTop) {
+        UIScrollView *scrollView = ((RCTScrollView *) tabBarItem).scrollView;
+        [scrollView setContentOffset:CGPointMake(0, 0) animated:YES];
+    }
 }
 
 @end

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.m
@@ -1,9 +1,11 @@
 #import "NVTabBarPagerView.h"
 
+#import <React/UIView+React.h>
+
 @implementation NVTabBarPagerView
 {
     UIPageViewController *_pageViewController;
-    NSArray<UIViewController *> *_tabs;
+    NSMutableArray<UIViewController *> *_tabs;
 }
 
 - (id)init
@@ -15,5 +17,29 @@
     }
     return self;
 }
+
+- (void)insertReactSubview:(UIView *)subview atIndex:(NSInteger)atIndex
+{
+    [super insertReactSubview:subview atIndex:atIndex];
+    UIViewController *viewController = [[UIViewController alloc] init];
+    viewController.view = subview;
+    [_tabs addObject:viewController];
+}
+
+- (void)removeReactSubview:(UIView *)subview
+{
+    [super removeReactSubview:subview];
+    NSInteger index = 0;
+    for(NSInteger i = 0; i < [_tabs count]; i++) {
+        index = _tabs[i].view == subview ? i : index;
+    }
+    [_tabs removeObjectAtIndex:index];
+}
+
+- (void)didUpdateReactSubviews
+{
+    [_pageViewController setViewControllers:@[_tabs[0]] direction:UIPageViewControllerNavigationDirectionForward animated:NO completion:nil];
+}
+
 
 @end

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.m
@@ -23,6 +23,17 @@
     return self;
 }
 
+- (void)setSelectedTab:(NSInteger)selectedTab
+{
+    NSInteger eventLag = _nativeEventCount - _mostRecentEventCount;
+    if (eventLag == 0 && _selectedTab != selectedTab) {
+        _selectedTab = selectedTab;
+        if (_tabs.count > selectedTab) {
+            [self setCurrentTab:selectedTab];
+        }
+    }
+}
+
 - (void)insertReactSubview:(UIView *)subview atIndex:(NSInteger)atIndex
 {
     [super insertReactSubview:subview atIndex:atIndex];
@@ -63,17 +74,6 @@
             UIView *view = [self.superview subviews][i];
             if ([view isKindOfClass:[NVSegmentedTabView class]])
                 [((NVSegmentedTabView *) view) setupWithPager:self];
-        }
-    }
-}
-
-- (void)setSelectedTab:(NSInteger)selectedTab
-{
-    NSInteger eventLag = _nativeEventCount - _mostRecentEventCount;
-    if (eventLag == 0 && _selectedTab != selectedTab) {
-        _selectedTab = selectedTab;
-        if (_tabs.count > selectedTab) {
-            [self setCurrentTab:selectedTab];
         }
     }
 }

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.m
@@ -77,8 +77,8 @@
 
 - (void)setCurrentTab:(NSInteger)index
 {
-    _nativeEventCount++;
     if (index != _selectedIndex && _selectedIndex != NSNotFound) {
+        _nativeEventCount++;
         self.onTabSelected(@{
             @"tab": @(index),
             @"eventCount": @(_nativeEventCount),

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.m
@@ -20,7 +20,7 @@
         _pageViewController = [[UIPageViewController alloc] init];
         [self addSubview:_pageViewController.view];
         _tabs = [[NSMutableArray alloc] init];
-        _selectedIndex = NSNotFound;
+        _selectedIndex = 0;
     }
     return self;
 }
@@ -77,7 +77,7 @@
 
 - (void)setCurrentTab:(NSInteger)index
 {
-    if (index != _selectedIndex && _selectedIndex != NSNotFound) {
+    if (index != _selectedIndex) {
         _nativeEventCount++;
         self.onTabSelected(@{
             @"tab": @(index),

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.m
@@ -8,6 +8,7 @@
 @implementation NVTabBarPagerView
 {
     UIPageViewController *_pageViewController;
+    UIViewController *_selectedTabView;
     NSMutableArray<UIViewController *> *_tabs;
     NSInteger _nativeEventCount;
 }
@@ -42,13 +43,21 @@
 
 - (void)didUpdateReactSubviews
 {
+    BOOL tabChanged = !_selectedTabView;
+    if (!!_selectedTabView) {
+        NSInteger reselectedTab = [_tabs indexOfObject:_selectedTabView];
+        NSInteger selectedIndex = reselectedTab != NSNotFound ? reselectedTab : MIN(_selectedTab, _tabs.count - 1);
+        tabChanged = _selectedTab != selectedIndex;
+    }
+    if (tabChanged) {
+        [self setCurrentTab:_selectedTab];
+    }
 }
 
 - (void)didMoveToWindow
 {
     [super didMoveToWindow];
     if (!!self.window) {
-        [self setCurrentTab:_selectedTab];
         for(NSInteger i = 0; i < [self.superview subviews].count; i++) {
             UIView *view = [self.superview subviews][i];
             if ([view isKindOfClass:[NVSegmentedTabView class]])
@@ -79,6 +88,7 @@
     }
     [_pageViewController setViewControllers:@[_tabs[index]] direction:UIPageViewControllerNavigationDirectionForward animated:NO completion:nil];
     _selectedTab = index;
+    _selectedTabView = _tabs[index];
 }
 
 - (void)scrollToTop

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.m
@@ -1,4 +1,5 @@
 #import "NVTabBarPagerView.h"
+#import "NVSegmentedTabView.h"
 
 #import <React/UIView+React.h>
 
@@ -38,8 +39,22 @@
 
 - (void)didUpdateReactSubviews
 {
-    [_pageViewController setViewControllers:@[_tabs[0]] direction:UIPageViewControllerNavigationDirectionForward animated:NO completion:nil];
+    [self setCurrentTab:0];
 }
 
+- (void)didMoveToWindow
+{
+    [super didMoveToWindow];
+    for(NSInteger i = 0; !!self.window && i < [self.superview subviews].count; i++) {
+        UIView *view = [self.superview subviews][i];
+        if ([view isKindOfClass:[NVSegmentedTabView class]])
+            ((NVSegmentedTabView *) view).tabBarPager = self;
+    }
+}
+
+- (void)setCurrentTab:(NSInteger)index
+{
+    [_pageViewController setViewControllers:@[_tabs[index]] direction:UIPageViewControllerNavigationDirectionForward animated:NO completion:nil];
+}
 
 @end

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.m
@@ -69,7 +69,7 @@
 - (void)setSelectedTab:(NSInteger)selectedTab
 {
     NSInteger eventLag = _nativeEventCount - _mostRecentEventCount;
-    if (eventLag == 0 && _tabs.count > selectedTab) {
+    if (eventLag == 0 && _selectedTab != selectedTab && _tabs.count > selectedTab) {
         [self setCurrentTab:selectedTab];
     }
 }

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.m
@@ -68,6 +68,7 @@
 - (void)setCurrentTab:(NSInteger)index
 {
     _nativeEventCount++;
+    [self.tabChange tabSelected:index];
     self.onTabSelected(@{
         @"tab": @(index),
         @"eventCount": @(_nativeEventCount),

--- a/NavigationReactNative/src/ios/NVTabBarView.m
+++ b/NavigationReactNative/src/ios/NVTabBarView.m
@@ -1,6 +1,6 @@
 #import "NVTabBarView.h"
 #import "NVTabBarItemView.h"
-#import "NVSegmentedTabView.h"
+#import "NVTabBarPagerView.h"
 
 #import <UIKit/UIKit.h>
 #import <React/UIView+React.h>
@@ -111,8 +111,8 @@
                 scrollView = ((RCTScrollView *) subview).scrollView;
             }
             for (UIView *subsubview in subview.subviews) {
-                if ([subsubview isKindOfClass:[NVSegmentedTabView class]]){
-                    [((NVSegmentedTabView *) subsubview) scrollToTop];
+                if ([subsubview isKindOfClass:[NVTabBarPagerView class]]){
+                    [((NVTabBarPagerView *) subsubview) scrollToTop];
                 }
             }
         }

--- a/NavigationReactNative/src/ios/NavigationReactNative.xcodeproj/project.pbxproj
+++ b/NavigationReactNative/src/ios/NavigationReactNative.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		704B594622A2AC77008C05C6 /* NVSceneManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 704B594522A2AC77008C05C6 /* NVSceneManager.m */; };
 		70587C86229A8688009457B7 /* NVSearchBarView.m in Sources */ = {isa = PBXBuildFile; fileRef = 70587C85229A8688009457B7 /* NVSearchBarView.m */; };
 		70587C89229A86B8009457B7 /* NVSearchBarManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 70587C88229A86B8009457B7 /* NVSearchBarManager.m */; };
+		707F41B024A74F4600A06BF2 /* NVTabBarPagerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 707F41AF24A74F4600A06BF2 /* NVTabBarPagerView.m */; };
+		707F41B324A74F6700A06BF2 /* NVTabBarPagerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 707F41B224A74F6700A06BF2 /* NVTabBarPagerManager.m */; };
 		70922F8422C0D143009CECB0 /* NVNavigationBarView.m in Sources */ = {isa = PBXBuildFile; fileRef = 70922F8322C0D143009CECB0 /* NVNavigationBarView.m */; };
 		70922F8622C0D153009CECB0 /* NVNavigationBarManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 70922F8522C0D153009CECB0 /* NVNavigationBarManager.m */; };
 		709F32CF22A7FF9C00A0358A /* NVTabBarView.m in Sources */ = {isa = PBXBuildFile; fileRef = 709F32CE22A7FF9C00A0358A /* NVTabBarView.m */; };
@@ -64,6 +66,10 @@
 		70587C85229A8688009457B7 /* NVSearchBarView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NVSearchBarView.m; sourceTree = "<group>"; };
 		70587C87229A86AA009457B7 /* NVSearchBarManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NVSearchBarManager.h; sourceTree = "<group>"; };
 		70587C88229A86B8009457B7 /* NVSearchBarManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NVSearchBarManager.m; sourceTree = "<group>"; };
+		707F41AF24A74F4600A06BF2 /* NVTabBarPagerView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NVTabBarPagerView.m; sourceTree = "<group>"; };
+		707F41B124A74F5600A06BF2 /* NVTabBarPagerView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NVTabBarPagerView.h; sourceTree = "<group>"; };
+		707F41B224A74F6700A06BF2 /* NVTabBarPagerManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NVTabBarPagerManager.m; sourceTree = "<group>"; };
+		707F41B424A74F7200A06BF2 /* NVTabBarPagerManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NVTabBarPagerManager.h; sourceTree = "<group>"; };
 		70922F8222C0D138009CECB0 /* NVNavigationBarView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NVNavigationBarView.h; sourceTree = "<group>"; };
 		70922F8322C0D143009CECB0 /* NVNavigationBarView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NVNavigationBarView.m; sourceTree = "<group>"; };
 		70922F8522C0D153009CECB0 /* NVNavigationBarManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NVNavigationBarManager.m; sourceTree = "<group>"; };
@@ -120,6 +126,10 @@
 		7020F6B520ECD07A00E7A74E = {
 			isa = PBXGroup;
 			children = (
+				707F41B424A74F7200A06BF2 /* NVTabBarPagerManager.h */,
+				707F41B224A74F6700A06BF2 /* NVTabBarPagerManager.m */,
+				707F41B124A74F5600A06BF2 /* NVTabBarPagerView.h */,
+				707F41AF24A74F4600A06BF2 /* NVTabBarPagerView.m */,
 				70E99F2C24461152004B520A /* NVSegmentedTabManager.m */,
 				70E99F2B24461144004B520A /* NVSegmentedTabManager.h */,
 				70E99F2924461103004B520A /* NVSegmentedTabView.m */,
@@ -254,12 +264,14 @@
 				EE17B6DD231E85C000C62B81 /* NVTitleBarView.m in Sources */,
 				70587C89229A86B8009457B7 /* NVSearchBarManager.m in Sources */,
 				709F32D322A7FFBF00A0358A /* NVTabBarManager.m in Sources */,
+				707F41B024A74F4600A06BF2 /* NVTabBarPagerView.m in Sources */,
 				709F32D522A7FFD600A0358A /* NVTabBarItemView.m in Sources */,
 				70E99F2D24461152004B520A /* NVSegmentedTabManager.m in Sources */,
 				70BB329A212B2C5100DE0D13 /* NVLeftBarManager.m in Sources */,
 				70BB32A0212B2CA000DE0D13 /* NVBarButtonView.m in Sources */,
 				70922F8622C0D153009CECB0 /* NVNavigationBarManager.m in Sources */,
 				70AFBC3521DCD320006355EE /* NVSharedElementView.m in Sources */,
+				707F41B324A74F6700A06BF2 /* NVTabBarPagerManager.m in Sources */,
 				70E99F2A24461103004B520A /* NVSegmentedTabView.m in Sources */,
 				70BB32A4212B2D4100DE0D13 /* NVBarView.m in Sources */,
 				70587C86229A8688009457B7 /* NVSearchBarView.m in Sources */,


### PR DESCRIPTION
For tabs, used `FragmentPagerAdapter` instead of `PagerAdapter` on Android and `UIPageViewController` instead of `UIView` on iOS. Offscreen tabs are automatically removed from the view hierarchy. 

Tried this approach on Android before but couldn’t get it working. Had to set offscreenPageLimit to the number of screens which defeated the purpose. Think that doing a measure inside `requestLayout` is the difference.

Tried using `ViewPager2` (and `FragmentStateAdapter`) as recommended by Android but it's `final`.  This makes it a no-go for react native because, for example, can’t override the `requestLayout`.

There’s room for further optimisation for primary tabs on Android. Can’t set the offscreenPageLimit to 0 so there’s always one offscreen page in the view hierarchy. This isn’t needed for primary tabs because can’t swipe between them.
