### PR TITLE
Fix NVTitleBar not reporting its final size to RN

### DIFF
--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TitleBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TitleBarView.java
@@ -3,6 +3,10 @@ package com.navigation.reactnative;
 import android.content.Context;
 import android.view.ViewGroup;
 
+import com.facebook.react.bridge.GuardedRunnable;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.uimanager.UIManagerModule;
+
 public class TitleBarView extends ViewGroup {
     public TitleBarView(Context context) {
         super(context);
@@ -10,5 +14,24 @@ public class TitleBarView extends ViewGroup {
 
     @Override
     protected void onLayout(boolean changed, int l, int t, int r, int b) {
+    }
+
+    @Override
+    protected void onSizeChanged(final int w, final int h, int oldw, int oldh) {
+        super.onSizeChanged(w, h, oldw, oldh);
+        if (w == oldw && h == oldh) {
+            return;
+        }
+        final int viewTag = getId();
+        final ReactContext reactContext = (ReactContext) getContext();
+        reactContext.runOnNativeModulesQueueThread(
+                new GuardedRunnable(reactContext) {
+                    @Override
+                    public void runGuarded() {
+                        UIManagerModule uiManager = reactContext.getNativeModule(UIManagerModule.class);
+                        if (uiManager != null)
+                            uiManager.updateNodeSize(viewTag, w, h);
+                    }
+                });
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarManager.java
@@ -145,6 +145,10 @@ public class ToolbarManager extends ViewGroupManager<ToolbarView> {
         return parent.children.get(index);
     }
 
+    @Override
+    public boolean needsCustomLayoutForChildren() {
+        return true;
+    }
 
     @Override
     protected void onAfterUpdateTransaction(@NonNull ToolbarView view) {

--- a/NavigationReactNative/src/ios/NVTitleBarManager.m
+++ b/NavigationReactNative/src/ios/NVTitleBarManager.m
@@ -6,7 +6,7 @@
 RCT_EXPORT_MODULE()
 
 - (UIView *)view {
-    return [[NVTitleBarView alloc] init];
+    return [[NVTitleBarView alloc] initWithBridge:self.bridge];
 }
 
 @end

--- a/NavigationReactNative/src/ios/NVTitleBarView.h
+++ b/NavigationReactNative/src/ios/NVTitleBarView.h
@@ -4,4 +4,6 @@
 
 @interface NVTitleBarView : UIView
 
+-(id)initWithBridge: (RCTBridge *)bridge;
+
 @end

--- a/NavigationReactNative/src/ios/NVTitleBarView.m
+++ b/NavigationReactNative/src/ios/NVTitleBarView.m
@@ -6,6 +6,7 @@
 @implementation NVTitleBarView
 {
     __weak RCTBridge *_bridge;
+    CGRect _lastViewFrame;
 }
 
 - (id)initWithBridge:(RCTBridge *)bridge
@@ -32,7 +33,10 @@
 
 - (void)layoutSubviews {
     [super layoutSubviews];
-    [_bridge.uiManager setSize:self.bounds.size forView:self];
+    if (!CGRectEqualToRect(_lastViewFrame, self.frame)) {
+        [_bridge.uiManager setSize:self.frame.size forView:self];
+        _lastViewFrame = self.frame;
+    }
 }
 
 @end

--- a/NavigationReactNative/src/ios/NVTitleBarView.m
+++ b/NavigationReactNative/src/ios/NVTitleBarView.m
@@ -1,8 +1,20 @@
 #import "NVTitleBarView.h"
 
 #import <React/UIView+React.h>
+#import <React/RCTUIManager.h>
 
 @implementation NVTitleBarView
+{
+    __weak RCTBridge *_bridge;
+}
+
+- (id)initWithBridge:(RCTBridge *)bridge
+{
+    if (self = [super initWithFrame:CGRectZero]) {
+        _bridge = bridge;
+    }
+    return self;
+}
 
 - (void)didMoveToWindow {
     [super didMoveToWindow];
@@ -16,6 +28,11 @@
     if (newSuperview == nil) {
         self.reactViewController.navigationItem.titleView = nil;
     }
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    [_bridge.uiManager setSize:self.bounds.size forView:self];
 }
 
 @end


### PR DESCRIPTION
Fixes #515 

When the NVTitleBar is mounted, it is given a size of the entire screen. As the rest of the navigation bar mounts, that size changes - buttons in the title will make it narrower. This makes it difficult to do things like truncate text.

This PR resolves that, by calling `setSize` on the UIManager inside `layoutSubviews`. This resolves most of the issue with layout in the title bar.

There is an outstanding issue with having multiple children within the `TitleBar` - each appears to layout as though they are the only child. This can be resolved by adding padding to the `TitleBar` if the width of some children is known ahead of time.