### PR TITLE
Supported action views in the navigation bar (Android)

### DIFF
--- a/NavigationReactNative/src/ActionBar.tsx
+++ b/NavigationReactNative/src/ActionBar.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { requireNativeComponent, Platform, StyleSheet } from 'react-native';
+
+const ActionBar = ({children}) => (
+    Platform.OS == 'android' ? <NVActionBar style={styles.actionView}>{children}</NVActionBar> : null
+)
+
+const NVActionBar = requireNativeComponent<any>('NVActionBar', null)
+
+const styles = StyleSheet.create({
+    actionView: {
+        flex: 1,
+    },
+});
+
+export default ActionBar;

--- a/NavigationReactNative/src/ActionBar.tsx
+++ b/NavigationReactNative/src/ActionBar.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { requireNativeComponent, Platform, StyleSheet } from 'react-native';
 
-const ActionBar = ({children}) => (
-    Platform.OS == 'android' ? <NVActionBar style={styles.actionView}>{children}</NVActionBar> : null
+const ActionBar = props => (
+    Platform.OS == 'android' ? <NVActionBar {...props} style={styles.actionView} /> : null
 )
 
 const NVActionBar = requireNativeComponent<any>('NVActionBar', null)

--- a/NavigationReactNative/src/BarButton.tsx
+++ b/NavigationReactNative/src/BarButton.tsx
@@ -1,14 +1,17 @@
 import React from 'react'
 import { requireNativeComponent, Image, Platform, UIManager } from 'react-native';
 
-const BarButton = ({image, show, search, ...props}) => {
+const BarButton = ({image, show, search, children, ...props}) => {
     var constants = (UIManager as any).getViewManagerConfig('NVNavigationBar').Constants;
     return (Platform.OS === 'android' || !search) && (
         <NVBarButton
             search={search}
+            showActionView={!!children}
             show={Platform.OS === 'android' ? constants.ShowAsAction[show] : null}
             image={Platform.OS === 'android' ? Image.resolveAssetSource(image) : image}
-            {...props} />
+            {...props}>
+            {Platform.OS === 'android' ? children : null}
+        </NVBarButton>
     )
 }
 

--- a/NavigationReactNative/src/BarButton.tsx
+++ b/NavigationReactNative/src/BarButton.tsx
@@ -10,10 +10,8 @@ const BarButton = ({image, show, search, style, children, ...props}) => {
             show={Platform.OS === 'android' ? constants.ShowAsAction[show] : null}
             image={Platform.OS === 'android' ? Image.resolveAssetSource(image) : image}
             style={styles.actionView}
-            {...props}>            
-            {Platform.OS === 'android' && children
-                ? <View collapsable={false} style={{flex: 1}}>{children}</View> : null}
-        </NVBarButton>
+            children={children}
+            {...props} />
     )
 }
 

--- a/NavigationReactNative/src/BarButton.tsx
+++ b/NavigationReactNative/src/BarButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { requireNativeComponent, Image, Platform, UIManager } from 'react-native';
+import { requireNativeComponent, Image, Platform, UIManager, View, StyleSheet } from 'react-native';
 
-const BarButton = ({image, show, search, children, ...props}) => {
+const BarButton = ({image, show, search, style, children, ...props}) => {
     var constants = (UIManager as any).getViewManagerConfig('NVNavigationBar').Constants;
     return (Platform.OS === 'android' || !search) && (
         <NVBarButton
@@ -9,12 +9,26 @@ const BarButton = ({image, show, search, children, ...props}) => {
             showActionView={!!children}
             show={Platform.OS === 'android' ? constants.ShowAsAction[show] : null}
             image={Platform.OS === 'android' ? Image.resolveAssetSource(image) : image}
-            {...props}>
-            {Platform.OS === 'android' ? children : null}
+            style={styles.actionView}
+            {...props}>            
+            {Platform.OS === 'android' && children
+                ? <View collapsable={false} style={{flex: 1}}>{children}</View> : null}
         </NVBarButton>
     )
 }
 
 const NVBarButton = requireNativeComponent<any>('NVBarButton', null)
+
+const styles = StyleSheet.create({
+    actionView: {
+        ...Platform.select({
+            android: {
+                position: 'absolute',
+                top: 0, right: 0,
+                bottom: 0, left: 0,
+            },
+        })
+    }
+});
 
 export default BarButton;

--- a/NavigationReactNative/src/BarButton.tsx
+++ b/NavigationReactNative/src/BarButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React from 'react';
 import { requireNativeComponent, Image, Platform, UIManager, View, StyleSheet } from 'react-native';
 
 const BarButton = ({image, show, search, style, children, ...props}) => {

--- a/NavigationReactNative/src/BarButton.tsx
+++ b/NavigationReactNative/src/BarButton.tsx
@@ -5,6 +5,7 @@ const BarButton = ({image, show, search, ...props}) => {
     var constants = (UIManager as any).getViewManagerConfig('NVNavigationBar').Constants;
     return (Platform.OS === 'android' || !search) && (
         <NVBarButton
+            search={search}
             show={Platform.OS === 'android' ? constants.ShowAsAction[show] : null}
             image={Platform.OS === 'android' ? Image.resolveAssetSource(image) : image}
             {...props} />

--- a/NavigationReactNative/src/BarButton.tsx
+++ b/NavigationReactNative/src/BarButton.tsx
@@ -3,11 +3,17 @@ import { requireNativeComponent, Image, Platform, UIManager, View, StyleSheet } 
 
 const BarButton = ({image, show, search, style, children, ...props}) => {
     var constants = (UIManager as any).getViewManagerConfig('NVNavigationBar').Constants;
+    var showActionView = !!children;
+    if (Platform.OS === 'android') {
+        var showAsAction = constants.ShowAsAction[show];
+        var collapseActionView = constants.ShowAsAction['collapseActionView'];
+        showAsAction = (!search && !showActionView) ? showAsAction : collapseActionView | showAsAction;
+    }
     return (Platform.OS === 'android' || !search) && (
         <NVBarButton
             search={search}
-            showActionView={!!children}
-            show={Platform.OS === 'android' ? constants.ShowAsAction[show] : null}
+            showActionView={showActionView}
+            showAsAction={showAsAction}
             image={Platform.OS === 'android' ? Image.resolveAssetSource(image) : image}
             style={styles.actionView}
             children={children}

--- a/NavigationReactNative/src/BarButton.tsx
+++ b/NavigationReactNative/src/BarButton.tsx
@@ -1,9 +1,15 @@
 import React from 'react'
-import { requireNativeComponent, Platform } from 'react-native';
+import { requireNativeComponent, Image, Platform, UIManager } from 'react-native';
 
-const BarButton = ({search, ...props}) => (
-    (Platform.OS === 'ios' && !search) ? <NVBarButton {...props} /> : null
-)
+const BarButton = ({image, show, search, ...props}) => {
+    var constants = (UIManager as any).getViewManagerConfig('NVNavigationBar').Constants;
+    return (Platform.OS === 'android' || !search) && (
+        <NVBarButton
+            show={Platform.OS === 'android' ? constants.ShowAsAction[show] : null}
+            image={Platform.OS === 'android' ? Image.resolveAssetSource(image) : image}
+            {...props} />
+    )
+}
 
 const NVBarButton = requireNativeComponent<any>('NVBarButton', null)
 

--- a/NavigationReactNative/src/BarButton.tsx
+++ b/NavigationReactNative/src/BarButton.tsx
@@ -3,17 +3,11 @@ import { requireNativeComponent, Image, Platform, UIManager, View, StyleSheet } 
 
 const BarButton = ({image, show, search, style, children, ...props}) => {
     var constants = (UIManager as any).getViewManagerConfig('NVNavigationBar').Constants;
-    var showActionView = !!children;
-    if (Platform.OS === 'android') {
-        var showAsAction = constants.ShowAsAction[show];
-        var collapseActionView = constants.ShowAsAction['collapseActionView'];
-        showAsAction = (!search && !showActionView) ? showAsAction : collapseActionView | showAsAction;
-    }
     return (Platform.OS === 'android' || !search) && (
         <NVBarButton
             search={search}
-            showActionView={showActionView}
-            showAsAction={showAsAction}
+            showActionView={!!children}
+            show={Platform.OS === 'android' ? constants.ShowAsAction[show] : null}
             image={Platform.OS === 'android' ? Image.resolveAssetSource(image) : image}
             style={styles.actionView}
             children={children}

--- a/NavigationReactNative/src/BarButton.tsx
+++ b/NavigationReactNative/src/BarButton.tsx
@@ -7,7 +7,7 @@ const BarButton = ({image, show, search, style, children, ...props}) => {
         <NVBarButton
             search={search}
             showActionView={!!children}
-            show={Platform.OS === 'android' ? constants.ShowAsAction[show] : null}
+            showAsAction={Platform.OS === 'android' ? constants.ShowAsAction[show] : null}
             image={Platform.OS === 'android' ? Image.resolveAssetSource(image) : image}
             style={styles.actionView}
             children={children}

--- a/NavigationReactNative/src/NavigationBar.tsx
+++ b/NavigationReactNative/src/NavigationBar.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { requireNativeComponent, Image, Platform, UIManager, Animated } from 'react-native';
+import { requireNativeComponent, Image, Platform, Animated } from 'react-native';
 import LeftBar from './LeftBar';
 import RightBar from './RightBar';
 import SearchBar from './SearchBar';
@@ -15,20 +15,7 @@ class NavigationBar extends React.Component<any, any> {
         var {hidden, logo, navigationImage, overflowImage, children, style = {height: undefined}, ...otherProps} = this.props;
         if (Platform.OS === 'android' && hidden)
             return null
-        var constants = (UIManager as any).getViewManagerConfig('NVNavigationBar').Constants;
         var childrenArray = (React.Children.toArray(children) as ReactElement<any>[]);
-        var menuItems = childrenArray
-            .filter(({type}) => (type === LeftBar || type === RightBar))
-            .sort((a, b) => (a.type === b.type ? 0 : (a.type === RightBar ? 1 : -1)))
-            .reduce((buttons, {props}) => (
-                buttons.concat((React.Children.toArray(props.children))
-                    .map(({props}: ReactElement<any>) => ({
-                        ...props,
-                        show: Platform.OS === 'android' ? constants.ShowAsAction[props.show] : undefined,
-                        image: Image.resolveAssetSource(props.image),
-                    })
-                ))
-            ), []);
         var collapsingBar = childrenArray.find(({type}) => type === CollapsingBar);
         return (
             <>
@@ -43,20 +30,18 @@ class NavigationBar extends React.Component<any, any> {
                             {...(collapsingBar && collapsingBar.props)}>
                             {collapsingBar && collapsingBar.props.children}
                             <NVToolbar
-                                menuItems={menuItems}
                                 logo={Image.resolveAssetSource(logo)}
                                 navigationImage={Image.resolveAssetSource(navigationImage)}
                                 overflowImage={Image.resolveAssetSource(overflowImage)}
                                 pin={!!collapsingBar}
                                 {...otherProps}
                                 barTintColor={!collapsingBar ? otherProps.barTintColor : null}
-                                style={{height: 56}}
-                                onActionSelected={({nativeEvent}) => {
-                                    var onPress = menuItems[nativeEvent.position].onPress;
-                                    if (onPress)
-                                        onPress();
-                                }}>
-                                {childrenArray.find(({type}) => type === TitleBar)}
+                                style={{height: 56}}>
+                                {[
+                                    childrenArray.find(({type}) => type === TitleBar),
+                                    childrenArray.find(({type}) => type === LeftBar),
+                                    childrenArray.find(({type}) => type === RightBar)
+                                ]}
                             </NVToolbar>
                             {childrenArray.find(({type}) => type === TabBar)}
                         </Container>}

--- a/NavigationReactNative/src/NavigationReactNative.ts
+++ b/NavigationReactNative/src/NavigationReactNative.ts
@@ -14,6 +14,7 @@ import BackHandlerContext from './BackHandlerContext';
 import ModalBackHandler from './ModalBackHandler';
 import CoordinatorLayout from './CoordinatorLayout';
 import CollapsingBar from './CollapsingBar';
+import ActionBar from './ActionBar';
 import useNavigating from './useNavigating';
 import useNavigated from './useNavigated';
 import useUnloading from './useUnloading';
@@ -29,4 +30,4 @@ var TabBarIOS = Platform.OS === 'ios' ? TabBar : () => null;
 var TabBarItemIOS = Platform.OS === 'ios' ? TabBarItem : () => null;
 var SharedElementAndroid = Platform.OS === 'android' ? SharedElement : () => null;
 
-export { NavigationStack, Scene, NavigationBar, LeftBar, RightBar, BarButton, TitleBar, NavigationBarIOS, LeftBarIOS, RightBarIOS, BarButtonIOS, TitleBarIOS, SearchBar, SearchBarIOS, TabBar, TabBarItem, TabBarIOS, TabBarItemIOS, SharedElement, SharedElementAndroid, BackHandlerContext, ModalBackHandler, CoordinatorLayout, CollapsingBar, useNavigating, useNavigated, useUnloading, useUnloaded };
+export { NavigationStack, Scene, NavigationBar, LeftBar, RightBar, BarButton, TitleBar, NavigationBarIOS, LeftBarIOS, RightBarIOS, BarButtonIOS, TitleBarIOS, SearchBar, SearchBarIOS, TabBar, TabBarItem, TabBarIOS, TabBarItemIOS, SharedElement, SharedElementAndroid, BackHandlerContext, ModalBackHandler, CoordinatorLayout, CollapsingBar, ActionBar, useNavigating, useNavigated, useUnloading, useUnloaded };

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ActionBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ActionBarManager.java
@@ -2,8 +2,11 @@ package com.navigation.reactnative;
 
 import androidx.annotation.NonNull;
 
+import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
+
+import java.util.Map;
 
 public class ActionBarManager extends ViewGroupManager<ActionBarView> {
     @NonNull
@@ -16,5 +19,13 @@ public class ActionBarManager extends ViewGroupManager<ActionBarView> {
     @Override
     protected ActionBarView createViewInstance(@NonNull ThemedReactContext reactContext) {
         return new ActionBarView(reactContext);
+    }
+
+    @Override
+    public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
+        return MapBuilder.<String, Object>builder()
+            .put("onExpanded", MapBuilder.of("registrationName", "onCollapsed"))
+            .put("onCollapsed", MapBuilder.of("registrationName", "onCollapsed"))
+            .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ActionBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ActionBarManager.java
@@ -1,0 +1,20 @@
+package com.navigation.reactnative;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewGroupManager;
+
+public class ActionBarManager extends ViewGroupManager<ActionBarView> {
+    @NonNull
+    @Override
+    public String getName() {
+        return "NVActionBar";
+    }
+
+    @NonNull
+    @Override
+    protected ActionBarView createViewInstance(@NonNull ThemedReactContext reactContext) {
+        return new ActionBarView(reactContext);
+    }
+}

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ActionBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ActionBarManager.java
@@ -24,7 +24,7 @@ public class ActionBarManager extends ViewGroupManager<ActionBarView> {
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("onExpanded", MapBuilder.of("registrationName", "onCollapsed"))
+            .put("onExpanded", MapBuilder.of("registrationName", "onExpanded"))
             .put("onCollapsed", MapBuilder.of("registrationName", "onCollapsed"))
             .build();
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ActionBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ActionBarView.java
@@ -23,6 +23,6 @@ public class ActionBarView extends ViewGroup {
 
     void collapsed() {
         ReactContext reactContext = (ReactContext) getContext();
-        reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onExpanded", null);
+        reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onCollapsed", null);
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ActionBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ActionBarView.java
@@ -1,0 +1,15 @@
+package com.navigation.reactnative;
+
+import android.content.Context;
+import android.view.ViewGroup;
+
+public class ActionBarView extends ViewGroup {
+
+    public ActionBarView(Context context) {
+        super(context);
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int l, int t, int r, int b) {
+    }
+}

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ActionBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ActionBarView.java
@@ -3,6 +3,9 @@ package com.navigation.reactnative;
 import android.content.Context;
 import android.view.ViewGroup;
 
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
 public class ActionBarView extends ViewGroup {
 
     public ActionBarView(Context context) {
@@ -11,5 +14,15 @@ public class ActionBarView extends ViewGroup {
 
     @Override
     protected void onLayout(boolean changed, int l, int t, int r, int b) {
+    }
+
+    void expanded() {
+        ReactContext reactContext = (ReactContext) getContext();
+        reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onExpanded", null);
+    }
+
+    void collapsed() {
+        ReactContext reactContext = (ReactContext) getContext();
+        reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onExpanded", null);
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonManager.java
@@ -5,9 +5,12 @@ import android.view.MenuItem;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
+
+import java.util.Map;
 
 public class BarButtonManager extends ViewGroupManager<BarButtonView> {
     @NonNull
@@ -35,5 +38,12 @@ public class BarButtonManager extends ViewGroupManager<BarButtonView> {
     @ReactProp(name = "search")
     public void setSearch(BarButtonView view, @Nullable Boolean search) {
         view.setSearch(search != null ? search : false);
+    }
+
+    @Override
+    public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
+        return MapBuilder.<String, Object>builder()
+            .put("onPress", MapBuilder.of("registrationName", "onPress"))
+            .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonManager.java
@@ -36,8 +36,8 @@ public class BarButtonManager extends ViewGroupManager<BarButtonView> {
         view.setIconSource(icon);
     }
 
-    @ReactProp(name = "show")
-    public void setShow(BarButtonView view, @Nullable Integer showAsAction) {
+    @ReactProp(name = "showAsAction")
+    public void setShowAsAction(BarButtonView view, @Nullable Integer showAsAction) {
         view.setShowAsAction(showAsAction != null ? showAsAction : MenuItem.SHOW_AS_ACTION_NEVER);
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonManager.java
@@ -33,7 +33,7 @@ public class BarButtonManager extends ViewGroupManager<BarButtonView> {
     }
 
     @ReactProp(name = "search")
-    public void setSearch(BarButtonView view, @Nullable boolean search) {
+    public void setSearch(BarButtonView view, boolean search) {
         view.search = search;
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonManager.java
@@ -1,9 +1,13 @@
 package com.navigation.reactnative;
 
+import android.view.MenuItem;
+
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.annotations.ReactProp;
 
 public class BarButtonManager extends ViewGroupManager<BarButtonView> {
     @NonNull
@@ -16,5 +20,20 @@ public class BarButtonManager extends ViewGroupManager<BarButtonView> {
     @Override
     protected BarButtonView createViewInstance(@NonNull ThemedReactContext reactContext) {
         return new BarButtonView(reactContext);
+    }
+
+    @ReactProp(name = "title")
+    public void setTitle(BarButtonView view, @Nullable String title) {
+        view.title = title;
+    }
+
+    @ReactProp(name = "show")
+    public void setShow(BarButtonView view, @Nullable Integer showAsAction) {
+        view.showAsAction = showAsAction != null ? showAsAction : MenuItem.SHOW_AS_ACTION_NEVER;
+    }
+
+    @ReactProp(name = "search")
+    public void setSearch(BarButtonView view, @Nullable boolean search) {
+        view.search = search;
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonManager.java
@@ -5,6 +5,7 @@ import android.view.MenuItem;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
@@ -28,6 +29,11 @@ public class BarButtonManager extends ViewGroupManager<BarButtonView> {
     @ReactProp(name = "title")
     public void setTitle(BarButtonView view, @Nullable String title) {
         view.setTitle(title);
+    }
+
+    @ReactProp(name = "image")
+    public void setImage(BarButtonView view, @Nullable ReadableMap icon) {
+        view.setIconSource(icon);
     }
 
     @ReactProp(name = "show")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonManager.java
@@ -24,16 +24,16 @@ public class BarButtonManager extends ViewGroupManager<BarButtonView> {
 
     @ReactProp(name = "title")
     public void setTitle(BarButtonView view, @Nullable String title) {
-        view.title = title;
+        view.setTitle(title);
     }
 
     @ReactProp(name = "show")
     public void setShow(BarButtonView view, @Nullable Integer showAsAction) {
-        view.showAsAction = showAsAction != null ? showAsAction : MenuItem.SHOW_AS_ACTION_NEVER;
+        view.setShowAsAction(showAsAction != null ? showAsAction : MenuItem.SHOW_AS_ACTION_NEVER);
     }
 
     @ReactProp(name = "search")
     public void setSearch(BarButtonView view, @Nullable Boolean search) {
-        view.search = search != null ? search : false;
+        view.setSearch(search != null ? search : false);
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonManager.java
@@ -33,7 +33,7 @@ public class BarButtonManager extends ViewGroupManager<BarButtonView> {
     }
 
     @ReactProp(name = "search")
-    public void setSearch(BarButtonView view, boolean search) {
-        view.search = search;
+    public void setSearch(BarButtonView view, @Nullable Boolean search) {
+        view.search = search != null ? search : false;
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonManager.java
@@ -36,8 +36,8 @@ public class BarButtonManager extends ViewGroupManager<BarButtonView> {
         view.setIconSource(icon);
     }
 
-    @ReactProp(name = "showAsAction")
-    public void setShowAsAction(BarButtonView view, @Nullable Integer showAsAction) {
+    @ReactProp(name = "show")
+    public void setShow(BarButtonView view, @Nullable Integer showAsAction) {
         view.setShowAsAction(showAsAction != null ? showAsAction : MenuItem.SHOW_AS_ACTION_NEVER);
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonManager.java
@@ -46,6 +46,11 @@ public class BarButtonManager extends ViewGroupManager<BarButtonView> {
         view.setSearch(search != null ? search : false);
     }
 
+    @ReactProp(name = "showActionView")
+    public void setShowActionView(BarButtonView view, boolean showActionView) {
+        view.setShowActionView(showActionView);
+    }
+
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonManager.java
@@ -1,0 +1,20 @@
+package com.navigation.reactnative;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewGroupManager;
+
+public class BarButtonManager extends ViewGroupManager<BarButtonView> {
+    @NonNull
+    @Override
+    public String getName() {
+        return "NVBarButton";
+    }
+
+    @NonNull
+    @Override
+    protected BarButtonView createViewInstance(@NonNull ThemedReactContext reactContext) {
+        return new BarButtonView(reactContext);
+    }
+}

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
@@ -16,6 +16,7 @@ public class BarButtonView extends ViewGroup {
     private String title;
     private int showAsAction;
     private boolean search;
+    private boolean showActionView;
     private MenuItem menuItem;
     private Integer tintColor;
     private Drawable icon;
@@ -51,7 +52,7 @@ public class BarButtonView extends ViewGroup {
     void setShowAsAction(int showAsAction) {
         this.showAsAction = showAsAction;
         if (menuItem != null)
-            menuItem.setShowAsAction(!search ? showAsAction : MenuItem.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW | showAsAction);
+            menuItem.setShowAsAction((!search && !showActionView) ? showAsAction : MenuItem.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW | showAsAction);
     }
 
     void setSearch(boolean search) {
@@ -59,11 +60,19 @@ public class BarButtonView extends ViewGroup {
         setShowAsAction(showAsAction);
     }
 
+    void setShowActionView(boolean showActionView) {
+        this.showActionView = showActionView;
+        setShowAsAction(showAsAction);
+        if (menuItem != null)
+            menuItem.setActionView(showActionView ? this : null);
+    }
+
     void setMenuItem(MenuItem menuItem) {
         this.menuItem = menuItem;
         setTitle(title);
         menuItem.setIcon(icon);
         setShowAsAction(showAsAction);
+        setShowActionView(showActionView);
         menuItem.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
             @Override
             public boolean onMenuItemClick(MenuItem item) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
@@ -41,6 +41,10 @@ public class BarButtonView extends ViewGroup {
         return search;
     }
 
+    MenuItem getMenuItem() {
+        return menuItem;
+    }
+
     void setTitle(String title) {
         this.title = title;
         if (menuItem != null)
@@ -75,14 +79,6 @@ public class BarButtonView extends ViewGroup {
         menuItem.setIcon(icon);
         setShowAsAction(showAsAction);
         setShowActionView(showActionView);
-        menuItem.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
-            @Override
-            public boolean onMenuItemClick(MenuItem item) {
-                ReactContext reactContext = (ReactContext) getContext();
-                reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onPress", null);
-                return true;
-            }
-        });
     }
 
     void setTintColor(Integer tintColor) {
@@ -93,6 +89,11 @@ public class BarButtonView extends ViewGroup {
             else
                 icon.clearColorFilter();
         }
+    }
+
+    protected void press() {
+        ReactContext reactContext = (ReactContext) getContext();
+        reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onPress", null);
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
@@ -1,0 +1,15 @@
+package com.navigation.reactnative;
+
+import android.content.Context;
+import android.view.ViewGroup;
+
+public class BarButtonView extends ViewGroup {
+
+    public BarButtonView(Context context) {
+        super(context);
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int l, int t, int r, int b) {
+    }
+}

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
@@ -59,17 +59,15 @@ public class BarButtonView extends ViewGroup implements CollapsibleActionView {
     void setShowAsAction(int showAsAction) {
         this.showAsAction = showAsAction;
         if (menuItem != null)
-            menuItem.setShowAsAction((!search && !showActionView) ? showAsAction : MenuItem.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW | showAsAction);
+            menuItem.setShowAsAction(showAsAction);
     }
 
     void setSearch(boolean search) {
         this.search = search;
-        setShowAsAction(showAsAction);
     }
 
     void setShowActionView(boolean showActionView) {
         this.showActionView = showActionView;
-        setShowAsAction(showAsAction);
         if (menuItem != null)
             menuItem.setActionView(showActionView ? this : null);
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
@@ -4,9 +4,7 @@ import android.content.Context;
 import android.view.MenuItem;
 import android.view.ViewGroup;
 
-import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 
 public class BarButtonView extends ViewGroup {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
@@ -4,6 +4,11 @@ import android.content.Context;
 import android.view.MenuItem;
 import android.view.ViewGroup;
 
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
 public class BarButtonView extends ViewGroup {
     private String title;
     private int showAsAction;
@@ -39,6 +44,14 @@ public class BarButtonView extends ViewGroup {
         this.menuItem = menuItem;
         setTitle(title);
         setShowAsAction(showAsAction);
+        menuItem.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
+            @Override
+            public boolean onMenuItemClick(MenuItem item) {
+                ReactContext reactContext = (ReactContext) getContext();
+                reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onPress", null);
+                return true;
+            }
+        });
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
@@ -59,15 +59,17 @@ public class BarButtonView extends ViewGroup implements CollapsibleActionView {
     void setShowAsAction(int showAsAction) {
         this.showAsAction = showAsAction;
         if (menuItem != null)
-            menuItem.setShowAsAction(showAsAction);
+            menuItem.setShowAsAction((!search && !showActionView) ? showAsAction : MenuItem.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW | showAsAction);
     }
 
     void setSearch(boolean search) {
         this.search = search;
+        setShowAsAction(showAsAction);
     }
 
     void setShowActionView(boolean showActionView) {
         this.showActionView = showActionView;
+        setShowAsAction(showAsAction);
         if (menuItem != null)
             menuItem.setActionView(showActionView ? this : null);
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
@@ -4,6 +4,9 @@ import android.content.Context;
 import android.view.ViewGroup;
 
 public class BarButtonView extends ViewGroup {
+    String title;
+    int showAsAction;
+    boolean search;
 
     public BarButtonView(Context context) {
         super(context);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
@@ -1,15 +1,44 @@
 package com.navigation.reactnative;
 
 import android.content.Context;
+import android.view.MenuItem;
 import android.view.ViewGroup;
 
 public class BarButtonView extends ViewGroup {
-    String title;
-    int showAsAction;
-    boolean search;
+    private String title;
+    private int showAsAction;
+    private boolean search;
+    private MenuItem menuItem;
 
     public BarButtonView(Context context) {
         super(context);
+    }
+
+    boolean getSearch() {
+        return search;
+    }
+
+    void setTitle(String title) {
+        this.title = title;
+        if (menuItem != null)
+            menuItem.setTitle(title);
+    }
+
+    void setShowAsAction(int showAsAction) {
+        this.showAsAction = showAsAction;
+        if (menuItem != null)
+            menuItem.setShowAsAction(!search ? showAsAction : MenuItem.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW | showAsAction);
+    }
+
+    void setSearch(boolean search) {
+        this.search = search;
+        setShowAsAction(showAsAction);
+    }
+
+    void setMenuItem(MenuItem menuItem) {
+        this.menuItem = menuItem;
+        setTitle(title);
+        setShowAsAction(showAsAction);
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
@@ -5,6 +5,7 @@ import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.view.MenuItem;
 import android.view.ViewGroup;
+import android.widget.ImageButton;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.view.CollapsibleActionView;
@@ -123,6 +124,9 @@ public class BarButtonView extends ViewGroup implements CollapsibleActionView {
     public void onActionViewExpanded() {
         if (getChildAt(0) instanceof ActionBarView)
             ((ActionBarView) getChildAt(0)).expanded();
+        ToolbarView toolbarView = (ToolbarView) getParent();
+        if (toolbarView.getChildAt(1) instanceof ImageButton)
+            toolbarView.setCollapseButton((ImageButton) toolbarView.getChildAt(1));
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
@@ -8,8 +8,10 @@ import android.view.ViewGroup;
 
 import androidx.annotation.Nullable;
 
+import com.facebook.react.bridge.GuardedRunnable;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 
 public class BarButtonView extends ViewGroup {
@@ -95,5 +97,23 @@ public class BarButtonView extends ViewGroup {
 
     @Override
     protected void onLayout(boolean changed, int l, int t, int r, int b) {
+    }
+
+    @Override
+    protected void onSizeChanged(final int w, final int h, int oldw, int oldh) {
+        super.onSizeChanged(w, h, oldw, oldh);
+        if (getChildCount() == 0)
+            return;
+        final int viewTag = getChildAt(0).getId();
+        final ReactContext reactContext = (ReactContext) getContext();
+        reactContext.runOnNativeModulesQueueThread(
+            new GuardedRunnable(reactContext) {
+                @Override
+                public void runGuarded() {
+                    UIManagerModule uiManager = reactContext.getNativeModule(UIManagerModule.class);
+                    if (uiManager != null)
+                        uiManager.updateNodeSize(viewTag, w, h);
+                }
+            });
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
@@ -1,10 +1,14 @@
 package com.navigation.reactnative;
 
 import android.content.Context;
+import android.graphics.drawable.Drawable;
 import android.view.MenuItem;
 import android.view.ViewGroup;
 
+import androidx.annotation.Nullable;
+
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 
 public class BarButtonView extends ViewGroup {
@@ -12,9 +16,19 @@ public class BarButtonView extends ViewGroup {
     private int showAsAction;
     private boolean search;
     private MenuItem menuItem;
+    private Drawable icon;
+    private IconResolver.IconResolverListener iconResolverListener;
 
     public BarButtonView(Context context) {
         super(context);
+        iconResolverListener = new IconResolver.IconResolverListener() {
+            @Override
+            public void setDrawable(Drawable d) {
+                icon = d;
+                if (menuItem != null)
+                    menuItem.setIcon(d);
+            }
+        };
     }
 
     boolean getSearch() {
@@ -25,6 +39,10 @@ public class BarButtonView extends ViewGroup {
         this.title = title;
         if (menuItem != null)
             menuItem.setTitle(title);
+    }
+
+    void setIconSource(@Nullable ReadableMap source) {
+        IconResolver.setIconSource(source, iconResolverListener, getContext());
     }
 
     void setShowAsAction(int showAsAction) {
@@ -41,6 +59,7 @@ public class BarButtonView extends ViewGroup {
     void setMenuItem(MenuItem menuItem) {
         this.menuItem = menuItem;
         setTitle(title);
+        menuItem.setIcon(icon);
         setShowAsAction(showAsAction);
         menuItem.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
             @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
@@ -7,6 +7,7 @@ import android.view.MenuItem;
 import android.view.ViewGroup;
 
 import androidx.annotation.Nullable;
+import androidx.appcompat.view.CollapsibleActionView;
 
 import com.facebook.react.bridge.GuardedRunnable;
 import com.facebook.react.bridge.ReactContext;
@@ -14,7 +15,7 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 
-public class BarButtonView extends ViewGroup {
+public class BarButtonView extends ViewGroup implements CollapsibleActionView {
     private String title;
     private int showAsAction;
     private boolean search;
@@ -116,5 +117,18 @@ public class BarButtonView extends ViewGroup {
                         uiManager.updateNodeSize(viewTag, w, h);
                 }
             });
+    }
+
+    @Override
+    public void onActionViewExpanded() {
+        if (getChildAt(0) instanceof ActionBarView)
+            ((ActionBarView) getChildAt(0)).expanded();
+    }
+
+    @Override
+    public void onActionViewCollapsed() {
+        if (getChildAt(0) instanceof ActionBarView)
+            ((ActionBarView) getChildAt(0)).collapsed();
+
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
@@ -1,6 +1,7 @@
 package com.navigation.reactnative;
 
 import android.content.Context;
+import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.view.MenuItem;
 import android.view.ViewGroup;
@@ -16,6 +17,7 @@ public class BarButtonView extends ViewGroup {
     private int showAsAction;
     private boolean search;
     private MenuItem menuItem;
+    private Integer tintColor;
     private Drawable icon;
     private IconResolver.IconResolverListener iconResolverListener;
 
@@ -25,6 +27,7 @@ public class BarButtonView extends ViewGroup {
             @Override
             public void setDrawable(Drawable d) {
                 icon = d;
+                setTintColor(tintColor);
                 if (menuItem != null)
                     menuItem.setIcon(d);
             }
@@ -69,6 +72,16 @@ public class BarButtonView extends ViewGroup {
                 return true;
             }
         });
+    }
+
+    void setTintColor(Integer tintColor) {
+        this.tintColor = tintColor;
+        if (icon != null) {
+            if (tintColor != null)
+                icon.setColorFilter(tintColor, PorterDuff.Mode.SRC_IN);
+            else
+                icon.clearColorFilter();
+        }
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarManager.java
@@ -71,7 +71,6 @@ public class NavigationBarManager extends ViewGroupManager<NavigationBarView> {
             MapBuilder.of(
                 "never", MenuItem.SHOW_AS_ACTION_NEVER,
                 "always", MenuItem.SHOW_AS_ACTION_ALWAYS,
-                "ifRoom", MenuItem.SHOW_AS_ACTION_IF_ROOM,
-                "collapseActionView", MenuItem.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW));
+                "ifRoom", MenuItem.SHOW_AS_ACTION_IF_ROOM));
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarManager.java
@@ -71,6 +71,7 @@ public class NavigationBarManager extends ViewGroupManager<NavigationBarView> {
             MapBuilder.of(
                 "never", MenuItem.SHOW_AS_ACTION_NEVER,
                 "always", MenuItem.SHOW_AS_ACTION_ALWAYS,
-                "ifRoom", MenuItem.SHOW_AS_ACTION_IF_ROOM));
+                "ifRoom", MenuItem.SHOW_AS_ACTION_IF_ROOM,
+                "collapseActionView", MenuItem.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW));
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationPackage.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationPackage.java
@@ -28,7 +28,8 @@ public class NavigationPackage implements ReactPackage {
             new SearchBarManager(),
             new CoordinatorLayoutManager(),
             new CollapsingBarManager(),
-            new BarButtonManager()
+            new BarButtonManager(),
+            new ActionBarManager()
         );
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationPackage.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationPackage.java
@@ -27,7 +27,8 @@ public class NavigationPackage implements ReactPackage {
             new TitleBarManager(),
             new SearchBarManager(),
             new CoordinatorLayoutManager(),
-            new CollapsingBarManager()
+            new CollapsingBarManager(),
+            new BarButtonManager()
         );
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
@@ -50,7 +50,7 @@ public class SearchBarView extends ReactViewGroup {
                 if (hasFocus) {
                     ToolbarView toolbarView = (ToolbarView) searchView.getParent();
                     if (toolbarView.getChildAt(1) instanceof ImageButton)
-                        toolbarView.setCollapseSearchButton((ImageButton) toolbarView.getChildAt(1));
+                        toolbarView.setCollapseButton((ImageButton) toolbarView.getChildAt(1));
                 }
             }
         });

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarManager.java
@@ -4,7 +4,6 @@ import android.view.View;
 
 import androidx.annotation.Nullable;
 
-import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.PixelUtil;
@@ -52,11 +51,6 @@ public class ToolbarManager extends ViewGroupManager<ToolbarView> {
         view.setOverflowIconSource(overflowIcon);
     }
 
-    @ReactProp(name = "menuItems")
-    public void setMenuItems(ToolbarView view, @Nullable ReadableArray menuItems) {
-        view.setMenuItems(menuItems);
-    }
-
     @ReactProp(name = "barTintColor", customType = "Color")
     public void setBarTintColor(ToolbarView view, @Nullable Integer barTintColor) {
         if (barTintColor != null)
@@ -98,6 +92,8 @@ public class ToolbarManager extends ViewGroupManager<ToolbarView> {
         parent.children.add(index, child);
         if (child instanceof TitleBarView)
             parent.addView(child);
+        if (child instanceof BarButtonView)
+            parent.setMenuItems();
     }
 
     @Override
@@ -105,6 +101,8 @@ public class ToolbarManager extends ViewGroupManager<ToolbarView> {
         View child = parent.children.remove(index);
         if (child instanceof TitleBarView)
             parent.removeView(child);
+        if (child instanceof BarButtonView)
+            parent.setMenuItems();
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarManager.java
@@ -118,9 +118,7 @@ public class ToolbarManager extends ViewGroupManager<ToolbarView> {
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-                .put("onNavigationPress", MapBuilder.of("registrationName", "onNavigationPress"))
-                .put("onActionSelected", MapBuilder.of("registrationName", "onActionSelected"))
-                .build();
+            .put("onNavigationPress", MapBuilder.of("registrationName", "onNavigationPress"))
+            .build();
     }
-
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarManager.java
@@ -1,5 +1,7 @@
 package com.navigation.reactnative;
 
+import android.view.View;
+
 import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.ReadableArray;
@@ -89,6 +91,30 @@ public class ToolbarManager extends ViewGroupManager<ToolbarView> {
             params.setScrollFlags(AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL | AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS);
             view.setLayoutParams(params);
         }
+    }
+
+    @Override
+    public void addView(ToolbarView parent, View child, int index) {
+        parent.children.add(index, child);
+        if (child instanceof TitleBarView)
+            parent.addView(child);
+    }
+
+    @Override
+    public void removeViewAt(ToolbarView parent, int index) {
+        View child = parent.children.remove(index);
+        if (child instanceof TitleBarView)
+            parent.removeView(child);
+    }
+
+    @Override
+    public int getChildCount(ToolbarView parent) {
+        return parent.children.size();
+    }
+
+    @Override
+    public View getChildAt(ToolbarView parent, int index) {
+        return parent.children.get(index);
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
@@ -31,10 +31,6 @@ public class ToolbarView extends Toolbar {
     private Integer tintColor;
     private ImageButton collapseSearchButton;
     private OnSearchListener onSearchAddedListener;
-    private static final String PROP_ACTION_ICON = "image";
-    private static final String PROP_ACTION_SHOW = "show";
-    private static final String PROP_ACTION_TITLE = "title";
-    private static final String PROP_ACTION_SEARCH = "search";
     int defaultTitleTextColor;
     Drawable defaultOverflowIcon;
     private Integer defaultMenuTintColor;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
@@ -144,14 +144,10 @@ public class ToolbarView extends Toolbar {
         for (int i = 0; i < children.size(); i++) {
             if (children.get(i) instanceof BarButtonView) {
                 BarButtonView barButton = (BarButtonView) children.get(i);
-                //ReadableMap iconSource = menuItemProps.getMap(PROP_ACTION_ICON);
-                MenuItem menuItem = getMenu().add(Menu.NONE, Menu.NONE, i, barButton.title);
-                //if (iconSource != null)
-                    //setMenuItemIcon(menuItem, iconSource);
-                int showAsAction = barButton.showAsAction;
-                if (barButton.search) {
+                MenuItem menuItem = getMenu().add(Menu.NONE, Menu.NONE, i, "");
+                barButton.setMenuItem(menuItem);
+                if (barButton.getSearch()) {
                     searchMenuItem = menuItem;
-                    showAsAction = MenuItem.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW | barButton.showAsAction;
                     if (onSearchAddedListener != null)
                         onSearchAddedListener.onSearchAdd(searchMenuItem);
                     menuItem.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
@@ -168,7 +164,6 @@ public class ToolbarView extends Toolbar {
                         }
                     });
                 }
-                menuItem.setShowAsAction(showAsAction);
             }
         }
         setMenuTintColor();

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
@@ -70,6 +70,21 @@ public class ToolbarView extends Toolbar {
                 reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onNavigationPress", null);
             }
         });
+        setOnMenuItemClickListener(new OnMenuItemClickListener() {
+            @Override
+            public boolean onMenuItemClick(MenuItem item) {
+                for (int i = 0; i < children.size(); i++) {
+                    if (children.get(i) instanceof BarButtonView) {
+                        BarButtonView barButtonView = (BarButtonView) children.get(i);
+                        if (barButtonView.getMenuItem() != item)
+                            barButtonView.getMenuItem().collapseActionView();
+                        else
+                            barButtonView.press();
+                    }
+                }
+                return true;
+            }
+        });
     }
 
     private int getDefaultTitleTextColor() {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
@@ -114,9 +114,6 @@ public class ToolbarView extends Toolbar {
         setTintColor(getLogo());
         setTintColor(getOverflowIcon());
         setMenuTintColor();
-        for(int i = 0; i < getMenu().size(); i++) {
-            setTintColor(getMenu().getItem(i).getIcon());
-        }
         setCollapseSearchTintColor();
     }
 
@@ -171,6 +168,11 @@ public class ToolbarView extends Toolbar {
                         menuItem.setTextColor(tintColor != null ? tintColor : defaultMenuTintColor);
                     }
                 }
+            }
+        }
+        for (int i = 0; i < children.size(); i++) {
+            if (children.get(i) instanceof BarButtonView) {
+                ((BarButtonView) children.get(i)).setTintColor(tintColor);
             }
         }
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
@@ -143,39 +143,37 @@ public class ToolbarView extends Toolbar {
         }
     }
 
-    void setMenuItems(@Nullable ReadableArray menuItems) {
+    void setMenuItems() {
         getMenu().clear();
-        for (int i = 0; menuItems != null && i < menuItems.size(); i++) {
-            ReadableMap menuItemProps = menuItems.getMap(i);
-            if (menuItemProps == null)
-                continue;
-            String title = menuItemProps.hasKey(PROP_ACTION_TITLE) ? menuItemProps.getString(PROP_ACTION_TITLE) : "";
-            ReadableMap iconSource = menuItemProps.getMap(PROP_ACTION_ICON);
-            MenuItem menuItem = getMenu().add(Menu.NONE, Menu.NONE, i, title);
-            if (iconSource != null)
-                setMenuItemIcon(menuItem, iconSource);
-            int showAsAction = menuItemProps.hasKey(PROP_ACTION_SHOW) ? menuItemProps.getInt(PROP_ACTION_SHOW) : MenuItem.SHOW_AS_ACTION_NEVER;
-            boolean search = menuItemProps.hasKey(PROP_ACTION_SEARCH) && menuItemProps.getBoolean(PROP_ACTION_SEARCH);
-            if (search) {
-                searchMenuItem = menuItem;
-                showAsAction = MenuItem.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW | showAsAction;
-                if (onSearchAddedListener != null)
-                    onSearchAddedListener.onSearchAdd(searchMenuItem);
-                menuItem.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
-                    @Override
-                    public boolean onMenuItemActionCollapse(MenuItem item) {
-                        onSearchAddedListener.onSearchCollapse();
-                        return true;
-                    }
+        for (int i = 0; i < children.size(); i++) {
+            if (children.get(i) instanceof BarButtonView) {
+                BarButtonView barButton = (BarButtonView) children.get(i);
+                //ReadableMap iconSource = menuItemProps.getMap(PROP_ACTION_ICON);
+                MenuItem menuItem = getMenu().add(Menu.NONE, Menu.NONE, i, barButton.title);
+                //if (iconSource != null)
+                    //setMenuItemIcon(menuItem, iconSource);
+                int showAsAction = barButton.showAsAction;
+                if (barButton.search) {
+                    searchMenuItem = menuItem;
+                    showAsAction = MenuItem.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW | barButton.showAsAction;
+                    if (onSearchAddedListener != null)
+                        onSearchAddedListener.onSearchAdd(searchMenuItem);
+                    menuItem.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
+                        @Override
+                        public boolean onMenuItemActionCollapse(MenuItem item) {
+                            onSearchAddedListener.onSearchCollapse();
+                            return true;
+                        }
 
-                    @Override
-                    public boolean onMenuItemActionExpand(MenuItem item) {
-                        onSearchAddedListener.onSearchExpand();
-                        return true;
-                    }
-                });
+                        @Override
+                        public boolean onMenuItemActionExpand(MenuItem item) {
+                            onSearchAddedListener.onSearchExpand();
+                            return true;
+                        }
+                    });
+                }
+                menuItem.setShowAsAction(showAsAction);
             }
-            menuItem.setShowAsAction(showAsAction);
         }
         setMenuTintColor();
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
@@ -73,16 +73,6 @@ public class ToolbarView extends Toolbar {
                 reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onNavigationPress", null);
             }
         });
-        setOnMenuItemClickListener(new Toolbar.OnMenuItemClickListener() {
-            @Override
-            public boolean onMenuItemClick(MenuItem item) {
-                WritableMap event = Arguments.createMap();
-                event.putInt("position", item.getOrder());
-                ReactContext reactContext = (ReactContext) getContext();
-                reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onActionSelected", event);
-                return true;
-            }
-        });
     }
 
     private int getDefaultTitleTextColor() {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
@@ -24,6 +24,8 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.google.android.material.appbar.AppBarLayout;
 
+import java.util.ArrayList;
+
 public class ToolbarView extends Toolbar {
     private MenuItem searchMenuItem;
     private Integer tintColor;
@@ -40,6 +42,7 @@ public class ToolbarView extends Toolbar {
     private IconResolver.IconResolverListener navIconResolverListener;
     private IconResolver.IconResolverListener overflowIconResolverListener;
     private boolean layoutRequested = false;
+    ArrayList<View> children = new ArrayList<>();
 
     public ToolbarView(Context context) {
         super(context);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
@@ -151,6 +151,7 @@ public class ToolbarView extends Toolbar {
             }
         }
         setMenuTintColor();
+        requestLayout();
     }
 
     private void setMenuTintColor()  {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
@@ -16,11 +16,8 @@ import androidx.appcompat.view.menu.ActionMenuItemView;
 import androidx.appcompat.widget.ActionMenuView;
 import androidx.appcompat.widget.Toolbar;
 
-import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.google.android.material.appbar.AppBarLayout;
 
@@ -177,11 +174,6 @@ public class ToolbarView extends Toolbar {
         }
     }
 
-    private void setMenuItemIcon(final MenuItem item, ReadableMap iconSource) {
-        ActionIconControllerListener controllerListener = new ActionIconControllerListener(item);
-        IconResolver.setIconSource(iconSource, controllerListener, getContext());
-    }
-
     void setOnSearchListener(OnSearchListener onSearchListener) {
         this.onSearchAddedListener = onSearchListener;
         if (searchMenuItem != null)
@@ -222,20 +214,6 @@ public class ToolbarView extends Toolbar {
             layout(getLeft(), getTop(), getRight(), getBottom());
         }
     };
-
-    class ActionIconControllerListener implements IconResolver.IconResolverListener {
-        private final MenuItem item;
-
-        ActionIconControllerListener(MenuItem item) {
-            this.item = item;
-        }
-
-        @Override
-        public void setDrawable(Drawable d) {
-            item.setIcon(d);
-            setTintColor(item.getIcon());
-        }
-    }
 
     interface OnSearchListener {
         void onSearchAdd(MenuItem searchMenuItem);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 public class ToolbarView extends Toolbar {
     private MenuItem searchMenuItem;
     private Integer tintColor;
-    private ImageButton collapseSearchButton;
+    private ImageButton collapseButton;
     private OnSearchListener onSearchAddedListener;
     int defaultTitleTextColor;
     Drawable defaultOverflowIcon;
@@ -197,17 +197,17 @@ public class ToolbarView extends Toolbar {
 
     }
 
-    void setCollapseSearchButton(ImageButton collapseSearchButton) {
-        this.collapseSearchButton = collapseSearchButton;
+    void setCollapseButton(ImageButton collapseButton) {
+        this.collapseButton = collapseButton;
         setCollapseSearchTintColor();
     }
 
     void setCollapseSearchTintColor() {
-        if (collapseSearchButton != null) {
+        if (collapseButton != null) {
             if (tintColor != null)
-                collapseSearchButton.setColorFilter(tintColor);
+                collapseButton.setColorFilter(tintColor);
             else
-                collapseSearchButton.clearColorFilter();
+                collapseButton.clearColorFilter();
         }
     }
 

--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -260,6 +260,25 @@ export class CoordinatorLayout extends Component<CoordinatorLayoutProps> {}
 export class CollapsingBar extends Component {}
 
 /**
+ * Defines the Action Bar Props contract
+ */
+export interface ActionBarProps {
+    /**
+     * Handles action bar expanded events
+     */
+    onExpanded?: () => void;
+    /**
+     * Handles action bar collapsed events
+     */
+    onCollapsed?: () => void;
+}
+
+/**
+ * Renders an action bar in the UI navigation bar
+ */
+export class ActionBar extends Component<ActionBarProps> {}
+
+/**
  * Defines the Shared Element Props contract
  */
 export interface SharedElementProps {

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -260,6 +260,25 @@ export class CoordinatorLayout extends Component<CoordinatorLayoutProps> {}
 export class CollapsingBar extends Component {}
 
 /**
+ * Defines the Action Bar Props contract
+ */
+export interface ActionBarProps {
+    /**
+     * Handles action bar expanded events
+     */
+    onExpanded?: () => void;
+    /**
+     * Handles action bar collapsed events
+     */
+    onCollapsed?: () => void;
+}
+
+/**
+ * Renders an action bar in the UI navigation bar
+ */
+export class ActionBar extends Component<ActionBarProps> {}
+
+/**
  * Defines the Shared Element Props contract
  */
 export interface SharedElementProps {


### PR DESCRIPTION
Wrapped the Android [action view](https://developer.android.com/training/appbar/action-views) in an `ActionBar` component. Its `children` content is expanded into the navigation bar when the containing `BarButton` component is pressed. For example,
```jsx
<BarButton title="find" show="always">
  <ActionBar>
    <TextInput onChangeText={text => find(text)} />
  </ActionBar>
</BarButton>
```
