### PR TITLE
Reset stack when reselecting tab on iOS 14

### DIFF
--- a/NavigationReactNative/src/ios/NVNavigationStackView.m
+++ b/NavigationReactNative/src/ios/NVNavigationStackView.m
@@ -109,7 +109,7 @@
 
 - (void)navigationController:(UINavigationController *)navigationController willShowViewController:(UIViewController *)viewController animated:(BOOL)animated
 {
-    NSInteger crumb = [navigationController.viewControllers indexOfObject:viewController];
+    NSInteger crumb = [((NVSceneView *) viewController.view).sceneKey intValue];
     if (crumb < [self.keys count] - 1) {
         self.onWillNavigateBack(@{ @"crumb": @(crumb) });
     }


### PR DESCRIPTION
On Twitter sample, Home ->  Tweet A -> Tweet B and then tap the Home tab. This should navigate to the first scene but it went to Tweet A instead! It's because iOS 14 calls willNavigate with the viewControllers out of sequence. The Home scene is the second element instead of the first. 
So used the sceneKey to access the crumb instead of indexOf. Checked it works with fluent navigation where the sceneKey can be "0++"