### PR TITLE
Compiled parseLink TypeScript definition with strict type checking enabled

### DIFF
--- a/Navigation/test/navigation-tests.ts
+++ b/Navigation/test/navigation-tests.ts
@@ -1,4 +1,4 @@
-// tsc --target es3 --lib ES2015,DOM --noImplicitAny true navigation-tests.ts
+// tsc --target es3 --lib ES2015,DOM --noImplicitAny true --strict true navigation-tests.ts
 import { HashHistoryManager, StateNavigator, State } from 'navigation';
 
 // History Manager

--- a/Navigation/test/node_modules/@types/navigation.d.ts
+++ b/Navigation/test/node_modules/@types/navigation.d.ts
@@ -563,8 +563,8 @@ export class StateNavigator<NavigationInfo extends { [index: string]: any } = an
      * Parses the url out into State and Navigation Data
      * @param url The url to parse
      */
-
-    parseLink<StateKey extends keyof NavigationInfo = undefined>(url: string): { state: StateKey extends undefined ? State : State<StateKey & string, NavigationInfo[StateKey]>; data: StateKey extends undefined ? any : NavigationInfo[StateKey]; crumbs: Crumb[] };
+    parseLink(url: string): { state: State; data: any; crumbs: Crumb[] };
+    parseLink<StateKey extends keyof NavigationInfo>(url: string): { state: State<StateKey & string, NavigationInfo[StateKey]>; data: NavigationInfo[StateKey]; crumbs: Crumb[] };
     /**
      * Creates a FluentNavigator
      * @param withContext a value indicating whether to inherit the current

--- a/NavigationReact/test/navigation-react-tests.tsx
+++ b/NavigationReact/test/navigation-react-tests.tsx
@@ -1,4 +1,4 @@
-// tsc --jsx react --target es3 --lib ES2015,DOM --esModuleInterop --noImplicitAny true navigation-react-tests.tsx
+// tsc --jsx react --target es3 --lib ES2015,DOM --esModuleInterop --noImplicitAny true --strict true navigation-react-tests.tsx
 import { StateNavigator } from 'navigation';
 import { NavigationHandler, NavigationContext, NavigationEvent, NavigationBackLink, NavigationLink, RefreshLink } from 'navigation-react';
 import React, { useContext } from 'react';
@@ -31,7 +31,7 @@ const People = () => {
                 ))}
             </ul>
             <RefreshLink<AppNavigation, 'people'>
-                navigationData={{ page: page + 1 }}
+                navigationData={{ page: page! + 1 }}
                 disableActive={true}
                 includeCurrentData={true}>
                 Next

--- a/NavigationReact/test/node_modules/@types/navigation.d.ts
+++ b/NavigationReact/test/node_modules/@types/navigation.d.ts
@@ -563,8 +563,8 @@ export class StateNavigator<NavigationInfo extends { [index: string]: any } = an
      * Parses the url out into State and Navigation Data
      * @param url The url to parse
      */
-
-    parseLink<StateKey extends keyof NavigationInfo = undefined>(url: string): { state: StateKey extends undefined ? State : State<StateKey & string, NavigationInfo[StateKey]>; data: StateKey extends undefined ? any : NavigationInfo[StateKey]; crumbs: Crumb[] };
+    parseLink(url: string): { state: State; data: any; crumbs: Crumb[] };
+    parseLink<StateKey extends keyof NavigationInfo>(url: string): { state: State<StateKey & string, NavigationInfo[StateKey]>; data: NavigationInfo[StateKey]; crumbs: Crumb[] };
     /**
      * Creates a FluentNavigator
      * @param withContext a value indicating whether to inherit the current

--- a/NavigationReactMobile/test/navigation-react-mobile-tests.tsx
+++ b/NavigationReactMobile/test/navigation-react-mobile-tests.tsx
@@ -1,4 +1,4 @@
-// tsc --jsx react --target es3 --lib ES2015,DOM --esModuleInterop --noImplicitAny true navigation-react-mobile-tests.tsx
+// tsc --jsx react --target es3 --lib ES2015,DOM --esModuleInterop --noImplicitAny true --strict true navigation-react-mobile-tests.tsx
 import { StateNavigator } from 'navigation';
 import { NavigationContext, NavigationEvent, NavigationLink } from 'navigation-react';
 import { NavigationMotion, MobileHistoryManager, SharedElement, SharedElementMotion } from 'navigation-react-mobile';

--- a/NavigationReactMobile/test/node_modules/@types/navigation.d.ts
+++ b/NavigationReactMobile/test/node_modules/@types/navigation.d.ts
@@ -563,8 +563,8 @@ export class StateNavigator<NavigationInfo extends { [index: string]: any } = an
      * Parses the url out into State and Navigation Data
      * @param url The url to parse
      */
