### PR TITLE
Allowed the navigation bar to be hidden when navigating from search results (iOS)

### DIFF
--- a/NavigationReactNative/src/NavigationBar.tsx
+++ b/NavigationReactNative/src/NavigationBar.tsx
@@ -23,7 +23,7 @@ class NavigationBar extends React.Component<any, any> {
                     hidden={hidden}
                     style={{height: Platform.OS === 'android' && collapsingBar ? style.height : null}}
                     {...otherProps}>
-                    {Platform.OS === 'ios' ? children :
+                    {Platform.OS === 'ios' ? !hidden && children :
                         <Container
                             collapse={!!collapsingBar}
                             {...otherProps}

--- a/NavigationReactNative/src/ios/NVSceneController.m
+++ b/NavigationReactNative/src/ios/NVSceneController.m
@@ -45,8 +45,11 @@
     UIViewController *previousController = crumb > 0 ? [self.navigationController.viewControllers objectAtIndex:crumb - 1] : nil;
     NVNavigationBarView *navigationBar = (NVNavigationBarView *) [self.view viewWithTag:NAVIGATION_BAR];
     BOOL hidden = navigationBar.hidden;
-    if (@available(iOS 11.0, *)) {
-        hidden = hidden || previousController.navigationItem.searchController.active;
+    if (@available(iOS 13.0, *)) {
+    } else {
+        if (@available(iOS 11.0, *)) {
+            hidden = hidden || previousController.navigationItem.searchController.active;
+        }
     }
     [self.navigationController setNavigationBarHidden:hidden];
     if (navigationBar.title.length != 0) {

--- a/NavigationReactNative/src/ios/NVSceneController.m
+++ b/NavigationReactNative/src/ios/NVSceneController.m
@@ -59,7 +59,8 @@
     }
 }
 
-- (void)viewWillLayoutSubviews {
+- (void)viewWillLayoutSubviews
+{
     [super viewWillLayoutSubviews];
     NVNavigationBarView *navigationBar = (NVNavigationBarView *) [self.view viewWithTag:NAVIGATION_BAR];
     [self.navigationController setNavigationBarHidden:navigationBar.hidden];

--- a/NavigationReactNative/src/ios/NVSceneController.m
+++ b/NavigationReactNative/src/ios/NVSceneController.m
@@ -59,6 +59,12 @@
     }
 }
 
+- (void)viewWillLayoutSubviews {
+    [super viewWillLayoutSubviews];
+    NVNavigationBarView *navigationBar = (NVNavigationBarView *) [self.view viewWithTag:NAVIGATION_BAR];
+    [self.navigationController setNavigationBarHidden:navigationBar.hidden];
+}
+
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];

--- a/NavigationReactNative/src/ios/NVSceneController.m
+++ b/NavigationReactNative/src/ios/NVSceneController.m
@@ -44,13 +44,11 @@
     NSInteger crumb = [self.navigationController.viewControllers indexOfObject:self];
     UIViewController *previousController = crumb > 0 ? [self.navigationController.viewControllers objectAtIndex:crumb - 1] : nil;
     NVNavigationBarView *navigationBar = (NVNavigationBarView *) [self.view viewWithTag:NAVIGATION_BAR];
-    BOOL setHidden = YES;
+    BOOL hidden = navigationBar.hidden;
     if (@available(iOS 11.0, *)) {
-        setHidden = !previousController.navigationItem.searchController.active;
+        hidden = hidden || previousController.navigationItem.searchController.active;
     }
-    if (setHidden) {
-        [self.navigationController setNavigationBarHidden:navigationBar.hidden];
-    }
+    [self.navigationController setNavigationBarHidden:hidden];
     if (navigationBar.title.length != 0) {
         [self.navigationItem setTitle:navigationBar.title];
     }

--- a/NavigationReactNative/src/ios/NVSceneController.m
+++ b/NavigationReactNative/src/ios/NVSceneController.m
@@ -41,13 +41,19 @@
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
+    NSInteger crumb = [self.navigationController.viewControllers indexOfObject:self];
+    UIViewController *previousController = crumb > 0 ? [self.navigationController.viewControllers objectAtIndex:crumb - 1] : nil;
     NVNavigationBarView *navigationBar = (NVNavigationBarView *) [self.view viewWithTag:NAVIGATION_BAR];
-    [self.navigationController setNavigationBarHidden:navigationBar.hidden];
+    BOOL setHidden = YES;
+    if (@available(iOS 11.0, *)) {
+        setHidden = !previousController.navigationItem.searchController.active;
+    }
+    if (setHidden) {
+        [self.navigationController setNavigationBarHidden:navigationBar.hidden];
+    }
     if (navigationBar.title.length != 0) {
         [self.navigationItem setTitle:navigationBar.title];
     }
-    NSInteger crumb = [self.navigationController.viewControllers indexOfObject:self];
-    UIViewController *previousController = crumb > 0 ? [self.navigationController.viewControllers objectAtIndex:crumb - 1] : nil;
     previousController.navigationItem.backBarButtonItem = nil;
     if (navigationBar.backTitle != nil) {
         previousController.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:navigationBar.backTitle style:UIBarButtonItemStylePlain target:nil action:nil];
@@ -62,8 +68,14 @@
 - (void)viewWillLayoutSubviews
 {
     [super viewWillLayoutSubviews];
+    NSInteger crumb = [self.navigationController.viewControllers indexOfObject:self];
+    UIViewController *previousController = crumb > 0 ? [self.navigationController.viewControllers objectAtIndex:crumb - 1] : nil;
     NVNavigationBarView *navigationBar = (NVNavigationBarView *) [self.view viewWithTag:NAVIGATION_BAR];
-    [self.navigationController setNavigationBarHidden:navigationBar.hidden];
+    if (@available(iOS 11.0, *)) {
+        if (previousController.navigationItem.searchController.active) {
+            [self.navigationController setNavigationBarHidden:navigationBar.hidden];
+        }
+    }
 }
 
 - (void)viewDidAppear:(BOOL)animated


### PR DESCRIPTION
Fixes #461

This is a known [iOS bug](https://stackoverflow.com/questions/8950541/setnavigationbarhiddenyes-doesnt-work-with-the-searchdisplaycontroller). The answer suggests to hide the [navigation bar in viewWillLayoutSubviews](https://stackoverflow.com/a/22169743/1310468). This generally works but also want to keep it in `viewWillAppear` because the earlier the better for consistent animation.

Noticed an existing iOS 12 bug where the navigation bar appears on the search results. In zoom sample, select search then color then cancel then color again and you'll see the search results. That's because iOS hides the navigation bar when search results are open and showing in viewWillAppear makes it show in search results as they animate away. So, if <= iOS 12 don't show navigation bar if search results open in viewWillAppear - wait until viewWillLayoutSubviews.

 




