### PR TITLE
Rendered primary iOS Twitter tabs inside a scene 

### DIFF
--- a/NavigationReactNative/sample/twitter/App.js
+++ b/NavigationReactNative/sample/twitter/App.js
@@ -1,8 +1,7 @@
-import React, {useState} from 'react';
-import {Platform} from 'react-native';
+import React from 'react';
 import {StateNavigator} from 'navigation';
 import {NavigationHandler} from 'navigation-react';
-import {NavigationStack, TabBar, TabBarItem} from 'navigation-react-native';
+import {NavigationStack} from 'navigation-react-native';
 import Home from './Home';
 import Notifications from './Notifications';
 import Tabs from './Tabs';
@@ -11,48 +10,27 @@ import Timeline from './Timeline';
 import {getHome, getNotifications, getTweet, getTimeline} from './data';
 
 const stateNavigator = new StateNavigator([
+  {key: 'tabs'},
   {key: 'home'},
   {key: 'notifications'},
   {key: 'tweet', trackCrumbTrail: true},
   {key: 'timeline', trackCrumbTrail: true}
 ]);
-const {home, notifications, tweet, timeline} = stateNavigator.states;
-const HomeLayout = Platform.OS === 'ios' ? Home : Tabs;
-home.renderScene = () => <HomeLayout tweets={getHome()} notifications={getNotifications()} />;
+const {tabs, home, notifications, tweet, timeline} = stateNavigator.states;
+tabs.renderScene = () => <Tabs  tweets={getHome()} notifications={getNotifications()} />;
+home.renderScene = () => <Home tweets={getHome()} />;
 notifications.renderScene = () => <Notifications notifications={getNotifications()} />;
 tweet.renderScene = ({id}) => <Tweet tweet={getTweet(id)}  />;
 timeline.renderScene = ({id}) => <Timeline timeline={getTimeline(id)}  />;
 
-const notificationsNavigator = new StateNavigator(stateNavigator);
-stateNavigator.navigate('home');
-notificationsNavigator.navigate('notifications');
+stateNavigator.navigate('tabs');
 
