### PR TITLE
Allowed the navigation bar to be hidden when navigating from search results (iOS)

### DIFF
--- a/NavigationReactNative/src/NavigationBar.tsx
+++ b/NavigationReactNative/src/NavigationBar.tsx
@@ -23,7 +23,7 @@ class NavigationBar extends React.Component<any, any> {
                     hidden={hidden}
                     style={{height: Platform.OS === 'android' && collapsingBar ? style.height : null}}
                     {...otherProps}>
-                    {Platform.OS === 'ios' ? children :
+                    {Platform.OS === 'ios' ? !hidden && children :
                         <Container
                             collapse={!!collapsingBar}
                             {...otherProps}

--- a/NavigationReactNative/src/ios/NVSceneController.m
+++ b/NavigationReactNative/src/ios/NVSceneController.m
@@ -59,7 +59,8 @@
     }
 }
 
-- (void)viewWillLayoutSubviews {
+- (void)viewWillLayoutSubviews
+{
     [super viewWillLayoutSubviews];
     NVNavigationBarView *navigationBar = (NVNavigationBarView *) [self.view viewWithTag:NAVIGATION_BAR];
     [self.navigationController setNavigationBarHidden:navigationBar.hidden];

--- a/NavigationReactNative/src/ios/NVSceneController.m
+++ b/NavigationReactNative/src/ios/NVSceneController.m
@@ -59,6 +59,12 @@
     }
 }
 
+- (void)viewWillLayoutSubviews {
+    [super viewWillLayoutSubviews];
+    NVNavigationBarView *navigationBar = (NVNavigationBarView *) [self.view viewWithTag:NAVIGATION_BAR];
+    [self.navigationController setNavigationBarHidden:navigationBar.hidden];
+}
+
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];


### PR DESCRIPTION
Fixes #461

This is a known [iOS bug](https://stackoverflow.com/questions/8950541/setnavigationbarhiddenyes-doesnt-work-with-the-searchdisplaycontroller). Followed [the answer](https://stackoverflow.com/a/22169743/1310468) and hid the navigation bar in `viewWillLayoutSubviews`
