### PR TITLE
Update BarButton to allow it to be used for anchoring an ActionSheetIOS

### DIFF
--- a/NavigationReactNative/src/BarButton.tsx
+++ b/NavigationReactNative/src/BarButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { requireNativeComponent, Image, Platform, UIManager, View, StyleSheet } from 'react-native';
 
-const BarButton = React.forwardRef<typeof NVBarButton, any>(({image, show, search, style, children, ...props}, ref) => {
+const BarButton = React.forwardRef<any, any>(({image, show, search, style, children, ...props}, ref) => {
     var constants = (UIManager as any).getViewManagerConfig('NVNavigationBar').Constants;
     return (Platform.OS === 'android' || !search) && (
         <NVBarButton

--- a/NavigationReactNative/src/BarButton.tsx
+++ b/NavigationReactNative/src/BarButton.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { requireNativeComponent, Image, Platform, UIManager, View, StyleSheet } from 'react-native';
 
-const BarButton = ({image, show, search, style, children, ...props}) => {
+const BarButton = React.forwardRef<typeof NVBarButton, any>(({image, show, search, style, children, ...props}, ref) => {
     var constants = (UIManager as any).getViewManagerConfig('NVNavigationBar').Constants;
     return (Platform.OS === 'android' || !search) && (
         <NVBarButton
+            ref={ref}
             search={search}
             showActionView={!!children}
             showAsAction={Platform.OS === 'android' ? constants.ShowAsAction[show] : null}
@@ -13,7 +14,7 @@ const BarButton = ({image, show, search, style, children, ...props}) => {
             children={children}
             {...props} />
     )
-}
+})
 
 const NVBarButton = requireNativeComponent<any>('NVBarButton', null)
 

--- a/NavigationReactNative/src/ios/NVBarButtonView.m
+++ b/NavigationReactNative/src/ios/NVBarButtonView.m
@@ -20,10 +20,10 @@
 {
     [super layoutSubviews];
     UIView *buttonView = ((UIView *) [self.button valueForKey:@"view"]);
-    UIView *rightBarView = buttonView.superview;
+    UIView *barView = buttonView.superview;
     UIView *labelView = buttonView.subviews.count > 0 ? buttonView.subviews[0] : buttonView;
-    CGRect labelFrameInBar = [buttonView convertRect:labelView.frame toView:rightBarView];
-    self.frame = [rightBarView convertRect:labelFrameInBar toView:nil];
+    CGRect labelFrameInBar = [buttonView convertRect:labelView.frame toView:barView];
+    self.frame = [barView convertRect:labelFrameInBar toView:nil];
 }
 
 - (void)setTitle:(NSString *)title

--- a/NavigationReactNative/src/ios/NVBarButtonView.m
+++ b/NavigationReactNative/src/ios/NVBarButtonView.m
@@ -16,6 +16,16 @@
     return self;
 }
 
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    UIView *buttonView = ((UIView *) [self.button valueForKey:@"view"]);
+    UIView *rightBarView = buttonView.superview;
+    UIView *labelView = buttonView.subviews.count > 0 ? buttonView.subviews[0] : buttonView;
+    CGRect labelFrameInBar = [buttonView convertRect:labelView.frame toView:rightBarView];
+    self.frame = [rightBarView convertRect:labelFrameInBar toView:nil];
+}
+
 - (void)setTitle:(NSString *)title
 {
     self.button.title = title;


### PR DESCRIPTION
Closes https://github.com/grahammendick/navigation/issues/441

The two requisite changes were:

* Updating the BarButton to pass the ref into the native NVBarButton
* Updating the NVBarButton to have its frame match that of the child button's label

Couple of questions:

1. For the `BarButton`, I've had to add types for the ref and the props. I noticed the props weren't typed before, and they don't appear to all be simple primitives. Do you have suggestions for the types here? I just left it as `any`.
2. For the `layoutSubviews` method in `NVBarButton`, let me know what sort of error handling I should take a look at here. The issue is that if we can't find the button's view, we can't really fallback to the old "show up in the middle" behaviour, since we'd still have the ref. I considered only setting the frame if the `labelView` is non-nil, what are your thoughts?