### PR TITLE
Reverse the buttons in the RightBar on iOS

### DIFF
--- a/NavigationReactNative/src/RightBar.ts
+++ b/NavigationReactNative/src/RightBar.ts
@@ -1,3 +1,0 @@
-import { requireNativeComponent, Platform } from 'react-native';
-
-export default Platform.OS === "ios" ? requireNativeComponent('NVRightBar', null) : ({children}) => children;

--- a/NavigationReactNative/src/RightBar.tsx
+++ b/NavigationReactNative/src/RightBar.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { Platform, requireNativeComponent } from "react-native";
+
+const NVRightBar = requireNativeComponent("NVRightBar", null);
+
+export default Platform.OS === "ios"
+  ? ({ children }) => (
+      <NVRightBar>{React.Children.toArray(children).reverse()}</NVRightBar>
+    )
+  : ({ children }) => children;


### PR DESCRIPTION
Fixes https://github.com/grahammendick/navigation/issues/442

On iOS, we need to reverse the buttons in the RightBar, otherwise they will appear in a different order from Android.