### PR TITLE
Supported fragment identifiers

### DIFF
--- a/Navigation/src/FluentNavigator.ts
+++ b/Navigation/src/FluentNavigator.ts
@@ -27,7 +27,7 @@ function createFluentNavigator(states: { [index: string]: State }, stateHandler:
         fluentContext.crumbs = crumbs;
         fluentContext.data = data;
         fluentContext.hash = hash;
-        fluentContext.nextCrumb = new Crumb(data, state, hash, url, stateHandler.getLink(state, data, hash), false);
+        fluentContext.nextCrumb = new Crumb(data, state, url, stateHandler.getLink(state, data, hash), false, hash);
         return createFluentNavigator(states, stateHandler, fluentContext);
     }
 

--- a/Navigation/src/StateHandler.ts
+++ b/Navigation/src/StateHandler.ts
@@ -149,7 +149,7 @@ class StateHandler {
             var { state, data, hash } = this.parseLink(crumblessUrl);
             delete data[state.crumbTrailKey];
             var url = this.getNavigationLink(state, data, hash, crumbTrail.slice(0, i));
-            crumbs.push(new Crumb(data, state, hash, url, crumblessUrl, i + 1 === len));
+            crumbs.push(new Crumb(data, state, url, crumblessUrl, i + 1 === len, hash));
         }
         return crumbs;
     }

--- a/Navigation/src/StateHandler.ts
+++ b/Navigation/src/StateHandler.ts
@@ -84,12 +84,12 @@ class StateHandler {
         if (query.length > 0)
             routeInfo.route += '?' + query.join('&');
         if (hash)
-            routeInfo.route += '#' + encodeURIComponent(hash);
+            routeInfo.route += '#' + hash;
         return routeInfo.route;
     }
 
     parseLink(url: string, fromRoute?: Route, err = ''): { state: State, data: any, hash: string } {
-        var hashIndex = url.lastIndexOf('#');
+        var hashIndex = url.indexOf('#');
         var pathAndQuery = hashIndex < 0 ? url : url.substring(0, hashIndex);
         var queryIndex = pathAndQuery.indexOf('?');
         var path = queryIndex < 0 ? pathAndQuery : pathAndQuery.substring(0, queryIndex);
@@ -104,7 +104,7 @@ class StateHandler {
             err += '\n' + e.message;
         }
         if (navigationData) {
-            var hash = hashIndex >= 0 ? decodeURIComponent(url.substring(hashIndex + 1)) : null;
+            var hash = hashIndex >= 0 ? url.substring(hashIndex + 1) : null;
             return { ...navigationData, hash };
         }
         return this.parseLink(url, route, err);        

--- a/Navigation/src/StateNavigator.ts
+++ b/Navigation/src/StateNavigator.ts
@@ -63,7 +63,7 @@ class StateNavigator {
         stateContext.crumbs = crumbs;
         stateContext.data = data;
         stateContext.hash = hash;
-        stateContext.nextCrumb = new Crumb(data, state, hash, url, this.stateHandler.getLink(state, data, hash), false);
+        stateContext.nextCrumb = new Crumb(data, state, url, this.stateHandler.getLink(state, data, hash), false, hash);
         stateContext.previousState = null;
         stateContext.previousData = {};
         stateContext.previousUrl = null;

--- a/Navigation/src/StateNavigator.ts
+++ b/Navigation/src/StateNavigator.ts
@@ -77,8 +77,8 @@ class StateNavigator {
         return stateContext;
     }
 
-    navigate(stateKey: string, navigationData?: any, historyAction?: 'add' | 'replace' | 'none', hash?: string) {
-        var url = this.getNavigationLink(stateKey, navigationData, hash);
+    navigate(stateKey: string, navigationData?: any, historyAction?: 'add' | 'replace' | 'none') {
+        var url = this.getNavigationLink(stateKey, navigationData);
         if (url == null)
             throw new Error('Invalid route data, a mandatory route parameter has not been supplied a value');
         this.navigateLink(url, historyAction);
@@ -106,8 +106,8 @@ class StateNavigator {
         return this.stateContext.crumbs[this.stateContext.crumbs.length - distance].url;
     }
 
-    refresh(navigationData?: any, historyAction?: 'add' | 'replace' | 'none', hash?: string) {
-        var url = this.getRefreshLink(navigationData, hash);
+    refresh(navigationData?: any, historyAction?: 'add' | 'replace' | 'none') {
+        var url = this.getRefreshLink(navigationData);
         if (url == null)
             throw new Error('Invalid route data, a mandatory route parameter has not been supplied a value');
         this.navigateLink(url, historyAction);

--- a/Navigation/src/StateNavigator.ts
+++ b/Navigation/src/StateNavigator.ts
@@ -107,7 +107,7 @@ class StateNavigator {
     }
 
     refresh(navigationData?: any, historyAction?: 'add' | 'replace' | 'none', hash?: string) {
-        var url = this.getRefreshLink(navigationData);
+        var url = this.getRefreshLink(navigationData, hash);
         if (url == null)
             throw new Error('Invalid route data, a mandatory route parameter has not been supplied a value');
         this.navigateLink(url, historyAction);

--- a/Navigation/src/config/Crumb.ts
+++ b/Navigation/src/config/Crumb.ts
@@ -9,7 +9,7 @@ class Crumb {
     url: string;
     crumblessUrl: string;
 
-    constructor(data: any, state: State, hash: string, url: string, crumblessUrl: string, last: boolean) {
+    constructor(data: any, state: State, url: string, crumblessUrl: string, last: boolean, hash: string) {
         this.data = data ? data : {};
         this.state = state;
         this.hash = hash;

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -1271,6 +1271,23 @@ describe('Fluent', function () {
         });
     });
 
+    describe('Hash Refresh Hash Back', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0', null, 'f0')
+                .navigate('s1')
+                .refresh(null, 'f1')
+                .navigateBack(1)
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0%23f0');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
     describe('Refresh Back Custom Trail', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -330,6 +330,22 @@ describe('Fluent', function () {
         });
     });
 
+    describe('Refresh Empty Hash', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .refresh(null, '')
+                .url;
+            assert.strictEqual(url, '/r1');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
     describe('Back With Trail', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -119,6 +119,21 @@ describe('Fluent', function () {
         });
     });
 
+    describe('Transition Hash', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1', null, 'f')
+                .url;
+            assert.strictEqual(url, '/r1#f');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
     describe('Transition With Trail', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -164,6 +164,21 @@ describe('Fluent', function () {
         });
     });
 
+    describe('Hash Transition Hash With Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0', null, 'f0')
+                .navigate('s1', null, 'f1')
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0%23f0#f1');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
     describe('Transition Hash With Trail', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -149,6 +149,21 @@ describe('Fluent', function () {
         });
     });
 
+    describe('Hash Transition With Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0', null, 'f')
+                .navigate('s1')
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0%23f');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
     describe('Transition Hash With Trail', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -266,6 +266,22 @@ describe('Fluent', function () {
         });
     });
 
+    describe('Refresh Hash With Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .refresh(null, 'f')
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0&crumb=%2Fr1#f');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
     describe('Refresh', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -149,6 +149,21 @@ describe('Fluent', function () {
         });
     });
 
+    describe('Transition Hash With Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1', null, 'f')
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0#f');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
     describe('State State', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -446,6 +446,24 @@ describe('Fluent', function () {
         });
     });
 
+    describe('Hash Back', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1', null, 'f')
+                .navigate('s2')
+                .navigateBack(1)
+                .url;
+            assert.strictEqual(url, '/r1#f');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
     describe('Back Two With Trail', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -55,6 +55,19 @@ describe('Fluent', function () {
         });
     });
 
+    describe('State Reserved Url Character Hash', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r' }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s', null, '*="/()\'-_+~@:?><.;[],{}!£$%^#&')
+                .url;
+            assert.strictEqual(url, '/r#*="/()\'-_+~@:?><.;[],{}!£$%^#&');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
     describe('Second State', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -48,7 +48,7 @@ describe('Fluent', function () {
             var stateNavigator = new StateNavigator([
                 { key: 's', route: 'r' }
             ]);
-            assert.throws(() =>  stateNavigator.fluent().navigate('s0'), /is not a valid State/);
+            assert.throws(() =>  (stateNavigator as StateNavigator<any>).fluent().navigate('s0'), /is not a valid State/);
         });
     });
 
@@ -675,7 +675,7 @@ describe('Fluent', function () {
             stateNavigator.configure([
                 { key: 's1', route: 'r' }
             ]);
-            var url = stateNavigator.fluent()
+            var url = (stateNavigator as StateNavigator<any>).fluent()
                 .navigate('s1')
                 .url;
             assert.strictEqual(url, '/r');
@@ -694,7 +694,7 @@ describe('Fluent', function () {
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
-            var url = stateNavigator.fluent()
+            var url = (stateNavigator as StateNavigator<any>).fluent()
                 .navigate('s0')
                 .navigate('s1')
                 .url;
@@ -714,7 +714,7 @@ describe('Fluent', function () {
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
-            var url = stateNavigator.fluent()
+            var url = (stateNavigator as StateNavigator<any>).fluent()
                 .navigate('s0')
                 .navigate('s1')
                 .refresh()
@@ -736,7 +736,7 @@ describe('Fluent', function () {
                 { key: 's1', route: 'r1', trackCrumbTrail: true },
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
-            var url = stateNavigator.fluent()
+            var url = (stateNavigator as StateNavigator<any>).fluent()
                 .navigate('s0')
                 .navigate('s1')
                 .navigate('s2')
@@ -895,14 +895,14 @@ describe('Fluent', function () {
                 .navigate('s0');
             var fluent1 = stateNavigator1.fluent()
                 .navigate('s2');
-            fluent0 = fluent0
+            var fluent2 = fluent0
                 .navigate('s1');
-            fluent1 = fluent1
+            var fluent3 = fluent1
                 .navigate('s3');
-            var url0 = fluent0
+            var url0 = fluent2
                 .refresh()
                 .url;
-            var url1 = fluent1
+            var url1 = fluent3
                 .refresh()
                 .url;
             assert.strictEqual(url0, '/r1?crumb=%2Fr0&crumb=%2Fr1');
@@ -928,18 +928,18 @@ describe('Fluent', function () {
                 .navigate('s0');
             var fluent1 = stateNavigator1.fluent()
                 .navigate('s3');
-            fluent0 = fluent0
+            var fluent2 = fluent0
                 .navigate('s1');
-            fluent1 = fluent1
+            var fluent3 = fluent1
                 .navigate('s4');
-            fluent0 = fluent0
+            var fluent4 = fluent2
                 .navigate('s2');
-            fluent1 = fluent1
+            var fluent5 = fluent3
                 .navigate('s5');
-            var url0 = fluent0
+            var url0 = fluent4
                 .navigateBack(1)
                 .url;
-            var url1 = fluent1
+            var url1 = fluent5
                 .navigateBack(1)
                 .url;
             assert.strictEqual(url0, '/r1?crumb=%2Fr0');

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -16,6 +16,19 @@ describe('Fluent', function () {
         });
     });
 
+    describe('State Hash', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r' }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s', null, 'f')
+                .url;
+            assert.strictEqual(url, '/r#f');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
     describe('Second State', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -314,6 +314,22 @@ describe('Fluent', function () {
         });
     });
 
+    describe('Refresh Null Hash', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .refresh(null, null)
+                .url;
+            assert.strictEqual(url, '/r1');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
     describe('Back With Trail', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -298,6 +298,22 @@ describe('Fluent', function () {
         });
     });
 
+    describe('Refresh Hash', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .refresh(null, 'f')
+                .url;
+            assert.strictEqual(url, '/r1#f');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
     describe('Back With Trail', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -410,6 +410,24 @@ describe('Fluent', function () {
         });
     });
 
+    describe('Hash Transition Back With Trail', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1', null, 'f')
+                .navigate('s2')
+                .navigateBack(1)
+                .url;
+            assert.strictEqual(url, '/r1?crumb=%2Fr0#f');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
     describe('Back', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -346,6 +346,22 @@ describe('Fluent', function () {
         });
     });
 
+    describe('Refresh Reserved Url Character Hash', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s0')
+                .navigate('s1')
+                .refresh(null, '*="/()\'-_+~@:?><.;[],{}!£$%^#&')
+                .url;
+            assert.strictEqual(url, '/r1#*="/()\'-_+~@:?><.;[],{}!£$%^#&');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
     describe('Back With Trail', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -29,6 +29,32 @@ describe('Fluent', function () {
         });
     });
 
+    describe('State Null Hash', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r' }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s', null, null)
+                .url;
+            assert.strictEqual(url, '/r');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
+    describe('State Empty Hash', function () {
+        it('should navigate', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r' }
+            ]);
+            var url = stateNavigator.fluent()
+                .navigate('s', null, '')
+                .url;
+            assert.strictEqual(url, '/r');
+            assert.strictEqual(stateNavigator.stateContext.url, null);
+        });
+    });
+
     describe('Second State', function () {
         it('should navigate', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -2238,6 +2238,75 @@ describe('Navigation Data', function () {
         }
     });
 
+
+    describe('Hash Transition Hash Transition Hash', function() {
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+        });
+        var data1 = {};
+        data1['s'] = 1;
+        var data2 = {};
+        data2['s'] = 2;
+        data2['t'] = '2';
+        var data3 = {};
+        data3['s'] = 3;
+        data3['t'] = '3';
+        
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = stateNavigator.getNavigationLink('s0', data1, 'f1');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s1', data2, 'f2');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s2', data3, 'f3');
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0', data1, 'f1')
+                    .navigate('s1', data2, 'f2')
+                    .url;
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.fluent(true)
+                    .navigate('s2', data3, 'f3')
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate data', function () {
+                assert.strictEqual(stateNavigator.stateContext.oldData['s'], 2);
+                assert.strictEqual(stateNavigator.stateContext.oldData['t'], '2');
+                assert.strictEqual(stateNavigator.stateContext.oldHash, 'f2');
+                assert.strictEqual(stateNavigator.stateContext.previousData['s'], 2);
+                assert.strictEqual(stateNavigator.stateContext.previousData['t'], '2');
+                assert.strictEqual(stateNavigator.stateContext.previousHash, 'f2');
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['s'], 1);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['t'], undefined);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].hash, 'f1');
+                assert.equal(Object.keys(stateNavigator.stateContext.crumbs[0].data).length, 1);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['s'], 2);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['t'], '2');
+                assert.strictEqual(stateNavigator.stateContext.crumbs[1].hash, 'f2');
+                assert.equal(Object.keys(stateNavigator.stateContext.crumbs[1].data).length, 2);
+                assert.strictEqual(stateNavigator.stateContext.data['s'], 3);
+                assert.strictEqual(stateNavigator.stateContext.data['t'], '3');
+                assert.strictEqual(stateNavigator.stateContext.hash, 'f3');
+            });
+        }
+    });
+
     describe('Transition Transition Crumb Trail Key', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -1819,6 +1819,57 @@ describe('Navigation Data', function () {
         }
     });
 
+
+    describe('Refresh Data Hash', function() {
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' }
+            ]);
+        });
+        var data = {};
+        data['string'] = 'Hello';
+        data['boolean'] = true;
+        data['number'] = 0;
+        data['date'] = new Date(2010, 3, 7);
+        
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = stateNavigator.getNavigationLink('s0');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s1');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getRefreshLink(data, 'f');
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s0')
+                    .navigate('s1')
+                    .refresh(data, 'f')
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate data', function () {
+                assert.strictEqual(stateNavigator.stateContext.data['string'], 'Hello');
+                assert.strictEqual(stateNavigator.stateContext.data['boolean'], true);
+                assert.strictEqual(stateNavigator.stateContext.data['number'], 0);
+                assert.strictEqual(+stateNavigator.stateContext.data['date'], +new Date(2010, 3, 7));
+                assert.strictEqual(stateNavigator.stateContext.hash, 'f');
+                assert.strictEqual(Object.keys(stateNavigator.stateContext.data).length, 4);
+            });
+        }
+    });
+
     describe('Refresh Data Blank', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -150,6 +150,92 @@ describe('Navigation Data', function () {
         }
     });
 
+    describe('Individual Data Hash', function() {
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
+                { key: 's', route: 'r' }
+            ]);
+        });
+        var individualNavigationData = {};
+        individualNavigationData['string'] = 'Hello';
+        individualNavigationData['boolean'] = true;
+        individualNavigationData['number'] = 0;
+        individualNavigationData['date'] = new Date(2010, 3, 7);
+        
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = stateNavigator.getNavigationLink('s', individualNavigationData, 'f');
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s', individualNavigationData, 'f')
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate data', function () {
+                assert.strictEqual(stateNavigator.stateContext.data['string'], 'Hello');
+                assert.strictEqual(stateNavigator.stateContext.data['boolean'], true);
+                assert.strictEqual(stateNavigator.stateContext.data['number'], 0);
+                assert.strictEqual(+stateNavigator.stateContext.data['date'], +new Date(2010, 3, 7));
+                assert.strictEqual(stateNavigator.stateContext.hash, 'f');
+                assert.strictEqual(Object.keys(stateNavigator.stateContext.data).length, 4);
+            });
+        }
+    });
+
+    describe('Individual Data Route Hash', function() {
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
+                { key: 's', route: 'r/{string}/{boolean}/{number}/{date}' }
+            ]);
+        });
+        var individualNavigationData = {};
+        individualNavigationData['string'] = 'Hello';
+        individualNavigationData['boolean'] = true;
+        individualNavigationData['number'] = 0;
+        individualNavigationData['date'] = new Date(2010, 3, 7);
+        
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = stateNavigator.getNavigationLink('s', individualNavigationData, 'f');
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s', individualNavigationData, 'f')
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate data', function () {
+                assert.strictEqual(stateNavigator.stateContext.data['string'], 'Hello');
+                assert.strictEqual(stateNavigator.stateContext.data['boolean'], true);
+                assert.strictEqual(stateNavigator.stateContext.data['number'], 0);
+                assert.strictEqual(+stateNavigator.stateContext.data['date'], +new Date(2010, 3, 7));
+                assert.strictEqual(stateNavigator.stateContext.hash, 'f');
+                assert.strictEqual(Object.keys(stateNavigator.stateContext.data).length, 4);
+            });
+        }
+    });
+
     describe('Array Data', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -410,6 +410,45 @@ describe('Navigation Data', function () {
         }
     });
 
+    describe('Array Data Splat Hash', function() {
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
+                { key: 's', route: 'r0/{*array_string}' }
+            ]);
+        });
+        var arrayNavigationData = {};
+        arrayNavigationData['array_string'] = ['He-llo', 'World'];
+        
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = stateNavigator.getNavigationLink('s', arrayNavigationData, 'f');
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        describe('Fluent Navigate', function() {
+            beforeEach(function() {
+                var link = stateNavigator.fluent()
+                    .navigate('s', arrayNavigationData, 'f')
+                    .url;
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+
+        function test() {
+            it('should populate data', function () {
+                assert.strictEqual(stateNavigator.stateContext.data['array_string'][0], 'He-llo');
+                assert.strictEqual(stateNavigator.stateContext.data['array_string'][1], 'World');
+                assert.strictEqual(stateNavigator.stateContext.data['array_string'].length, 2);
+                assert.strictEqual(Object.keys(stateNavigator.stateContext.data).length, 1);
+                assert.strictEqual(stateNavigator.stateContext.hash, 'f');
+            });
+        }
+    });
+
     describe('Invalid Data', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {

--- a/Navigation/test/NavigationRoutingTest.ts
+++ b/Navigation/test/NavigationRoutingTest.ts
@@ -138,6 +138,35 @@ describe('MatchTest', function () {
         });
     });
 
+    describe('One Param Hash', function () {
+        var stateNavigator: StateNavigator;
+        beforeEach(function () {
+            stateNavigator = new StateNavigator([
+                { key: 's', route: '{x}' }
+            ]);
+        });
+
+        it('should match', function() {
+            var { data, hash } = stateNavigator.parseLink('/abcd#f');
+            assert.strictEqual(Object.keys(data).length, 1);
+            assert.strictEqual(data.x, 'abcd');
+            assert.strictEqual(hash, 'f');
+            var { data, hash } = stateNavigator.parseLink('/ab?y=cd#f');
+            assert.strictEqual(Object.keys(data).length, 2);
+            assert.strictEqual(data.x, 'ab');
+            assert.strictEqual(data.y, 'cd');
+            assert.strictEqual(hash, 'f');
+        });
+
+        it('should not match', function() {
+            assert.throws(() => stateNavigator.parseLink('/ab/cd#f'), /The Url .+ is invalid/);
+            assert.throws(() => stateNavigator.parseLink('/ab//#f'), /The Url .+ is invalid/);
+            assert.throws(() => stateNavigator.parseLink('//a#f'), /The Url .+ is invalid/);
+            assert.throws(() => stateNavigator.parseLink('/#f'), /The Url .+ is invalid/);
+            assert.throws(() => stateNavigator.parseLink('/a?x=b#f'), /The Url .+ is invalid/);
+        });
+    });
+
     describe('One Param Two Segment', function () {
         var stateNavigator: StateNavigator;
         beforeEach(function () {

--- a/Navigation/test/NavigationRoutingTest.ts
+++ b/Navigation/test/NavigationRoutingTest.ts
@@ -111,13 +111,15 @@ describe('MatchTest', function () {
         });
 
         it('should match', function() {
-            var { data } = stateNavigator.parseLink('/abcd');
+            var { data, hash } = stateNavigator.parseLink('/abcd');
             assert.strictEqual(Object.keys(data).length, 1);
             assert.strictEqual(data.x, 'abcd');
-            var { data } = stateNavigator.parseLink('/ab?y=cd');
+            assert.strictEqual(hash, null);
+            var { data, hash } = stateNavigator.parseLink('/ab?y=cd');
             assert.strictEqual(Object.keys(data).length, 2);
             assert.strictEqual(data.x, 'ab');
             assert.strictEqual(data.y, 'cd');
+            assert.strictEqual(hash, null);
         });
 
         it('should not match', function() {

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -1040,6 +1040,58 @@ describe('Navigation', function () {
         }
     });
 
+    describe('Hash Hash Hash Back With Trail', function() {
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+        });
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                stateNavigator.navigate('s0', null, undefined, 'f0');
+                stateNavigator.navigate('s1', null, undefined, 'f1');
+                stateNavigator.navigate('s2', null, undefined, 'f2');
+                stateNavigator.navigateBack(1);
+            });
+            test();
+        });
+        
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = stateNavigator.getNavigationLink('s0', null, 'f0');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s1', null, 'f1');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s2', null, 'f2');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationBackLink(1);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+        
+        function test() {
+            it('should populate context', function() {
+                assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+                assert.strictEqual(stateNavigator.stateContext.hash, 'f1');
+                assert.equal(stateNavigator.stateContext.url, '/r1?crumb=%2Fr0%23f0#f1');
+                assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s2']);
+                assert.equal(stateNavigator.stateContext.oldHash, 'f2');
+                assert.equal(stateNavigator.stateContext.oldUrl, '/r2?crumb=%2Fr0%23f0&crumb=%2Fr1%23f1#f2');
+                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
+                assert.equal(stateNavigator.stateContext.previousHash, 'f0');
+                assert.equal(stateNavigator.stateContext.previousUrl, '/r0#f0');
+                assert.equal(stateNavigator.stateContext.crumbs.length, 1);
+                assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
+                assert.equal(stateNavigator.stateContext.crumbs[0].hash, 'f0');
+                assert.ok(stateNavigator.stateContext.crumbs[0].last);
+            });
+        }
+    });
 
     describe('Back', function() {
         var stateNavigator: StateNavigator;

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -1057,6 +1057,32 @@ describe('Navigation', function () {
         }
     });
 
+    describe('Hash Hash Back', function() {
+        it('should populate context', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+            var link = stateNavigator.getNavigationLink('s0');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationLink('s1', null, 'f1');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationLink('s2', null, 'f2');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationBackLink(1);
+            stateNavigator.navigateLink(link);
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+            assert.equal(stateNavigator.stateContext.url, '/r1#f1');
+            assert.equal(stateNavigator.stateContext.hash, 'f1');
+            assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s2']);
+            assert.equal(stateNavigator.stateContext.oldHash, 'f2');
+            assert.equal(stateNavigator.stateContext.previousState, null);
+            assert.equal(stateNavigator.stateContext.previousHash, null);
+            assert.equal(stateNavigator.stateContext.crumbs.length, 0);
+        });
+    });
+
     describe('Back Two With Trail', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -800,6 +800,24 @@ describe('Navigation', function () {
         });
     });
 