-
-    parseLink<StateKey extends keyof NavigationInfo = undefined>(url: string): { state: StateKey extends undefined ? State : State<StateKey & string, NavigationInfo[StateKey]>; data: StateKey extends undefined ? any : NavigationInfo[StateKey]; crumbs: Crumb[] };
+    parseLink(url: string): { state: State; data: any; crumbs: Crumb[] };
+    parseLink<StateKey extends keyof NavigationInfo>(url: string): { state: State<StateKey & string, NavigationInfo[StateKey]>; data: NavigationInfo[StateKey]; crumbs: Crumb[] };
     /**
      * Creates a FluentNavigator
      * @param withContext a value indicating whether to inherit the current

--- a/NavigationReactNative/test/navigation-react-native-tests.tsx
+++ b/NavigationReactNative/test/navigation-react-native-tests.tsx
@@ -1,4 +1,4 @@
-// tsc --jsx react --target es6 --lib ES2015 --esModuleInterop --noImplicitAny true navigation-react-native-tests.tsx
+// tsc --jsx react --target es6 --lib ES2015 --esModuleInterop --noImplicitAny true --strict true navigation-react-native-tests.tsx
 import React, { useContext, useState } from 'react';
 import { View, Text, ScrollView, TouchableHighlight } from 'react-native';
 import { StateNavigator } from 'navigation';

--- a/NavigationReactNative/test/node_modules/@types/navigation.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation.d.ts
@@ -563,8 +563,8 @@ export class StateNavigator<NavigationInfo extends { [index: string]: any } = an
      * Parses the url out into State and Navigation Data
      * @param url The url to parse
      */
-
-    parseLink<StateKey extends keyof NavigationInfo = undefined>(url: string): { state: StateKey extends undefined ? State : State<StateKey & string, NavigationInfo[StateKey]>; data: StateKey extends undefined ? any : NavigationInfo[StateKey]; crumbs: Crumb[] };
+    parseLink(url: string): { state: State; data: any; crumbs: Crumb[] };
+    parseLink<StateKey extends keyof NavigationInfo>(url: string): { state: State<StateKey & string, NavigationInfo[StateKey]>; data: NavigationInfo[StateKey]; crumbs: Crumb[] };
     /**
      * Creates a FluentNavigator
      * @param withContext a value indicating whether to inherit the current

--- a/build/npm/navigation/navigation.d.ts
+++ b/build/npm/navigation/navigation.d.ts
@@ -563,8 +563,8 @@ export class StateNavigator<NavigationInfo extends { [index: string]: any } = an
      * Parses the url out into State and Navigation Data
      * @param url The url to parse
      */
-
-    parseLink<StateKey extends keyof NavigationInfo = undefined>(url: string): { state: StateKey extends undefined ? State : State<StateKey & string, NavigationInfo[StateKey]>; data: StateKey extends undefined ? any : NavigationInfo[StateKey]; crumbs: Crumb[] };
+    parseLink(url: string): { state: State; data: any; crumbs: Crumb[] };
+    parseLink<StateKey extends keyof NavigationInfo>(url: string): { state: State<StateKey & string, NavigationInfo[StateKey]>; data: NavigationInfo[StateKey]; crumbs: Crumb[] };
     /**
      * Creates a FluentNavigator
      * @param withContext a value indicating whether to inherit the current


### PR DESCRIPTION
Fixes #513

Overloaded `parseLink` type definition with generic version to get correct return types
```ts
parseLink('list') // returns State<string, any>
parseLink<'people'>('list') // returns State<’people', {page?: number}>
```
