### PR TITLE
Survived application restarts

### DIFF
--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -124,14 +124,19 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
     public static class StackFragment extends Fragment {
         private NavigationStackView stack;
 
+        public StackFragment() {
+            super();
+        }
+
         StackFragment(NavigationStackView stack) {
+            super();
             this.stack = stack;
         }
 
         @Nullable
         @Override
         public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-            return stack;
+            return stack != null ? stack : new View(getContext());
         }
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -16,6 +16,10 @@ import java.util.HashSet;
 public class SceneFragment extends Fragment implements SharedElementContainer {
     private SceneView scene;
 
+    public SceneFragment() {
+        super();
+    }
+
     SceneFragment(SceneView scene, HashSet<String> sharedElements) {
         super();
         this.scene = scene;
@@ -27,11 +31,14 @@ public class SceneFragment extends Fragment implements SharedElementContainer {
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        if (scene.getParent() != null)
-            ((ViewGroup) scene.getParent()).endViewTransition(scene);
-        if (scene.transitioner != null)
-            postponeEnterTransition();
-        return scene;
+        if (scene != null) {
+            if (scene.getParent() != null)
+                ((ViewGroup) scene.getParent()).endViewTransition(scene);
+            if (scene.transitioner != null)
+                postponeEnterTransition();
+            return scene;
+        }
+        return new View(getContext());
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -228,6 +228,10 @@ public class TabBarView extends ViewPager {
         TabBarItemView tabBarItem;
         View view;
 
+        public TabFragment() {
+            super();
+        }
+
         TabFragment(TabBarItemView tabBarItem) {
             super();
             this.tabBarItem = tabBarItem;
@@ -239,7 +243,7 @@ public class TabBarView extends ViewPager {
         @Nullable
         @Override
         public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-            return view;
+            return view != null ? view : new View(getContext());
         }
     }
 


### PR DESCRIPTION
Fixes #409, #347 and #314

The app can restart, for example, when the language changes (see #409). After the restart, android tries to recreate the UI as it was. It recreates each Fragment by calling their default constructor and falls over when it doesn’t find one.

Added default constructors to all Fragments and returned blank views in this case. Don’t need to recreate the Fragments because React Native recreates the Activity. The JavaScript context wasn’t recycled so React Native hooks up to the old stateNavigator - the one that was there before the restart. So the stack is recreated automatically.