+    describe('Refresh Null Hash', function() {
+        it('should populate context', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' }
+            ]);
+            var link = stateNavigator.getNavigationLink('s0');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationLink('s1');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getRefreshLink(null, null);
+            stateNavigator.navigateLink(link);
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+            assert.equal(stateNavigator.stateContext.url, '/r1');
+            assert.equal(stateNavigator.stateContext.hash, null);
+        });
+    });
+
     describe('Refresh Reserved Url Character Hash', function() {
         it('should populate context', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -814,6 +814,7 @@ describe('Navigation', function () {
             stateNavigator.navigateLink(link);
             assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
             assert.equal(stateNavigator.stateContext.hash, '*="/()\'-_+~@:?><.;[],{}!£$%^#&');
+            assert.equal(stateNavigator.stateContext.url, '/r1#*="/()\'-_+~@:?><.;[],{}!£$%^#&');
             assert.equal(stateNavigator.stateContext.crumbs.length, 0);
         });
     });

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -5809,7 +5809,7 @@ describe('Navigation', function () {
             var stateNavigated = false;
             stateNavigator.states.s1.navigated = () => stateNavigated = true;
             stateNavigator.navigate('s0', {x: 'a'});
-            var link = stateNavigator.getNavigationLink('s1', {y: 'b'});
+            var link = stateNavigator.getNavigationLink('s1', {y: 'b'}, 'f');
             var navigated = false;
             stateNavigator.onNavigate(() => navigated = true);
             stateNavigator.navigateLink(link, 'add', false, stateContext => {
@@ -5819,7 +5819,8 @@ describe('Navigation', function () {
                 assert.equal(stateContext.state, stateNavigator.states['s1']);
                 assert.equal(stateContext.data.y, 'b');
                 assert.equal(stateContext.asyncData.z, 'c');
-                assert.equal(stateContext.url, '/r1?y=b');
+                assert.equal(stateContext.url, '/r1?y=b#f');
+                assert.equal(stateContext.hash, 'f');
             });
             assert.equal(stateNavigator.stateContext.oldState, null);
             assert.equal(Object.keys(stateNavigator.stateContext.oldData).length, 0);
@@ -5828,6 +5829,7 @@ describe('Navigation', function () {
             assert.equal(stateNavigator.stateContext.data.x, 'a');
             assert.equal(stateNavigator.stateContext.asyncData, undefined);
             assert.equal(stateNavigator.stateContext.url, '/r0?x=a');
+            assert.equal(stateNavigator.stateContext.hash, null);
             assert.equal(stateNavigated, false);
             assert.equal(navigated, false);
         });
@@ -5843,7 +5845,7 @@ describe('Navigation', function () {
             var stateNavigated = false;
             stateNavigator.states.s1.navigated = () => stateNavigated = true;
             stateNavigator.navigate('s0', {x: 'a'});
-            var link = stateNavigator.getNavigationLink('s1', {y: 'b'});
+            var link = stateNavigator.getNavigationLink('s1', {y: 'b'}, 'f');
             var navigated = false;
             stateNavigator.onNavigate(() => navigated = true);
             stateNavigator.navigateLink(link, 'add', false, (stateContext, resume) => {
@@ -5853,7 +5855,8 @@ describe('Navigation', function () {
                 assert.equal(stateContext.state, stateNavigator.states['s1']);
                 assert.equal(stateContext.data.y, 'b');
                 assert.equal(stateContext.asyncData.z, 'c');
-                assert.equal(stateContext.url, '/r1?y=b');
+                assert.equal(stateContext.url, '/r1?y=b#f');
+                assert.equal(stateContext.hash, 'f');
                 resume();
             });
             assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s0']);
@@ -5862,7 +5865,8 @@ describe('Navigation', function () {
             assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
             assert.equal(stateNavigator.stateContext.data.y, 'b');
             assert.equal(stateNavigator.stateContext.asyncData.z, 'c');
-            assert.equal(stateNavigator.stateContext.url, '/r1?y=b');
+            assert.equal(stateNavigator.stateContext.url, '/r1?y=b#f');
+            assert.equal(stateNavigator.stateContext.hash, 'f');
             assert.equal(stateNavigated, true);
             assert.equal(navigated, true);
         });

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -808,6 +808,55 @@ describe('Navigation', function () {
         }
     });
 
+    describe('Refresh Hash With Trail', function() {
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+        });
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                stateNavigator.navigate('s0');
+                stateNavigator.navigate('s1');
+                stateNavigator.refresh(null, undefined, 'f');
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = stateNavigator.getNavigationLink('s0');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s1');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getRefreshLink(null, 'f');
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+        
+        function test() {            
+            it('should populate context', function() {
+                assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+                assert.equal(stateNavigator.stateContext.hash, 'f');
+                assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
+                assert.strictEqual(stateNavigator.stateContext.oldHash, null);
+                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s1']);
+                assert.strictEqual(stateNavigator.stateContext.previousHash, null);
+                assert.equal(stateNavigator.stateContext.crumbs.length, 2);
+                assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].hash, null);
+                assert.equal(stateNavigator.stateContext.crumbs[1].state, stateNavigator.states['s1']);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[1].hash, null);
+                assert.ok(!stateNavigator.stateContext.crumbs[0].last);
+                assert.ok(stateNavigator.stateContext.crumbs[1].last);
+            });
+        }
+    });
+
     describe('Refresh', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -818,6 +818,24 @@ describe('Navigation', function () {
         });
     });
 
+    describe('Refresh Empty Hash', function() {
+        it('should populate context', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' }
+            ]);
+            var link = stateNavigator.getNavigationLink('s0');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationLink('s1');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getRefreshLink(null, '');
+            stateNavigator.navigateLink(link);
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+            assert.equal(stateNavigator.stateContext.url, '/r1');
+            assert.equal(stateNavigator.stateContext.hash, null);
+        });
+    });
+
     describe('Refresh Reserved Url Character Hash', function() {
         it('should populate context', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -286,10 +286,10 @@ describe('Navigation', function () {
                 assert.equal(stateNavigator.stateContext.hash, 'anchor');
                 assert.equal(stateNavigator.stateContext.url, '/r1#anchor');
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.oldHash, null);
+                assert.strictEqual(stateNavigator.stateContext.oldHash, null);
                 assert.equal(stateNavigator.stateContext.oldUrl, '/r0');
                 assert.equal(stateNavigator.stateContext.previousState, null);
-                assert.equal(stateNavigator.stateContext.previousHash, null);
+                assert.strictEqual(stateNavigator.stateContext.previousHash, null);
                 assert.equal(stateNavigator.stateContext.previousUrl, null);
                 assert.equal(stateNavigator.stateContext.crumbs.length, 0);
             });
@@ -325,11 +325,11 @@ describe('Navigation', function () {
         
         function test() {
             it('should populate context', function() {
-                assert.equal(stateNavigator.stateContext.hash, null);
+                assert.strictEqual(stateNavigator.stateContext.hash, null);
                 assert.equal(stateNavigator.stateContext.url, '/r1');
                 assert.equal(stateNavigator.stateContext.oldHash, 'anchor');
                 assert.equal(stateNavigator.stateContext.oldUrl, '/r0#anchor');
-                assert.equal(stateNavigator.stateContext.previousHash, null);
+                assert.strictEqual(stateNavigator.stateContext.previousHash, null);
                 assert.equal(stateNavigator.stateContext.previousUrl, null);
             });
         }
@@ -368,7 +368,7 @@ describe('Navigation', function () {
                 assert.equal(stateNavigator.stateContext.url, '/r1#anchor1');
                 assert.equal(stateNavigator.stateContext.oldHash, 'anchor0');
                 assert.equal(stateNavigator.stateContext.oldUrl, '/r0#anchor0');
-                assert.equal(stateNavigator.stateContext.previousHash, null);
+                assert.strictEqual(stateNavigator.stateContext.previousHash, null);
                 assert.equal(stateNavigator.stateContext.previousUrl, null);
             });
         }

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -939,7 +939,7 @@ describe('Navigation', function () {
             });
         }
     });
-    
+
     describe('Back With Trail', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {
@@ -987,6 +987,59 @@ describe('Navigation', function () {
             });
         }
     });
+
+    describe('Hash Transition Hash Back With Trail', function() {
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true }
+            ]);
+        });
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                stateNavigator.navigate('s0', null, undefined, 'f0');
+                stateNavigator.navigate('s1');
+                stateNavigator.navigate('s2', null, undefined, 'f2');
+                stateNavigator.navigateBack(1);
+            });
+            test();
+        });
+        
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = stateNavigator.getNavigationLink('s0', null, 'f0');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s1');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s2', null, 'f2');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationBackLink(1);
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+        
+        function test() {
+            it('should populate context', function() {
+                assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+                assert.strictEqual(stateNavigator.stateContext.hash, null);
+                assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s2']);
+                assert.equal(stateNavigator.stateContext.oldHash, 'f2');
+                assert.equal(stateNavigator.stateContext.oldUrl, '/r2?crumb=%2Fr0%23f0&crumb=%2Fr1#f2');
+                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
+                assert.equal(stateNavigator.stateContext.previousHash, 'f0');
+                assert.equal(stateNavigator.stateContext.previousUrl, '/r0#f0');
+                assert.equal(stateNavigator.stateContext.crumbs.length, 1);
+                assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
+                assert.equal(stateNavigator.stateContext.crumbs[0].hash, 'f0');
+                assert.ok(stateNavigator.stateContext.crumbs[0].last);
+            });
+        }
+    });
+
 
     describe('Back', function() {
         var stateNavigator: StateNavigator;

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -896,6 +896,49 @@ describe('Navigation', function () {
             });
         }
     });
+
+    describe('Refresh Hash', function() {
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' }
+            ]);
+        });
+
+        describe('Navigate', function() {
+            beforeEach(function() {
+                stateNavigator.navigate('s0');
+                stateNavigator.navigate('s1');
+                stateNavigator.refresh(null, undefined, 'f');
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = stateNavigator.getNavigationLink('s0');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s1');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getRefreshLink(null, 'f');
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+        
+        function test() {
+            it('should populate context', function() {
+                assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+                assert.equal(stateNavigator.stateContext.hash, 'f');
+                assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
+                assert.strictEqual(stateNavigator.stateContext.oldHash, null);
+                assert.equal(stateNavigator.stateContext.previousState, null);
+                assert.strictEqual(stateNavigator.stateContext.previousHash, null);
+                assert.equal(stateNavigator.stateContext.crumbs.length, 0);
+            });
+        }
+    });
     
     describe('Back With Trail', function() {
         var stateNavigator: StateNavigator;

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -1093,6 +1093,51 @@ describe('Navigation', function () {
         }
     });
 
+    describe('Hash Transition Hash Transition Trail', function() {
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true },
+                { key: 's2', route: 'r2', trackCrumbTrail: true },
+                { key: 's3', route: 'r3', trackCrumbTrail: true }
+            ]);
+        });
+        
+        describe('Navigate', function() {
+            beforeEach(function() {
+                stateNavigator.navigate('s0', null, undefined, 'f0');
+                stateNavigator.navigate('s1');
+                stateNavigator.navigate('s2', null, undefined, 'f2');
+                stateNavigator.navigate('s3');
+            });
+            test();
+        });
+        
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = stateNavigator.getNavigationLink('s0', null, 'f0');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s1');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s2', null, 'f2');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s3');
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+        
+        function test() {
+            it('should populate context', function() {
+                assert.equal(stateNavigator.stateContext.crumbs[0].hash, 'f0');
+                assert.strictEqual(stateNavigator.stateContext.crumbs[1].hash, null);
+                assert.equal(stateNavigator.stateContext.crumbs[2].hash, 'f2');
+                assert.equal(stateNavigator.stateContext.crumbs.length, 3);
+            });
+        }
+    });
+
     describe('Back', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -68,6 +68,38 @@ describe('Navigation', function () {
         }
     });
 
+    describe('State Reserved Url Character Hash', function() {
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
+                { key: 's', route: 'r' }
+            ]);
+        });
+
+        describe('Navigate', function() {
+            beforeEach(function() {
+                stateNavigator.navigate('s', null, undefined, '*="/()\'-_+~@:?><.;[],{}!£$%^#&');
+            });
+            test();
+        });
+        
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = stateNavigator.getNavigationLink('s', undefined, '*="/()\'-_+~@:?><.;[],{}!£$%^#&');
+                stateNavigator.navigateLink(link);
+            });            
+            test();
+        });
+        
+        function test(){
+            it('should populate context', function() {
+                assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s']);
+                assert.equal(stateNavigator.stateContext.hash, '*="/()\'-_+~@:?><.;[],{}!£$%^#&');
+                assert.equal(stateNavigator.stateContext.crumbs.length, 0);
+            });
+        }
+    });
+
     describe('Second State', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {
@@ -935,6 +967,45 @@ describe('Navigation', function () {
                 assert.strictEqual(stateNavigator.stateContext.oldHash, null);
                 assert.equal(stateNavigator.stateContext.previousState, null);
                 assert.strictEqual(stateNavigator.stateContext.previousHash, null);
+                assert.equal(stateNavigator.stateContext.crumbs.length, 0);
+            });
+        }
+    });
+
+    describe('Refresh Reserved Url Character Hash', function() {
+        var stateNavigator: StateNavigator;
+        beforeEach(function() {
+            stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' }
+            ]);
+        });
+
+        describe('Navigate', function() {
+            beforeEach(function() {
+                stateNavigator.navigate('s0');
+                stateNavigator.navigate('s1');
+                stateNavigator.refresh(null, undefined, '*="/()\'-_+~@:?><.;[],{}!£$%^#&');
+            });
+            test();
+        });
+
+        describe('Navigate Link', function() {
+            beforeEach(function() {
+                var link = stateNavigator.getNavigationLink('s0');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getNavigationLink('s1');
+                stateNavigator.navigateLink(link);
+                link = stateNavigator.getRefreshLink(null, '*="/()\'-_+~@:?><.;[],{}!£$%^#&');
+                stateNavigator.navigateLink(link);
+            });
+            test();
+        });
+        
+        function test() {
+            it('should populate context', function() {
+                assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+                assert.equal(stateNavigator.stateContext.hash, '*="/()\'-_+~@:?><.;[],{}!£$%^#&');
                 assert.equal(stateNavigator.stateContext.crumbs.length, 0);
             });
         }

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -5604,6 +5604,32 @@ describe('Navigation', function () {
             });
         }
     });
