### PR TITLE
Scrolled stack to top when tab reselected (Android)

### DIFF
--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -19,6 +19,7 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
         this.handleBack = this.handleBack.bind(this);
         this.onWillNavigateBack = this.onWillNavigateBack.bind(this);
         this.onDidNavigateBack = this.onDidNavigateBack.bind(this);
+        this.onNavigateToTop = this.onNavigateToTop.bind(this);
     }
     static defaultProps = {
         fragmentMode: true,
@@ -55,6 +56,12 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
         this.ref.current.setNativeProps({mostRecentEventCount});
         if (this.resumeNavigation)
             this.resumeNavigation();
+    }
+    onNavigateToTop() {
+        var {stateNavigator} = this.props;
+        var {crumbs} = stateNavigator.stateContext;
+        if (crumbs.length > 0)
+            stateNavigator.navigateBack(crumbs.length);
     }
     handleBack() {
         var {primary, fragmentMode} = this.props;
@@ -100,7 +107,8 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
                 style={[styles.stack, fragmentMode ? {backgroundColor: '#000'} : null]}
                 {...this.getAnimation()}
                 onWillNavigateBack={this.onWillNavigateBack}
-                onDidNavigateBack={this.onDidNavigateBack}>
+                onDidNavigateBack={this.onDidNavigateBack}
+                onNavigateToTop={this.onNavigateToTop}>
                 <BackButton onPress={this.handleBack} />
                 <PrimaryStackContext.Provider value={false}>
                     <PopSync<{crumb: number}>

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CoordinatorLayoutView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CoordinatorLayoutView.java
@@ -53,6 +53,17 @@ public class CoordinatorLayoutView extends CoordinatorLayout {
         }
     };
 
