### PR TITLE
Applied barTintColor prop to large title background (iOS >= 13)

### DIFF
--- a/NavigationReactNative/src/ios/NVNavigationBarView.m
+++ b/NavigationReactNative/src/ios/NVNavigationBarView.m
@@ -46,10 +46,12 @@
     if (@available(iOS 13.0, *)) {
         [navigationBar setTintColor: self.tintColor];
         UINavigationBarAppearance *appearance = [UINavigationBarAppearance new];
-        bool transparent = self.barTintColor && CGColorGetAlpha(self.barTintColor.CGColor) == 0;
         [appearance configureWithDefaultBackground];
-        if (transparent) {
-            [appearance configureWithTransparentBackground];
+        if (self.barTintColor) {
+            [appearance configureWithOpaqueBackground];
+            if (CGColorGetAlpha(self.barTintColor.CGColor) == 0) {
+                [appearance configureWithTransparentBackground];
+            }
         }
         NSMutableDictionary *attributes = [NSMutableDictionary new];
         if (self.tintColor != nil) {
@@ -63,6 +65,9 @@
         appearance.backButtonAppearance = [UIBarButtonItemAppearance new];
         appearance.backButtonAppearance.normal.titleTextAttributes = [self backAttributes];
         self.reactViewController.navigationItem.standardAppearance = appearance;
+        if (self.barTintColor) {
+            self.reactViewController.navigationItem.scrollEdgeAppearance = appearance;
+        }
     } else {
         bool transparent = self.barTintColor && CGColorGetAlpha(self.barTintColor.CGColor) == 0;
         [navigationBar setValue:@(transparent) forKey:@"hidesShadow"];

--- a/NavigationReactNative/src/ios/NVNavigationBarView.m
+++ b/NavigationReactNative/src/ios/NVNavigationBarView.m
@@ -65,9 +65,7 @@
         appearance.backButtonAppearance = [UIBarButtonItemAppearance new];
         appearance.backButtonAppearance.normal.titleTextAttributes = [self backAttributes];
         self.reactViewController.navigationItem.standardAppearance = appearance;
-        if (self.barTintColor) {
-            self.reactViewController.navigationItem.scrollEdgeAppearance = appearance;
-        }
+        self.reactViewController.navigationItem.scrollEdgeAppearance = self.barTintColor ? appearance : nil;
     } else {
         bool transparent = self.barTintColor && CGColorGetAlpha(self.barTintColor.CGColor) == 0;
         [navigationBar setValue:@(transparent) forKey:@"hidesShadow"];


### PR DESCRIPTION
Accidentally lost this in #471.  Still want to keep system defaults for large titles, so only set a `scrollEdgeAppearance` if the `barTintColor` prop is set