### PR TITLE
Loaded BarButton and TabBar images asynchronously (iOS)

### DIFF
--- a/NavigationReactNative/src/BarButton.tsx
+++ b/NavigationReactNative/src/BarButton.tsx
@@ -10,7 +10,7 @@ const BarButton = React.forwardRef<any, any>(({image, systemItem, show, search, 
             search={search}
             showActionView={!!children}
             showAsAction={Platform.OS === 'android' ? constants.ShowAsAction[show] : null}
-            image={Platform.OS === 'android' ? Image.resolveAssetSource(image) : image}
+            image={Image.resolveAssetSource(image)}
             systemItem={systemItem || ''}
             style={styles.actionView}
             children={children}

--- a/NavigationReactNative/src/TabBarItem.tsx
+++ b/NavigationReactNative/src/TabBarItem.tsx
@@ -21,7 +21,7 @@ class TabBarItem extends React.Component<any> {
             <NVTabBarItem
                 {...props}
                 badge={badge != null ? (Platform.OS === 'ios' ? '' + badge : +badge) : undefined}
-                image={Platform.OS === 'ios' ? image : Image.resolveAssetSource(image)}
+                image={Image.resolveAssetSource(image)}
                 systemItem={systemItem || ''}
                 style={styles.tabBarItem}
                 onPress={event => {

--- a/NavigationReactNative/src/ios/NVBarButtonManager.m
+++ b/NavigationReactNative/src/ios/NVBarButtonManager.m
@@ -3,6 +3,7 @@
 
 #import <UIKit/UIKit.h>
 #import <React/RCTComponent.h>
+#import <React/RCTImageSource.h>
 
 @implementation RCTConvert (UIBarButtonSystemItem)
 
@@ -41,7 +42,7 @@ RCT_EXPORT_MODULE()
 
 - (UIView *)view
 {
-    return [[NVBarButtonView alloc] init];
+    return [[NVBarButtonView alloc] initWithBridge:self.bridge];
 }
 
 RCT_EXPORT_VIEW_PROPERTY(title, NSString)
@@ -49,7 +50,7 @@ RCT_EXPORT_VIEW_PROPERTY(fontFamily, NSString)
 RCT_EXPORT_VIEW_PROPERTY(fontWeight, NSString)
 RCT_EXPORT_VIEW_PROPERTY(fontStyle, NSString)
 RCT_EXPORT_VIEW_PROPERTY(fontSize, NSNumber)
-RCT_EXPORT_VIEW_PROPERTY(image, UIImage)
+RCT_EXPORT_VIEW_PROPERTY(image, RCTImageSource)
 RCT_EXPORT_VIEW_PROPERTY(systemItem, UIBarButtonSystemItem)
 RCT_EXPORT_VIEW_PROPERTY(onPress, RCTBubblingEventBlock)
 

--- a/NavigationReactNative/src/ios/NVBarButtonView.h
+++ b/NavigationReactNative/src/ios/NVBarButtonView.h
@@ -1,4 +1,5 @@
 #import <UIKit/UIKit.h>
+#import <React/RCTBridge.h>
 #import <React/RCTComponent.h>
 
 @interface NVBarButtonView : UIView
@@ -9,5 +10,7 @@
 @property (nonatomic, copy) NSString *fontStyle;
 @property (nonatomic, copy) NSNumber *fontSize;
 @property (nonatomic, copy) RCTBubblingEventBlock onPress;
+
+-(id)initWithBridge: (RCTBridge *)bridge;
 
 @end

--- a/NavigationReactNative/src/ios/NVBarButtonView.m
+++ b/NavigationReactNative/src/ios/NVBarButtonView.m
@@ -5,6 +5,7 @@
 #import <React/RCTFont.h>
 #import <React/RCTImageLoaderProtocol.h>
 #import <React/RCTImageSource.h>
+#import <React/RCTResizeMode.h>
 #import <React/UIView+React.h>
 
 @implementation NVBarButtonView
@@ -45,7 +46,7 @@
 - (void)setImage:(RCTImageSource *)source
 {
     if (!!source) {
-        [[_bridge moduleForName:@"ImageLoader"] loadImageWithURLRequest:source.request callback:^(NSError *error, UIImage *image) {
+        [[_bridge moduleForName:@"ImageLoader"] loadImageWithURLRequest:source.request size:source.size scale:source.scale clipped:NO resizeMode:RCTResizeModeCover progressBlock:nil partialLoadBlock:nil completionBlock:^(NSError *error, UIImage *image) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 self -> _image = image;
                 self -> _button.image = image;

--- a/NavigationReactNative/src/ios/NVBarButtonView.m
+++ b/NavigationReactNative/src/ios/NVBarButtonView.m
@@ -1,18 +1,23 @@
 #import "NVBarButtonView.h"
 
 #import <UIKit/UIKit.h>
+#import <React/RCTBridge.h>
 #import <React/RCTFont.h>
+#import <React/RCTImageLoaderProtocol.h>
+#import <React/RCTImageSource.h>
 #import <React/UIView+React.h>
 
 @implementation NVBarButtonView
 {
+    __weak RCTBridge *_bridge;
     NSString *_title;
     UIImage *_image;
 }
 
-- (id)init
+- (id)initWithBridge:(RCTBridge *)bridge
 {
     if (self = [super init]) {
+        _bridge = bridge;
         self.button = [[UIBarButtonItem alloc] init];
         self.button.style = UIBarButtonItemStylePlain;
         self.button.target = self;
@@ -37,10 +42,14 @@
     self.button.title = title;
 }
 
-- (void)setImage:(UIImage *)image
+- (void)setImage:(RCTImageSource *)source
 {
-    _image = image;
-    self.button.image = image;
+    [[_bridge moduleForName:@"ImageLoader"] loadImageWithURLRequest:source.request callback:^(NSError *error, UIImage *image) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            self -> _image = image;
+            self -> _button.image = image;
+        });
+    }];
 }
 
 - (void)setSystemItem:(UIBarButtonSystemItem)systemItem

--- a/NavigationReactNative/src/ios/NVBarButtonView.m
+++ b/NavigationReactNative/src/ios/NVBarButtonView.m
@@ -44,12 +44,17 @@
 
 - (void)setImage:(RCTImageSource *)source
 {
-    [[_bridge moduleForName:@"ImageLoader"] loadImageWithURLRequest:source.request callback:^(NSError *error, UIImage *image) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            self -> _image = image;
-            self -> _button.image = image;
-        });
-    }];
+    if (!!source) {
+        [[_bridge moduleForName:@"ImageLoader"] loadImageWithURLRequest:source.request callback:^(NSError *error, UIImage *image) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                self -> _image = image;
+                self -> _button.image = image;
+            });
+        }];
+    } else {
+        _image = nil;
+        _button.image = nil;
+    }
 }
 
 - (void)setSystemItem:(UIBarButtonSystemItem)systemItem

--- a/NavigationReactNative/src/ios/NVTabBarItemManager.m
+++ b/NavigationReactNative/src/ios/NVTabBarItemManager.m
@@ -3,6 +3,7 @@
 
 #import <UIKit/UIKit.h>
 #import <React/RCTComponent.h>
+#import <React/RCTImageSource.h>
 
  @implementation RCTConvert (UITabBarSystemItem)
 
@@ -30,7 +31,7 @@ RCT_EXPORT_MODULE()
 
 - (UIView *)view
 {
-    return [[NVTabBarItemView alloc] init];
+    return [[NVTabBarItemView alloc] initWithBridge:self.bridge];
 }
 
 RCT_EXPORT_VIEW_PROPERTY(title, NSString)
@@ -40,7 +41,7 @@ RCT_EXPORT_VIEW_PROPERTY(fontStyle, NSString)
 RCT_EXPORT_VIEW_PROPERTY(fontSize, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(badge, NSString)
 RCT_EXPORT_VIEW_PROPERTY(badgeColor, UIColor)
-RCT_EXPORT_VIEW_PROPERTY(image, UIImage)
+RCT_EXPORT_VIEW_PROPERTY(image, RCTImageSource)
 RCT_EXPORT_VIEW_PROPERTY(systemItem, UITabBarSystemItem)
 RCT_EXPORT_VIEW_PROPERTY(onPress, RCTBubblingEventBlock)
 

--- a/NavigationReactNative/src/ios/NVTabBarItemView.h
+++ b/NavigationReactNative/src/ios/NVTabBarItemView.h
@@ -1,4 +1,5 @@
 #import <UIKit/UIKit.h>
+#import <React/RCTBridge.h>
 #import <React/RCTComponent.h>
 
 @interface NVTabBarItemView : UIView
@@ -10,5 +11,7 @@
 @property (nonatomic, copy) NSNumber *fontSize;
 @property (nonatomic, strong) UINavigationController *navigationController;
 @property (nonatomic, copy) RCTBubblingEventBlock onPress;
+
+-(id)initWithBridge: (RCTBridge *)bridge;
 
 @end

--- a/NavigationReactNative/src/ios/NVTabBarItemView.m
+++ b/NavigationReactNative/src/ios/NVTabBarItemView.m
@@ -1,18 +1,24 @@
 #import "NVTabBarItemView.h"
 #import "NVNavigationStackView.h"
 
+#import <React/RCTBridge.h>
 #import <React/RCTFont.h>
+#import <React/RCTImageLoaderProtocol.h>
+#import <React/RCTImageSource.h>
+#import <React/RCTResizeMode.h>
 #import <React/UIView+React.h>
 
 @implementation NVTabBarItemView
 {
+    __weak RCTBridge *_bridge;
     NSString *_title;
     UIImage *_image;
 }
 
-- (id)init
+- (id)initWithBridge:(RCTBridge *)bridge
 {
     if (self = [super init]) {
+        _bridge = bridge;
         self.tab = [[UITabBarItem alloc] init];
     }
     return self;
@@ -36,10 +42,19 @@
     }
 }
 
-- (void)setImage:(UIImage *)image
+- (void)setImage:(RCTImageSource *)source
 {
-    _image = image;
-    self.tab.image = image;
+    if (!!source) {
+        [[_bridge moduleForName:@"ImageLoader"] loadImageWithURLRequest:source.request size:source.size scale:source.scale clipped:NO resizeMode:RCTResizeModeCover progressBlock:nil partialLoadBlock:nil completionBlock:^(NSError *error, UIImage *image) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                self -> _image = image;
+                self -> _tab.image = image;
+            });
+        }];
+    } else {
+        _image = nil;
+        _tab.image = nil;
+    }
 }
 
 - (void)setSystemItem:(UITabBarSystemItem)systemItem


### PR DESCRIPTION
Mapped image props to `RCTImageSource`, instead of loading synchronously with `UIImage`, as [recommended by React Native](https://github.com/facebook/react-native/blob/2103839525444f40e0a802fac8bb74126d7a1379/React/Base/RCTConvert.h#L152)