### PR TITLE
Reset color to default when prop cleared (Android)

### DIFF
--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
@@ -55,14 +55,14 @@ public class CollapsingBarManager extends ViewGroupManager<CollapsingBarView> {
         view.setContentScrim(contentScrimColor != null ? new ColorDrawable(contentScrimColor) : view.defaultContentScrim);
     }
 
-    @ReactProp(name = "collapsedTitleColor", customType = "Color")
-    public void setCollapsedTitleColor(CollapsingBarView view, @Nullable Integer collapsedTitleColor) {
-        view.setCollapsedTitleTextColor(collapsedTitleColor != null ? collapsedTitleColor : view.defaultTitleTextColor);
+    @ReactProp(name = "collapsedTitleColor", customType = "Color", defaultInt = Integer.MAX_VALUE)
+    public void setCollapsedTitleColor(CollapsingBarView view, int collapsedTitleColor) {
+        view.setCollapsedTitleTextColor(collapsedTitleColor != Integer.MAX_VALUE ? collapsedTitleColor : view.defaultTitleTextColor);
     }
 
-    @ReactProp(name = "expandedTitleColor", customType = "Color")
-    public void setExpandedTitleColor(CollapsingBarView view, @Nullable Integer expandedTitleColor) {
-        view.setExpandedTitleColor(expandedTitleColor != null ? expandedTitleColor : view.defaultTitleTextColor);
+    @ReactProp(name = "expandedTitleColor", customType = "Color", defaultInt = Integer.MAX_VALUE)
+    public void setExpandedTitleColor(CollapsingBarView view, int expandedTitleColor) {
+        view.setExpandedTitleColor(expandedTitleColor != Integer.MAX_VALUE ? expandedTitleColor : view.defaultTitleTextColor);
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CollapsingBarManager.java
@@ -50,9 +50,9 @@ public class CollapsingBarManager extends ViewGroupManager<CollapsingBarView> {
         view.setTitleEnabled(titleEnabled);
     }
 
-    @ReactProp(name = "contentScrimColor", customType = "Color")
-    public void setContentScrimColor(CollapsingBarView view, @Nullable Integer contentScrimColor) {
-        view.setContentScrim(contentScrimColor != null ? new ColorDrawable(contentScrimColor) : view.defaultContentScrim);
+    @ReactProp(name = "contentScrimColor", customType = "Color", defaultInt = Integer.MAX_VALUE)
+    public void setContentScrimColor(CollapsingBarView view, int contentScrimColor) {
+        view.setContentScrim(contentScrimColor != Integer.MAX_VALUE ? new ColorDrawable(contentScrimColor) : view.defaultContentScrim);
     }
 
     @ReactProp(name = "collapsedTitleColor", customType = "Color", defaultInt = Integer.MAX_VALUE)

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarManager.java
@@ -31,9 +31,9 @@ public class NavigationBarManager extends ViewGroupManager<NavigationBarView> {
         return new NavigationBarView(reactContext);
     }
 
-    @ReactProp(name = "barTintColor", customType = "Color")
-    public void setBarTintColor(NavigationBarView view, @Nullable Integer barTintColor) {
-        if (barTintColor != null) {
+    @ReactProp(name = "barTintColor", customType = "Color", defaultInt = Integer.MAX_VALUE)
+    public void setBarTintColor(NavigationBarView view, int barTintColor) {
+        if (barTintColor != Integer.MAX_VALUE) {
             view.setBackground(new ColorDrawable(barTintColor));
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 if (Color.alpha(barTintColor) < 255)

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarManager.java
@@ -40,9 +40,9 @@ public class SearchBarManager extends ViewGroupManager<SearchBarView> {
         view.searchView.setInputType(autoCapitalize);
     }
 
-    @ReactProp(name = "barTintColor", customType = "Color")
-    public void setBarTintColor(SearchBarView view, @Nullable Integer barTintColor) {
-        view.setBarTintColor(barTintColor);
+    @ReactProp(name = "barTintColor", customType = "Color", defaultInt = Integer.MAX_VALUE)
+    public void setBarTintColor(SearchBarView view, int barTintColor) {
+        view.setBarTintColor(barTintColor != Integer.MAX_VALUE ? barTintColor : null);
     }
 
     @Nonnull

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemManager.java
@@ -58,9 +58,9 @@ public class TabBarItemManager extends ViewGroupManager<TabBarItemView> {
         view.setBadge(badge);
     }
 
-    @ReactProp(name = "badgeColor", customType = "Color")
-    public void setBadgeColor(TabBarItemView view, @Nullable Integer badgeColor) {
-        view.setBadgeColor(badgeColor);
+    @ReactProp(name = "badgeColor", customType = "Color", defaultInt = Integer.MAX_VALUE)
+    public void setBadgeColor(TabBarItemView view, int badgeColor) {
+        view.setBadgeColor(badgeColor != Integer.MAX_VALUE ? badgeColor : null);
     }
 
     @ReactProp(name = "testID")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutManager.java
@@ -22,9 +22,9 @@ public class TabLayoutManager extends ViewGroupManager<TabLayoutView> {
         view.bottomTabs = bottomTabs;
     }
 
-    @ReactProp(name = "selectedTintColor", customType = "Color")
-    public void setSelectedTintColor(TabLayoutView view, @Nullable Integer selectedTintColor) {
-        view.selectedTintColor = selectedTintColor != null ? selectedTintColor : view.defaultTextColor;
+    @ReactProp(name = "selectedTintColor", customType = "Color", defaultInt = Integer.MAX_VALUE)
+    public void setSelectedTintColor(TabLayoutView view, int selectedTintColor) {
+        view.selectedTintColor = selectedTintColor != Integer.MAX_VALUE ? selectedTintColor : view.defaultTextColor;
         view.setTabTextColors(view.unselectedTintColor, view.selectedTintColor);
         view.setSelectedTabIndicatorColor(view.selectedTintColor);
         view.setTabIconTint(view.getTabTextColors());

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutManager.java
@@ -30,9 +30,9 @@ public class TabLayoutManager extends ViewGroupManager<TabLayoutView> {
         view.setTabIconTint(view.getTabTextColors());
     }
 
-    @ReactProp(name = "unselectedTintColor", customType = "Color")
-    public void setUnselectedTintColor(TabLayoutView view, @Nullable Integer  unselectedTintColor) {
-        view.unselectedTintColor = unselectedTintColor != null ? unselectedTintColor : view.defaultTextColor;
+    @ReactProp(name = "unselectedTintColor", customType = "Color", defaultInt = Integer.MAX_VALUE)
+    public void setUnselectedTintColor(TabLayoutView view, int unselectedTintColor) {
+        view.unselectedTintColor = unselectedTintColor != Integer.MAX_VALUE ? unselectedTintColor : view.defaultTextColor;
         view.setTabTextColors(view.unselectedTintColor, view.selectedTintColor);
         view.setTabIconTint(view.getTabTextColors());
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutRTLManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutRTLManager.java
@@ -17,17 +17,17 @@ public class TabLayoutRTLManager extends ViewGroupManager<TabLayoutRTLView> {
         return "NVTabLayoutRTL";
     }
 
-    @ReactProp(name = "selectedTintColor", customType = "Color")
-    public void setSelectedTintColor(TabLayoutRTLView view, @Nullable Integer selectedTintColor) {
-        view.selectedTintColor = selectedTintColor != null ? selectedTintColor : view.defaultTextColor;
+    @ReactProp(name = "selectedTintColor", customType = "Color", defaultInt = Integer.MAX_VALUE)
+    public void setSelectedTintColor(TabLayoutRTLView view, int selectedTintColor) {
+        view.selectedTintColor = selectedTintColor != Integer.MAX_VALUE ? selectedTintColor : view.defaultTextColor;
         view.setTabTextColors(view.unselectedTintColor, view.selectedTintColor);
         view.setSelectedTabIndicatorColor(view.selectedTintColor);
         view.setTabIconTint(view.getTabTextColors());
     }
 
-    @ReactProp(name = "unselectedTintColor", customType = "Color")
-    public void setUnselectedTintColor(TabLayoutRTLView view, @Nullable Integer  unselectedTintColor) {
-        view.unselectedTintColor = unselectedTintColor != null ? unselectedTintColor : view.defaultTextColor;
+    @ReactProp(name = "unselectedTintColor", customType = "Color", defaultInt = Integer.MAX_VALUE)
+    public void setUnselectedTintColor(TabLayoutRTLView view, int unselectedTintColor) {
+        view.unselectedTintColor = unselectedTintColor != Integer.MAX_VALUE ? unselectedTintColor : view.defaultTextColor;
         view.setTabTextColors(view.unselectedTintColor, view.selectedTintColor);
         view.setTabIconTint(view.getTabTextColors());
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationManager.java
@@ -34,9 +34,9 @@ public class TabNavigationManager extends ViewGroupManager<TabNavigationView> {
         view.setItemIconTintList(view.getItemTextColor());
     }
 
-    @ReactProp(name = "unselectedTintColor", customType = "Color")
-    public void setUnselectedTintColor(TabNavigationView view, @Nullable Integer unselectedTintColor) {
-        view.unselectedTintColor = unselectedTintColor != null ? unselectedTintColor : view.defaultTextColor;
+    @ReactProp(name = "unselectedTintColor", customType = "Color", defaultInt = Integer.MAX_VALUE)
+    public void setUnselectedTintColor(TabNavigationView view, int unselectedTintColor) {
+        view.unselectedTintColor = unselectedTintColor != Integer.MAX_VALUE ? unselectedTintColor : view.defaultTextColor;
         view.setItemTextColor(new ColorStateList(
             new int[][]{ new int[]{-android.R.attr.state_checked}, new int[]{android.R.attr.state_checked }},
             new int[]{ view.unselectedTintColor, view.selectedTintColor }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationManager.java
@@ -24,9 +24,9 @@ public class TabNavigationManager extends ViewGroupManager<TabNavigationView> {
         view.bottomTabs = bottomTabs;
     }
 
-    @ReactProp(name = "selectedTintColor", customType = "Color")
-    public void setSelectedTintColor(TabNavigationView view, @Nullable Integer selectedTintColor) {
-        view.selectedTintColor = selectedTintColor != null ? selectedTintColor : view.defaultTextColor;
+    @ReactProp(name = "selectedTintColor", customType = "Color", defaultInt = Integer.MAX_VALUE)
+    public void setSelectedTintColor(TabNavigationView view, int selectedTintColor) {
+        view.selectedTintColor = selectedTintColor != Integer.MAX_VALUE ? selectedTintColor : view.defaultTextColor;
         view.setItemTextColor(new ColorStateList(
             new int[][]{ new int[]{-android.R.attr.state_checked}, new int[]{android.R.attr.state_checked }},
             new int[]{ view.unselectedTintColor, view.selectedTintColor }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarManager.java
@@ -84,9 +84,9 @@ public class ToolbarManager extends ViewGroupManager<ToolbarView> {
         view.setTintColor(tintColor);
     }
 
-    @ReactProp(name = "titleColor", customType = "Color")
-    public void setTitleColor(ToolbarView view, Integer textColor) {
-        view.setTitleTextColor(textColor != null ? textColor : view.defaultTitleTextColor);
+    @ReactProp(name = "titleColor", customType = "Color", defaultInt = Integer.MAX_VALUE)
+    public void setTitleColor(ToolbarView view, int textColor) {
+        view.setTitleTextColor(textColor != Integer.MAX_VALUE ? textColor : view.defaultTitleTextColor);
     }
 
     @ReactProp(name = "height")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarManager.java
@@ -71,9 +71,9 @@ public class ToolbarManager extends ViewGroupManager<ToolbarView> {
         view.setOverflowIconSource(overflowIcon);
     }
 
-    @ReactProp(name = "barTintColor", customType = "Color")
-    public void setBarTintColor(ToolbarView view, Integer barTintColor) {
-        if (barTintColor != null)
+    @ReactProp(name = "barTintColor", customType = "Color", defaultInt = Integer.MAX_VALUE)
+    public void setBarTintColor(ToolbarView view, int barTintColor) {
+        if (barTintColor != Integer.MAX_VALUE)
             view.setBackgroundColor(barTintColor);
         else
             view.setBackground(null);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarManager.java
@@ -79,9 +79,9 @@ public class ToolbarManager extends ViewGroupManager<ToolbarView> {
             view.setBackground(null);
     }
 
-    @ReactProp(name = "tintColor", customType = "Color")
-    public void setTintColor(ToolbarView view, Integer tintColor) {
-        view.setTintColor(tintColor);
+    @ReactProp(name = "tintColor", customType = "Color", defaultInt = Integer.MAX_VALUE)
+    public void setTintColor(ToolbarView view, int tintColor) {
+        view.setTintColor(tintColor != Integer.MAX_VALUE ? tintColor : null);
     }
 
     @ReactProp(name = "titleColor", customType = "Color", defaultInt = Integer.MAX_VALUE)


### PR DESCRIPTION
Take any color prop and reset it to null then it should have its default value. But this stopped working on Android because React Native won't ever pass null for a color value. Used a null value for colors of MAX_INT instead