### PR TITLE
Now uses system default styles for the navigation bar

### DIFF
--- a/NavigationReactNative/src/ios/NVNavigationBarView.m
+++ b/NavigationReactNative/src/ios/NVNavigationBarView.m
@@ -63,8 +63,6 @@
         appearance.backButtonAppearance = [UIBarButtonItemAppearance new];
         appearance.backButtonAppearance.normal.titleTextAttributes = [self backAttributes];
         self.reactViewController.navigationItem.standardAppearance = appearance;
-        self.reactViewController.navigationItem.scrollEdgeAppearance = appearance;
-        self.reactViewController.navigationItem.compactAppearance = appearance;
     } else {
         bool transparent = self.barTintColor && CGColorGetAlpha(self.barTintColor.CGColor) == 0;
         [navigationBar setValue:@(transparent) forKey:@"hidesShadow"];


### PR DESCRIPTION
Fix for #470 

Removed scrollEdgeAppearance and compactAppearance to allow the large title to use the default platform styles.