+    
+    describe('Hash Refresh Hash Back', function() {
+        it('should populate context', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var link = stateNavigator.getNavigationLink('s0', null, 'f0');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationLink('s1');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getRefreshLink(null, 'f1');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationBackLink(1);
+            stateNavigator.navigateLink(link);
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+            assert.equal(stateNavigator.stateContext.hash, null);
+            assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
+            assert.equal(stateNavigator.stateContext.oldHash, 'f1');
+            assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
+            assert.equal(stateNavigator.stateContext.previousHash, 'f0');
+            assert.equal(stateNavigator.stateContext.crumbs.length, 1);
+            assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
+            assert.ok(stateNavigator.stateContext.crumbs[0].last);
+        });
+    });
 
     describe('Refresh Back Custom Trail', function() {
         var stateNavigator: StateNavigator;

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -37,67 +37,29 @@ describe('Navigation', function () {
     });
 
     describe('State Hash', function() {
-        var stateNavigator: StateNavigator;
-        beforeEach(function() {
-            stateNavigator = new StateNavigator([
+        it('should populate context', function() {
+            var stateNavigator = new StateNavigator([
                 { key: 's', route: 'r' }
             ]);
+            var link = stateNavigator.getNavigationLink('s', undefined, 'f');
+            stateNavigator.navigateLink(link);
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s']);
+            assert.equal(stateNavigator.stateContext.hash, 'f');
+            assert.equal(stateNavigator.stateContext.crumbs.length, 0);
         });
-
-        describe('Navigate', function() {
-            beforeEach(function() {
-                stateNavigator.navigate('s', null, undefined, 'f');
-            });
-            test();
-        });
-        
-        describe('Navigate Link', function() {
-            beforeEach(function() {
-                var link = stateNavigator.getNavigationLink('s', undefined, 'f');
-                stateNavigator.navigateLink(link);
-            });            
-            test();
-        });
-        
-        function test(){
-            it('should populate context', function() {
-                assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s']);
-                assert.equal(stateNavigator.stateContext.hash, 'f');
-                assert.equal(stateNavigator.stateContext.crumbs.length, 0);
-            });
-        }
     });
 
     describe('State Reserved Url Character Hash', function() {
-        var stateNavigator: StateNavigator;
-        beforeEach(function() {
-            stateNavigator = new StateNavigator([
+        it('should populate context', function() {
+            var stateNavigator = new StateNavigator([
                 { key: 's', route: 'r' }
             ]);
+            var link = stateNavigator.getNavigationLink('s', undefined, '*="/()\'-_+~@:?><.;[],{}!£$%^#&');
+            stateNavigator.navigateLink(link);
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s']);
+            assert.equal(stateNavigator.stateContext.hash, '*="/()\'-_+~@:?><.;[],{}!£$%^#&');
+            assert.equal(stateNavigator.stateContext.crumbs.length, 0);
         });
-
-        describe('Navigate', function() {
-            beforeEach(function() {
-                stateNavigator.navigate('s', null, undefined, '*="/()\'-_+~@:?><.;[],{}!£$%^#&');
-            });
-            test();
-        });
-        
-        describe('Navigate Link', function() {
-            beforeEach(function() {
-                var link = stateNavigator.getNavigationLink('s', undefined, '*="/()\'-_+~@:?><.;[],{}!£$%^#&');
-                stateNavigator.navigateLink(link);
-            });            
-            test();
-        });
-        
-        function test(){
-            it('should populate context', function() {
-                assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s']);
-                assert.equal(stateNavigator.stateContext.hash, '*="/()\'-_+~@:?><.;[],{}!£$%^#&');
-                assert.equal(stateNavigator.stateContext.crumbs.length, 0);
-            });
-        }
     });
 
     describe('Second State', function() {
@@ -286,124 +248,65 @@ describe('Navigation', function () {
     });
 
     describe('Transition Hash', function() {
-        var stateNavigator: StateNavigator;
-        beforeEach(function() {
-            stateNavigator = new StateNavigator([
+        it('should populate context', function() {
+            var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1' }
             ]);
-        });
+            var link = stateNavigator.getNavigationLink('s0');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationLink('s1', undefined, 'f');
+            stateNavigator.navigateLink(link);
         
-        describe('Navigate', function() {
-            beforeEach(function() {
-                stateNavigator.navigate('s0');
-                stateNavigator.navigate('s1', null, undefined, 'f');
-            });
-            test();
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+            assert.equal(stateNavigator.stateContext.hash, 'f');
+            assert.equal(stateNavigator.stateContext.url, '/r1#f');
+            assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s0']);
+            assert.strictEqual(stateNavigator.stateContext.oldHash, null);
+            assert.equal(stateNavigator.stateContext.oldUrl, '/r0');
+            assert.equal(stateNavigator.stateContext.previousState, null);
+            assert.strictEqual(stateNavigator.stateContext.previousHash, null);
+            assert.equal(stateNavigator.stateContext.previousUrl, null);
+            assert.equal(stateNavigator.stateContext.crumbs.length, 0);
         });
-
-        describe('Navigate Link', function() {
-            beforeEach(function() {
-                var link = stateNavigator.getNavigationLink('s0');
-                stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationLink('s1', undefined, 'f');
-                stateNavigator.navigateLink(link);
-            });
-            test();
-        });
-        
-        function test() {
-            it('should populate context', function() {
-                assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.hash, 'f');
-                assert.equal(stateNavigator.stateContext.url, '/r1#f');
-                assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s0']);
-                assert.strictEqual(stateNavigator.stateContext.oldHash, null);
-                assert.equal(stateNavigator.stateContext.oldUrl, '/r0');
-                assert.equal(stateNavigator.stateContext.previousState, null);
-                assert.strictEqual(stateNavigator.stateContext.previousHash, null);
-                assert.equal(stateNavigator.stateContext.previousUrl, null);
-                assert.equal(stateNavigator.stateContext.crumbs.length, 0);
-            });
-        }
     });
 
     describe('Hash Transition', function() {
-        var stateNavigator: StateNavigator;
-        beforeEach(function() {
-            stateNavigator = new StateNavigator([
+        it('should populate context', function() {
+            var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1' }
             ]);
+            var link = stateNavigator.getNavigationLink('s0', undefined, 'f');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationLink('s1');
+            stateNavigator.navigateLink(link);
+            assert.strictEqual(stateNavigator.stateContext.hash, null);
+            assert.equal(stateNavigator.stateContext.url, '/r1');
+            assert.equal(stateNavigator.stateContext.oldHash, 'f');
+            assert.equal(stateNavigator.stateContext.oldUrl, '/r0#f');
+            assert.strictEqual(stateNavigator.stateContext.previousHash, null);
+            assert.equal(stateNavigator.stateContext.previousUrl, null);
         });
-        
-        describe('Navigate', function() {
-            beforeEach(function() {
-                stateNavigator.navigate('s0', null, undefined, 'f');
-                stateNavigator.navigate('s1');
-            });
-            test();
-        });
-
-        describe('Navigate Link', function() {
-            beforeEach(function() {
-                var link = stateNavigator.getNavigationLink('s0', undefined, 'f');
-                stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationLink('s1');
-                stateNavigator.navigateLink(link);
-            });
-            test();
-        });
-        
-        function test() {
-            it('should populate context', function() {
-                assert.strictEqual(stateNavigator.stateContext.hash, null);
-                assert.equal(stateNavigator.stateContext.url, '/r1');
-                assert.equal(stateNavigator.stateContext.oldHash, 'f');
-                assert.equal(stateNavigator.stateContext.oldUrl, '/r0#f');
-                assert.strictEqual(stateNavigator.stateContext.previousHash, null);
-                assert.equal(stateNavigator.stateContext.previousUrl, null);
-            });
-        }
     });
 
     describe('Hash Transition Hash', function() {
-        var stateNavigator: StateNavigator;
-        beforeEach(function() {
-            stateNavigator = new StateNavigator([
+        it('should populate context', function() {
+            var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1' }
             ]);
+            var link = stateNavigator.getNavigationLink('s0', undefined, 'f0');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationLink('s1', undefined, 'f1');
+            stateNavigator.navigateLink(link);
+            assert.equal(stateNavigator.stateContext.hash, 'f1');
+            assert.equal(stateNavigator.stateContext.url, '/r1#f1');
+            assert.equal(stateNavigator.stateContext.oldHash, 'f0');
+            assert.equal(stateNavigator.stateContext.oldUrl, '/r0#f0');
+            assert.strictEqual(stateNavigator.stateContext.previousHash, null);
+            assert.equal(stateNavigator.stateContext.previousUrl, null);
         });
-        
-        describe('Navigate', function() {
-            beforeEach(function() {
-                stateNavigator.navigate('s0', null, undefined, 'f0');
-                stateNavigator.navigate('s1', null, undefined, 'f1');
-            });
-            test();
-        });
-
-        describe('Navigate Link', function() {
-            beforeEach(function() {
-                var link = stateNavigator.getNavigationLink('s0', undefined, 'f0');
-                stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationLink('s1', undefined, 'f1');
-                stateNavigator.navigateLink(link);
-            });
-            test();
-        });
-        
-        function test() {
-            it('should populate context', function() {
-                assert.equal(stateNavigator.stateContext.hash, 'f1');
-                assert.equal(stateNavigator.stateContext.url, '/r1#f1');
-                assert.equal(stateNavigator.stateContext.oldHash, 'f0');
-                assert.equal(stateNavigator.stateContext.oldUrl, '/r0#f0');
-                assert.strictEqual(stateNavigator.stateContext.previousHash, null);
-                assert.equal(stateNavigator.stateContext.previousUrl, null);
-            });
-        }
     });
 
     describe('Transition With Trail', function() {
@@ -449,129 +352,69 @@ describe('Navigation', function () {
     });
 
     describe('Transition Hash With Trail', function() {
-        var stateNavigator: StateNavigator;
-        beforeEach(function() {
-            stateNavigator = new StateNavigator([
+        it('should populate context', function() {
+            var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
+            var link = stateNavigator.getNavigationLink('s0');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationLink('s1', null, 'f');
+            stateNavigator.navigateLink(link);
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+            assert.equal(stateNavigator.stateContext.hash, 'f');
+            assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s0']);
+            assert.strictEqual(stateNavigator.stateContext.oldHash, null);
+            assert.equal(stateNavigator.stateContext.oldUrl, '/r0');
+            assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
+            assert.strictEqual(stateNavigator.stateContext.previousHash, null);
+            assert.equal(stateNavigator.stateContext.previousUrl, '/r0');
+            assert.equal(stateNavigator.stateContext.crumbs.length, 1);
         });
-
-        describe('Navigate', function() {
-            beforeEach(function() {
-                stateNavigator.navigate('s0');
-                stateNavigator.navigate('s1', null, undefined, 'f');
-            });
-            test();
-        });
-
-        describe('Navigate Link', function() {
-            beforeEach(function() {
-                var link = stateNavigator.getNavigationLink('s0');
-                stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationLink('s1', null, 'f');
-                stateNavigator.navigateLink(link);
-            });
-            test();
-        });
-        
-        function test() {
-            it('should populate context', function() {
-                assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.hash, 'f');
-                assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s0']);
-                assert.strictEqual(stateNavigator.stateContext.oldHash, null);
-                assert.equal(stateNavigator.stateContext.oldUrl, '/r0');
-                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-                assert.strictEqual(stateNavigator.stateContext.previousHash, null);
-                assert.equal(stateNavigator.stateContext.previousUrl, '/r0');
-                assert.equal(stateNavigator.stateContext.crumbs.length, 1);
-            });
-        }
     });
 
     describe('Hash Transition With Trail', function() {
-        var stateNavigator: StateNavigator;
-        beforeEach(function() {
-            stateNavigator = new StateNavigator([
+        it('should populate context', function() {
+            var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
+            var link = stateNavigator.getNavigationLink('s0', null, 'f');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationLink('s1');
+            stateNavigator.navigateLink(link);
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+            assert.strictEqual(stateNavigator.stateContext.hash, null);
+            assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s0']);
+            assert.equal(stateNavigator.stateContext.oldHash, 'f');
+            assert.equal(stateNavigator.stateContext.oldUrl, '/r0#f');
+            assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
+            assert.equal(stateNavigator.stateContext.previousHash, 'f');
+            assert.equal(stateNavigator.stateContext.previousUrl, '/r0#f');
+            assert.equal(stateNavigator.stateContext.crumbs.length, 1);
         });
-
-        describe('Navigate', function() {
-            beforeEach(function() {
-                stateNavigator.navigate('s0', null, undefined, 'f');
-                stateNavigator.navigate('s1');
-            });
-            test();
-        });
-
-        describe('Navigate Link', function() {
-            beforeEach(function() {
-                var link = stateNavigator.getNavigationLink('s0', null, 'f');
-                stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationLink('s1');
-                stateNavigator.navigateLink(link);
-            });
-            test();
-        });
-        
-        function test() {
-            it('should populate context', function() {
-                assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-                assert.strictEqual(stateNavigator.stateContext.hash, null);
-                assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.oldHash, 'f');
-                assert.equal(stateNavigator.stateContext.oldUrl, '/r0#f');
-                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.previousHash, 'f');
-                assert.equal(stateNavigator.stateContext.previousUrl, '/r0#f');
-                assert.equal(stateNavigator.stateContext.crumbs.length, 1);
-            });
-        }
     });
 
     describe('Hash Transition Hash With Trail', function() {
-        var stateNavigator: StateNavigator;
-        beforeEach(function() {
-            stateNavigator = new StateNavigator([
+        it('should populate context', function() {
+            var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
+            var link = stateNavigator.getNavigationLink('s0', null, 'f0');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationLink('s1', null, 'f1');
+            stateNavigator.navigateLink(link);
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+            assert.equal(stateNavigator.stateContext.hash, 'f1');
+            assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s0']);
+            assert.equal(stateNavigator.stateContext.oldHash, 'f0');
+            assert.equal(stateNavigator.stateContext.oldUrl, '/r0#f0');
+            assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
+            assert.equal(stateNavigator.stateContext.previousHash, 'f0');
+            assert.equal(stateNavigator.stateContext.previousUrl, '/r0#f0');
+            assert.equal(stateNavigator.stateContext.crumbs.length, 1);
         });
-
-        describe('Navigate', function() {
-            beforeEach(function() {
-                stateNavigator.navigate('s0', null, undefined, 'f0');
-                stateNavigator.navigate('s1', null, undefined, 'f1');
-            });
-            test();
-        });
-
-        describe('Navigate Link', function() {
-            beforeEach(function() {
-                var link = stateNavigator.getNavigationLink('s0', null, 'f0');
-                stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationLink('s1', null, 'f1');
-                stateNavigator.navigateLink(link);
-            });
-            test();
-        });
-        
-        function test() {
-            it('should populate context', function() {
-                assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.hash, 'f1');
-                assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.oldHash, 'f0');
-                assert.equal(stateNavigator.stateContext.oldUrl, '/r0#f0');
-                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.previousHash, 'f0');
-                assert.equal(stateNavigator.stateContext.previousUrl, '/r0#f0');
-                assert.equal(stateNavigator.stateContext.crumbs.length, 1);
-            });
-        }
     });
 
     describe('State State', function() {
@@ -841,52 +684,31 @@ describe('Navigation', function () {
     });
 
     describe('Refresh Hash With Trail', function() {
-        var stateNavigator: StateNavigator;
-        beforeEach(function() {
-            stateNavigator = new StateNavigator([
+        it('should populate context', function() {
+            var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1', trackCrumbTrail: true }
             ]);
+            var link = stateNavigator.getNavigationLink('s0');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationLink('s1');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getRefreshLink(null, 'f');
+            stateNavigator.navigateLink(link);
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+            assert.equal(stateNavigator.stateContext.hash, 'f');
+            assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
+            assert.strictEqual(stateNavigator.stateContext.oldHash, null);
+            assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s1']);
+            assert.strictEqual(stateNavigator.stateContext.previousHash, null);
+            assert.equal(stateNavigator.stateContext.crumbs.length, 2);
+            assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
+            assert.strictEqual(stateNavigator.stateContext.crumbs[0].hash, null);
+            assert.equal(stateNavigator.stateContext.crumbs[1].state, stateNavigator.states['s1']);
+            assert.strictEqual(stateNavigator.stateContext.crumbs[1].hash, null);
+            assert.ok(!stateNavigator.stateContext.crumbs[0].last);
+            assert.ok(stateNavigator.stateContext.crumbs[1].last);
         });
-        
-        describe('Navigate', function() {
-            beforeEach(function() {
-                stateNavigator.navigate('s0');
-                stateNavigator.navigate('s1');
-                stateNavigator.refresh(null, undefined, 'f');
-            });
-            test();
-        });
-
-        describe('Navigate Link', function() {
-            beforeEach(function() {
-                var link = stateNavigator.getNavigationLink('s0');
-                stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationLink('s1');
-                stateNavigator.navigateLink(link);
-                link = stateNavigator.getRefreshLink(null, 'f');
-                stateNavigator.navigateLink(link);
-            });
-            test();
-        });
-        
-        function test() {            
-            it('should populate context', function() {
-                assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.hash, 'f');
-                assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
-                assert.strictEqual(stateNavigator.stateContext.oldHash, null);
-                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s1']);
-                assert.strictEqual(stateNavigator.stateContext.previousHash, null);
-                assert.equal(stateNavigator.stateContext.crumbs.length, 2);
-                assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[0].hash, null);
-                assert.equal(stateNavigator.stateContext.crumbs[1].state, stateNavigator.states['s1']);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].hash, null);
-                assert.ok(!stateNavigator.stateContext.crumbs[0].last);
-                assert.ok(stateNavigator.stateContext.crumbs[1].last);
-            });
-        }
     });
 
     describe('Refresh', function() {
@@ -930,85 +752,43 @@ describe('Navigation', function () {
     });
 
     describe('Refresh Hash', function() {
-        var stateNavigator: StateNavigator;
-        beforeEach(function() {
-            stateNavigator = new StateNavigator([
+        it('should populate context', function() {
+            var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1' }
             ]);
+            var link = stateNavigator.getNavigationLink('s0');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationLink('s1');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getRefreshLink(null, 'f');
+            stateNavigator.navigateLink(link);
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+            assert.equal(stateNavigator.stateContext.hash, 'f');
+            assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
+            assert.strictEqual(stateNavigator.stateContext.oldHash, null);
+            assert.equal(stateNavigator.stateContext.previousState, null);
+            assert.strictEqual(stateNavigator.stateContext.previousHash, null);
+            assert.equal(stateNavigator.stateContext.crumbs.length, 0);
         });
-
-        describe('Navigate', function() {
-            beforeEach(function() {
-                stateNavigator.navigate('s0');
-                stateNavigator.navigate('s1');
-                stateNavigator.refresh(null, undefined, 'f');
-            });
-            test();
-        });
-
-        describe('Navigate Link', function() {
-            beforeEach(function() {
-                var link = stateNavigator.getNavigationLink('s0');
-                stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationLink('s1');
-                stateNavigator.navigateLink(link);
-                link = stateNavigator.getRefreshLink(null, 'f');
-                stateNavigator.navigateLink(link);
-            });
-            test();
-        });
-        
-        function test() {
-            it('should populate context', function() {
-                assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.hash, 'f');
-                assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
-                assert.strictEqual(stateNavigator.stateContext.oldHash, null);
-                assert.equal(stateNavigator.stateContext.previousState, null);
-                assert.strictEqual(stateNavigator.stateContext.previousHash, null);
-                assert.equal(stateNavigator.stateContext.crumbs.length, 0);
-            });
-        }
     });
 
     describe('Refresh Reserved Url Character Hash', function() {
-        var stateNavigator: StateNavigator;
-        beforeEach(function() {
-            stateNavigator = new StateNavigator([
+        it('should populate context', function() {
+            var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1' }
             ]);
+            var link = stateNavigator.getNavigationLink('s0');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationLink('s1');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getRefreshLink(null, '*="/()\'-_+~@:?><.;[],{}!£$%^#&');
+            stateNavigator.navigateLink(link);
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+            assert.equal(stateNavigator.stateContext.hash, '*="/()\'-_+~@:?><.;[],{}!£$%^#&');
+            assert.equal(stateNavigator.stateContext.crumbs.length, 0);
         });
-
-        describe('Navigate', function() {
-            beforeEach(function() {
-                stateNavigator.navigate('s0');
-                stateNavigator.navigate('s1');
-                stateNavigator.refresh(null, undefined, '*="/()\'-_+~@:?><.;[],{}!£$%^#&');
-            });
-            test();
-        });
-
-        describe('Navigate Link', function() {
-            beforeEach(function() {
-                var link = stateNavigator.getNavigationLink('s0');
-                stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationLink('s1');
-                stateNavigator.navigateLink(link);
-                link = stateNavigator.getRefreshLink(null, '*="/()\'-_+~@:?><.;[],{}!£$%^#&');
-                stateNavigator.navigateLink(link);
-            });
-            test();
-        });
-        
-        function test() {
-            it('should populate context', function() {
-                assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.hash, '*="/()\'-_+~@:?><.;[],{}!£$%^#&');
-                assert.equal(stateNavigator.stateContext.crumbs.length, 0);
-            });
-        }
     });
 
     describe('Back With Trail', function() {
@@ -1060,153 +840,87 @@ describe('Navigation', function () {
     });
 
     describe('Hash Transition Hash Back With Trail', function() {
-        var stateNavigator: StateNavigator;
-        beforeEach(function() {
-            stateNavigator = new StateNavigator([
+        it('should populate context', function() {
+            var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1', trackCrumbTrail: true },
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
+            var link = stateNavigator.getNavigationLink('s0', null, 'f0');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationLink('s1');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationLink('s2', null, 'f2');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationBackLink(1);
+            stateNavigator.navigateLink(link);
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+            assert.strictEqual(stateNavigator.stateContext.hash, null);
+            assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s2']);
+            assert.equal(stateNavigator.stateContext.oldHash, 'f2');
+            assert.equal(stateNavigator.stateContext.oldUrl, '/r2?crumb=%2Fr0%23f0&crumb=%2Fr1#f2');
+            assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
+            assert.equal(stateNavigator.stateContext.previousHash, 'f0');
+            assert.equal(stateNavigator.stateContext.previousUrl, '/r0#f0');
+            assert.equal(stateNavigator.stateContext.crumbs.length, 1);
+            assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
+            assert.equal(stateNavigator.stateContext.crumbs[0].hash, 'f0');
+            assert.ok(stateNavigator.stateContext.crumbs[0].last);
         });
-        
-        describe('Navigate', function() {
-            beforeEach(function() {
-                stateNavigator.navigate('s0', null, undefined, 'f0');
-                stateNavigator.navigate('s1');
-                stateNavigator.navigate('s2', null, undefined, 'f2');
-                stateNavigator.navigateBack(1);
-            });
-            test();
-        });
-        
-        describe('Navigate Link', function() {
-            beforeEach(function() {
-                var link = stateNavigator.getNavigationLink('s0', null, 'f0');
-                stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationLink('s1');
-                stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationLink('s2', null, 'f2');
-                stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationBackLink(1);
-                stateNavigator.navigateLink(link);
-            });
-            test();
-        });
-        
-        function test() {
-            it('should populate context', function() {
-                assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-                assert.strictEqual(stateNavigator.stateContext.hash, null);
-                assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s2']);
-                assert.equal(stateNavigator.stateContext.oldHash, 'f2');
-                assert.equal(stateNavigator.stateContext.oldUrl, '/r2?crumb=%2Fr0%23f0&crumb=%2Fr1#f2');
-                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.previousHash, 'f0');
-                assert.equal(stateNavigator.stateContext.previousUrl, '/r0#f0');
-                assert.equal(stateNavigator.stateContext.crumbs.length, 1);
-                assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.crumbs[0].hash, 'f0');
-                assert.ok(stateNavigator.stateContext.crumbs[0].last);
-            });
-        }
     });
 
     describe('Hash Hash Hash Back With Trail', function() {
-        var stateNavigator: StateNavigator;
-        beforeEach(function() {
-            stateNavigator = new StateNavigator([
+        it('should populate context', function() {
+            var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1', trackCrumbTrail: true },
                 { key: 's2', route: 'r2', trackCrumbTrail: true }
             ]);
+            var link = stateNavigator.getNavigationLink('s0', null, 'f0');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationLink('s1', null, 'f1');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationLink('s2', null, 'f2');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationBackLink(1);
+            stateNavigator.navigateLink(link);
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+            assert.strictEqual(stateNavigator.stateContext.hash, 'f1');
+            assert.equal(stateNavigator.stateContext.url, '/r1?crumb=%2Fr0%23f0#f1');
+            assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s2']);
+            assert.equal(stateNavigator.stateContext.oldHash, 'f2');
+            assert.equal(stateNavigator.stateContext.oldUrl, '/r2?crumb=%2Fr0%23f0&crumb=%2Fr1%23f1#f2');
+            assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
+            assert.equal(stateNavigator.stateContext.previousHash, 'f0');
+            assert.equal(stateNavigator.stateContext.previousUrl, '/r0#f0');
+            assert.equal(stateNavigator.stateContext.crumbs.length, 1);
+            assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
+            assert.equal(stateNavigator.stateContext.crumbs[0].hash, 'f0');
+            assert.ok(stateNavigator.stateContext.crumbs[0].last);
         });
-        
-        describe('Navigate', function() {
-            beforeEach(function() {
-                stateNavigator.navigate('s0', null, undefined, 'f0');
-                stateNavigator.navigate('s1', null, undefined, 'f1');
-                stateNavigator.navigate('s2', null, undefined, 'f2');
-                stateNavigator.navigateBack(1);
-            });
-            test();
-        });
-        
-        describe('Navigate Link', function() {
-            beforeEach(function() {
-                var link = stateNavigator.getNavigationLink('s0', null, 'f0');
-                stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationLink('s1', null, 'f1');
-                stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationLink('s2', null, 'f2');
-                stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationBackLink(1);
-                stateNavigator.navigateLink(link);
-            });
-            test();
-        });
-        
-        function test() {
-            it('should populate context', function() {
-                assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-                assert.strictEqual(stateNavigator.stateContext.hash, 'f1');
-                assert.equal(stateNavigator.stateContext.url, '/r1?crumb=%2Fr0%23f0#f1');
-                assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s2']);
-                assert.equal(stateNavigator.stateContext.oldHash, 'f2');
-                assert.equal(stateNavigator.stateContext.oldUrl, '/r2?crumb=%2Fr0%23f0&crumb=%2Fr1%23f1#f2');
-                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.previousHash, 'f0');
-                assert.equal(stateNavigator.stateContext.previousUrl, '/r0#f0');
-                assert.equal(stateNavigator.stateContext.crumbs.length, 1);
-                assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.crumbs[0].hash, 'f0');
-                assert.ok(stateNavigator.stateContext.crumbs[0].last);
-            });
-        }
     });
 
     describe('Hash Transition Hash Transition With Trail', function() {
-        var stateNavigator: StateNavigator;
-        beforeEach(function() {
-            stateNavigator = new StateNavigator([
+        it('should populate context', function() {
+            var stateNavigator = new StateNavigator([
                 { key: 's0', route: 'r0' },
                 { key: 's1', route: 'r1', trackCrumbTrail: true },
                 { key: 's2', route: 'r2', trackCrumbTrail: true },
                 { key: 's3', route: 'r3', trackCrumbTrail: true }
             ]);
+            var link = stateNavigator.getNavigationLink('s0', null, 'f0');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationLink('s1');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationLink('s2', null, 'f2');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationLink('s3');
+            stateNavigator.navigateLink(link);
+            assert.equal(stateNavigator.stateContext.crumbs[0].hash, 'f0');
+            assert.strictEqual(stateNavigator.stateContext.crumbs[1].hash, null);
+            assert.equal(stateNavigator.stateContext.crumbs[2].hash, 'f2');
+            assert.equal(stateNavigator.stateContext.crumbs.length, 3);
         });
-        
-        describe('Navigate', function() {
-            beforeEach(function() {
-                stateNavigator.navigate('s0', null, undefined, 'f0');
-                stateNavigator.navigate('s1');
-                stateNavigator.navigate('s2', null, undefined, 'f2');
-                stateNavigator.navigate('s3');
-            });
-            test();
-        });
-        
-        describe('Navigate Link', function() {
-            beforeEach(function() {
-                var link = stateNavigator.getNavigationLink('s0', null, 'f0');
-                stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationLink('s1');
-                stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationLink('s2', null, 'f2');
-                stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationLink('s3');
-                stateNavigator.navigateLink(link);
-            });
-            test();
-        });
-        
-        function test() {
-            it('should populate context', function() {
-                assert.equal(stateNavigator.stateContext.crumbs[0].hash, 'f0');
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].hash, null);
-                assert.equal(stateNavigator.stateContext.crumbs[2].hash, 'f2');
-                assert.equal(stateNavigator.stateContext.crumbs.length, 3);
-            });
-        }
     });
 
     describe('Back', function() {

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -791,10 +791,36 @@ describe('Navigation', function () {
             link = stateNavigator.getRefreshLink(null, 'f');
             stateNavigator.navigateLink(link);
             assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+            assert.equal(stateNavigator.stateContext.url, '/r1#f');
             assert.equal(stateNavigator.stateContext.hash, 'f');
             assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
             assert.strictEqual(stateNavigator.stateContext.oldHash, null);
             assert.equal(stateNavigator.stateContext.previousState, null);
+            assert.strictEqual(stateNavigator.stateContext.previousHash, null);
+            assert.equal(stateNavigator.stateContext.crumbs.length, 0);
+        });
+    });
+
+    describe('Hash Refresh', function() {
+        it('should populate context', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' }
+            ]);
+            var link = stateNavigator.getNavigationLink('s0');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getNavigationLink('s1', null, 'f');
+            stateNavigator.navigateLink(link);
+            link = stateNavigator.getRefreshLink(null);
+            stateNavigator.navigateLink(link);
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+            assert.equal(stateNavigator.stateContext.url, '/r1');
+            assert.equal(stateNavigator.stateContext.hash, null);
+            assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
+            assert.equal(stateNavigator.stateContext.oldUrl, '/r1#f');
+            assert.strictEqual(stateNavigator.stateContext.oldHash, 'f');
+            assert.equal(stateNavigator.stateContext.previousState, null);
+            assert.equal(stateNavigator.stateContext.previousUrl, null);
             assert.strictEqual(stateNavigator.stateContext.previousHash, null);
             assert.equal(stateNavigator.stateContext.crumbs.length, 0);
         });

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -1093,7 +1093,7 @@ describe('Navigation', function () {
         }
     });
 
-    describe('Hash Transition Hash Transition Trail', function() {
+    describe('Hash Transition Hash Transition With Trail', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {
             stateNavigator = new StateNavigator([

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -46,14 +46,14 @@ describe('Navigation', function () {
 
         describe('Navigate', function() {
             beforeEach(function() {
-                stateNavigator.navigate('s', null, undefined, 'anchor');
+                stateNavigator.navigate('s', null, undefined, 'f');
             });
             test();
         });
         
         describe('Navigate Link', function() {
             beforeEach(function() {
-                var link = stateNavigator.getNavigationLink('s', undefined, 'anchor');
+                var link = stateNavigator.getNavigationLink('s', undefined, 'f');
                 stateNavigator.navigateLink(link);
             });            
             test();
@@ -62,7 +62,7 @@ describe('Navigation', function () {
         function test(){
             it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s']);
-                assert.equal(stateNavigator.stateContext.hash, 'anchor');
+                assert.equal(stateNavigator.stateContext.hash, 'f');
                 assert.equal(stateNavigator.stateContext.crumbs.length, 0);
             });
         }
@@ -265,7 +265,7 @@ describe('Navigation', function () {
         describe('Navigate', function() {
             beforeEach(function() {
                 stateNavigator.navigate('s0');
-                stateNavigator.navigate('s1', null, undefined, 'anchor');
+                stateNavigator.navigate('s1', null, undefined, 'f');
             });
             test();
         });
@@ -274,7 +274,7 @@ describe('Navigation', function () {
             beforeEach(function() {
                 var link = stateNavigator.getNavigationLink('s0');
                 stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationLink('s1', undefined, 'anchor');
+                link = stateNavigator.getNavigationLink('s1', undefined, 'f');
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -283,8 +283,8 @@ describe('Navigation', function () {
         function test() {
             it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.hash, 'anchor');
-                assert.equal(stateNavigator.stateContext.url, '/r1#anchor');
+                assert.equal(stateNavigator.stateContext.hash, 'f');
+                assert.equal(stateNavigator.stateContext.url, '/r1#f');
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s0']);
                 assert.strictEqual(stateNavigator.stateContext.oldHash, null);
                 assert.equal(stateNavigator.stateContext.oldUrl, '/r0');
@@ -307,7 +307,7 @@ describe('Navigation', function () {
         
         describe('Navigate', function() {
             beforeEach(function() {
-                stateNavigator.navigate('s0', null, undefined, 'anchor');
+                stateNavigator.navigate('s0', null, undefined, 'f');
                 stateNavigator.navigate('s1');
             });
             test();
@@ -315,7 +315,7 @@ describe('Navigation', function () {
 
         describe('Navigate Link', function() {
             beforeEach(function() {
-                var link = stateNavigator.getNavigationLink('s0', undefined, 'anchor');
+                var link = stateNavigator.getNavigationLink('s0', undefined, 'f');
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationLink('s1');
                 stateNavigator.navigateLink(link);
@@ -327,8 +327,8 @@ describe('Navigation', function () {
             it('should populate context', function() {
                 assert.strictEqual(stateNavigator.stateContext.hash, null);
                 assert.equal(stateNavigator.stateContext.url, '/r1');
-                assert.equal(stateNavigator.stateContext.oldHash, 'anchor');
-                assert.equal(stateNavigator.stateContext.oldUrl, '/r0#anchor');
+                assert.equal(stateNavigator.stateContext.oldHash, 'f');
+                assert.equal(stateNavigator.stateContext.oldUrl, '/r0#f');
                 assert.strictEqual(stateNavigator.stateContext.previousHash, null);
                 assert.equal(stateNavigator.stateContext.previousUrl, null);
             });
@@ -346,17 +346,17 @@ describe('Navigation', function () {
         
         describe('Navigate', function() {
             beforeEach(function() {
-                stateNavigator.navigate('s0', null, undefined, 'anchor0');
-                stateNavigator.navigate('s1', null, undefined, 'anchor1');
+                stateNavigator.navigate('s0', null, undefined, 'f0');
+                stateNavigator.navigate('s1', null, undefined, 'f1');
             });
             test();
         });
 
         describe('Navigate Link', function() {
             beforeEach(function() {
-                var link = stateNavigator.getNavigationLink('s0', undefined, 'anchor0');
+                var link = stateNavigator.getNavigationLink('s0', undefined, 'f0');
                 stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationLink('s1', undefined, 'anchor1');
+                link = stateNavigator.getNavigationLink('s1', undefined, 'f1');
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -364,10 +364,10 @@ describe('Navigation', function () {
         
         function test() {
             it('should populate context', function() {
-                assert.equal(stateNavigator.stateContext.hash, 'anchor1');
-                assert.equal(stateNavigator.stateContext.url, '/r1#anchor1');
-                assert.equal(stateNavigator.stateContext.oldHash, 'anchor0');
-                assert.equal(stateNavigator.stateContext.oldUrl, '/r0#anchor0');
+                assert.equal(stateNavigator.stateContext.hash, 'f1');
+                assert.equal(stateNavigator.stateContext.url, '/r1#f1');
+                assert.equal(stateNavigator.stateContext.oldHash, 'f0');
+                assert.equal(stateNavigator.stateContext.oldUrl, '/r0#f0');
                 assert.strictEqual(stateNavigator.stateContext.previousHash, null);
                 assert.equal(stateNavigator.stateContext.previousUrl, null);
             });
@@ -428,7 +428,7 @@ describe('Navigation', function () {
         describe('Navigate', function() {
             beforeEach(function() {
                 stateNavigator.navigate('s0');
-                stateNavigator.navigate('s1', null, undefined, 'anchor');
+                stateNavigator.navigate('s1', null, undefined, 'f');
             });
             test();
         });
@@ -437,7 +437,7 @@ describe('Navigation', function () {
             beforeEach(function() {
                 var link = stateNavigator.getNavigationLink('s0');
                 stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationLink('s1', null, 'anchor');
+                link = stateNavigator.getNavigationLink('s1', null, 'f');
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -446,7 +446,7 @@ describe('Navigation', function () {
         function test() {
             it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.hash, 'anchor');
+                assert.equal(stateNavigator.stateContext.hash, 'f');
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s0']);
                 assert.strictEqual(stateNavigator.stateContext.oldHash, null);
                 assert.equal(stateNavigator.stateContext.oldUrl, '/r0');
@@ -469,7 +469,7 @@ describe('Navigation', function () {
 
         describe('Navigate', function() {
             beforeEach(function() {
-                stateNavigator.navigate('s0', null, undefined, 'anchor');
+                stateNavigator.navigate('s0', null, undefined, 'f');
                 stateNavigator.navigate('s1');
             });
             test();
@@ -477,7 +477,7 @@ describe('Navigation', function () {
 
         describe('Navigate Link', function() {
             beforeEach(function() {
-                var link = stateNavigator.getNavigationLink('s0', null, 'anchor');
+                var link = stateNavigator.getNavigationLink('s0', null, 'f');
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationLink('s1');
                 stateNavigator.navigateLink(link);
@@ -490,11 +490,11 @@ describe('Navigation', function () {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
                 assert.strictEqual(stateNavigator.stateContext.hash, null);
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.oldHash, 'anchor');
-                assert.equal(stateNavigator.stateContext.oldUrl, '/r0#anchor');
+                assert.equal(stateNavigator.stateContext.oldHash, 'f');
+                assert.equal(stateNavigator.stateContext.oldUrl, '/r0#f');
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.previousHash, 'anchor');
-                assert.equal(stateNavigator.stateContext.previousUrl, '/r0#anchor');
+                assert.equal(stateNavigator.stateContext.previousHash, 'f');
+                assert.equal(stateNavigator.stateContext.previousUrl, '/r0#f');
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
             });
         }
@@ -511,17 +511,17 @@ describe('Navigation', function () {
 
         describe('Navigate', function() {
             beforeEach(function() {
-                stateNavigator.navigate('s0', null, undefined, 'anchor0');
-                stateNavigator.navigate('s1', null, undefined, 'anchor1');
+                stateNavigator.navigate('s0', null, undefined, 'f0');
+                stateNavigator.navigate('s1', null, undefined, 'f1');
             });
             test();
         });
 
         describe('Navigate Link', function() {
             beforeEach(function() {
-                var link = stateNavigator.getNavigationLink('s0', null, 'anchor0');
+                var link = stateNavigator.getNavigationLink('s0', null, 'f0');
                 stateNavigator.navigateLink(link);
-                link = stateNavigator.getNavigationLink('s1', null, 'anchor1');
+                link = stateNavigator.getNavigationLink('s1', null, 'f1');
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -530,13 +530,13 @@ describe('Navigation', function () {
         function test() {
             it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.hash, 'anchor1');
+                assert.equal(stateNavigator.stateContext.hash, 'f1');
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.oldHash, 'anchor0');
-                assert.equal(stateNavigator.stateContext.oldUrl, '/r0#anchor0');
+                assert.equal(stateNavigator.stateContext.oldHash, 'f0');
+                assert.equal(stateNavigator.stateContext.oldUrl, '/r0#f0');
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.previousHash, 'anchor0');
-                assert.equal(stateNavigator.stateContext.previousUrl, '/r0#anchor0');
+                assert.equal(stateNavigator.stateContext.previousHash, 'f0');
+                assert.equal(stateNavigator.stateContext.previousUrl, '/r0#f0');
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
             });
         }

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -84,6 +84,7 @@ describe('Navigation', function () {
             stateNavigator.navigateLink(link);
             assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s']);
             assert.equal(stateNavigator.stateContext.hash, '*="/()\'-_+~@:?><.;[],{}!£$%^#&');
+            assert.equal(stateNavigator.stateContext.url, '/r#*="/()\'-_+~@:?><.;[],{}!£$%^#&');
             assert.equal(stateNavigator.stateContext.crumbs.length, 0);
         });
     });

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -49,6 +49,32 @@ describe('Navigation', function () {
         });
     });
 
+    describe('State Null Hash', function() {
+        it('should populate context', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r' }
+            ]);
+            var link = stateNavigator.getNavigationLink('s', undefined, null);
+            stateNavigator.navigateLink(link);
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s']);
+            assert.equal(stateNavigator.stateContext.url, '/r');
+            assert.equal(stateNavigator.stateContext.hash, null);
+        });
+    });
+
+    describe('State Empty Hash', function() {
+        it('should populate context', function() {
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r' }
+            ]);
+            var link = stateNavigator.getNavigationLink('s', undefined, '');
+            stateNavigator.navigateLink(link);
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s']);
+            assert.equal(stateNavigator.stateContext.url, '/r');
+            assert.equal(stateNavigator.stateContext.hash, null);
+        });
+    });
+
     describe('State Reserved Url Character Hash', function() {
         it('should populate context', function() {
             var stateNavigator = new StateNavigator([

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -30,7 +30,7 @@ describe('Navigation', function () {
             it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s']);
                 assert.equal(stateNavigator.stateContext.history, false);
-                assert.equal(stateNavigator.stateContext.hash, null);
+                assert.strictEqual(stateNavigator.stateContext.hash, null);
                 assert.equal(stateNavigator.stateContext.crumbs.length, 0);
             });
         }
@@ -237,13 +237,13 @@ describe('Navigation', function () {
         function test() {
             it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.hash, null);
+                assert.strictEqual(stateNavigator.stateContext.hash, null);
                 assert.equal(stateNavigator.stateContext.url, '/r1');
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.oldHash, null);
+                assert.strictEqual(stateNavigator.stateContext.oldHash, null);
                 assert.equal(stateNavigator.stateContext.oldUrl, '/r0');
                 assert.equal(stateNavigator.stateContext.previousState, null);
-                assert.equal(stateNavigator.stateContext.previousHash, null);
+                assert.strictEqual(stateNavigator.stateContext.previousHash, null);
                 assert.equal(stateNavigator.stateContext.previousUrl, null);
                 assert.equal(stateNavigator.stateContext.crumbs.length, 0);
             });
@@ -448,10 +448,10 @@ describe('Navigation', function () {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
                 assert.equal(stateNavigator.stateContext.hash, 'anchor');
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.oldHash, null);
+                assert.strictEqual(stateNavigator.stateContext.oldHash, null);
                 assert.equal(stateNavigator.stateContext.oldUrl, '/r0');
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.previousHash, null);
+                assert.strictEqual(stateNavigator.stateContext.previousHash, null);
                 assert.equal(stateNavigator.stateContext.previousUrl, '/r0');
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1);
             });
@@ -488,7 +488,7 @@ describe('Navigation', function () {
         function test() {
             it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.hash, null);
+                assert.strictEqual(stateNavigator.stateContext.hash, null);
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s0']);
                 assert.equal(stateNavigator.stateContext.oldHash, 'anchor');
                 assert.equal(stateNavigator.stateContext.oldUrl, '/r0#anchor');

--- a/Navigation/test/node_modules/@types/navigation.d.ts
+++ b/Navigation/test/node_modules/@types/navigation.d.ts
@@ -514,12 +514,11 @@ export class StateNavigator<NavigationInfo extends { [index: string]: any } = an
      * @param navigationData The NavigationData to be passed to the next
      * State and stored in the StateContext
      * @param historyAction A value determining the effect on browser history
-     * @param hash The fragment identifier of the Url to navigate to
      * @throws state does not match the key of a State or there is
      * NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    navigate<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], historyAction?: 'add' | 'replace' | 'none', hash?: string): void;
+    navigate<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], historyAction?: 'add' | 'replace' | 'none'): void;
     /**
      * Gets a Url to navigate to a State
      * @param stateKey The key of a State
@@ -555,11 +554,10 @@ export class StateNavigator<NavigationInfo extends { [index: string]: any } = an
      * @param navigationData The NavigationData to be passed to the current
      * State and stored in the StateContext
      * @param historyAction A value determining the effect on browser history
-     * @param hash The fragment identifier of the Url to navigate to
      * @throws There is NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    refresh(navigationData?: null | NavigationInfo[Key], historyAction?: 'add' | 'replace' | 'none', hash?: string): void;
+    refresh(navigationData?: null | NavigationInfo[Key], historyAction?: 'add' | 'replace' | 'none'): void;
     /**
      * Gets a Url to navigate to the current State
      * @param navigationData The NavigationData to be passed to the current

--- a/Navigation/test/node_modules/@types/navigation.d.ts
+++ b/Navigation/test/node_modules/@types/navigation.d.ts
@@ -583,8 +583,8 @@ export class StateNavigator<NavigationInfo extends { [index: string]: any } = an
      * Parses the url out into State and Navigation Data
      * @param url The url to parse
      */
-    parseLink(url: string): { state: State; data: any; crumbs: Crumb[], hash: string };
-    parseLink<StateKey extends keyof NavigationInfo>(url: string): { state: State<StateKey & string, NavigationInfo[StateKey]>; data: NavigationInfo[StateKey]; crumbs: Crumb[], hash: string };
+    parseLink(url: string): { state: State; data: any; hash: string; crumbs: Crumb[] };
+    parseLink<StateKey extends keyof NavigationInfo>(url: string): { state: State<StateKey & string, NavigationInfo[StateKey]>; data: NavigationInfo[StateKey]; hash: string; crumbs: Crumb[] };
     /**
      * Creates a FluentNavigator
      * @param withContext a value indicating whether to inherit the current

--- a/Navigation/test/node_modules/@types/navigation.d.ts
+++ b/Navigation/test/node_modules/@types/navigation.d.ts
@@ -453,11 +453,11 @@ export interface FluentNavigator<NavigationInfo extends { [index: string]: any }
      * Navigates to the current State
      * @param navigationData The NavigationData to be passed to the current
      * State and stored in the StateContext
-     * @param A value determining the effect on browser history
+     * @param hash The fragment identifier of the Url to navigate to
      * @throws There is NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    refresh(navigationData?: null | NavigationInfo[Key]): FluentNavigator<NavigationInfo, Key>;
+    refresh(navigationData?: null | NavigationInfo[Key], hash?: string): FluentNavigator<NavigationInfo, Key>;
 }
 
 /**

--- a/Navigation/test/node_modules/@types/navigation.d.ts
+++ b/Navigation/test/node_modules/@types/navigation.d.ts
@@ -583,8 +583,8 @@ export class StateNavigator<NavigationInfo extends { [index: string]: any } = an
      * Parses the url out into State and Navigation Data
      * @param url The url to parse
      */
-    parseLink(url: string): { state: State; data: any; crumbs: Crumb[] };
-    parseLink<StateKey extends keyof NavigationInfo>(url: string): { state: State<StateKey & string, NavigationInfo[StateKey]>; data: NavigationInfo[StateKey]; crumbs: Crumb[] };
+    parseLink(url: string): { state: State; data: any; crumbs: Crumb[], hash: string };
+    parseLink<StateKey extends keyof NavigationInfo>(url: string): { state: State<StateKey & string, NavigationInfo[StateKey]>; data: NavigationInfo[StateKey]; crumbs: Crumb[], hash: string };
     /**
      * Creates a FluentNavigator
      * @param withContext a value indicating whether to inherit the current

--- a/Navigation/test/node_modules/@types/navigation.d.ts
+++ b/Navigation/test/node_modules/@types/navigation.d.ts
@@ -1,7 +1,7 @@
 /**
  * Defines a contract a class must implement in order to configure a State
  */
- export interface StateInfo<Key extends string> {
+export interface StateInfo<Key extends string> {
     /**
      * Gets the unique key
      */

--- a/Navigation/test/node_modules/@types/navigation.d.ts
+++ b/Navigation/test/node_modules/@types/navigation.d.ts
@@ -297,6 +297,10 @@ export class Crumb<Key extends string = string, Data extends object = any> {
      */
     state: State<Key, Data>;
     /**
+     * Gets the fragment identifier associated with this navigation
+     */
+     hash: string;
+    /**
      * Gets a value indicating whether the Crumb is the last in the crumb
      * trail
      */
@@ -321,6 +325,7 @@ export class Crumb<Key extends string = string, Data extends object = any> {
      * from this State
      * @param state The configuration information associated with this
      * navigation
+     * @oaram hash The fragment identifier associated with this navigation
      * @param link The link navigation to return to the State and pass the
      * associated Data
      * @param crumblessLink The link navigation without crumb trail to
@@ -328,7 +333,7 @@ export class Crumb<Key extends string = string, Data extends object = any> {
      * @param last A value indicating whether the Crumb is the last in the
      * crumb trail
      */
-    constructor(data: Data, state: State<Key, Data>, link: string, crumblessLink: string, last: boolean);
+    constructor(data: Data, state: State<Key, Data>, hash: string, link: string, crumblessLink: string, last: boolean);
 }
 
 /**
@@ -550,18 +555,20 @@ export class StateNavigator<NavigationInfo extends { [index: string]: any } = an
      * @param navigationData The NavigationData to be passed to the current
      * State and stored in the StateContext
      * @param historyAction A value determining the effect on browser history
+     * @param hash The fragment identifier of the Url to navigate to
      * @throws There is NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    refresh(navigationData?: null | NavigationInfo[Key], historyAction?: 'add' | 'replace' | 'none'): void;
+    refresh(navigationData?: null | NavigationInfo[Key], historyAction?: 'add' | 'replace' | 'none', hash?: string): void;
     /**
      * Gets a Url to navigate to the current State
      * @param navigationData The NavigationData to be passed to the current
      * State and stored in the StateContext
+     * @param hash The fragment identifier of the Url to navigate to
      * @returns Url that will navigate to the current State
      * @throws There is NavigationData that cannot be converted to a String
      */
-    getRefreshLink(navigationData?: null | NavigationInfo[Key]): string;
+    getRefreshLink(navigationData?: null | NavigationInfo[Key], hash?: string): string;
     /**
      * Navigates to the url
      * @param url The target location

--- a/Navigation/test/node_modules/@types/navigation.d.ts
+++ b/Navigation/test/node_modules/@types/navigation.d.ts
@@ -344,6 +344,9 @@ export class StateContext<Key extends string = string, Data extends object = any
      * Gets the NavigationData for the last displayed State
      */
     oldData: any;
+    /**
+     * Gets the fragment identifier of the last displayed State
+     */
     oldHash: string;
     /**
      * Gets the Url for the last displayed State
@@ -357,6 +360,9 @@ export class StateContext<Key extends string = string, Data extends object = any
      * Gets the NavigationData of the last Crumb in the crumb trail
      */
     previousData: any;
+    /**
+     * Gets the fragment identifier of the last Crumb in the crumb trail
+     */
     previousHash: string;
     /**
      * Gets the Url of the last Crumb in the crumb trail
@@ -370,6 +376,9 @@ export class StateContext<Key extends string = string, Data extends object = any
      * Gets the NavigationData for the current State
      */
     data: Data;
+    /**
+     * Gets the fragment identifier of the current Url
+     */
     hash: string;
     /**
      * Gets the current Url
@@ -500,6 +509,7 @@ export class StateNavigator<NavigationInfo extends { [index: string]: any } = an
      * @param navigationData The NavigationData to be passed to the next
      * State and stored in the StateContext
      * @param historyAction A value determining the effect on browser history
+     * @param hash The fragment identifier of the Url to navigate to
      * @throws state does not match the key of a State or there is
      * NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
@@ -510,6 +520,7 @@ export class StateNavigator<NavigationInfo extends { [index: string]: any } = an
      * @param stateKey The key of a State
      * @param navigationData The NavigationData to be passed to the next
      * State and stored in the StateContext
+     * @param hash The fragment identifier of the Url to navigate to
      * @returns Url that will navigate to State specified in the action
      * @throws state does not match the key of a State or there is
      * NavigationData that cannot be converted to a String

--- a/Navigation/test/node_modules/@types/navigation.d.ts
+++ b/Navigation/test/node_modules/@types/navigation.d.ts
@@ -436,11 +436,12 @@ export interface FluentNavigator<NavigationInfo extends { [index: string]: any }
      * @param stateKey The key of a State
      * @param navigationData The NavigationData to be passed to the next
      * State and stored in the StateContext
+     * @param hash The fragment identifier of the Url to navigate to
      * @throws state does not match the key of a State or there is
      * NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    navigate<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey]): FluentNavigator<NavigationInfo, StateKey>;
+    navigate<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], hash?: string): FluentNavigator<NavigationInfo, StateKey>;
     /**
      * Navigates back along the crumb trail
      * @param distance Starting at 1, the number of Crumb steps to go back

--- a/Navigation/test/node_modules/@types/navigation.d.ts
+++ b/Navigation/test/node_modules/@types/navigation.d.ts
@@ -1,7 +1,7 @@
 /**
  * Defines a contract a class must implement in order to configure a State
  */
-export interface StateInfo<Key extends string> {
+ export interface StateInfo<Key extends string> {
     /**
      * Gets the unique key
      */
@@ -519,7 +519,7 @@ export class StateNavigator<NavigationInfo extends { [index: string]: any } = an
      * NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    navigate<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], historyAction?: 'add' | 'replace' | 'none'): void;
+    navigate<StateKey extends keyof NavigationInfo & string>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], historyAction?: 'add' | 'replace' | 'none'): void;
     /**
      * Gets a Url to navigate to a State
      * @param stateKey The key of a State
@@ -530,7 +530,7 @@ export class StateNavigator<NavigationInfo extends { [index: string]: any } = an
      * @throws state does not match the key of a State or there is
      * NavigationData that cannot be converted to a String
      */
-    getNavigationLink<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], hash?: string): string;
+    getNavigationLink<StateKey extends keyof NavigationInfo & string>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], hash?: string): string;
     /**
      * Determines if the distance specified is within the bounds of the
      * crumb trail represented by the Crumbs collection

--- a/Navigation/test/node_modules/@types/navigation.d.ts
+++ b/Navigation/test/node_modules/@types/navigation.d.ts
@@ -333,7 +333,7 @@ export class Crumb<Key extends string = string, Data extends object = any> {
      * crumb trail
      * @param hash The fragment identifier associated with this navigation
      */
-    constructor(data: Data, state: State<Key, Data>, link: string, crumblessLink: string, last: boolean, hash: string);
+    constructor(data: Data, state: State<Key, Data>, link: string, crumblessLink: string, last: boolean, hash?: string);
 }
 
 /**

--- a/Navigation/test/node_modules/@types/navigation.d.ts
+++ b/Navigation/test/node_modules/@types/navigation.d.ts
@@ -325,15 +325,15 @@ export class Crumb<Key extends string = string, Data extends object = any> {
      * from this State
      * @param state The configuration information associated with this
      * navigation
-     * @oaram hash The fragment identifier associated with this navigation
      * @param link The link navigation to return to the State and pass the
      * associated Data
      * @param crumblessLink The link navigation without crumb trail to
      * return to the State and pass the associated Data
      * @param last A value indicating whether the Crumb is the last in the
      * crumb trail
+     * @param hash The fragment identifier associated with this navigation
      */
-    constructor(data: Data, state: State<Key, Data>, hash: string, link: string, crumblessLink: string, last: boolean);
+    constructor(data: Data, state: State<Key, Data>, link: string, crumblessLink: string, last: boolean, hash: string);
 }
 
 /**

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -59,7 +59,7 @@ class LinkUtility {
         }
         return htmlProps;
     }
-    
+
     static getOnClick(stateNavigator: AsyncStateNavigator, props: LinkProps, link: string) {
         return e => {
             if (!e.ctrlKey && !e.shiftKey && !e.metaKey && !e.altKey && !e.button) {

--- a/NavigationReact/src/LinkUtility.ts
+++ b/NavigationReact/src/LinkUtility.ts
@@ -51,10 +51,10 @@ class LinkUtility {
         var htmlProps = {};
         for(var key in props) {
             if (key !== 'stateNavigator' && key !== 'stateKey' && key !== 'navigationData'
-                && key !== 'includeCurrentData' && key !== 'currentDataKeys'&& key !== 'activeStyle'
-                && key !== 'activeCssClass' && key !== 'disableActive' && key !== 'distance'
-                && key !== 'historyAction' && key !== 'navigating' && key !== 'navigate'
-                && key !== 'withContext' && key !== 'defer')
+                && key !== 'includeCurrentData' && key !== 'currentDataKeys' && key !== 'hash'
+                && key !== 'activeStyle' && key !== 'activeCssClass' && key !== 'disableActive'
+                && key !== 'distance' && key !== 'historyAction' && key !== 'navigating'
+                && key !== 'navigate' && key !== 'withContext' && key !== 'defer')
                 htmlProps[key] = props[key];
         }
         return htmlProps;

--- a/NavigationReact/src/NavigationLink.tsx
+++ b/NavigationReact/src/NavigationLink.tsx
@@ -5,11 +5,11 @@ import * as React from 'react';
 
 var NavigationLink = (props: NavigationLinkProps) => {
     var htmlProps = LinkUtility.toHtmlProps(props);
-    var { stateKey, navigationData, includeCurrentData, currentDataKeys, stateNavigator } = props;
+    var { stateKey, navigationData, includeCurrentData, currentDataKeys, hash, stateNavigator } = props;
     var { state } = stateNavigator.stateContext;
     navigationData = LinkUtility.getData(stateNavigator, navigationData, includeCurrentData, currentDataKeys);
     try {
-        var link = stateNavigator.getNavigationLink(stateKey, navigationData);
+        var link = stateNavigator.getNavigationLink(stateKey, navigationData, hash);
     } catch {}
     htmlProps.href = link && stateNavigator.historyManager.getHref(link);
     htmlProps.onClick = link && LinkUtility.getOnClick(stateNavigator, props, link);

--- a/NavigationReact/src/Props.ts
+++ b/NavigationReact/src/Props.ts
@@ -13,6 +13,7 @@ interface RefreshLinkProps extends LinkProps {
     navigationData?: any;
     includeCurrentData?: boolean;
     currentDataKeys?: string | string[];
+    hash?: string;
     activeStyle?: any;
     activeCssClass?: string;
     disableActive?: boolean;

--- a/NavigationReact/src/RefreshLink.tsx
+++ b/NavigationReact/src/RefreshLink.tsx
@@ -5,10 +5,10 @@ import * as React from 'react';
 
 var RefreshLink = (props: RefreshLinkProps) => {
     var htmlProps = LinkUtility.toHtmlProps(props);
-    var { navigationData, includeCurrentData, currentDataKeys, stateNavigator } = props;
+    var { navigationData, includeCurrentData, currentDataKeys, hash, stateNavigator } = props;
     navigationData = LinkUtility.getData(stateNavigator, navigationData, includeCurrentData, currentDataKeys);
     try {
-        var link = stateNavigator.getRefreshLink(navigationData);
+        var link = stateNavigator.getRefreshLink(navigationData, hash);
     } catch {}
     htmlProps.href = link && stateNavigator.historyManager.getHref(link);
     htmlProps.onClick = link && LinkUtility.getOnClick(stateNavigator, props, link);

--- a/NavigationReact/src/node_modules/@types/navigation.d.ts
+++ b/NavigationReact/src/node_modules/@types/navigation.d.ts
@@ -1,7 +1,7 @@
 /**
  * Defines a contract a class must implement in order to configure a State
  */
- export interface StateInfo<Key extends string> {
+export interface StateInfo<Key extends string> {
     /**
      * Gets the unique key
      */

--- a/NavigationReact/src/node_modules/@types/navigation.d.ts
+++ b/NavigationReact/src/node_modules/@types/navigation.d.ts
@@ -1,11 +1,11 @@
 /**
  * Defines a contract a class must implement in order to configure a State
  */
-export interface StateInfo {
+ export interface StateInfo<Key extends string> {
     /**
      * Gets the unique key
      */
-    key: string;
+    key: Key;
     /**
      * Gets the default NavigationData for this State
      */
@@ -40,15 +40,15 @@ export interface StateInfo {
 /**
  * Represents a view and is the destination of a navigation
  */
-export class State implements StateInfo {
+export class State<Key extends string = string, Data extends object = any> implements StateInfo<Key> {
     /**
      * Gets the unique key
      */
-    key: string;
+    key: Key;
     /**
      * Gets the default NavigationData for this State
      */
-    defaults: any;
+    defaults: Partial<Data>;
     /**
      * Gets the default NavigationData Types for  this State
      */
@@ -104,7 +104,7 @@ export class State implements StateInfo {
      * @param data The current NavigationData
      * @param asyncData The data passed asynchronously while navigating
      */
-    navigated: (data: any, asyncData: any) => void;
+    navigated: (data: Data, asyncData: any) => void;
     /**
      * Called on the new State before navigating to it
      * @param data The new NavigationData
@@ -112,7 +112,7 @@ export class State implements StateInfo {
      * @param navigate The function to call to continue to navigate
      * @param history A value indicating whether browser history was used
      */
-    navigating: (data: any, url: string, navigate: (asyncData?: any) => void, history: boolean) => void;
+    navigating: (data: Data, url: string, navigate: (asyncData?: any) => void, history: boolean) => void;
     /**
      * Encodes the Url value
      * @param state The State navigated to
@@ -121,7 +121,7 @@ export class State implements StateInfo {
      * @param queryString A value indicating the Url value's location
      * @param index The index of the navigation data array item
      */
-    urlEncode(state: State, key: string, val: string, queryString: boolean, index?: number): string;
+    urlEncode(state: State<Key, Data>, key: keyof Data & string, val: string, queryString: boolean, index?: number): string;
     /**
      * Decodes the Url value
      * @param state The State navigated to
@@ -129,13 +129,13 @@ export class State implements StateInfo {
      * @param val The Url value of the navigation data item
      * @param queryString A value indicating the Url value's location
      */
-    urlDecode(state: State, key: string, val: string, queryString: boolean): string;
+    urlDecode(state: State<Key, Data>, key: keyof Data & string, val: string, queryString: boolean): string;
     /**
      * Validates the NavigationData before navigating to the new State
      * @param data The new NavigationData
      * @returns Validation success indicator
      */
-    validate(data: any): boolean;
+    validate(data: Data): boolean;
     /**
      * Truncates the crumb trail whenever a repeated or initial State is
      * encountered
@@ -144,7 +144,7 @@ export class State implements StateInfo {
      * @param The Crumb collection representing the crumb trail
      * @returns Truncated crumb trail
      */
-    truncateCrumbTrail(state: State, data: any, crumbs: Crumb[]): Crumb[];
+    truncateCrumbTrail(state: State<Key, Data>, data: Data, crumbs: Crumb[]): Crumb[];
 }
 
 /**
@@ -286,16 +286,20 @@ export class HTML5HistoryManager implements HistoryManager {
  * Represents one piece of the crumb trail and holds the information needed
  * to return to and recreate the State as previously visited
  */
-export class Crumb {
+export class Crumb<Key extends string = string, Data extends object = any> {
     /**
      * Gets the Context Data held at the time of navigating away from this
      * State
      */
-    data: any;
+    data: Data;
     /**
      * Gets the configuration information associated with this navigation
      */
-    state: State;
+    state: State<Key, Data>;
+    /**
+     * Gets the fragment identifier associated with this navigation
+     */
+     hash: string;
     /**
      * Gets a value indicating whether the Crumb is the last in the crumb
      * trail
@@ -327,15 +331,16 @@ export class Crumb {
      * return to the State and pass the associated Data
      * @param last A value indicating whether the Crumb is the last in the
      * crumb trail
+     * @param hash The fragment identifier associated with this navigation
      */
-    constructor(data: any, state: State, link: string, crumblessLink: string, last: boolean);
+    constructor(data: Data, state: State<Key, Data>, link: string, crumblessLink: string, last: boolean, hash?: string);
 }
 
 /**
  * Provides properties for accessing context sensitive navigation
  * information. Holds the current State and NavigationData
  */
-export class StateContext {
+export class StateContext<Key extends string = string, Data extends object = any> {
     /**
      * Gets the last State displayed before the current State
      */
@@ -344,6 +349,10 @@ export class StateContext {
      * Gets the NavigationData for the last displayed State
      */
     oldData: any;
+    /**
+     * Gets the fragment identifier of the last displayed State
+     */
+    oldHash: string;
     /**
      * Gets the Url for the last displayed State
      */
@@ -357,17 +366,25 @@ export class StateContext {
      */
     previousData: any;
     /**
+     * Gets the fragment identifier of the last Crumb in the crumb trail
+     */
+    previousHash: string;
+    /**
      * Gets the Url of the last Crumb in the crumb trail
      */
     previousUrl: string;
     /**
      * Gets the current State
      */
-    state: State;
+    state: State<Key, Data>;
     /**
      * Gets the NavigationData for the current State
      */
-    data: any;
+    data: Data;
+    /**
+     * Gets the fragment identifier of the current Url
+     */
+    hash: string;
     /**
      * Gets the current Url
      */
@@ -392,7 +409,7 @@ export class StateContext {
     /**
      * Gets the next crumb
      */
-    nextCrumb: Crumb;
+    nextCrumb: Crumb<Key, Data>;
     /**
      * Clears the Context Data
      */
@@ -402,14 +419,14 @@ export class StateContext {
      * @param The data to add to the current NavigationData
      * @returns The combined data
      */
-    includeCurrentData(data: any, keys?: string[]): any;
+    includeCurrentData(data: Data, keys?: string[]): Data;
 }
 
 /**
  * Fluently manages all navigation. These can be forward, backward or
  * refreshing the current State
  */
-export interface FluentNavigator {
+export interface FluentNavigator<NavigationInfo extends { [index: string]: any } = any, Key extends keyof NavigationInfo = string>  {
     /**
      * Gets the current Url
      */
@@ -419,11 +436,12 @@ export interface FluentNavigator {
      * @param stateKey The key of a State
      * @param navigationData The NavigationData to be passed to the next
      * State and stored in the StateContext
+     * @param hash The fragment identifier of the Url to navigate to
      * @throws state does not match the key of a State or there is
      * NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    navigate(stateKey: string, navigationData?: any): FluentNavigator;
+    navigate<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], hash?: string): FluentNavigator<NavigationInfo, StateKey>;
     /**
      * Navigates back along the crumb trail
      * @param distance Starting at 1, the number of Crumb steps to go back
@@ -435,22 +453,22 @@ export interface FluentNavigator {
      * Navigates to the current State
      * @param navigationData The NavigationData to be passed to the current
      * State and stored in the StateContext
-     * @param A value determining the effect on browser history
+     * @param hash The fragment identifier of the Url to navigate to
      * @throws There is NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    refresh(navigationData?: any): FluentNavigator;
+    refresh(navigationData?: null | NavigationInfo[Key], hash?: string): FluentNavigator<NavigationInfo, Key>;
 }
 
 /**
  * Manages all navigation. These can be forward, backward or refreshing the
  * current State
  */
-export class StateNavigator {
+export class StateNavigator<NavigationInfo extends { [index: string]: any } = any, Key extends keyof NavigationInfo = string> {
     /**
      * Provides access to context sensitive navigation information
      */
-    stateContext: StateContext;
+    stateContext: StateContext<Key & string, Key extends keyof NavigationInfo ? NavigationInfo[Key] : any>;
     /**
      * Gets the browser Url manager
      */
@@ -458,19 +476,19 @@ export class StateNavigator {
     /**
      * Gets a list of States
      */
-    states: { [index: string]: State; };
+    states: { [Key in keyof NavigationInfo & string]: State<Key, NavigationInfo[Key]> };
     /**
      * Initializes a new instance of the StateNavigator class
      * @param stateInfos A collection of State Infos or another State Navigator
      * @param historyManager The manager of the browser Url
      */
-    constructor(stateInfos?: StateInfo[] | StateNavigator, historyManager?: HistoryManager);
+    constructor(stateInfos?: StateInfo<keyof NavigationInfo & string | string>[] | StateNavigator<NavigationInfo>, historyManager?: HistoryManager);
     /**
      * Configures the StateNavigator
      * @param stateInfos A collection of State Infos or another State Navigator
      * @param historyManager The manager of the browser Url
      */
-    configure(stateInfos: StateInfo[] | StateNavigator, historyManager?: HistoryManager): void;
+    configure(stateInfos: StateInfo<keyof NavigationInfo & string | string>[] | StateNavigator<NavigationInfo>, historyManager?: HistoryManager): void;
     /**
      * Registers a before navigate event listener
      * @param handler The before navigate event listener
@@ -501,17 +519,18 @@ export class StateNavigator {
      * NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    navigate(stateKey: string, navigationData?: any, historyAction?: 'add' | 'replace' | 'none'): void;
+    navigate<StateKey extends keyof NavigationInfo & string>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], historyAction?: 'add' | 'replace' | 'none'): void;
     /**
      * Gets a Url to navigate to a State
      * @param stateKey The key of a State
      * @param navigationData The NavigationData to be passed to the next
      * State and stored in the StateContext
+     * @param hash The fragment identifier of the Url to navigate to
      * @returns Url that will navigate to State specified in the action
      * @throws state does not match the key of a State or there is
      * NavigationData that cannot be converted to a String
      */
-    getNavigationLink(stateKey: string, navigationData?: any): string;
+    getNavigationLink<StateKey extends keyof NavigationInfo & string>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], hash?: string): string;
     /**
      * Determines if the distance specified is within the bounds of the
      * crumb trail represented by the Crumbs collection
@@ -539,15 +558,16 @@ export class StateNavigator {
      * @throws There is NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    refresh(navigationData?: any, historyAction?: 'add' | 'replace' | 'none'): void;
+    refresh(navigationData?: null | NavigationInfo[Key], historyAction?: 'add' | 'replace' | 'none'): void;
     /**
      * Gets a Url to navigate to the current State
      * @param navigationData The NavigationData to be passed to the current
      * State and stored in the StateContext
+     * @param hash The fragment identifier of the Url to navigate to
      * @returns Url that will navigate to the current State
      * @throws There is NavigationData that cannot be converted to a String
      */
-    getRefreshLink(navigationData?: any): string;
+    getRefreshLink(navigationData?: null | NavigationInfo[Key], hash?: string): string;
     /**
      * Navigates to the url
      * @param url The target location
@@ -558,19 +578,20 @@ export class StateNavigator {
      */
     navigateLink(url: string, historyAction?: 'add' | 'replace' | 'none', history?: boolean,
         suspendNavigation?: (stateContext: StateContext, resumeNavigation: () => void) => void,
-        currentContext?: StateContext): void;
+        currentContext?: StateContext<Key & string, Key extends keyof NavigationInfo ? NavigationInfo[Key] : any>): void;
     /**
      * Parses the url out into State and Navigation Data
      * @param url The url to parse
      */
-    parseLink(url: string): { state: State; data: any; crumbs: Crumb[] };
+    parseLink(url: string): { state: State; data: any; hash: string; crumbs: Crumb[] };
+    parseLink<StateKey extends keyof NavigationInfo>(url: string): { state: State<StateKey & string, NavigationInfo[StateKey]>; data: NavigationInfo[StateKey]; hash: string; crumbs: Crumb[] };
     /**
      * Creates a FluentNavigator
      * @param withContext a value indicating whether to inherit the current
      * context
      * @returns A FluentNavigator
      */
-    fluent(withContext?: boolean): FluentNavigator;
+    fluent<B extends boolean>(withContext?: B): FluentNavigator<NavigationInfo, B extends true ? Key : string>
     /**
      * Navigates to the passed in url
      * @param url The url to navigate to

--- a/NavigationReact/test/NavigationLinkTest.tsx
+++ b/NavigationReact/test/NavigationLinkTest.tsx
@@ -83,6 +83,7 @@ describe('NavigationLinkTest', function () {
                         navigationData={{x: 'a'}}
                         includeCurrentData={true}
                         currentDataKeys="y"
+                        hash='f'
                         activeStyle={{color: 'green', fontWeight: 'bold'}}
                         activeCssClass="active"
                         disableActive={true}
@@ -96,7 +97,7 @@ describe('NavigationLinkTest', function () {
                 container
             );
             var link = container.querySelector<HTMLAnchorElement>('a');
-            assert.equal(link.hash, '#/r?x=a');
+            assert.equal(link.hash, '#/r?x=a#f');
             assert.equal(link.innerHTML, 'link text');
             assert.equal(link.getAttribute('aria-label'), 'z');
             assert.equal(link.target, '_blank');

--- a/NavigationReact/test/NavigationLinkTest.tsx
+++ b/NavigationReact/test/NavigationLinkTest.tsx
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import * as mocha from 'mocha';
-import { StateNavigator, HTML5HistoryManager } from 'navigation';
+import { StateNavigator } from 'navigation';
 import { NavigationLink, NavigationHandler, NavigationContext } from 'navigation-react';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
@@ -381,28 +381,6 @@ describe('NavigationLinkTest', function () {
             );
             var link = container.querySelector<HTMLAnchorElement>('a');
             assert.equal(link.hash, '#/r');
-            assert.equal(link.innerHTML, 'link text');
-        })
-    });
-
-    describe('HTML5 History Hash Navigation Link', function () {
-        it('should render', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 's', route: 'r' }
-            ], new HTML5HistoryManager());
-            var container = document.createElement('div');
-            ReactDOM.render(
-                <NavigationHandler stateNavigator={stateNavigator}>
-                    <NavigationLink
-                        stateKey="s"
-                        hash='f'>
-                        link text
-                    </NavigationLink>
-                </NavigationHandler>,
-                container
-            );
-            var link = container.querySelector<HTMLAnchorElement>('a');
-            assert.equal(link.href, '/r#f');
             assert.equal(link.innerHTML, 'link text');
         })
     });

--- a/NavigationReact/test/NavigationLinkTest.tsx
+++ b/NavigationReact/test/NavigationLinkTest.tsx
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import * as mocha from 'mocha';
-import { StateNavigator } from 'navigation';
+import { StateNavigator, HTML5HistoryManager } from 'navigation';
 import { NavigationLink, NavigationHandler, NavigationContext } from 'navigation-react';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
@@ -336,6 +336,28 @@ describe('NavigationLinkTest', function () {
             );
             var link = container.querySelector<HTMLAnchorElement>('a');
             assert.equal(link.hash, '#/r#f');
+            assert.equal(link.innerHTML, 'link text');
+        })
+    });
+
+    describe('HTML5 History Hash Navigation Link', function () {
+        it('should render', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r' }
+            ], new HTML5HistoryManager());
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <NavigationLink
+                        stateKey="s"
+                        hash='f'>
+                        link text
+                    </NavigationLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            assert.equal(link.href, '/r#f');
             assert.equal(link.innerHTML, 'link text');
         })
     });

--- a/NavigationReact/test/NavigationLinkTest.tsx
+++ b/NavigationReact/test/NavigationLinkTest.tsx
@@ -340,6 +340,50 @@ describe('NavigationLinkTest', function () {
         })
     });
 
+    describe('Null Hash Navigation Link', function () {
+        it('should render', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r' }
+            ]);
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <NavigationLink
+                        stateKey="s"
+                        hash={null}>
+                        link text
+                    </NavigationLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            assert.equal(link.hash, '#/r');
+            assert.equal(link.innerHTML, 'link text');
+        })
+    });
+
+    describe('Empty Hash Navigation Link', function () {
+        it('should render', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r' }
+            ]);
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <NavigationLink
+                        stateKey="s"
+                        hash=''>
+                        link text
+                    </NavigationLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            assert.equal(link.hash, '#/r');
+            assert.equal(link.innerHTML, 'link text');
+        })
+    });
+
     describe('HTML5 History Hash Navigation Link', function () {
         it('should render', function(){
             var stateNavigator = new StateNavigator([

--- a/NavigationReact/test/NavigationLinkTest.tsx
+++ b/NavigationReact/test/NavigationLinkTest.tsx
@@ -318,6 +318,28 @@ describe('NavigationLinkTest', function () {
         })
     });
 
+    describe('Hash Navigation Link', function () {
+        it('should render', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r' }
+            ]);
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <NavigationLink
+                        stateKey="s"
+                        hash='f'>
+                        link text
+                    </NavigationLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            assert.equal(link.hash, '#/r#f');
+            assert.equal(link.innerHTML, 'link text');
+        })
+    });
+
     describe('Active Style Navigation Link', function () {
         it('should render', function(){
             var stateNavigator = new StateNavigator([

--- a/NavigationReact/test/RefreshLinkTest.tsx
+++ b/NavigationReact/test/RefreshLinkTest.tsx
@@ -83,6 +83,7 @@ describe('RefreshLinkTest', function () {
                         navigationData={{x: 'a'}}
                         includeCurrentData={true}
                         currentDataKeys="y"
+                        hash='f'
                         activeStyle={{color: 'green', fontWeight: 'bold'}}
                         activeCssClass="active"
                         disableActive={true}
@@ -96,7 +97,7 @@ describe('RefreshLinkTest', function () {
                 container
             );
             var link = container.querySelector<HTMLAnchorElement>('a');
-            assert.equal(link.hash, '#/r?x=a');
+            assert.equal(link.hash, '#/r?x=a#f');
             assert.equal(link.innerHTML, 'link text');
             assert.equal(link.getAttribute('aria-label'), 'z');
             assert.equal(link.target, '_blank');
@@ -306,6 +307,69 @@ describe('RefreshLinkTest', function () {
             var link = container.querySelector<HTMLAnchorElement>('a');
             assert.equal(link.hash, '#/r?y=a&z=c');
             assert.equal(link.innerHTML, 'link text');
+        })
+    });
+
+    describe('Hash Refresh Link', function () {
+        it('should render', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r' }
+            ]);
+            stateNavigator.navigate('s');
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <RefreshLink hash='f'>
+                        <span>link text</span>
+                    </RefreshLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            assert.equal(link.hash, '#/r#f');
+            assert.equal(link.innerHTML, '<span>link text</span>');
+        })
+    });
+
+    describe('Null Hash Refresh Link', function () {
+        it('should render', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r' }
+            ]);
+            stateNavigator.navigate('s');
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <RefreshLink hash={null}>
+                        <span>link text</span>
+                    </RefreshLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            assert.equal(link.hash, '#/r');
+            assert.equal(link.innerHTML, '<span>link text</span>');
+        })
+    });
+
+    describe('Empty Hash Refresh Link', function () {
+        it('should render', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's', route: 'r' }
+            ]);
+            stateNavigator.navigate('s');
+            var container = document.createElement('div');
+            ReactDOM.render(
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <RefreshLink hash=''>
+                        <span>link text</span>
+                    </RefreshLink>
+                </NavigationHandler>,
+                container
+            );
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            assert.equal(link.hash, '#/r');
+            assert.equal(link.innerHTML, '<span>link text</span>');
         })
     });
 

--- a/NavigationReact/test/node_modules/@types/navigation-react.d.ts
+++ b/NavigationReact/test/node_modules/@types/navigation-react.d.ts
@@ -129,6 +129,10 @@ export interface RefreshLinkProps<NavigationInfo extends { [index: string]: any 
      */
     currentDataKeys?: string & (Key extends keyof NavigationInfo ? keyof NavigationInfo[Key] : any) | (string & (Key extends keyof NavigationInfo ? keyof NavigationInfo[Key] : any))[];
     /**
+     * The fragment identifier
+     */
+    hash?: string;
+    /**
      * The style to display when the Link is active
      */
     activeStyle?: any;

--- a/NavigationReact/test/node_modules/@types/navigation-react.d.ts
+++ b/NavigationReact/test/node_modules/@types/navigation-react.d.ts
@@ -16,7 +16,7 @@ export class AsyncStateNavigator<NavigationInfo extends { [index: string]: any }
      * NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    navigate<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], historyAction?: 'add' | 'replace' | 'none', defer?: boolean): void;
+    navigate<StateKey extends keyof NavigationInfo & string>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], historyAction?: 'add' | 'replace' | 'none', defer?: boolean): void;
     /**
      * Navigates back along the crumb trail
      * @param distance Starting at 1, the number of Crumb steps to go back

--- a/NavigationReact/test/node_modules/@types/navigation.d.ts
+++ b/NavigationReact/test/node_modules/@types/navigation.d.ts
@@ -297,6 +297,10 @@ export class Crumb<Key extends string = string, Data extends object = any> {
      */
     state: State<Key, Data>;
     /**
+     * Gets the fragment identifier associated with this navigation
+     */
+     hash: string;
+    /**
      * Gets a value indicating whether the Crumb is the last in the crumb
      * trail
      */
@@ -327,8 +331,9 @@ export class Crumb<Key extends string = string, Data extends object = any> {
      * return to the State and pass the associated Data
      * @param last A value indicating whether the Crumb is the last in the
      * crumb trail
+     * @param hash The fragment identifier associated with this navigation
      */
-    constructor(data: Data, state: State<Key, Data>, link: string, crumblessLink: string, last: boolean);
+    constructor(data: Data, state: State<Key, Data>, link: string, crumblessLink: string, last: boolean, hash?: string);
 }
 
 /**
@@ -345,6 +350,10 @@ export class StateContext<Key extends string = string, Data extends object = any
      */
     oldData: any;
     /**
+     * Gets the fragment identifier of the last displayed State
+     */
+    oldHash: string;
+    /**
      * Gets the Url for the last displayed State
      */
     oldUrl: string;
@@ -357,6 +366,10 @@ export class StateContext<Key extends string = string, Data extends object = any
      */
     previousData: any;
     /**
+     * Gets the fragment identifier of the last Crumb in the crumb trail
+     */
+    previousHash: string;
+    /**
      * Gets the Url of the last Crumb in the crumb trail
      */
     previousUrl: string;
@@ -368,6 +381,10 @@ export class StateContext<Key extends string = string, Data extends object = any
      * Gets the NavigationData for the current State
      */
     data: Data;
+    /**
+     * Gets the fragment identifier of the current Url
+     */
+    hash: string;
     /**
      * Gets the current Url
      */
@@ -419,11 +436,12 @@ export interface FluentNavigator<NavigationInfo extends { [index: string]: any }
      * @param stateKey The key of a State
      * @param navigationData The NavigationData to be passed to the next
      * State and stored in the StateContext
+     * @param hash The fragment identifier of the Url to navigate to
      * @throws state does not match the key of a State or there is
      * NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    navigate<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey]): FluentNavigator<NavigationInfo, StateKey>;
+    navigate<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], hash?: string): FluentNavigator<NavigationInfo, StateKey>;
     /**
      * Navigates back along the crumb trail
      * @param distance Starting at 1, the number of Crumb steps to go back
@@ -435,11 +453,11 @@ export interface FluentNavigator<NavigationInfo extends { [index: string]: any }
      * Navigates to the current State
      * @param navigationData The NavigationData to be passed to the current
      * State and stored in the StateContext
-     * @param A value determining the effect on browser history
+     * @param hash The fragment identifier of the Url to navigate to
      * @throws There is NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    refresh(navigationData?: null | NavigationInfo[Key]): FluentNavigator<NavigationInfo, Key>;
+    refresh(navigationData?: null | NavigationInfo[Key], hash?: string): FluentNavigator<NavigationInfo, Key>;
 }
 
 /**
@@ -501,17 +519,18 @@ export class StateNavigator<NavigationInfo extends { [index: string]: any } = an
      * NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    navigate<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], historyAction?: 'add' | 'replace' | 'none'): void;
+    navigate<StateKey extends keyof NavigationInfo & string>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], historyAction?: 'add' | 'replace' | 'none'): void;
     /**
      * Gets a Url to navigate to a State
      * @param stateKey The key of a State
      * @param navigationData The NavigationData to be passed to the next
      * State and stored in the StateContext
+     * @param hash The fragment identifier of the Url to navigate to
      * @returns Url that will navigate to State specified in the action
      * @throws state does not match the key of a State or there is
      * NavigationData that cannot be converted to a String
      */
-    getNavigationLink<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey]): string;
+    getNavigationLink<StateKey extends keyof NavigationInfo & string>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], hash?: string): string;
     /**
      * Determines if the distance specified is within the bounds of the
      * crumb trail represented by the Crumbs collection
@@ -544,10 +563,11 @@ export class StateNavigator<NavigationInfo extends { [index: string]: any } = an
      * Gets a Url to navigate to the current State
      * @param navigationData The NavigationData to be passed to the current
      * State and stored in the StateContext
+     * @param hash The fragment identifier of the Url to navigate to
      * @returns Url that will navigate to the current State
      * @throws There is NavigationData that cannot be converted to a String
      */
-    getRefreshLink(navigationData?: null | NavigationInfo[Key]): string;
+    getRefreshLink(navigationData?: null | NavigationInfo[Key], hash?: string): string;
     /**
      * Navigates to the url
      * @param url The target location
@@ -563,8 +583,8 @@ export class StateNavigator<NavigationInfo extends { [index: string]: any } = an
      * Parses the url out into State and Navigation Data
      * @param url The url to parse
      */
-    parseLink(url: string): { state: State; data: any; crumbs: Crumb[] };
-    parseLink<StateKey extends keyof NavigationInfo>(url: string): { state: State<StateKey & string, NavigationInfo[StateKey]>; data: NavigationInfo[StateKey]; crumbs: Crumb[] };
+    parseLink(url: string): { state: State; data: any; hash: string; crumbs: Crumb[] };
+    parseLink<StateKey extends keyof NavigationInfo>(url: string): { state: State<StateKey & string, NavigationInfo[StateKey]>; data: NavigationInfo[StateKey]; hash: string; crumbs: Crumb[] };
     /**
      * Creates a FluentNavigator
      * @param withContext a value indicating whether to inherit the current

--- a/NavigationReactMobile/sample/isomorphic/index.js
+++ b/NavigationReactMobile/sample/isomorphic/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { NavigationHandler } from 'navigation-react';
-import { NavigationMotion } from 'navigation-react-mobile';
 import getStateNavigator from './getStateNavigator';
 import Isomorphic from './Isomorphic';
 

--- a/NavigationReactMobile/src/MobileHistoryManager.ts
+++ b/NavigationReactMobile/src/MobileHistoryManager.ts
@@ -28,10 +28,12 @@ class MobileHistoryManager extends HTML5HistoryManager {
     }
 
     getHref(url: string): string {
-        var queryIndex = url.indexOf('?');
+        var hashIndex = url.indexOf('#');
+        var pathAndQuery = hashIndex < 0 ? url : url.substring(0, hashIndex);
+        var queryIndex = pathAndQuery.indexOf('?');
         if (queryIndex >= 0) {
-            var path = url.substring(0, queryIndex);            
-            var query = url.substring(queryIndex + 1);
+            var path = pathAndQuery.substring(0, queryIndex);
+            var query = pathAndQuery.substring(queryIndex + 1);
             var params = query.split('&');
             var crumblessParams = [];
             for (var i = 0; i < params.length; i++) {
@@ -40,7 +42,8 @@ class MobileHistoryManager extends HTML5HistoryManager {
                 }
             }
             var crumblessQuery = crumblessParams.join('&');
-            url = `${path}${crumblessQuery && '?'}${crumblessQuery}`;
+            var hash = hashIndex >= 0 ? url.substring(hashIndex) : '';
+            url = `${path}${crumblessQuery && '?'}${crumblessQuery}${hash}`;
         }
         return !this.hash ? super.getHref(url) : '#' + url;
     }

--- a/NavigationReactMobile/src/Motion.tsx
+++ b/NavigationReactMobile/src/Motion.tsx
@@ -12,7 +12,7 @@ class Motion<T> extends React.Component<MotionProps<T>, any> {
         progress: 0,
     }
     static getDerivedStateFromProps(props, {items: prevItems}) {
-        var tick = typeof window.performance !== 'undefined' ? window.performance.now() : 0;
+        var tick = typeof window !== 'undefined' && window.performance ? window.performance.now() : 0;
         var {items, moving} = Motion.move(tick, prevItems, props);
         return {items, restart: moving};
     }

--- a/NavigationReactMobile/src/node_modules/@types/navigation-react.d.ts
+++ b/NavigationReactMobile/src/node_modules/@types/navigation-react.d.ts
@@ -4,7 +4,7 @@ import { Component, Context, AnchorHTMLAttributes, DetailedHTMLProps, MouseEvent
 /**
  * Makes all navigation immutable and deferrable
  */
-export class AsyncStateNavigator extends StateNavigator {
+export class AsyncStateNavigator<NavigationInfo extends { [index: string]: any } = any, Key extends keyof NavigationInfo = string> extends StateNavigator<NavigationInfo, Key> {
     /**
      * Navigates to a State
      * @param stateKey The key of a State
@@ -16,7 +16,7 @@ export class AsyncStateNavigator extends StateNavigator {
      * NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    navigate(stateKey: string, navigationData?: any, historyAction?: 'add' | 'replace' | 'none', defer?: boolean): void;
+    navigate<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], historyAction?: 'add' | 'replace' | 'none', defer?: boolean): void;
     /**
      * Navigates back along the crumb trail
      * @param distance Starting at 1, the number of Crumb steps to go back
@@ -35,7 +35,7 @@ export class AsyncStateNavigator extends StateNavigator {
      * @throws There is NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    refresh(navigationData?: any, historyAction?: 'add' | 'replace' | 'none', defer?: boolean): void;
+    refresh(navigationData?: null | NavigationInfo[Key], historyAction?: 'add' | 'replace' | 'none', defer?: boolean): void;
     /**
      * Navigates to the url
      * @param url The target location
@@ -47,13 +47,13 @@ export class AsyncStateNavigator extends StateNavigator {
      */
     navigateLink(url: string, historyAction?: 'add' | 'replace' | 'none', history?: boolean,
         suspendNavigation?: (stateContext: StateContext, resumeNavigation: () => void) => void,
-        currentContext?: StateContext, defer?: boolean): void;
+        currentContext?: StateContext<Key & string, Key extends keyof NavigationInfo ? NavigationInfo[Key] : any>, defer?: boolean): void;
 }
 
 /**
  * Navigation event data
  */
-export interface NavigationEvent {
+export interface NavigationEvent<NavigationInfo extends { [index: string]: any } = any, Key extends keyof NavigationInfo = string> {
     /**
      * The last State displayed before the current State
      */
@@ -61,11 +61,11 @@ export interface NavigationEvent {
     /**
      * The current State
      */
-    state: State;
+    state: State<Key & string, Key extends keyof NavigationInfo ? NavigationInfo[Key] : any>;
     /**
      * The NavigationData for the current State
      */
-    data: any;
+    data: Key extends keyof NavigationInfo ? NavigationInfo[Key] : any;
     /**
      * The current asynchronous data
      */
@@ -81,13 +81,13 @@ export interface NavigationEvent {
     /**
      * State navigator for the current context
      */
-    stateNavigator: AsyncStateNavigator;
+    stateNavigator: AsyncStateNavigator<NavigationInfo, Key>;
 }
 
 /**
  * The context for providers and consumers of navigation event data
  */
-export var NavigationContext: Context<NavigationEvent>;
+export var NavigationContext: Context<NavigationEvent<any, any>> & Context<NavigationEvent<any, string>>;
 
 /**
  * Provides the navigation event data
@@ -115,11 +115,11 @@ export interface LinkProps extends DetailedHTMLProps<AnchorHTMLAttributes<HTMLAn
 /**
  * Defines the Refresh Link Props contract
  */
-export interface RefreshLinkProps extends LinkProps {
+export interface RefreshLinkProps<NavigationInfo extends { [index: string]: any } = any, Key extends keyof NavigationInfo = string> extends LinkProps {
     /**
      * The NavigationData to pass
      */
-    navigationData?: any;
+    navigationData?: Key extends keyof NavigationInfo ? NavigationInfo[Key] : any;
     /**
      * Indicates whether to include all the current NavigationData
      */
@@ -127,7 +127,11 @@ export interface RefreshLinkProps extends LinkProps {
     /**
      * The data to add from the current NavigationData
      */
-    currentDataKeys?: string | string[];
+    currentDataKeys?: string & (Key extends keyof NavigationInfo ? keyof NavigationInfo[Key] : any) | (string & (Key extends keyof NavigationInfo ? keyof NavigationInfo[Key] : any))[];
+    /**
+     * The fragment identifier
+     */
+    hash?: string;
     /**
      * The style to display when the Link is active
      */
@@ -145,22 +149,22 @@ export interface RefreshLinkProps extends LinkProps {
 /**
  * Hyperlink Component that navigates to the current State
  */
-export class RefreshLink extends Component<RefreshLinkProps> { }
+export class RefreshLink<NavigationInfo extends { [index: string]: any } = any, Key extends keyof NavigationInfo = string> extends Component<RefreshLinkProps<NavigationInfo, Key>> { }
 
 /**
  * Defines the Navigation Link Props contract
  */
-export interface NavigationLinkProps extends RefreshLinkProps {
+export interface NavigationLinkProps<NavigationInfo extends { [index: string]: any } = any, StateKey extends keyof NavigationInfo = string> extends RefreshLinkProps<NavigationInfo, StateKey> {
     /**
      * The key of the State to navigate to
      */
-    stateKey: string;
+    stateKey: StateKey & keyof NavigationInfo;
 }
 
 /**
  * Hyperlink Component that navigates to a State
  */
-export class NavigationLink extends Component<NavigationLinkProps> { }
+export class NavigationLink<NavigationInfo extends { [index: string]: any } = any, StateKey extends keyof NavigationInfo = string> extends Component<NavigationLinkProps<NavigationInfo, StateKey>> { }
 
 /**
  * Defines the Navigation Back Link Props contract
@@ -180,7 +184,7 @@ export class NavigationBackLink extends Component<NavigationBackLinkProps> { }
 /**
  * Defines the Fluent Link Props contract
  */
-export interface FluentLinkProps extends LinkProps {
+export interface FluentLinkProps<NavigationInfo extends { [index: string]: any } = any, Key extends keyof NavigationInfo = string> extends LinkProps {
     /**
      * Indicates whether to inherit the current context
      */
@@ -188,10 +192,10 @@ export interface FluentLinkProps extends LinkProps {
     /**
      * The function that fluently navigates to a State
      */
-    navigate: (fluentNavigator: FluentNavigator) => FluentNavigator;
+    navigate: (fluentNavigator: FluentNavigator<NavigationInfo, Key>) => FluentNavigator<NavigationInfo>;
 }
 
 /**
  * Hyperlink Component that fluently navigates to a State
  */
-export class FluentLink extends Component<FluentLinkProps> { }
+export class FluentLink<NavigationInfo extends { [index: string]: any } = any, Key extends keyof NavigationInfo = string> extends Component<FluentLinkProps<NavigationInfo, Key>> { }

--- a/NavigationReactMobile/src/node_modules/@types/navigation-react.d.ts
+++ b/NavigationReactMobile/src/node_modules/@types/navigation-react.d.ts
@@ -16,7 +16,7 @@ export class AsyncStateNavigator<NavigationInfo extends { [index: string]: any }
      * NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    navigate<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], historyAction?: 'add' | 'replace' | 'none', defer?: boolean): void;
+    navigate<StateKey extends keyof NavigationInfo & string>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], historyAction?: 'add' | 'replace' | 'none', defer?: boolean): void;
     /**
      * Navigates back along the crumb trail
      * @param distance Starting at 1, the number of Crumb steps to go back

--- a/NavigationReactMobile/src/node_modules/@types/navigation.d.ts
+++ b/NavigationReactMobile/src/node_modules/@types/navigation.d.ts
@@ -1,11 +1,11 @@
 /**
  * Defines a contract a class must implement in order to configure a State
  */
-export interface StateInfo {
+export interface StateInfo<Key extends string> {
     /**
      * Gets the unique key
      */
-    key: string;
+    key: Key;
     /**
      * Gets the default NavigationData for this State
      */
@@ -40,15 +40,15 @@ export interface StateInfo {
 /**
  * Represents a view and is the destination of a navigation
  */
-export class State implements StateInfo {
+export class State<Key extends string = string, Data extends object = any> implements StateInfo<Key> {
     /**
      * Gets the unique key
      */
-    key: string;
+    key: Key;
     /**
      * Gets the default NavigationData for this State
      */
-    defaults: any;
+    defaults: Partial<Data>;
     /**
      * Gets the default NavigationData Types for  this State
      */
@@ -104,7 +104,7 @@ export class State implements StateInfo {
      * @param data The current NavigationData
      * @param asyncData The data passed asynchronously while navigating
      */
-    navigated: (data: any, asyncData: any) => void;
+    navigated: (data: Data, asyncData: any) => void;
     /**
      * Called on the new State before navigating to it
      * @param data The new NavigationData
@@ -112,7 +112,7 @@ export class State implements StateInfo {
      * @param navigate The function to call to continue to navigate
      * @param history A value indicating whether browser history was used
      */
-    navigating: (data: any, url: string, navigate: (asyncData?: any) => void, history: boolean) => void;
+    navigating: (data: Data, url: string, navigate: (asyncData?: any) => void, history: boolean) => void;
     /**
      * Encodes the Url value
      * @param state The State navigated to
@@ -121,7 +121,7 @@ export class State implements StateInfo {
      * @param queryString A value indicating the Url value's location
      * @param index The index of the navigation data array item
      */
-    urlEncode(state: State, key: string, val: string, queryString: boolean, index?: number): string;
+    urlEncode(state: State<Key, Data>, key: keyof Data & string, val: string, queryString: boolean, index?: number): string;
     /**
      * Decodes the Url value
      * @param state The State navigated to
@@ -129,13 +129,13 @@ export class State implements StateInfo {
      * @param val The Url value of the navigation data item
      * @param queryString A value indicating the Url value's location
      */
-    urlDecode(state: State, key: string, val: string, queryString: boolean): string;
+    urlDecode(state: State<Key, Data>, key: keyof Data & string, val: string, queryString: boolean): string;
     /**
      * Validates the NavigationData before navigating to the new State
      * @param data The new NavigationData
      * @returns Validation success indicator
      */
-    validate(data: any): boolean;
+    validate(data: Data): boolean;
     /**
      * Truncates the crumb trail whenever a repeated or initial State is
      * encountered
@@ -144,7 +144,7 @@ export class State implements StateInfo {
      * @param The Crumb collection representing the crumb trail
      * @returns Truncated crumb trail
      */
-    truncateCrumbTrail(state: State, data: any, crumbs: Crumb[]): Crumb[];
+    truncateCrumbTrail(state: State<Key, Data>, data: Data, crumbs: Crumb[]): Crumb[];
 }
 
 /**
@@ -286,16 +286,20 @@ export class HTML5HistoryManager implements HistoryManager {
  * Represents one piece of the crumb trail and holds the information needed
  * to return to and recreate the State as previously visited
  */
-export class Crumb {
+export class Crumb<Key extends string = string, Data extends object = any> {
     /**
      * Gets the Context Data held at the time of navigating away from this
      * State
      */
-    data: any;
+    data: Data;
     /**
      * Gets the configuration information associated with this navigation
      */
-    state: State;
+    state: State<Key, Data>;
+    /**
+     * Gets the fragment identifier associated with this navigation
+     */
+     hash: string;
     /**
      * Gets a value indicating whether the Crumb is the last in the crumb
      * trail
@@ -327,15 +331,16 @@ export class Crumb {
      * return to the State and pass the associated Data
      * @param last A value indicating whether the Crumb is the last in the
      * crumb trail
+     * @param hash The fragment identifier associated with this navigation
      */
-    constructor(data: any, state: State, link: string, crumblessLink: string, last: boolean);
+    constructor(data: Data, state: State<Key, Data>, link: string, crumblessLink: string, last: boolean, hash?: string);
 }
 
 /**
  * Provides properties for accessing context sensitive navigation
  * information. Holds the current State and NavigationData
  */
-export class StateContext {
+export class StateContext<Key extends string = string, Data extends object = any> {
     /**
      * Gets the last State displayed before the current State
      */
@@ -344,6 +349,10 @@ export class StateContext {
      * Gets the NavigationData for the last displayed State
      */
     oldData: any;
+    /**
+     * Gets the fragment identifier of the last displayed State
+     */
+    oldHash: string;
     /**
      * Gets the Url for the last displayed State
      */
@@ -357,17 +366,25 @@ export class StateContext {
      */
     previousData: any;
     /**
+     * Gets the fragment identifier of the last Crumb in the crumb trail
+     */
+    previousHash: string;
+    /**
      * Gets the Url of the last Crumb in the crumb trail
      */
     previousUrl: string;
     /**
      * Gets the current State
      */
-    state: State;
+    state: State<Key, Data>;
     /**
      * Gets the NavigationData for the current State
      */
-    data: any;
+    data: Data;
+    /**
+     * Gets the fragment identifier of the current Url
+     */
+    hash: string;
     /**
      * Gets the current Url
      */
@@ -392,7 +409,7 @@ export class StateContext {
     /**
      * Gets the next crumb
      */
-    nextCrumb: Crumb;
+    nextCrumb: Crumb<Key, Data>;
     /**
      * Clears the Context Data
      */
@@ -402,14 +419,14 @@ export class StateContext {
      * @param The data to add to the current NavigationData
      * @returns The combined data
      */
-    includeCurrentData(data: any, keys?: string[]): any;
+    includeCurrentData(data: Data, keys?: string[]): Data;
 }
 
 /**
  * Fluently manages all navigation. These can be forward, backward or
  * refreshing the current State
  */
-export interface FluentNavigator {
+export interface FluentNavigator<NavigationInfo extends { [index: string]: any } = any, Key extends keyof NavigationInfo = string>  {
     /**
      * Gets the current Url
      */
@@ -419,11 +436,12 @@ export interface FluentNavigator {
      * @param stateKey The key of a State
      * @param navigationData The NavigationData to be passed to the next
      * State and stored in the StateContext
+     * @param hash The fragment identifier of the Url to navigate to
      * @throws state does not match the key of a State or there is
      * NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    navigate(stateKey: string, navigationData?: any): FluentNavigator;
+    navigate<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], hash?: string): FluentNavigator<NavigationInfo, StateKey>;
     /**
      * Navigates back along the crumb trail
      * @param distance Starting at 1, the number of Crumb steps to go back
@@ -435,22 +453,22 @@ export interface FluentNavigator {
      * Navigates to the current State
      * @param navigationData The NavigationData to be passed to the current
      * State and stored in the StateContext
-     * @param A value determining the effect on browser history
+     * @param hash The fragment identifier of the Url to navigate to
      * @throws There is NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    refresh(navigationData?: any): FluentNavigator;
+    refresh(navigationData?: null | NavigationInfo[Key], hash?: string): FluentNavigator<NavigationInfo, Key>;
 }
 
 /**
  * Manages all navigation. These can be forward, backward or refreshing the
  * current State
  */
-export class StateNavigator {
+export class StateNavigator<NavigationInfo extends { [index: string]: any } = any, Key extends keyof NavigationInfo = string> {
     /**
      * Provides access to context sensitive navigation information
      */
-    stateContext: StateContext;
+    stateContext: StateContext<Key & string, Key extends keyof NavigationInfo ? NavigationInfo[Key] : any>;
     /**
      * Gets the browser Url manager
      */
@@ -458,19 +476,19 @@ export class StateNavigator {
     /**
      * Gets a list of States
      */
-    states: { [index: string]: State; };
+    states: { [Key in keyof NavigationInfo & string]: State<Key, NavigationInfo[Key]> };
     /**
      * Initializes a new instance of the StateNavigator class
      * @param stateInfos A collection of State Infos or another State Navigator
      * @param historyManager The manager of the browser Url
      */
-    constructor(stateInfos?: StateInfo[] | StateNavigator, historyManager?: HistoryManager);
+    constructor(stateInfos?: StateInfo<keyof NavigationInfo & string | string>[] | StateNavigator<NavigationInfo>, historyManager?: HistoryManager);
     /**
      * Configures the StateNavigator
      * @param stateInfos A collection of State Infos or another State Navigator
      * @param historyManager The manager of the browser Url
      */
-    configure(stateInfos: StateInfo[] | StateNavigator, historyManager?: HistoryManager): void;
+    configure(stateInfos: StateInfo<keyof NavigationInfo & string | string>[] | StateNavigator<NavigationInfo>, historyManager?: HistoryManager): void;
     /**
      * Registers a before navigate event listener
      * @param handler The before navigate event listener
@@ -501,17 +519,18 @@ export class StateNavigator {
      * NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    navigate(stateKey: string, navigationData?: any, historyAction?: 'add' | 'replace' | 'none'): void;
+    navigate<StateKey extends keyof NavigationInfo & string>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], historyAction?: 'add' | 'replace' | 'none'): void;
     /**
      * Gets a Url to navigate to a State
      * @param stateKey The key of a State
      * @param navigationData The NavigationData to be passed to the next
      * State and stored in the StateContext
+     * @param hash The fragment identifier of the Url to navigate to
      * @returns Url that will navigate to State specified in the action
      * @throws state does not match the key of a State or there is
      * NavigationData that cannot be converted to a String
      */
-    getNavigationLink(stateKey: string, navigationData?: any): string;
+    getNavigationLink<StateKey extends keyof NavigationInfo & string>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], hash?: string): string;
     /**
      * Determines if the distance specified is within the bounds of the
      * crumb trail represented by the Crumbs collection
@@ -539,15 +558,16 @@ export class StateNavigator {
      * @throws There is NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    refresh(navigationData?: any, historyAction?: 'add' | 'replace' | 'none'): void;
+    refresh(navigationData?: null | NavigationInfo[Key], historyAction?: 'add' | 'replace' | 'none'): void;
     /**
      * Gets a Url to navigate to the current State
      * @param navigationData The NavigationData to be passed to the current
      * State and stored in the StateContext
+     * @param hash The fragment identifier of the Url to navigate to
      * @returns Url that will navigate to the current State
      * @throws There is NavigationData that cannot be converted to a String
      */
-    getRefreshLink(navigationData?: any): string;
+    getRefreshLink(navigationData?: null | NavigationInfo[Key], hash?: string): string;
     /**
      * Navigates to the url
      * @param url The target location
@@ -558,19 +578,20 @@ export class StateNavigator {
      */
     navigateLink(url: string, historyAction?: 'add' | 'replace' | 'none', history?: boolean,
         suspendNavigation?: (stateContext: StateContext, resumeNavigation: () => void) => void,
-        currentContext?: StateContext): void;
+        currentContext?: StateContext<Key & string, Key extends keyof NavigationInfo ? NavigationInfo[Key] : any>): void;
     /**
      * Parses the url out into State and Navigation Data
      * @param url The url to parse
      */
-    parseLink(url: string): { state: State; data: any; crumbs: Crumb[] };
+    parseLink(url: string): { state: State; data: any; hash: string; crumbs: Crumb[] };
+    parseLink<StateKey extends keyof NavigationInfo>(url: string): { state: State<StateKey & string, NavigationInfo[StateKey]>; data: NavigationInfo[StateKey]; hash: string; crumbs: Crumb[] };
     /**
      * Creates a FluentNavigator
      * @param withContext a value indicating whether to inherit the current
      * context
      * @returns A FluentNavigator
      */
-    fluent(withContext?: boolean): FluentNavigator;
+    fluent<B extends boolean>(withContext?: B): FluentNavigator<NavigationInfo, B extends true ? Key : string>
     /**
      * Navigates to the passed in url
      * @param url The url to navigate to

--- a/NavigationReactMobile/test/node_modules/@types/navigation-react.d.ts
+++ b/NavigationReactMobile/test/node_modules/@types/navigation-react.d.ts
@@ -129,6 +129,10 @@ export interface RefreshLinkProps<NavigationInfo extends { [index: string]: any 
      */
     currentDataKeys?: string & (Key extends keyof NavigationInfo ? keyof NavigationInfo[Key] : any) | (string & (Key extends keyof NavigationInfo ? keyof NavigationInfo[Key] : any))[];
     /**
+     * The fragment identifier
+     */
+    hash?: string;
+    /**
      * The style to display when the Link is active
      */
     activeStyle?: any;

--- a/NavigationReactMobile/test/node_modules/@types/navigation-react.d.ts
+++ b/NavigationReactMobile/test/node_modules/@types/navigation-react.d.ts
@@ -16,7 +16,7 @@ export class AsyncStateNavigator<NavigationInfo extends { [index: string]: any }
      * NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    navigate<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], historyAction?: 'add' | 'replace' | 'none', defer?: boolean): void;
+    navigate<StateKey extends keyof NavigationInfo & string>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], historyAction?: 'add' | 'replace' | 'none', defer?: boolean): void;
     /**
      * Navigates back along the crumb trail
      * @param distance Starting at 1, the number of Crumb steps to go back

--- a/NavigationReactMobile/test/node_modules/@types/navigation.d.ts
+++ b/NavigationReactMobile/test/node_modules/@types/navigation.d.ts
@@ -297,6 +297,10 @@ export class Crumb<Key extends string = string, Data extends object = any> {
      */
     state: State<Key, Data>;
     /**
+     * Gets the fragment identifier associated with this navigation
+     */
+     hash: string;
+    /**
      * Gets a value indicating whether the Crumb is the last in the crumb
      * trail
      */
@@ -327,8 +331,9 @@ export class Crumb<Key extends string = string, Data extends object = any> {
      * return to the State and pass the associated Data
      * @param last A value indicating whether the Crumb is the last in the
      * crumb trail
+     * @param hash The fragment identifier associated with this navigation
      */
-    constructor(data: Data, state: State<Key, Data>, link: string, crumblessLink: string, last: boolean);
+    constructor(data: Data, state: State<Key, Data>, link: string, crumblessLink: string, last: boolean, hash?: string);
 }
 
 /**
@@ -345,6 +350,10 @@ export class StateContext<Key extends string = string, Data extends object = any
      */
     oldData: any;
     /**
+     * Gets the fragment identifier of the last displayed State
+     */
+    oldHash: string;
+    /**
      * Gets the Url for the last displayed State
      */
     oldUrl: string;
@@ -357,6 +366,10 @@ export class StateContext<Key extends string = string, Data extends object = any
      */
     previousData: any;
     /**
+     * Gets the fragment identifier of the last Crumb in the crumb trail
+     */
+    previousHash: string;
+    /**
      * Gets the Url of the last Crumb in the crumb trail
      */
     previousUrl: string;
@@ -368,6 +381,10 @@ export class StateContext<Key extends string = string, Data extends object = any
      * Gets the NavigationData for the current State
      */
     data: Data;
+    /**
+     * Gets the fragment identifier of the current Url
+     */
+    hash: string;
     /**
      * Gets the current Url
      */
@@ -419,11 +436,12 @@ export interface FluentNavigator<NavigationInfo extends { [index: string]: any }
      * @param stateKey The key of a State
      * @param navigationData The NavigationData to be passed to the next
      * State and stored in the StateContext
+     * @param hash The fragment identifier of the Url to navigate to
      * @throws state does not match the key of a State or there is
      * NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    navigate<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey]): FluentNavigator<NavigationInfo, StateKey>;
+    navigate<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], hash?: string): FluentNavigator<NavigationInfo, StateKey>;
     /**
      * Navigates back along the crumb trail
      * @param distance Starting at 1, the number of Crumb steps to go back
@@ -435,11 +453,11 @@ export interface FluentNavigator<NavigationInfo extends { [index: string]: any }
      * Navigates to the current State
      * @param navigationData The NavigationData to be passed to the current
      * State and stored in the StateContext
-     * @param A value determining the effect on browser history
+     * @param hash The fragment identifier of the Url to navigate to
      * @throws There is NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    refresh(navigationData?: null | NavigationInfo[Key]): FluentNavigator<NavigationInfo, Key>;
+    refresh(navigationData?: null | NavigationInfo[Key], hash?: string): FluentNavigator<NavigationInfo, Key>;
 }
 
 /**
@@ -501,17 +519,18 @@ export class StateNavigator<NavigationInfo extends { [index: string]: any } = an
      * NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    navigate<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], historyAction?: 'add' | 'replace' | 'none'): void;
+    navigate<StateKey extends keyof NavigationInfo & string>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], historyAction?: 'add' | 'replace' | 'none'): void;
     /**
      * Gets a Url to navigate to a State
      * @param stateKey The key of a State
      * @param navigationData The NavigationData to be passed to the next
      * State and stored in the StateContext
+     * @param hash The fragment identifier of the Url to navigate to
      * @returns Url that will navigate to State specified in the action
      * @throws state does not match the key of a State or there is
      * NavigationData that cannot be converted to a String
      */
-    getNavigationLink<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey]): string;
+    getNavigationLink<StateKey extends keyof NavigationInfo & string>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], hash?: string): string;
     /**
      * Determines if the distance specified is within the bounds of the
      * crumb trail represented by the Crumbs collection
@@ -544,10 +563,11 @@ export class StateNavigator<NavigationInfo extends { [index: string]: any } = an
      * Gets a Url to navigate to the current State
      * @param navigationData The NavigationData to be passed to the current
      * State and stored in the StateContext
+     * @param hash The fragment identifier of the Url to navigate to
      * @returns Url that will navigate to the current State
      * @throws There is NavigationData that cannot be converted to a String
      */
-    getRefreshLink(navigationData?: null | NavigationInfo[Key]): string;
+    getRefreshLink(navigationData?: null | NavigationInfo[Key], hash?: string): string;
     /**
      * Navigates to the url
      * @param url The target location
@@ -563,8 +583,8 @@ export class StateNavigator<NavigationInfo extends { [index: string]: any } = an
      * Parses the url out into State and Navigation Data
      * @param url The url to parse
      */
-    parseLink(url: string): { state: State; data: any; crumbs: Crumb[] };
-    parseLink<StateKey extends keyof NavigationInfo>(url: string): { state: State<StateKey & string, NavigationInfo[StateKey]>; data: NavigationInfo[StateKey]; crumbs: Crumb[] };
+    parseLink(url: string): { state: State; data: any; hash: string; crumbs: Crumb[] };
+    parseLink<StateKey extends keyof NavigationInfo>(url: string): { state: State<StateKey & string, NavigationInfo[StateKey]>; data: NavigationInfo[StateKey]; hash: string; crumbs: Crumb[] };
     /**
      * Creates a FluentNavigator
      * @param withContext a value indicating whether to inherit the current

--- a/NavigationReactNative/src/node_modules/@types/navigation-react.d.ts
+++ b/NavigationReactNative/src/node_modules/@types/navigation-react.d.ts
@@ -4,7 +4,7 @@ import { Component, Context, AnchorHTMLAttributes, DetailedHTMLProps, MouseEvent
 /**
  * Makes all navigation immutable and deferrable
  */
-export class AsyncStateNavigator extends StateNavigator {
+export class AsyncStateNavigator<NavigationInfo extends { [index: string]: any } = any, Key extends keyof NavigationInfo = string> extends StateNavigator<NavigationInfo, Key> {
     /**
      * Navigates to a State
      * @param stateKey The key of a State
@@ -16,7 +16,7 @@ export class AsyncStateNavigator extends StateNavigator {
      * NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    navigate(stateKey: string, navigationData?: any, historyAction?: 'add' | 'replace' | 'none', defer?: boolean): void;
+    navigate<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], historyAction?: 'add' | 'replace' | 'none', defer?: boolean): void;
     /**
      * Navigates back along the crumb trail
      * @param distance Starting at 1, the number of Crumb steps to go back
@@ -35,7 +35,7 @@ export class AsyncStateNavigator extends StateNavigator {
      * @throws There is NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    refresh(navigationData?: any, historyAction?: 'add' | 'replace' | 'none', defer?: boolean): void;
+    refresh(navigationData?: null | NavigationInfo[Key], historyAction?: 'add' | 'replace' | 'none', defer?: boolean): void;
     /**
      * Navigates to the url
      * @param url The target location
@@ -47,13 +47,13 @@ export class AsyncStateNavigator extends StateNavigator {
      */
     navigateLink(url: string, historyAction?: 'add' | 'replace' | 'none', history?: boolean,
         suspendNavigation?: (stateContext: StateContext, resumeNavigation: () => void) => void,
-        currentContext?: StateContext, defer?: boolean): void;
+        currentContext?: StateContext<Key & string, Key extends keyof NavigationInfo ? NavigationInfo[Key] : any>, defer?: boolean): void;
 }
 
 /**
  * Navigation event data
  */
-export interface NavigationEvent {
+export interface NavigationEvent<NavigationInfo extends { [index: string]: any } = any, Key extends keyof NavigationInfo = string> {
     /**
      * The last State displayed before the current State
      */
@@ -61,11 +61,11 @@ export interface NavigationEvent {
     /**
      * The current State
      */
-    state: State;
+    state: State<Key & string, Key extends keyof NavigationInfo ? NavigationInfo[Key] : any>;
     /**
      * The NavigationData for the current State
      */
-    data: any;
+    data: Key extends keyof NavigationInfo ? NavigationInfo[Key] : any;
     /**
      * The current asynchronous data
      */
@@ -81,13 +81,13 @@ export interface NavigationEvent {
     /**
      * State navigator for the current context
      */
-    stateNavigator: AsyncStateNavigator;
+    stateNavigator: AsyncStateNavigator<NavigationInfo, Key>;
 }
 
 /**
  * The context for providers and consumers of navigation event data
  */
-export var NavigationContext: Context<NavigationEvent>;
+export var NavigationContext: Context<NavigationEvent<any, any>> & Context<NavigationEvent<any, string>>;
 
 /**
  * Provides the navigation event data
@@ -115,11 +115,11 @@ export interface LinkProps extends DetailedHTMLProps<AnchorHTMLAttributes<HTMLAn
 /**
  * Defines the Refresh Link Props contract
  */
-export interface RefreshLinkProps extends LinkProps {
+export interface RefreshLinkProps<NavigationInfo extends { [index: string]: any } = any, Key extends keyof NavigationInfo = string> extends LinkProps {
     /**
      * The NavigationData to pass
      */
-    navigationData?: any;
+    navigationData?: Key extends keyof NavigationInfo ? NavigationInfo[Key] : any;
     /**
      * Indicates whether to include all the current NavigationData
      */
@@ -127,7 +127,11 @@ export interface RefreshLinkProps extends LinkProps {
     /**
      * The data to add from the current NavigationData
      */
-    currentDataKeys?: string | string[];
+    currentDataKeys?: string & (Key extends keyof NavigationInfo ? keyof NavigationInfo[Key] : any) | (string & (Key extends keyof NavigationInfo ? keyof NavigationInfo[Key] : any))[];
+    /**
+     * The fragment identifier
+     */
+    hash?: string;
     /**
      * The style to display when the Link is active
      */
@@ -145,22 +149,22 @@ export interface RefreshLinkProps extends LinkProps {
 /**
  * Hyperlink Component that navigates to the current State
  */
-export class RefreshLink extends Component<RefreshLinkProps> { }
+export class RefreshLink<NavigationInfo extends { [index: string]: any } = any, Key extends keyof NavigationInfo = string> extends Component<RefreshLinkProps<NavigationInfo, Key>> { }
 
 /**
  * Defines the Navigation Link Props contract
  */
-export interface NavigationLinkProps extends RefreshLinkProps {
+export interface NavigationLinkProps<NavigationInfo extends { [index: string]: any } = any, StateKey extends keyof NavigationInfo = string> extends RefreshLinkProps<NavigationInfo, StateKey> {
     /**
      * The key of the State to navigate to
      */
-    stateKey: string;
+    stateKey: StateKey & keyof NavigationInfo;
 }
 
 /**
  * Hyperlink Component that navigates to a State
  */
-export class NavigationLink extends Component<NavigationLinkProps> { }
+export class NavigationLink<NavigationInfo extends { [index: string]: any } = any, StateKey extends keyof NavigationInfo = string> extends Component<NavigationLinkProps<NavigationInfo, StateKey>> { }
 
 /**
  * Defines the Navigation Back Link Props contract
@@ -180,7 +184,7 @@ export class NavigationBackLink extends Component<NavigationBackLinkProps> { }
 /**
  * Defines the Fluent Link Props contract
  */
-export interface FluentLinkProps extends LinkProps {
+export interface FluentLinkProps<NavigationInfo extends { [index: string]: any } = any, Key extends keyof NavigationInfo = string> extends LinkProps {
     /**
      * Indicates whether to inherit the current context
      */
@@ -188,10 +192,10 @@ export interface FluentLinkProps extends LinkProps {
     /**
      * The function that fluently navigates to a State
      */
-    navigate: (fluentNavigator: FluentNavigator) => FluentNavigator;
+    navigate: (fluentNavigator: FluentNavigator<NavigationInfo, Key>) => FluentNavigator<NavigationInfo>;
 }
 
 /**
  * Hyperlink Component that fluently navigates to a State
  */
-export class FluentLink extends Component<FluentLinkProps> { }
+export class FluentLink<NavigationInfo extends { [index: string]: any } = any, Key extends keyof NavigationInfo = string> extends Component<FluentLinkProps<NavigationInfo, Key>> { }

--- a/NavigationReactNative/src/node_modules/@types/navigation-react.d.ts
+++ b/NavigationReactNative/src/node_modules/@types/navigation-react.d.ts
@@ -16,7 +16,7 @@ export class AsyncStateNavigator<NavigationInfo extends { [index: string]: any }
      * NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    navigate<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], historyAction?: 'add' | 'replace' | 'none', defer?: boolean): void;
+    navigate<StateKey extends keyof NavigationInfo & string>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], historyAction?: 'add' | 'replace' | 'none', defer?: boolean): void;
     /**
      * Navigates back along the crumb trail
      * @param distance Starting at 1, the number of Crumb steps to go back

--- a/NavigationReactNative/src/node_modules/@types/navigation.d.ts
+++ b/NavigationReactNative/src/node_modules/@types/navigation.d.ts
@@ -1,11 +1,11 @@
 /**
  * Defines a contract a class must implement in order to configure a State
  */
-export interface StateInfo {
+export interface StateInfo<Key extends string> {
     /**
      * Gets the unique key
      */
-    key: string;
+    key: Key;
     /**
      * Gets the default NavigationData for this State
      */
@@ -40,15 +40,15 @@ export interface StateInfo {
 /**
  * Represents a view and is the destination of a navigation
  */
-export class State implements StateInfo {
+export class State<Key extends string = string, Data extends object = any> implements StateInfo<Key> {
     /**
      * Gets the unique key
      */
-    key: string;
+    key: Key;
     /**
      * Gets the default NavigationData for this State
      */
-    defaults: any;
+    defaults: Partial<Data>;
     /**
      * Gets the default NavigationData Types for  this State
      */
@@ -104,7 +104,7 @@ export class State implements StateInfo {
      * @param data The current NavigationData
      * @param asyncData The data passed asynchronously while navigating
      */
-    navigated: (data: any, asyncData: any) => void;
+    navigated: (data: Data, asyncData: any) => void;
     /**
      * Called on the new State before navigating to it
      * @param data The new NavigationData
@@ -112,7 +112,7 @@ export class State implements StateInfo {
      * @param navigate The function to call to continue to navigate
      * @param history A value indicating whether browser history was used
      */
-    navigating: (data: any, url: string, navigate: (asyncData?: any) => void, history: boolean) => void;
+    navigating: (data: Data, url: string, navigate: (asyncData?: any) => void, history: boolean) => void;
     /**
      * Encodes the Url value
      * @param state The State navigated to
@@ -121,7 +121,7 @@ export class State implements StateInfo {
      * @param queryString A value indicating the Url value's location
      * @param index The index of the navigation data array item
      */
-    urlEncode(state: State, key: string, val: string, queryString: boolean, index?: number): string;
+    urlEncode(state: State<Key, Data>, key: keyof Data & string, val: string, queryString: boolean, index?: number): string;
     /**
      * Decodes the Url value
      * @param state The State navigated to
@@ -129,13 +129,13 @@ export class State implements StateInfo {
      * @param val The Url value of the navigation data item
      * @param queryString A value indicating the Url value's location
      */
-    urlDecode(state: State, key: string, val: string, queryString: boolean): string;
+    urlDecode(state: State<Key, Data>, key: keyof Data & string, val: string, queryString: boolean): string;
     /**
      * Validates the NavigationData before navigating to the new State
      * @param data The new NavigationData
      * @returns Validation success indicator
      */
-    validate(data: any): boolean;
+    validate(data: Data): boolean;
     /**
      * Truncates the crumb trail whenever a repeated or initial State is
      * encountered
@@ -144,7 +144,7 @@ export class State implements StateInfo {
      * @param The Crumb collection representing the crumb trail
      * @returns Truncated crumb trail
      */
-    truncateCrumbTrail(state: State, data: any, crumbs: Crumb[]): Crumb[];
+    truncateCrumbTrail(state: State<Key, Data>, data: Data, crumbs: Crumb[]): Crumb[];
 }
 
 /**
@@ -286,16 +286,20 @@ export class HTML5HistoryManager implements HistoryManager {
  * Represents one piece of the crumb trail and holds the information needed
  * to return to and recreate the State as previously visited
  */
-export class Crumb {
+export class Crumb<Key extends string = string, Data extends object = any> {
     /**
      * Gets the Context Data held at the time of navigating away from this
      * State
      */
-    data: any;
+    data: Data;
     /**
      * Gets the configuration information associated with this navigation
      */
-    state: State;
+    state: State<Key, Data>;
+    /**
+     * Gets the fragment identifier associated with this navigation
+     */
+     hash: string;
     /**
      * Gets a value indicating whether the Crumb is the last in the crumb
      * trail
@@ -327,15 +331,16 @@ export class Crumb {
      * return to the State and pass the associated Data
      * @param last A value indicating whether the Crumb is the last in the
      * crumb trail
+     * @param hash The fragment identifier associated with this navigation
      */
-    constructor(data: any, state: State, link: string, crumblessLink: string, last: boolean);
+    constructor(data: Data, state: State<Key, Data>, link: string, crumblessLink: string, last: boolean, hash?: string);
 }
 
 /**
  * Provides properties for accessing context sensitive navigation
  * information. Holds the current State and NavigationData
  */
-export class StateContext {
+export class StateContext<Key extends string = string, Data extends object = any> {
     /**
      * Gets the last State displayed before the current State
      */
@@ -344,6 +349,10 @@ export class StateContext {
      * Gets the NavigationData for the last displayed State
      */
     oldData: any;
+    /**
+     * Gets the fragment identifier of the last displayed State
+     */
+    oldHash: string;
     /**
      * Gets the Url for the last displayed State
      */
@@ -357,17 +366,25 @@ export class StateContext {
      */
     previousData: any;
     /**
+     * Gets the fragment identifier of the last Crumb in the crumb trail
+     */
+    previousHash: string;
+    /**
      * Gets the Url of the last Crumb in the crumb trail
      */
     previousUrl: string;
     /**
      * Gets the current State
      */
-    state: State;
+    state: State<Key, Data>;
     /**
      * Gets the NavigationData for the current State
      */
-    data: any;
+    data: Data;
+    /**
+     * Gets the fragment identifier of the current Url
+     */
+    hash: string;
     /**
      * Gets the current Url
      */
@@ -392,7 +409,7 @@ export class StateContext {
     /**
      * Gets the next crumb
      */
-    nextCrumb: Crumb;
+    nextCrumb: Crumb<Key, Data>;
     /**
      * Clears the Context Data
      */
@@ -402,14 +419,14 @@ export class StateContext {
      * @param The data to add to the current NavigationData
      * @returns The combined data
      */
-    includeCurrentData(data: any, keys?: string[]): any;
+    includeCurrentData(data: Data, keys?: string[]): Data;
 }
 
 /**
  * Fluently manages all navigation. These can be forward, backward or
  * refreshing the current State
  */
-export interface FluentNavigator {
+export interface FluentNavigator<NavigationInfo extends { [index: string]: any } = any, Key extends keyof NavigationInfo = string>  {
     /**
      * Gets the current Url
      */
@@ -419,11 +436,12 @@ export interface FluentNavigator {
      * @param stateKey The key of a State
      * @param navigationData The NavigationData to be passed to the next
      * State and stored in the StateContext
+     * @param hash The fragment identifier of the Url to navigate to
      * @throws state does not match the key of a State or there is
      * NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    navigate(stateKey: string, navigationData?: any): FluentNavigator;
+    navigate<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], hash?: string): FluentNavigator<NavigationInfo, StateKey>;
     /**
      * Navigates back along the crumb trail
      * @param distance Starting at 1, the number of Crumb steps to go back
@@ -435,22 +453,22 @@ export interface FluentNavigator {
      * Navigates to the current State
      * @param navigationData The NavigationData to be passed to the current
      * State and stored in the StateContext
-     * @param A value determining the effect on browser history
+     * @param hash The fragment identifier of the Url to navigate to
      * @throws There is NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    refresh(navigationData?: any): FluentNavigator;
+    refresh(navigationData?: null | NavigationInfo[Key], hash?: string): FluentNavigator<NavigationInfo, Key>;
 }
 
 /**
  * Manages all navigation. These can be forward, backward or refreshing the
  * current State
  */
-export class StateNavigator {
+export class StateNavigator<NavigationInfo extends { [index: string]: any } = any, Key extends keyof NavigationInfo = string> {
     /**
      * Provides access to context sensitive navigation information
      */
-    stateContext: StateContext;
+    stateContext: StateContext<Key & string, Key extends keyof NavigationInfo ? NavigationInfo[Key] : any>;
     /**
      * Gets the browser Url manager
      */
@@ -458,19 +476,19 @@ export class StateNavigator {
     /**
      * Gets a list of States
      */
-    states: { [index: string]: State; };
+    states: { [Key in keyof NavigationInfo & string]: State<Key, NavigationInfo[Key]> };
     /**
      * Initializes a new instance of the StateNavigator class
      * @param stateInfos A collection of State Infos or another State Navigator
      * @param historyManager The manager of the browser Url
      */
-    constructor(stateInfos?: StateInfo[] | StateNavigator, historyManager?: HistoryManager);
+    constructor(stateInfos?: StateInfo<keyof NavigationInfo & string | string>[] | StateNavigator<NavigationInfo>, historyManager?: HistoryManager);
     /**
      * Configures the StateNavigator
      * @param stateInfos A collection of State Infos or another State Navigator
      * @param historyManager The manager of the browser Url
      */
-    configure(stateInfos: StateInfo[] | StateNavigator, historyManager?: HistoryManager): void;
+    configure(stateInfos: StateInfo<keyof NavigationInfo & string | string>[] | StateNavigator<NavigationInfo>, historyManager?: HistoryManager): void;
     /**
      * Registers a before navigate event listener
      * @param handler The before navigate event listener
@@ -501,17 +519,18 @@ export class StateNavigator {
      * NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    navigate(stateKey: string, navigationData?: any, historyAction?: 'add' | 'replace' | 'none'): void;
+    navigate<StateKey extends keyof NavigationInfo & string>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], historyAction?: 'add' | 'replace' | 'none'): void;
     /**
      * Gets a Url to navigate to a State
      * @param stateKey The key of a State
      * @param navigationData The NavigationData to be passed to the next
      * State and stored in the StateContext
+     * @param hash The fragment identifier of the Url to navigate to
      * @returns Url that will navigate to State specified in the action
      * @throws state does not match the key of a State or there is
      * NavigationData that cannot be converted to a String
      */
-    getNavigationLink(stateKey: string, navigationData?: any): string;
+    getNavigationLink<StateKey extends keyof NavigationInfo & string>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], hash?: string): string;
     /**
      * Determines if the distance specified is within the bounds of the
      * crumb trail represented by the Crumbs collection
@@ -539,15 +558,16 @@ export class StateNavigator {
      * @throws There is NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    refresh(navigationData?: any, historyAction?: 'add' | 'replace' | 'none'): void;
+    refresh(navigationData?: null | NavigationInfo[Key], historyAction?: 'add' | 'replace' | 'none'): void;
     /**
      * Gets a Url to navigate to the current State
      * @param navigationData The NavigationData to be passed to the current
      * State and stored in the StateContext
+     * @param hash The fragment identifier of the Url to navigate to
      * @returns Url that will navigate to the current State
      * @throws There is NavigationData that cannot be converted to a String
      */
-    getRefreshLink(navigationData?: any): string;
+    getRefreshLink(navigationData?: null | NavigationInfo[Key], hash?: string): string;
     /**
      * Navigates to the url
      * @param url The target location
@@ -558,19 +578,20 @@ export class StateNavigator {
      */
     navigateLink(url: string, historyAction?: 'add' | 'replace' | 'none', history?: boolean,
         suspendNavigation?: (stateContext: StateContext, resumeNavigation: () => void) => void,
-        currentContext?: StateContext): void;
+        currentContext?: StateContext<Key & string, Key extends keyof NavigationInfo ? NavigationInfo[Key] : any>): void;
     /**
      * Parses the url out into State and Navigation Data
      * @param url The url to parse
      */
-    parseLink(url: string): { state: State; data: any; crumbs: Crumb[] };
+    parseLink(url: string): { state: State; data: any; hash: string; crumbs: Crumb[] };
+    parseLink<StateKey extends keyof NavigationInfo>(url: string): { state: State<StateKey & string, NavigationInfo[StateKey]>; data: NavigationInfo[StateKey]; hash: string; crumbs: Crumb[] };
     /**
      * Creates a FluentNavigator
      * @param withContext a value indicating whether to inherit the current
      * context
      * @returns A FluentNavigator
      */
-    fluent(withContext?: boolean): FluentNavigator;
+    fluent<B extends boolean>(withContext?: B): FluentNavigator<NavigationInfo, B extends true ? Key : string>
     /**
      * Navigates to the passed in url
      * @param url The url to navigate to

--- a/build/npm/navigation-react/navigation.react.d.ts
+++ b/build/npm/navigation-react/navigation.react.d.ts
@@ -68,6 +68,10 @@ export interface RefreshLinkProps<NavigationInfo extends { [index: string]: any 
      */
     currentDataKeys?: string & (Key extends keyof NavigationInfo ? keyof NavigationInfo[Key] : any) | (string & (Key extends keyof NavigationInfo ? keyof NavigationInfo[Key] : any))[];
     /**
+     * The fragment identifier
+     */
+     hash?: string;
+    /**
      * The style to display when the Link is active
      */
     activeStyle?: any;

--- a/build/npm/navigation/navigation.d.ts
+++ b/build/npm/navigation/navigation.d.ts
@@ -297,6 +297,10 @@ export class Crumb<Key extends string = string, Data extends object = any> {
      */
     state: State<Key, Data>;
     /**
+     * Gets the fragment identifier associated with this navigation
+     */
+     hash: string;
+    /**
      * Gets a value indicating whether the Crumb is the last in the crumb
      * trail
      */
@@ -327,8 +331,9 @@ export class Crumb<Key extends string = string, Data extends object = any> {
      * return to the State and pass the associated Data
      * @param last A value indicating whether the Crumb is the last in the
      * crumb trail
+     * @param hash The fragment identifier associated with this navigation
      */
-    constructor(data: Data, state: State<Key, Data>, link: string, crumblessLink: string, last: boolean);
+    constructor(data: Data, state: State<Key, Data>, link: string, crumblessLink: string, last: boolean, hash?: string);
 }
 
 /**
@@ -345,6 +350,10 @@ export class StateContext<Key extends string = string, Data extends object = any
      */
     oldData: any;
     /**
+     * Gets the fragment identifier of the last displayed State
+     */
+    oldHash: string;
+    /**
      * Gets the Url for the last displayed State
      */
     oldUrl: string;
@@ -357,6 +366,10 @@ export class StateContext<Key extends string = string, Data extends object = any
      */
     previousData: any;
     /**
+     * Gets the fragment identifier of the last Crumb in the crumb trail
+     */
+    previousHash: string;
+    /**
      * Gets the Url of the last Crumb in the crumb trail
      */
     previousUrl: string;
@@ -368,6 +381,10 @@ export class StateContext<Key extends string = string, Data extends object = any
      * Gets the NavigationData for the current State
      */
     data: Data;
+    /**
+     * Gets the fragment identifier of the current Url
+     */
+    hash: string;
     /**
      * Gets the current Url
      */
@@ -419,11 +436,12 @@ export interface FluentNavigator<NavigationInfo extends { [index: string]: any }
      * @param stateKey The key of a State
      * @param navigationData The NavigationData to be passed to the next
      * State and stored in the StateContext
+     * @param hash The fragment identifier of the Url to navigate to
      * @throws state does not match the key of a State or there is
      * NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    navigate<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey]): FluentNavigator<NavigationInfo, StateKey>;
+    navigate<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], hash?: string): FluentNavigator<NavigationInfo, StateKey>;
     /**
      * Navigates back along the crumb trail
      * @param distance Starting at 1, the number of Crumb steps to go back
@@ -435,11 +453,11 @@ export interface FluentNavigator<NavigationInfo extends { [index: string]: any }
      * Navigates to the current State
      * @param navigationData The NavigationData to be passed to the current
      * State and stored in the StateContext
-     * @param A value determining the effect on browser history
+     * @param hash The fragment identifier of the Url to navigate to
      * @throws There is NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    refresh(navigationData?: null | NavigationInfo[Key]): FluentNavigator<NavigationInfo, Key>;
+    refresh(navigationData?: null | NavigationInfo[Key], hash?: string): FluentNavigator<NavigationInfo, Key>;
 }
 
 /**
@@ -501,17 +519,18 @@ export class StateNavigator<NavigationInfo extends { [index: string]: any } = an
      * NavigationData that cannot be converted to a String
      * @throws A mandatory route parameter has not been supplied a value
      */
-    navigate<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], historyAction?: 'add' | 'replace' | 'none'): void;
+    navigate<StateKey extends keyof NavigationInfo & string>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], historyAction?: 'add' | 'replace' | 'none'): void;
     /**
      * Gets a Url to navigate to a State
      * @param stateKey The key of a State
      * @param navigationData The NavigationData to be passed to the next
      * State and stored in the StateContext
+     * @param hash The fragment identifier of the Url to navigate to
      * @returns Url that will navigate to State specified in the action
      * @throws state does not match the key of a State or there is
      * NavigationData that cannot be converted to a String
      */
-    getNavigationLink<StateKey extends keyof NavigationInfo>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey]): string;
+    getNavigationLink<StateKey extends keyof NavigationInfo & string>(stateKey: StateKey, navigationData?: null | NavigationInfo[StateKey], hash?: string): string;
     /**
      * Determines if the distance specified is within the bounds of the
      * crumb trail represented by the Crumbs collection
@@ -544,10 +563,11 @@ export class StateNavigator<NavigationInfo extends { [index: string]: any } = an
      * Gets a Url to navigate to the current State
      * @param navigationData The NavigationData to be passed to the current
      * State and stored in the StateContext
+     * @param hash The fragment identifier of the Url to navigate to
      * @returns Url that will navigate to the current State
      * @throws There is NavigationData that cannot be converted to a String
      */
-    getRefreshLink(navigationData?: null | NavigationInfo[Key]): string;
+    getRefreshLink(navigationData?: null | NavigationInfo[Key], hash?: string): string;
     /**
      * Navigates to the url
      * @param url The target location
@@ -563,8 +583,8 @@ export class StateNavigator<NavigationInfo extends { [index: string]: any } = an
      * Parses the url out into State and Navigation Data
      * @param url The url to parse
      */
-    parseLink(url: string): { state: State; data: any; crumbs: Crumb[] };
-    parseLink<StateKey extends keyof NavigationInfo>(url: string): { state: State<StateKey & string, NavigationInfo[StateKey]>; data: NavigationInfo[StateKey]; crumbs: Crumb[] };
+    parseLink(url: string): { state: State; data: any; hash: string; crumbs: Crumb[] };
+    parseLink<StateKey extends keyof NavigationInfo>(url: string): { state: State<StateKey & string, NavigationInfo[StateKey]>; data: NavigationInfo[StateKey]; hash: string; crumbs: Crumb[] };
     /**
      * Creates a FluentNavigator
      * @param withContext a value indicating whether to inherit the current


### PR DESCRIPTION
Can get a link like '/person/12#hobbies' that scrolls to the hobbies section of a person's details
```jsx
<NavigationLink
  stateKey="person"
  navigationData={{ id: 12 }}
  hash="hobbies" />
```
Or programmatically
```js
stateNavigator.getNavigationLink('person', { id: 12 }, 'hobbies')
```

Because HTML5 history doesn’t respect fragment identifiers, this will only work if the link is opened in a new tab or when javascript is off.
