### PR TITLE
Improved performance of search bar initialisation (iOS)

### DIFF
--- a/NavigationReactNative/src/ios/NVSceneController.m
+++ b/NavigationReactNative/src/ios/NVSceneController.m
@@ -27,8 +27,8 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    NVSearchBarView *searchBar = (NVSearchBarView *) [self.view viewWithTag:SEARCH_BAR];
     NVNavigationBarView *navigationBar = (NVNavigationBarView *) [self.view viewWithTag:NAVIGATION_BAR];
+    NVSearchBarView *searchBar = (NVSearchBarView *) [navigationBar viewWithTag:SEARCH_BAR];
     self.definesPresentationContext = true;
     if (!!searchBar && !navigationBar.hidden)
     {


### PR DESCRIPTION
The search bar is always inside a navigation bar. So used `viewWithTag` from the navigation bar instead of from the scene to avoid searching the whole view hierarchy. There's likely not to be a search bar anyway so it was searching all views in the hierarchy