### PR TITLE
Supported custom views in BarButtons on iOS

### DIFF
--- a/NavigationReactNative/src/BarButton.tsx
+++ b/NavigationReactNative/src/BarButton.tsx
@@ -23,9 +23,9 @@ const NVBarButton = requireNativeComponent<any>('NVBarButton', null)
 
 const styles = StyleSheet.create({
     actionView: {
+        position: 'absolute',
         ...Platform.select({
             android: {
-                position: 'absolute',
                 top: 0, right: 0,
                 bottom: 0, left: 0,
             },

--- a/NavigationReactNative/src/ios/NVBarButtonView.m
+++ b/NavigationReactNative/src/ios/NVBarButtonView.m
@@ -73,6 +73,23 @@
     }
 }
 
+- (void)insertReactSubview:(UIView *)subview atIndex:(NSInteger)atIndex
+{
+    [super insertReactSubview:subview atIndex:atIndex];
+    [self.button setCustomView:subview];
+}
+
+- (void)removeReactSubview:(UIView *)subview
+{
+    [super removeReactSubview:subview];
+    if (self.button.customView == subview)
+        [self.button setCustomView:nil];
+}
+
+- (void)didUpdateReactSubviews
+{
+}
+
 - (void)didSetProps:(NSArray<NSString *> *)changedProps
 {
     if ([changedProps containsObject:@"fontFamily"] || [changedProps containsObject:@"fontWeight"]

--- a/NavigationReactNative/src/ios/NVBarButtonView.m
+++ b/NavigationReactNative/src/ios/NVBarButtonView.m
@@ -14,9 +14,7 @@
 @implementation NVBarButtonView
 {
     __weak RCTBridge *_bridge;
-    NSString *_title;
     NSString *_testID;
-    UIImage *_image;
 }
 
 - (id)initWithBridge:(RCTBridge *)bridge
@@ -33,7 +31,6 @@
 
 - (void)setTitle:(NSString *)title
 {
-    _title = title;
     self.button.title = title;
 }
 
@@ -48,12 +45,10 @@
     if (!!source) {
         [[_bridge moduleForName:@"ImageLoader"] loadImageWithURLRequest:source.request size:source.size scale:source.scale clipped:NO resizeMode:RCTResizeModeCover progressBlock:nil partialLoadBlock:nil completionBlock:^(NSError *error, UIImage *image) {
             dispatch_async(dispatch_get_main_queue(), ^{
-                self -> _image = image;
                 self -> _button.image = image;
             });
         }];
     } else {
-        _image = nil;
         _button.image = nil;
     }
 }
@@ -62,13 +57,6 @@
 {
     if (systemItem != NSNotFound) {
         self.button = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:systemItem target:self action:@selector(buttonPressed)];
-    } else {
-        self.button = [[UIBarButtonItem alloc] init];
-        self.button.style = UIBarButtonItemStylePlain;
-        self.button.target = self;
-        self.button.action = @selector(buttonPressed);
-        self.button.image = _image;
-        self.button.title = _title;
         self.button.accessibilityIdentifier = _testID;
     }
 }


### PR DESCRIPTION
Fixes #496 & #502

Render the custom view as a child of the `BarButton`, for example,

```jsx
<LeftBar>
  <BarButton>
    <TouchableHighlight onPress={() => {}}>
      <Image />
    </TouchableHighlight>
  </BarButton>
</LeftBar>
```
