### PR TITLE
Allowed left bar buttons to be displayed in addition to the back button

### DIFF
--- a/NavigationReactNative/src/LeftBar.ts
+++ b/NavigationReactNative/src/LeftBar.ts
@@ -1,3 +1,0 @@
-import { requireNativeComponent, Platform } from 'react-native';
-
-export default Platform.OS == "ios" ? requireNativeComponent('NVLeftBar', null) : ({children}) => children;

--- a/NavigationReactNative/src/LeftBar.tsx
+++ b/NavigationReactNative/src/LeftBar.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { requireNativeComponent, Platform } from 'react-native';
+
+const LeftBar = ({supplementBack = false, children}) => (
+    Platform.OS === "ios" ?
+        <NVLeftBar supplementBack={supplementBack}>{children}</NVLeftBar> : children
+);
+
+const NVLeftBar = requireNativeComponent<any>("NVLeftBar", null);
+
+export default LeftBar;

--- a/NavigationReactNative/src/RightBar.tsx
+++ b/NavigationReactNative/src/RightBar.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { Platform, requireNativeComponent } from "react-native";
 
-const NVRightBar = requireNativeComponent("NVRightBar", null);
+const RightBar = ({children}) => (
+    Platform.OS === "ios" ?
+        <NVRightBar>{React.Children.toArray(children).reverse()}</NVRightBar> : children
+);
 
-export default Platform.OS === "ios"
-  ? ({ children }) => (
-      <NVRightBar>{React.Children.toArray(children).reverse()}</NVRightBar>
-    )
-  : ({ children }) => children;
+const NVRightBar = requireNativeComponent<any>("NVRightBar", null);
+
+export default RightBar;

--- a/NavigationReactNative/src/ios/NVLeftBarManager.m
+++ b/NavigationReactNative/src/ios/NVLeftBarManager.m
@@ -10,4 +10,6 @@ RCT_EXPORT_MODULE()
     return [[NVLeftBarView alloc] init];
 }
 
+RCT_EXPORT_VIEW_PROPERTY(supplementBack, BOOL)
+
 @end

--- a/NavigationReactNative/src/ios/NVLeftBarView.h
+++ b/NavigationReactNative/src/ios/NVLeftBarView.h
@@ -3,4 +3,7 @@
 #import <UIKit/UIKit.h>
 
 @interface NVLeftBarView : NVBarView
+
+@property (nonatomic, assign) BOOL supplementBack;
+
 @end

--- a/NavigationReactNative/src/ios/NVLeftBarView.m
+++ b/NavigationReactNative/src/ios/NVLeftBarView.m
@@ -9,4 +9,15 @@
     [self.reactViewController.navigationItem setLeftBarButtonItems:buttons];
 }
 
+- (void)didSetProps:(NSArray<NSString *> *)changedProps
+{
+    [self.reactViewController.navigationItem setLeftItemsSupplementBackButton:self.supplementBack];
+}
+
+- (void)didMoveToWindow
+{
+    [super didMoveToWindow];
+    [self.reactViewController.navigationItem setLeftItemsSupplementBackButton:self.supplementBack];
+}
+
 @end

--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -135,9 +135,19 @@ export interface NavigationBarProps {
 export class NavigationBar extends Component<NavigationBarProps> { }
 
 /**
+ * Defines the Left Bar Props contract
+ */
+export interface LeftBarProps {
+    /**
+     * Indicates whether bar buttons display in addition to the back button
+     */
+    supplementBack?: boolean;
+}
+
+    /**
  * Renders buttons in the left UI bar
  */
-export class LeftBar extends Component { }
+export class LeftBar extends Component<LeftBarProps> { }
 
 /**
  * Renders buttons in the right UI bar

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -135,9 +135,19 @@ export interface NavigationBarProps {
 export class NavigationBar extends Component<NavigationBarProps> { }
 
 /**
+ * Defines the Left Bar Props contract
+ */
+export interface LeftBarProps {
+    /**
+     * Indicates whether bar buttons display in addition to the back button
+     */
+    supplementBack?: boolean;
+}
+
+    /**
  * Renders buttons in the left UI bar
  */
-export class LeftBar extends Component { }
+export class LeftBar extends Component<LeftBarProps> { }
 
 /**
  * Renders buttons in the right UI bar


### PR DESCRIPTION
Wrapped the [leftItemsSupplementBackButton from UIKit](https://developer.apple.com/documentation/uikit/uinavigationitem/1624933-leftitemssupplementbackbutton?language=objc) by adding a `supplementBack` prop to the `LeftBar`
```jsx
<LeftBar supplementBack={true}>
  …
</LeftBar>
```
