### PR TITLE
Removed manual finish when pressing back from primary NavigationStack

### DIFF
--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -2,18 +2,20 @@ import React, { ReactNode } from 'react';
 import { requireNativeComponent, StyleSheet, View } from 'react-native';
 import { Crumb, State } from 'navigation';
 import { NavigationContext, AsyncStateNavigator } from 'navigation-react';
+import BackButton from './BackButton';
 import PopSync from './PopSync';
 import Scene from './Scene';
 type NavigationStackProps = {stateNavigator: AsyncStateNavigator, fragmentMode: boolean, title: (state: State, data: any) => string, crumbStyle: any, unmountStyle: any, hidesTabBar: any, sharedElements: any, renderScene: (state: State, data: any) => ReactNode};
-type NavigationStackState = {stateNavigator: AsyncStateNavigator, keys: string[]};
+type NavigationStackState = {stateNavigator: AsyncStateNavigator, keys: string[], finish: boolean};
 
 class NavigationStack extends React.Component<NavigationStackProps, NavigationStackState> {
     private ref: React.RefObject<View>;
     private resumeNavigation: () => void;
     constructor(props) {
         super(props);
-        this.state = {stateNavigator: null, keys: []};
+        this.state = {stateNavigator: null, keys: [], finish: false};
         this.ref = React.createRef<View>();
+        this.handleBack = this.handleBack.bind(this);
         this.onWillNavigateBack = this.onWillNavigateBack.bind(this);
         this.onDidNavigateBack = this.onDidNavigateBack.bind(this);
         this.onNavigateToTop = this.onNavigateToTop.bind(this);
@@ -60,6 +62,11 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
         if (crumbs.length > 0)
             stateNavigator.navigateBack(crumbs.length);
     }
+    handleBack() {
+        var {fragmentMode} = this.props;
+        this.setState(() => !fragmentMode ? ({finish: true}): null);
+        return !fragmentMode;
+    }
     getAnimation() {
         var {stateNavigator, unmountStyle, crumbStyle, sharedElements: getSharedElements} = this.props;
         var {state, data, oldState, oldData, oldUrl, crumbs, nextCrumb} = stateNavigator.stateContext;
@@ -86,19 +93,21 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
         return {enterAnim, exitAnim, sharedElements, oldSharedElements};
     }
     render() {
-        var {keys} = this.state;
+        var {keys, finish} = this.state;
         var {stateNavigator, fragmentMode, unmountStyle, crumbStyle, hidesTabBar, title, renderScene} = this.props;
         var {crumbs, nextCrumb} = stateNavigator.stateContext;
         return (
             <NVNavigationStack
                 ref={this.ref}
                 keys={keys}
+                finish={finish}
                 fragmentMode={fragmentMode}
                 style={[styles.stack, fragmentMode ? {backgroundColor: '#000'} : null]}
                 {...this.getAnimation()}
                 onWillNavigateBack={this.onWillNavigateBack}
                 onDidNavigateBack={this.onDidNavigateBack}
                 onNavigateToTop={this.onNavigateToTop}>
+                <BackButton onPress={this.handleBack} />
                 <PopSync<{crumb: number}>
                     data={crumbs.concat(nextCrumb || []).map((_, crumb) => ({crumb}))}
                     getKey={({crumb}) => keys[crumb]}>

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -2,21 +2,18 @@ import React, { ReactNode } from 'react';
 import { requireNativeComponent, StyleSheet, View } from 'react-native';
 import { Crumb, State } from 'navigation';
 import { NavigationContext, AsyncStateNavigator } from 'navigation-react';
-import BackButton from './BackButton';
 import PopSync from './PopSync';
 import Scene from './Scene';
-import PrimaryStackContext from './PrimaryStackContext';
-type NavigationStackProps = {stateNavigator: AsyncStateNavigator, primary: boolean, fragmentMode: boolean, title: (state: State, data: any) => string, crumbStyle: any, unmountStyle: any, hidesTabBar: any, sharedElements: any, renderScene: (state: State, data: any) => ReactNode};
-type NavigationStackState = {stateNavigator: AsyncStateNavigator, keys: string[], finish: boolean};
+type NavigationStackProps = {stateNavigator: AsyncStateNavigator, fragmentMode: boolean, title: (state: State, data: any) => string, crumbStyle: any, unmountStyle: any, hidesTabBar: any, sharedElements: any, renderScene: (state: State, data: any) => ReactNode};
+type NavigationStackState = {stateNavigator: AsyncStateNavigator, keys: string[]};
 
 class NavigationStack extends React.Component<NavigationStackProps, NavigationStackState> {
     private ref: React.RefObject<View>;
     private resumeNavigation: () => void;
     constructor(props) {
         super(props);
-        this.state = {stateNavigator: null, keys: [], finish: false};
+        this.state = {stateNavigator: null, keys: []};
         this.ref = React.createRef<View>();
-        this.handleBack = this.handleBack.bind(this);
         this.onWillNavigateBack = this.onWillNavigateBack.bind(this);
         this.onDidNavigateBack = this.onDidNavigateBack.bind(this);
         this.onNavigateToTop = this.onNavigateToTop.bind(this);
@@ -63,11 +60,6 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
         if (crumbs.length > 0)
             stateNavigator.navigateBack(crumbs.length);
     }
-    handleBack() {
-        var {primary, fragmentMode} = this.props;
-        this.setState(() => (!fragmentMode || primary) ? ({finish: true}): null);
-        return !fragmentMode || primary;
-    }
     getAnimation() {
         var {stateNavigator, unmountStyle, crumbStyle, sharedElements: getSharedElements} = this.props;
         var {state, data, oldState, oldData, oldUrl, crumbs, nextCrumb} = stateNavigator.stateContext;
@@ -94,40 +86,35 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
         return {enterAnim, exitAnim, sharedElements, oldSharedElements};
     }
     render() {
-        var {keys, finish} = this.state;
-        var {stateNavigator, primary, fragmentMode, unmountStyle, crumbStyle, hidesTabBar, title, renderScene} = this.props;
+        var {keys} = this.state;
+        var {stateNavigator, fragmentMode, unmountStyle, crumbStyle, hidesTabBar, title, renderScene} = this.props;
         var {crumbs, nextCrumb} = stateNavigator.stateContext;
         return (
             <NVNavigationStack
                 ref={this.ref}
                 keys={keys}
-                primary={primary}
-                finish={finish}
                 fragmentMode={fragmentMode}
                 style={[styles.stack, fragmentMode ? {backgroundColor: '#000'} : null]}
                 {...this.getAnimation()}
                 onWillNavigateBack={this.onWillNavigateBack}
                 onDidNavigateBack={this.onDidNavigateBack}
                 onNavigateToTop={this.onNavigateToTop}>
-                <BackButton onPress={this.handleBack} />
-                <PrimaryStackContext.Provider value={false}>
-                    <PopSync<{crumb: number}>
-                        data={crumbs.concat(nextCrumb || []).map((_, crumb) => ({crumb}))}
-                        getKey={({crumb}) => keys[crumb]}>
-                        {(scenes, popNative) => scenes.map(({key, data: {crumb}}) => (
-                            <Scene
-                                key={key}
-                                crumb={crumb}
-                                sceneKey={key}
-                                unmountStyle={unmountStyle}
-                                crumbStyle={crumbStyle}
-                                hidesTabBar={hidesTabBar}
-                                title={title}
-                                popped={popNative}
-                                renderScene={renderScene} />
-                        ))}
-                    </PopSync>
-                </PrimaryStackContext.Provider>
+                <PopSync<{crumb: number}>
+                    data={crumbs.concat(nextCrumb || []).map((_, crumb) => ({crumb}))}
+                    getKey={({crumb}) => keys[crumb]}>
+                    {(scenes, popNative) => scenes.map(({key, data: {crumb}}) => (
+                        <Scene
+                            key={key}
+                            crumb={crumb}
+                            sceneKey={key}
+                            unmountStyle={unmountStyle}
+                            crumbStyle={crumbStyle}
+                            hidesTabBar={hidesTabBar}
+                            title={title}
+                            popped={popNative}
+                            renderScene={renderScene} />
+                    ))}
+                </PopSync>
             </NVNavigationStack>
         );
     }
@@ -143,10 +130,6 @@ const styles = StyleSheet.create({
 
 export default props => (
     <NavigationContext.Consumer>
-        {({stateNavigator}) => (
-            <PrimaryStackContext.Consumer>
-                {(primary) => <NavigationStack stateNavigator={stateNavigator} {...props} primary={primary} />}
-            </PrimaryStackContext.Consumer>
-        )}
+        {({stateNavigator}) => <NavigationStack stateNavigator={stateNavigator} {...props} />}
     </NavigationContext.Consumer>
 );

--- a/NavigationReactNative/src/PrimaryStackContext.ts
+++ b/NavigationReactNative/src/PrimaryStackContext.ts
@@ -1,3 +1,0 @@
-import * as React from 'react';
-
-export default React.createContext(true);

--- a/NavigationReactNative/src/TabBarItem.tsx
+++ b/NavigationReactNative/src/TabBarItem.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { requireNativeComponent, Image, Platform, StyleSheet } from 'react-native';
 import BackButton from './BackButton';
 import BackHandlerContext from './BackHandlerContext';
-import PrimaryStackContext from './PrimaryStackContext';
 import createBackHandler from './createBackHandler';
 
 class TabBarItem extends React.Component<any> {
@@ -30,11 +29,9 @@ class TabBarItem extends React.Component<any> {
                         onPress(event);
                 }}>
                 <BackButton onPress={this.handleBack} />
-                <PrimaryStackContext.Provider value={primary && index === 0}>
-                    <BackHandlerContext.Provider value={this.backHandler}>
-                        {children}
-                    </BackHandlerContext.Provider>
-                </PrimaryStackContext.Provider>
+                <BackHandlerContext.Provider value={this.backHandler}>
+                    {children}
+                </BackHandlerContext.Provider>
             </NVTabBarItem>
         );
     }
@@ -50,8 +47,4 @@ const styles = StyleSheet.create({
     },
 });
 
-export default (props) => (
-    <PrimaryStackContext.Consumer>
-        {(primary) => <TabBarItem {...props} primary={primary} />}
-    </PrimaryStackContext.Consumer>    
-);
+export default TabBarItem;

--- a/NavigationReactNative/src/TabBarItem.tsx
+++ b/NavigationReactNative/src/TabBarItem.tsx
@@ -15,7 +15,7 @@ class TabBarItem extends React.Component<any> {
         return this.props.selected && this.backHandler.handleBack();
     }
     render() {
-        var {onPress, children, image, badge, index, primary, ...props} = this.props;
+        var {onPress, children, image, badge, index, ...props} = this.props;
         image = typeof image === 'string' ? (Platform.OS === 'ios' ? null : {uri: image}) : image;
         return (
             <NVTabBarItem

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -53,6 +53,11 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
         view.oldSharedElementNames = oldSharedElements;
     }
 
+    @ReactProp(name = "finish")
+    public void setFinish(NavigationStackView view, boolean finish) {
+        view.finish = finish;
+    }
+
     @Nonnull
     @Override
     protected NavigationStackView createViewInstance(@Nonnull ThemedReactContext reactContext) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -53,16 +53,6 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
         view.oldSharedElementNames = oldSharedElements;
     }
 
-    @ReactProp(name = "primary")
-    public void setPrimary(NavigationStackView view, boolean primary) {
-        view.primary = primary;
-    }
-
-    @ReactProp(name = "finish")
-    public void setFinish(NavigationStackView view, boolean finish) {
-        view.finish = finish;
-    }
-
     @Nonnull
     @Override
     protected NavigationStackView createViewInstance(@Nonnull ThemedReactContext reactContext) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -36,6 +36,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
     protected String exitAnim;
     protected ReadableArray sharedElementNames;
     protected ReadableArray oldSharedElementNames;
+    protected boolean finish = false;
     SceneNavigator navigator;
 
     public NavigationStackView(Context context) {
@@ -54,6 +55,10 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                 DeviceEventManagerModule deviceEventManagerModule = ((ThemedReactContext) getContext()).getNativeModule(DeviceEventManagerModule.class);
                 deviceEventManagerModule.emitNewIntentReceived(uri);
             }
+        }
+        if (finish) {
+            currentActivity.finishAffinity();
+            return;
         }
         if (fragment == null) {
             fragment = new StackFragment(this);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -36,8 +36,6 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
     protected String exitAnim;
     protected ReadableArray sharedElementNames;
     protected ReadableArray oldSharedElementNames;
-    protected boolean primary = true;
-    protected boolean finish = false;
     SceneNavigator navigator;
 
     public NavigationStackView(Context context) {
@@ -56,10 +54,6 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                 DeviceEventManagerModule deviceEventManagerModule = ((ThemedReactContext) getContext()).getNativeModule(DeviceEventManagerModule.class);
                 deviceEventManagerModule.emitNewIntentReceived(uri);
             }
-        }
-        if (finish) {
-            currentActivity.finishAffinity();
-            return;
         }
         if (fragment == null) {
             fragment = new StackFragment(this);


### PR DESCRIPTION
Was tracking the primary stack so could kill the activity when pressing back. Adding to the activity fragment manager’s back stack prevented React Native from doing it automatically. Now all fragment navigation is done in the child fragment manager, React Native takes care of finishing the app when the default back is pressed.

Had to leave the finish logic in for when fragmentMode is turned off.