+    void scrollToTop() {
+        for(int i = 0; i < getChildCount(); i++) {
+            if (getChildAt(i) instanceof NavigationBarView)
+                ((NavigationBarView) getChildAt(i)).setExpanded(true);
+            if (getChildAt(i) instanceof ScrollView)
+                ((ScrollView) getChildAt(i)).smoothScrollTo(0,0);
+            if (getChildAt(i) instanceof TabBarPagerView)
+                ((TabBarPagerView) getChildAt(i)).scrollToTop();
+        }
+    }
+
     ScrollView getScrollView() {
         for(int i = 0; i < getChildCount(); i++) {
             if (getChildAt(i) instanceof ScrollView)

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -6,9 +6,12 @@ import android.view.View;
 import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
+
+import java.util.Map;
 
 import javax.annotation.Nonnull;
 
@@ -101,5 +104,12 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
     public void onDropViewInstance(@NonNull NavigationStackView view) {
         view.removeFragment();
         super.onDropViewInstance(view);
+    }
+
+    @Override
+    public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
+        return MapBuilder.<String, Object>builder()
+                .put("onNavigateToTop", MapBuilder.of("registrationName", "onNavigateToTop"))
+                .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -105,13 +105,16 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
         }
         if (keys.size() == 1) {
             SceneView scene = scenes.get(keys.getString(0));
-            View sceneItem = scene.getChildAt(0);
-            if (sceneItem instanceof CoordinatorLayoutView)
-                ((CoordinatorLayoutView) sceneItem).scrollToTop();
-            if (sceneItem instanceof ScrollView)
-                ((ScrollView) sceneItem).smoothScrollTo(0,0);
-            if (sceneItem instanceof TabBarPagerView)
-                ((TabBarPagerView) sceneItem).scrollToTop();
+            for (int i = 0; i < scene.getChildCount(); i++) {
+                if (scene.getChildAt(i) instanceof CoordinatorLayoutView)
+                    ((CoordinatorLayoutView) scene.getChildAt(i)).scrollToTop();
+                if (scene.getChildAt(i) instanceof NavigationBarView)
+                    ((NavigationBarView) scene.getChildAt(i)).setExpanded(true);
+                if (scene.getChildAt(i) instanceof ScrollView)
+                    ((ScrollView) scene.getChildAt(i)).smoothScrollTo(0, 0);
+                if (scene.getChildAt(i) instanceof TabBarPagerView)
+                    ((TabBarPagerView) scene.getChildAt(i)).scrollToTop();
+            }
         }
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -16,9 +16,11 @@ import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
 import com.facebook.react.bridge.LifecycleEventListener;
+import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -93,6 +95,13 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
         ((ThemedReactContext) getContext()).removeLifecycleEventListener(this);
+    }
+
+    void scrollToTop() {
+        if (keys.size() > 1) {
+            ReactContext reactContext = (ReactContext) getContext();
+            reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "onNavigateToTop", null);
+        }
     }
 
     void removeFragment() {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ScrollView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -101,6 +102,16 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
         if (keys.size() > 1) {
             ReactContext reactContext = (ReactContext) getContext();
             reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "onNavigateToTop", null);
+        }
+        if (keys.size() == 1) {
+            SceneView scene = scenes.get(keys.getString(0));
+            View sceneItem = scene.getChildAt(0);
+            if (sceneItem instanceof CoordinatorLayoutView)
+                ((CoordinatorLayoutView) sceneItem).scrollToTop();
+            if (sceneItem instanceof ScrollView)
+                ((ScrollView) sceneItem).smoothScrollTo(0,0);
+            if (sceneItem instanceof TabBarPagerView)
+                ((TabBarPagerView) sceneItem).scrollToTop();
         }
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
@@ -97,6 +97,8 @@ public class TabBarPagerView extends ViewPager {
             ((CoordinatorLayoutView) tabBarItem).scrollToTop();
         if (tabBarItem instanceof ScrollView)
             ((ScrollView) tabBarItem).smoothScrollTo(0, 0);
+        if (tabBarItem instanceof NavigationStackView)
+            ((NavigationStackView) tabBarItem).scrollToTop();
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
@@ -93,8 +93,17 @@ public class TabBarPagerView extends ViewPager {
         if (!scrollsToTop)
             return;
         View tabBarItem = getTabAt(getCurrentItem()).content.get(0);
-        if (tabBarItem instanceof CoordinatorLayoutView)
-            ((CoordinatorLayoutView) tabBarItem).scrollToTop();
+        if (tabBarItem instanceof ViewGroup) {
+            ViewGroup viewGroup = (ViewGroup) tabBarItem;
+            for(int i = 0; i < viewGroup.getChildCount(); i++) {
+                if (viewGroup.getChildAt(i) instanceof NavigationBarView)
+                    ((NavigationBarView) viewGroup.getChildAt(i)).setExpanded(true);
+                if (viewGroup.getChildAt(i) instanceof ScrollView)
+                    ((ScrollView) viewGroup.getChildAt(i)).smoothScrollTo(0,0);
+                if (viewGroup.getChildAt(i) instanceof TabBarPagerView)
+                    ((TabBarPagerView) viewGroup.getChildAt(i)).scrollToTop();
+            }
+        }
         if (tabBarItem instanceof ScrollView)
             ((ScrollView) tabBarItem).smoothScrollTo(0, 0);
         if (tabBarItem instanceof NavigationStackView)

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
@@ -93,17 +93,8 @@ public class TabBarPagerView extends ViewPager {
         if (!scrollsToTop)
             return;
         View tabBarItem = getTabAt(getCurrentItem()).content.get(0);
-        if (tabBarItem instanceof ViewGroup) {
-            ViewGroup viewGroup = (ViewGroup) tabBarItem;
-            for(int i = 0; i < viewGroup.getChildCount(); i++) {
-                if (viewGroup.getChildAt(i) instanceof NavigationBarView)
-                    ((NavigationBarView) viewGroup.getChildAt(i)).setExpanded(true);
-                if (viewGroup.getChildAt(i) instanceof ScrollView)
-                    ((ScrollView) viewGroup.getChildAt(i)).smoothScrollTo(0,0);
-                if (viewGroup.getChildAt(i) instanceof TabBarPagerView)
-                    ((TabBarPagerView) viewGroup.getChildAt(i)).scrollToTop();
-            }
-        }
+        if (tabBarItem instanceof CoordinatorLayoutView)
+            ((CoordinatorLayoutView) tabBarItem).scrollToTop();
         if (tabBarItem instanceof ScrollView)
             ((ScrollView) tabBarItem).smoothScrollTo(0, 0);
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -110,6 +110,8 @@ public class TabBarView extends ViewGroup {
             ((CoordinatorLayoutView) tabBarItem).scrollToTop();
         if (tabBarItem instanceof ScrollView)
             ((ScrollView) tabBarItem).smoothScrollTo(0, 0);
+        if (tabBarItem instanceof NavigationStackView)
+            ((NavigationStackView) tabBarItem).scrollToTop();
     }
 
     void removeFragment() {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -106,8 +106,17 @@ public class TabBarView extends ViewGroup {
         if (!scrollsToTop)
             return;
         View tabBarItem = tabFragments.get(selectedTab).tabBarItem.content.get(0);
-        if (tabBarItem instanceof CoordinatorLayoutView)
-            ((CoordinatorLayoutView) tabBarItem).scrollToTop();
+        if (tabBarItem instanceof ViewGroup) {
+            ViewGroup viewGroup = (ViewGroup) tabBarItem;
+            for(int i = 0; i < viewGroup.getChildCount(); i++) {
+                if (viewGroup.getChildAt(i) instanceof NavigationBarView)
+                    ((NavigationBarView) viewGroup.getChildAt(i)).setExpanded(true);
+                if (viewGroup.getChildAt(i) instanceof ScrollView)
+                    ((ScrollView) viewGroup.getChildAt(i)).smoothScrollTo(0,0);
+                if (viewGroup.getChildAt(i) instanceof TabBarPagerView)
+                    ((TabBarPagerView) viewGroup.getChildAt(i)).scrollToTop();
+            }
+        }
         if (tabBarItem instanceof ScrollView)
             ((ScrollView) tabBarItem).smoothScrollTo(0, 0);
         if (tabBarItem instanceof NavigationStackView)

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -106,17 +106,8 @@ public class TabBarView extends ViewGroup {
         if (!scrollsToTop)
             return;
         View tabBarItem = tabFragments.get(selectedTab).tabBarItem.content.get(0);
-        if (tabBarItem instanceof ViewGroup) {
-            ViewGroup viewGroup = (ViewGroup) tabBarItem;
-            for(int i = 0; i < viewGroup.getChildCount(); i++) {
-                if (viewGroup.getChildAt(i) instanceof NavigationBarView)
-                    ((NavigationBarView) viewGroup.getChildAt(i)).setExpanded(true);
-                if (viewGroup.getChildAt(i) instanceof ScrollView)
-                    ((ScrollView) viewGroup.getChildAt(i)).smoothScrollTo(0,0);
-                if (viewGroup.getChildAt(i) instanceof TabBarPagerView)
-                    ((TabBarPagerView) viewGroup.getChildAt(i)).scrollToTop();
-            }
-        }
+        if (tabBarItem instanceof CoordinatorLayoutView)
+            ((CoordinatorLayoutView) tabBarItem).scrollToTop();
         if (tabBarItem instanceof ScrollView)
             ((ScrollView) tabBarItem).smoothScrollTo(0, 0);
     }


### PR DESCRIPTION
Follow up to #416 Implemented for tabs containing NavigationStacks on Android.

Matches the native behaviour on iOS. The first reselect navigates back to the top of the stack. The second reselect scrolls the first scene to the top.
