### PR TITLE
Applied UINavigationBar updates when scene is on top of the stack (iOS)

### DIFF
--- a/NavigationReactNative/src/ios/NVNavigationBarView.m
+++ b/NavigationReactNative/src/ios/NVNavigationBarView.m
@@ -39,7 +39,10 @@
 }
 
 - (void)updateStyle {
-    UINavigationBar *navigationBar = self.reactViewController.navigationController.navigationBar;
+    UINavigationBar *navigationBar;
+    if (self.reactViewController == self.reactViewController.navigationController.topViewController) {
+        navigationBar = self.reactViewController.navigationController.navigationBar;
+    }
     if (@available(iOS 13.0, *)) {
         [navigationBar setTintColor: self.tintColor];
         UINavigationBarAppearance *appearance = [UINavigationBarAppearance new];


### PR DESCRIPTION
There’s one `UINavigationBar` per stack, not one per scene. Applying `tintColor` prop change, for example, when the scene isn’t visible updates the navigation bar of the visible scene. So only applied changes when the scene is at the top of the stack.