-const Stack = ({navigator}) => (
-  <NavigationHandler stateNavigator={navigator}>
+const App = () => (
+  <NavigationHandler stateNavigator={stateNavigator}>
     <NavigationStack
       crumbStyle={from => from ? 'scale_in' : 'scale_out'}
       unmountStyle={from => from ? 'slide_in' : 'slide_out'} />
   </NavigationHandler>
 );
-
-const App = () => {
-  const [notified, setNotified] = useState(false);
-  return Platform.OS === 'ios' ? (
-    <TabBar primary={true}>
-      <TabBarItem title="Home" image={require('./home.png')}>
-        <Stack navigator={stateNavigator} />
-      </TabBarItem>
-      <TabBarItem
-        title="Notifications"
-        image={require('./notifications.png')}
-        badge={!notified ? getNotifications().length : null} 
-        onPress={() => {setNotified(true)}}>
-        <Stack navigator={notificationsNavigator} />
-      </TabBarItem>
-    </TabBar>
-  ) : (
-    <Stack navigator={stateNavigator} />
-  );
-};
 
 export default App;

--- a/NavigationReactNative/sample/twitter/App.js
+++ b/NavigationReactNative/sample/twitter/App.js
@@ -17,7 +17,7 @@ const stateNavigator = new StateNavigator([
   {key: 'timeline', trackCrumbTrail: true}
 ]);
 const {tabs, home, notifications, tweet, timeline} = stateNavigator.states;
-tabs.renderScene = () => <Tabs  tweets={getHome()} notifications={getNotifications()} />;
+tabs.renderScene = () => <Tabs tweets={getHome()} notifications={getNotifications()} />;
 home.renderScene = () => <Home tweets={getHome()} />;
 notifications.renderScene = () => <Notifications notifications={getNotifications()} />;
 tweet.renderScene = ({id}) => <Tweet tweet={getTweet(id)}  />;

--- a/NavigationReactNative/sample/twitter/Tabs.js
+++ b/NavigationReactNative/sample/twitter/Tabs.js
@@ -28,7 +28,9 @@ export default ({tweets, notifications}) => {
   return (
     <>
       <NavigationBar hidden={true} />
-      <TabBar primary={true} selectedTintColor="#1da1f2">
+      <TabBar
+        primary={true}
+        selectedTintColor={Platform.OS === 'android' ? '#1da1f2' : null}>
         <TabBarItem title="Home" image={require('./home.png')}>
           {Platform.OS === 'android'
             ? <Home tweets={tweets} />

--- a/NavigationReactNative/sample/twitter/Tabs.js
+++ b/NavigationReactNative/sample/twitter/Tabs.js
@@ -15,12 +15,6 @@ const useStateNavigator = start => {
   }, [])
 };
 
-const Stack = ({stateNavigator}) => (
-  <NavigationHandler stateNavigator={stateNavigator}>
-    <NavigationStack />
-  </NavigationHandler>
-);
-
 export default ({tweets, notifications}) => {
   const [notified, setNotified] = useState(false);
   const homeNavigator = useStateNavigator('home');
@@ -32,18 +26,22 @@ export default ({tweets, notifications}) => {
         primary={true}
         selectedTintColor={Platform.OS === 'android' ? '#1da1f2' : null}>
         <TabBarItem title="Home" image={require('./home.png')}>
-          {Platform.OS === 'android'
-            ? <Home tweets={tweets} />
-            : <Stack stateNavigator={homeNavigator} />}
+          {Platform.OS === 'ios'
+            ? (<NavigationHandler stateNavigator={homeNavigator}>
+                <NavigationStack />
+              </NavigationHandler>)
+            : <Home tweets={tweets} />}
         </TabBarItem>
         <TabBarItem
           title="Notifications"
           image={require('./notifications.png')}
           badge={!notified ? notifications.length : null} 
           onPress={() => {setNotified(true)}}>
-          {Platform.OS === 'android'
-            ? <Notifications notifications={notifications} />
-            : <Stack stateNavigator={notificationsNavigator} />}        
+          {Platform.OS === 'ios'
+            ? (<NavigationHandler stateNavigator={notificationsNavigator}>
+                <NavigationStack />
+              </NavigationHandler>)
+            : <Notifications notifications={notifications} />}
         </TabBarItem>
       </TabBar>
     </>

--- a/NavigationReactNative/sample/twitter/Tabs.js
+++ b/NavigationReactNative/sample/twitter/Tabs.js
@@ -1,22 +1,49 @@
-import React, {useState} from 'react';
-import {TabBar, TabBarItem} from 'navigation-react-native';
+import React, {useState, useMemo, useContext} from 'react';
+import {Platform} from 'react-native';
+import {StateNavigator} from 'navigation';
+import {NavigationHandler, NavigationContext} from 'navigation-react';
+import {NavigationStack, TabBar, TabBarItem, NavigationBar} from 'navigation-react-native';
 import Home from './Home';
 import Notifications from './Notifications';
 
+const Stack = ({navigator}) => (
+  <NavigationHandler stateNavigator={navigator}>
+    <NavigationStack />
+  </NavigationHandler>
+);
+
+const useStateNavigator = start => {
+  const {stateNavigator} = useContext(NavigationContext);
+  return useMemo(() => {
+    const navigator = new StateNavigator(stateNavigator);
+    navigator.navigate(start);
+    return navigator;
+  }, [])
+};
+
 export default ({tweets, notifications}) => {
   const [notified, setNotified] = useState(false);
+  const homeNavigator = useStateNavigator('home');
+  const notificationsNavigator = useStateNavigator('notifications');
   return (
-    <TabBar primary={true} selectedTintColor="#1da1f2">
-      <TabBarItem title="Home" image={require('./home.png')}>
-        <Home tweets={tweets} notifications={notifications} />
-      </TabBarItem>
-      <TabBarItem
-        title="Notifications"
-        image={require('./notifications.png')}
-        badge={!notified ? notifications.length : null} 
-        onPress={() => {setNotified(true)}}>
-        <Notifications notifications={notifications} />
-      </TabBarItem>
-    </TabBar>
+    <>
+      <NavigationBar hidden={true} />
+      <TabBar primary={true} selectedTintColor="#1da1f2">
+        <TabBarItem title="Home" image={require('./home.png')}>
+          {Platform.OS === 'android'
+            ? <Home tweets={tweets} />
+            : <Stack navigator={homeNavigator} />}
+        </TabBarItem>
+        <TabBarItem
+          title="Notifications"
+          image={require('./notifications.png')}
+          badge={!notified ? notifications.length : null} 
+          onPress={() => {setNotified(true)}}>
+          {Platform.OS === 'android'
+            ? <Notifications notifications={notifications} />
+            : <Stack navigator={notificationsNavigator} />}        
+        </TabBarItem>
+      </TabBar>
+    </>
   );
 }

--- a/NavigationReactNative/sample/twitter/Tabs.js
+++ b/NavigationReactNative/sample/twitter/Tabs.js
@@ -22,9 +22,7 @@ export default ({tweets, notifications}) => {
   return (
     <>
       <NavigationBar hidden={true} />
-      <TabBar
-        primary={true}
-        selectedTintColor={Platform.OS === 'android' ? '#1da1f2' : null}>
+      <TabBar primary={true} selectedTintColor={Platform.OS === 'android' ? '#1da1f2' : null}>
         <TabBarItem title="Home" image={require('./home.png')}>
           {Platform.OS === 'ios'
             ? (<NavigationHandler stateNavigator={homeNavigator}>

--- a/NavigationReactNative/sample/twitter/Tabs.js
+++ b/NavigationReactNative/sample/twitter/Tabs.js
@@ -15,8 +15,8 @@ const useStateNavigator = start => {
   }, [])
 };
 
-const Stack = ({navigator}) => (
-  <NavigationHandler stateNavigator={navigator}>
+const Stack = ({stateNavigator}) => (
+  <NavigationHandler stateNavigator={stateNavigator}>
     <NavigationStack />
   </NavigationHandler>
 );
@@ -32,7 +32,7 @@ export default ({tweets, notifications}) => {
         <TabBarItem title="Home" image={require('./home.png')}>
           {Platform.OS === 'android'
             ? <Home tweets={tweets} />
-            : <Stack navigator={homeNavigator} />}
+            : <Stack stateNavigator={homeNavigator} />}
         </TabBarItem>
         <TabBarItem
           title="Notifications"
@@ -41,7 +41,7 @@ export default ({tweets, notifications}) => {
           onPress={() => {setNotified(true)}}>
           {Platform.OS === 'android'
             ? <Notifications notifications={notifications} />
-            : <Stack navigator={notificationsNavigator} />}        
+            : <Stack stateNavigator={notificationsNavigator} />}        
         </TabBarItem>
       </TabBar>
     </>

--- a/NavigationReactNative/sample/twitter/Tabs.js
+++ b/NavigationReactNative/sample/twitter/Tabs.js
@@ -6,12 +6,6 @@ import {NavigationStack, TabBar, TabBarItem, NavigationBar} from 'navigation-rea
 import Home from './Home';
 import Notifications from './Notifications';
 
-const Stack = ({navigator}) => (
-  <NavigationHandler stateNavigator={navigator}>
-    <NavigationStack />
-  </NavigationHandler>
-);
-
 const useStateNavigator = start => {
   const {stateNavigator} = useContext(NavigationContext);
   return useMemo(() => {
@@ -20,6 +14,12 @@ const useStateNavigator = start => {
     return navigator;
   }, [])
 };
+
+const Stack = ({navigator}) => (
+  <NavigationHandler stateNavigator={navigator}>
+    <NavigationStack />
+  </NavigationHandler>
+);
 
 export default ({tweets, notifications}) => {
   const [notified, setNotified] = useState(false);


### PR DESCRIPTION
Thought the primary tabs on iOS had to be rendered by the root `App` component. But they can be pushed onto the `NavigationStack` inside a scene just like any other component. Updated the Twitter example to render `Tabs` component in a scene on both platforms.

Better for authentication, for example, because can navigate from 'login' scene to 'tabs' scene. Don’t have to change the root component. Also the standard scene push stack animation runs. 
