### PR TITLE
Supported Material motion shared element container transforms (Android)

### DIFF
--- a/NavigationReactNative/sample/twitter/android/app/build.gradle
+++ b/NavigationReactNative/sample/twitter/android/app/build.gradle
@@ -189,7 +189,7 @@ dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
 
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
-    implementation 'com.google.android.material:material:1.1.0'
+    implementation 'com.google.android.material:material:1.4.0'
 
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
       exclude group:'com.facebook.fbjni'

--- a/NavigationReactNative/sample/zoom/App.js
+++ b/NavigationReactNative/sample/zoom/App.js
@@ -48,7 +48,7 @@ Linking.addEventListener('url', ({url}) => openLink(url));
 const App = () => (
   <NavigationHandler stateNavigator={stateNavigator}>
     <NavigationStack
-      sharedElement={(_, {name}) => name}
+      sharedElement={(_, {color, search}) => !search ? color : null}
       crumbStyle={from => from ? 'enter_crumb' : 'exit_crumb'}
       unmountStyle={from => from ? 'enter_mount' : 'exit_mount'} />
   </NavigationHandler>

--- a/NavigationReactNative/sample/zoom/App.js
+++ b/NavigationReactNative/sample/zoom/App.js
@@ -47,7 +47,9 @@ Linking.addEventListener('url', ({url}) => openLink(url));
 
 const App = () => (
   <NavigationHandler stateNavigator={stateNavigator}>
-    <NavigationStack sharedElement={(_, {name}) => name} />
+    <NavigationStack sharedElement={(_, {name}) => name}
+      crumbStyle={from => from ? 'enter_crumb' : 'exit_crumb'}
+      unmountStyle={from => from ? 'enter_mount' : 'exit_mount'} />
   </NavigationHandler>
 );
 export default App;

--- a/NavigationReactNative/sample/zoom/App.js
+++ b/NavigationReactNative/sample/zoom/App.js
@@ -47,7 +47,8 @@ Linking.addEventListener('url', ({url}) => openLink(url));
 
 const App = () => (
   <NavigationHandler stateNavigator={stateNavigator}>
-    <NavigationStack sharedElement={(_, {name}) => name}
+    <NavigationStack
+      sharedElement={(_, {name}) => name}
       crumbStyle={from => from ? 'enter_crumb' : 'exit_crumb'}
       unmountStyle={from => from ? 'enter_mount' : 'exit_mount'} />
   </NavigationHandler>

--- a/NavigationReactNative/sample/zoom/App.js
+++ b/NavigationReactNative/sample/zoom/App.js
@@ -47,7 +47,7 @@ Linking.addEventListener('url', ({url}) => openLink(url));
 
 const App = () => (
   <NavigationHandler stateNavigator={stateNavigator}>
-    <NavigationStack sharedElements={(_, {name}) => name && [name]} />
+    <NavigationStack sharedElement={(_, {name}) => name} />
   </NavigationHandler>
 );
 export default App;

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -21,7 +21,7 @@ const Detail = ({colors, color, name, filter, search}) => {
         </RightBar>
       </NavigationBar>
       <ScrollView contentInsetAdjustmentBehavior="automatic">
-        <SharedElement name={name} style={styles.color} transition="overshoot">
+        <SharedElement name={name} style={styles.color} duration={250}>
           <View style={{backgroundColor: color, flex: 1}} />
         </SharedElement>
         <Text style={styles.text}>{color}</Text>

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -3,7 +3,7 @@ import {Platform, StyleSheet, ScrollView, Text, View, TouchableHighlight} from '
 import {NavigationContext} from 'navigation-react';
 import {NavigationBar, RightBar, BarButton, TitleBar, SharedElement} from 'navigation-react-native';
 
-const Detail = ({colors, color, name, filter, search}) => {
+const Detail = ({colors, color, search}) => {
   const {stateNavigator} = useContext(NavigationContext);
   return (
     <>
@@ -21,28 +21,23 @@ const Detail = ({colors, color, name, filter, search}) => {
         </RightBar>
       </NavigationBar>
       <ScrollView contentInsetAdjustmentBehavior="automatic">
-        <SharedElement name={name} style={styles.color} duration={250}>
+        <SharedElement name={color} style={styles.color} duration={250}>
           <View style={{backgroundColor: color, flex: 1}} />
         </SharedElement>
         <Text style={styles.text}>{color}</Text>
         <View style={styles.colors}>
           {[1,2,3].map(i => colors[(colors.indexOf(color) + i) % 15])
-            .map(subcolor => {
-              const suffix = search ? '_search' : '';
-              const matched = !filter || subcolor.indexOf(filter.toLowerCase()) !== -1;
-              const name = matched ? subcolor + suffix : null;
-              return (
-                <TouchableHighlight
-                  key={subcolor}
-                  style={[styles.subcolor, {backgroundColor: subcolor}]}
-                  underlayColor={subcolor}
-                  onPress={() => {
-                    stateNavigator.navigate('detail', {color: subcolor, name, filter, search});
-                  }}>
-                    <View />
-                </TouchableHighlight>
-              )
-            }
+            .map(subcolor => (
+              <TouchableHighlight
+                key={subcolor}
+                style={[styles.subcolor, {backgroundColor: subcolor}]}
+                underlayColor={subcolor}
+                onPress={() => {
+                  stateNavigator.navigate('detail', {color: subcolor, search});
+                }}>
+                  <View />
+              </TouchableHighlight>
+            )
           )}
         </View>
       </ScrollView>

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -23,8 +23,8 @@ const Detail = ({colors, color, search}) => {
       <ScrollView contentInsetAdjustmentBehavior="automatic">
         <SharedElement name={color} style={styles.color} duration={250}>
           <View style={{backgroundColor: color, flex: 1}} />
+          <Text style={styles.text}>{color}</Text>
         </SharedElement>
-        <Text style={styles.text}>{color}</Text>
         <View style={styles.colors}>
           {[1,2,3].map(i => colors[(colors.indexOf(color) + i) % 15])
             .map(subcolor => (
@@ -65,16 +65,17 @@ const styles = StyleSheet.create({
     paddingTop: 10,
   },
   color: {
-    height: 300,
+    height: 400,
     marginTop: 10,
     marginLeft: 15,
-    marginRight: 15,
+    marginRight: 15
   },
   text:{
     fontSize: 80,
     color: '#000',
     textAlign:'center',
     fontWeight: 'bold',
+    backgroundColor: 'white'
   },
   colors: {
     flexDirection: 'row',

--- a/NavigationReactNative/sample/zoom/Grid.js
+++ b/NavigationReactNative/sample/zoom/Grid.js
@@ -1,47 +1,46 @@
 import React, {useContext, useState} from 'react';
-import {Platform, StyleSheet, ScrollView, View, TouchableHighlight} from 'react-native';
+import {Platform, StyleSheet, ScrollView, View, TouchableHighlight, Text} from 'react-native';
 import {NavigationContext} from 'navigation-react';
 import {SharedElement, NavigationBar, SearchBar, RightBar, BarButton} from 'navigation-react-native';
-
-const Colors = ({colors, children, filter}) => {
-  const {stateNavigator} = useContext(NavigationContext);
-  const suffix = filter != null ? '_search' : '';
-  const matchedColors = colors.filter(color => (
-    !filter || color.indexOf(filter.toLowerCase()) !== -1
-  ));
-  return (
-    <ScrollView
-      style={styles.scene}
-      contentInsetAdjustmentBehavior="automatic">
-      <View style={styles.colors}>
-        {matchedColors.map(color => (
-          <TouchableHighlight
-            key={color}
-            style={styles.color}
-            underlayColor={color}                
-            onPress={() => {
-              stateNavigator.navigate('detail', {
-                color, name: color + suffix, filter, search: filter != null
-              });
-            }}>
-            <SharedElement name={color + suffix} style={{flex: 1}} duration={250}>
-              <View style={{backgroundColor: color, flex: 1}} />
-            </SharedElement>
-          </TouchableHighlight>
-        ))}
-        {children}
-      </View>
-    </ScrollView>
-  );
-}
 
 const Container = (props) => (
   Platform.OS === 'ios' ? <ScrollView {...props}/> : <View {...props} />
 );
 
+const SearchResults = ({colors, text}) => {
+  const {stateNavigator} = useContext(NavigationContext);
+  return (
+    <ScrollView
+      style={styles.scene}
+      contentInsetAdjustmentBehavior="automatic">
+      <View>
+        {colors
+          .filter(color => (
+            !text || color.indexOf(text.toLowerCase()) !== -1
+          ))
+          .map(color => (
+            <TouchableHighlight
+              key={color}
+              style={{flex: 1, flexDirection: 'row', margin: 10, alignItems: 'center'}}
+              underlayColor="white"
+              onPress={() => {
+                stateNavigator.navigate('detail', {color, search: true});
+              }}>
+                <>
+                  <View style={{backgroundColor: color, width: 100, height: 50}} />
+                  <Text style={{fontSize: 25, marginLeft: 10}}>{color}</Text>
+                </>
+            </TouchableHighlight>
+          ))}
+      </View>
+    </ScrollView>
+  )
+}
+
 const Grid = ({colors}) => {
   const [text, setText] = useState('');
-  return (    
+  const {stateNavigator} = useContext(NavigationContext);
+  return (
     <Container
       style={styles.scene}
       collapsable={false}
@@ -55,13 +54,31 @@ const Grid = ({colors}) => {
           autoCapitalize="none"
           obscureBackground={false}
           onChangeText={text => setText(text)}>
-          <Colors colors={colors} filter={text} />
+          <SearchResults colors={colors} text={text} />
         </SearchBar>
         <RightBar>
           <BarButton title="search" show="always" search={true} />
         </RightBar>
       </NavigationBar>
-      <Colors colors={colors} />
+      <ScrollView
+        style={styles.scene}
+        contentInsetAdjustmentBehavior="automatic">
+        <View style={styles.colors}>
+          {colors.map(color => (
+            <TouchableHighlight
+              key={color}
+              style={styles.color}
+              underlayColor={color}                
+              onPress={() => {
+                stateNavigator.navigate('detail', {color});
+              }}>
+              <SharedElement name={color} style={{flex: 1}} duration={250}>
+                <View style={{backgroundColor: color, flex: 1}} />
+              </SharedElement>
+            </TouchableHighlight>
+          ))}
+        </View>
+      </ScrollView>
     </Container>
   );
 };

--- a/NavigationReactNative/sample/zoom/Grid.js
+++ b/NavigationReactNative/sample/zoom/Grid.js
@@ -68,12 +68,13 @@ const Grid = ({colors}) => {
             <TouchableHighlight
               key={color}
               style={styles.color}
-              underlayColor={color}                
+              underlayColor="transparent"                
               onPress={() => {
                 stateNavigator.navigate('detail', {color});
               }}>
               <SharedElement name={color} style={{flex: 1}} duration={250}>
                 <View style={{backgroundColor: color, flex: 1}} />
+                <Text style={styles.text}>{color}</Text>
               </SharedElement>
             </TouchableHighlight>
           ))}
@@ -102,6 +103,12 @@ const styles = StyleSheet.create({
     marginLeft: 10,
     marginRight: 10,
     marginBottom: 20,
+  },
+  text: {
+    fontSize: 25,
+    textAlign: 'center',
+    fontWeight: 'bold',
+    backgroundColor: 'white'
   },
   result: {
     flex: 1,

--- a/NavigationReactNative/sample/zoom/Grid.js
+++ b/NavigationReactNative/sample/zoom/Grid.js
@@ -24,7 +24,7 @@ const Colors = ({colors, children, filter}) => {
                 color, name: color + suffix, filter, search: filter != null
               });
             }}>
-            <SharedElement name={color + suffix} style={{flex: 1}}>
+            <SharedElement name={color + suffix} style={{flex: 1}} duration={250}>
               <View style={{backgroundColor: color, flex: 1}} />
             </SharedElement>
           </TouchableHighlight>

--- a/NavigationReactNative/sample/zoom/Grid.js
+++ b/NavigationReactNative/sample/zoom/Grid.js
@@ -21,7 +21,7 @@ const SearchResults = ({colors, text}) => {
           .map(color => (
             <TouchableHighlight
               key={color}
-              style={{flex: 1, flexDirection: 'row', margin: 10, alignItems: 'center'}}
+              style={styles.result}
               underlayColor="white"
               onPress={() => {
                 stateNavigator.navigate('detail', {color, search: true});
@@ -103,4 +103,10 @@ const styles = StyleSheet.create({
     marginRight: 10,
     marginBottom: 20,
   },
+  result: {
+    flex: 1,
+    flexDirection: 'row',
+    margin: 10,
+    alignItems: 'center'    
+  }
 });

--- a/NavigationReactNative/sample/zoom/android/app/src/main/res/anim/enter_crumb.xml
+++ b/NavigationReactNative/sample/zoom/android/app/src/main/res/anim/enter_crumb.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <scale android:fromXScale="80%p"
+        android:toXScale="100%p"
+        android:fromYScale="80%p"
+        android:toYScale="100%p"
+        android:pivotX="50%p"
+        android:pivotY="50%p"
+        android:duration="250" />
+    <alpha android:fromAlpha="0"
+        android:toAlpha="1.0"
+        android:duration="250"/>
+</set>

--- a/NavigationReactNative/sample/zoom/android/app/src/main/res/anim/enter_mount.xml
+++ b/NavigationReactNative/sample/zoom/android/app/src/main/res/anim/enter_mount.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <alpha android:fromAlpha="0"
+        android:toAlpha="1.0"
+        android:duration="250"/>
+</set>

--- a/NavigationReactNative/sample/zoom/android/app/src/main/res/anim/exit_crumb.xml
+++ b/NavigationReactNative/sample/zoom/android/app/src/main/res/anim/exit_crumb.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <scale android:fromXScale="100%p"
+        android:toXScale="80%p"
+        android:fromYScale="100%p"
+        android:toYScale="80%p"
+        android:pivotX="50%p"
+        android:pivotY="50%p"
+        android:duration="250" />
+    <alpha android:fromAlpha="1"
+        android:toAlpha="0"
+        android:duration="250"/>
+</set>

--- a/NavigationReactNative/sample/zoom/android/app/src/main/res/anim/exit_mount.xml
+++ b/NavigationReactNative/sample/zoom/android/app/src/main/res/anim/exit_mount.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <alpha android:fromAlpha="1"
+        android:toAlpha="0"
+        android:duration="250"/>
+</set>

--- a/NavigationReactNative/sample/zoom/android/app/src/main/res/transition/overshoot.xml
+++ b/NavigationReactNative/sample/zoom/android/app/src/main/res/transition/overshoot.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<transitionSet xmlns:android="http://schemas.android.com/apk/res/android">
-    <changeBounds android:interpolator="@android:interpolator/overshoot"/>
-    <changeTransform android:interpolator="@android:interpolator/overshoot"/>
-</transitionSet>

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -4,7 +4,7 @@ import { Crumb, State } from 'navigation';
 import { NavigationContext, AsyncStateNavigator } from 'navigation-react';
 import PopSync from './PopSync';
 import Scene from './Scene';
-type NavigationStackProps = {stateNavigator: AsyncStateNavigator, title: (state: State, data: any) => string, crumbStyle: any, unmountStyle: any, hidesTabBar: any, sharedElements: any, renderScene: (state: State, data: any) => ReactNode};
+type NavigationStackProps = {stateNavigator: AsyncStateNavigator, title: (state: State, data: any) => string, crumbStyle: any, unmountStyle: any, hidesTabBar: any, sharedElement: any, renderScene: (state: State, data: any) => ReactNode};
 type NavigationStackState = {stateNavigator: AsyncStateNavigator, keys: string[]};
 
 class NavigationStack extends React.Component<NavigationStackProps, NavigationStackState> {
@@ -62,7 +62,7 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
             stateNavigator.navigateBack(crumbs.length);
     }
     getAnimation() {
-        var {stateNavigator, unmountStyle, crumbStyle, sharedElements: getSharedElements} = this.props;
+        var {stateNavigator, unmountStyle, crumbStyle, sharedElement: getSharedElement} = this.props;
         var {state, data, oldState, oldData, oldUrl, crumbs, nextCrumb} = stateNavigator.stateContext;
         if (!oldState)
             return null;
@@ -71,20 +71,20 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
             var {state: nextState, data: nextData} = crumbs.concat(nextCrumb)[oldCrumbs.length + 1];
             var enterAnim = unmountStyle(true, state, data, crumbs);
             var exitAnim = crumbStyle(false, oldState, oldData, oldCrumbs, nextState, nextData);
-            var sharedElements = getSharedElements(state, data, crumbs);
+            var sharedElement = getSharedElement(state, data, crumbs);
         }
         if (crumbs.length < oldCrumbs.length) {
             var nextCrumb = new Crumb(oldData, oldState, null, null, false);
             var {state: nextState, data: nextData} = oldCrumbs.concat(nextCrumb)[crumbs.length + 1];
             var enterAnim = crumbStyle(true, state, data, crumbs, nextState, nextData);
             var exitAnim = unmountStyle(false, oldState, oldData, oldCrumbs);
-            var oldSharedElements = getSharedElements(oldState, oldData, oldCrumbs);
+            var oldSharedElement = getSharedElement(oldState, oldData, oldCrumbs);
         }
         if (crumbs.length === oldCrumbs.length) {
             var enterAnim = unmountStyle(true, state, data, crumbs);
             var exitAnim = unmountStyle(false, oldState, oldData, oldCrumbs, state, data);
         }
-        return {enterAnim, exitAnim, sharedElements, oldSharedElements};
+        return {enterAnim, exitAnim, sharedElement, oldSharedElement};
     }
     render() {
         var {keys} = this.state;

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -22,7 +22,7 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
         unmountStyle: () => null,
         crumbStyle: () => null,
         hidesTabBar: () => false,
-        sharedElements: () => null
+        sharedElement: () => null
     }
     static getDerivedStateFromProps({stateNavigator}: NavigationStackProps, {keys: prevKeys, stateNavigator: prevStateNavigator}: NavigationStackState) {
         if (stateNavigator === prevStateNavigator)

--- a/NavigationReactNative/src/SharedElement.tsx
+++ b/NavigationReactNative/src/SharedElement.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { requireNativeComponent, Platform, View } from 'react-native';
 
 var SharedElement = ({ style, children, ...props }) => (
-    Platform.OS == 'android' ? <NVSharedElement {...props} style={style} children={children} /> : <View style={style} children={children} />
+    Platform.OS == 'android'
+        ? <NVSharedElement {...props} style={style}>{children}</NVSharedElement>
+        : <View style={style}>{children}</View>
 );
 
 var NVSharedElement = requireNativeComponent<any>('NVSharedElement', null);

--- a/NavigationReactNative/src/SharedElement.tsx
+++ b/NavigationReactNative/src/SharedElement.tsx
@@ -1,13 +1,8 @@
 import React from 'react';
 import { requireNativeComponent, Platform, View } from 'react-native';
 
-var SharedElement = ({transition, ...props}) => (
-    Platform.OS == 'android' ? (
-        <NVSharedElement
-            enterTransition={typeof transition !== 'function' ? transition : transition(true)}
-            exitTransition={typeof transition !== 'function' ? transition : transition(false)}
-            {...props} />
-    ) : <View {...props} />
+var SharedElement = (props) => (
+    Platform.OS == 'android' ? <NVSharedElement {...props} /> : <View {...props} />
 );
 
 var NVSharedElement = requireNativeComponent<any>('NVSharedElement', null);

--- a/NavigationReactNative/src/SharedElement.tsx
+++ b/NavigationReactNative/src/SharedElement.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { requireNativeComponent, Platform, View } from 'react-native';
 
-var SharedElement = ({ style, ...props }) => (
-    Platform.OS == 'android' ? <NVSharedElement {...props} style={style} /> : <View style={style} />
+var SharedElement = ({ style, children, ...props }) => (
+    Platform.OS == 'android' ? <NVSharedElement {...props} style={style} /> : <View style={style} children={children} />
 );
 
 var NVSharedElement = requireNativeComponent<any>('NVSharedElement', null);

--- a/NavigationReactNative/src/SharedElement.tsx
+++ b/NavigationReactNative/src/SharedElement.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { requireNativeComponent, Platform, View } from 'react-native';
 
 var SharedElement = ({ style, children, ...props }) => (
-    Platform.OS == 'android' ? <NVSharedElement {...props} style={style} /> : <View style={style} children={children} />
+    Platform.OS == 'android' ? <NVSharedElement {...props} style={style} children={children} /> : <View style={style} children={children} />
 );
 
 var NVSharedElement = requireNativeComponent<any>('NVSharedElement', null);

--- a/NavigationReactNative/src/SharedElement.tsx
+++ b/NavigationReactNative/src/SharedElement.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { requireNativeComponent, Platform, View } from 'react-native';
 
-var SharedElement = (props) => (
-    Platform.OS == 'android' ? <NVSharedElement {...props} /> : <View {...props} />
+var SharedElement = ({ style, ...props }) => (
+    Platform.OS == 'android' ? <NVSharedElement {...props} style={style} /> : <View style={style} />
 );
 
 var NVSharedElement = requireNativeComponent<any>('NVSharedElement', null);

--- a/NavigationReactNative/src/android/build.gradle
+++ b/NavigationReactNative/src/android/build.gradle
@@ -38,7 +38,7 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.google.android.material:material:1.1.0'
+    implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.viewpager2:viewpager2:1.0.0'
 }
   

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -38,14 +38,14 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
         view.exitAnim = exitAnim;
     }
 
-    @ReactProp(name = "sharedElements")
-    public void setSharedElements(NavigationStackView view, ReadableArray sharedElements) {
-        view.sharedElementNames = sharedElements;
+    @ReactProp(name = "sharedElement")
+    public void setSharedElement(NavigationStackView view, String sharedElement) {
+        view.sharedElementName = sharedElement;
     }
 
-    @ReactProp(name = "oldSharedElements")
-    public void setOldSharedElements(NavigationStackView view, ReadableArray oldSharedElements) {
-        view.oldSharedElementNames = oldSharedElements;
+    @ReactProp(name = "oldSharedElement")
+    public void setOldSharedElement(NavigationStackView view, String oldSharedElement) {
+        view.oldSharedElementName = oldSharedElement;
     }
 
     @Nonnull

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -96,7 +96,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
             Pair<SharedElementView, String> sharedElement = fragment != null ? getOldSharedElement(currentCrumb, crumb, fragment, currentActivity) : null;
             SceneFragment prevFragment = (SceneFragment) fragmentManager.findFragmentByTag(keys.getString(crumb));
             if (sharedElement != null && prevFragment != null && prevFragment.getScene() != null)
-                prevFragment.getScene().transitioner = new SharedElementTransitioner(fragment, prevFragment, oldSharedElementName);
+                prevFragment.getScene().transitioner = new SharedElementMotion(fragment, prevFragment, oldSharedElementName);
             fragmentManager.popBackStack(String.valueOf(crumb), 0);
         }
         if (crumb > currentCrumb) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -127,10 +127,8 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                     for(Pair sharedElement : sharedElements) {
                         fragmentTransaction.addSharedElement((View) sharedElement.first, (String) sharedElement.second);
                     }
-                    fragmentTransaction.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE);
-                } else {
-                    fragmentTransaction.setCustomAnimations(oldCrumb != -1 ? enter : 0, exit, popEnter, popExit);
                 }
+                fragmentTransaction.setCustomAnimations(oldCrumb != -1 ? enter : 0, exit, popEnter, popExit);
                 SceneFragment fragment = new SceneFragment(scene, getSharedElementSet(sharedElementNames));
                 fragmentTransaction.replace(getId(), fragment, key);
                 fragmentTransaction.addToBackStack(String.valueOf(nextCrumb));

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -97,7 +97,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
             Pair[] sharedElements = fragment != null ? getOldSharedElements(currentCrumb, crumb, fragment, currentActivity) : null;
             SceneFragment prevFragment = (SceneFragment) fragmentManager.findFragmentByTag(keys.getString(crumb));
             if (sharedElements != null && prevFragment != null && prevFragment.getScene() != null)
-                prevFragment.getScene().transitioner = new SharedElementTransitioner(prevFragment, getSharedElementSet(oldSharedElementNames));
+                prevFragment.getScene().transitioner = new SharedElementTransitioner(fragment, prevFragment, getSharedElementSet(oldSharedElementNames));
             fragmentManager.popBackStack(String.valueOf(crumb), 0);
         }
         if (crumb > currentCrumb) {
@@ -195,13 +195,6 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
         final HashMap<String, SharedElementView> oldSharedElementsMap = getSharedElementMap(sceneFragment.getScene());
         final Pair[] oldSharedElements = currentCrumb - crumb == 1 ? getSharedElements(oldSharedElementsMap, oldSharedElementNames) : null;
         if (oldSharedElements != null && oldSharedElements.length != 0) {
-            final SharedElementTransitioner transitioner = new SharedElementTransitioner(sceneFragment, getSharedElementSet(oldSharedElementNames));
-            for(int i = 0; i < oldSharedElementNames.size(); i++) {
-                String name = oldSharedElementNames.getString(i);
-                if (oldSharedElementsMap.containsKey(name)) {
-                    transitioner.load(name);
-                }
-            }
             sceneFragment.setEnterSharedElementCallback(new SharedElementCallback() {
                 @Override
                 public void onMapSharedElements(List<String> names, Map<String, View> elements) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.util.Pair;
 import android.util.SparseIntArray;
@@ -42,7 +41,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
     protected ReadableArray keys;
     private int oldCrumb = -1;
     private String oldKey;
-    private SparseIntArray defaultAnimation;
+    private final SparseIntArray defaultAnimation = new SparseIntArray();
     private Activity mainActivity;
     protected String enterAnim;
     protected String exitAnim;
@@ -52,7 +51,6 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
 
     public NavigationStackView(Context context) {
         super(context);
-        defaultAnimation = new SparseIntArray();
         TypedArray activityStyle = context.getTheme().obtainStyledAttributes(new int[] {android.R.attr.windowAnimationStyle});
         int windowAnimationStyleResId = activityStyle.getResourceId(0, 0);
         activityStyle.recycle();
@@ -174,8 +172,6 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
     }
 
     HashMap<String, SharedElementView> getSharedElementMap(SceneView scene) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP)
-            return null;
         HashMap<String, SharedElementView> sharedElementMap = new HashMap<>();
         for(SharedElementView sharedElement : scene.sharedElements) {
             sharedElementMap.put(sharedElement.getTransitionName(), sharedElement);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -175,17 +175,17 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
         return sharedElementSet;
     }
 
-    HashMap<String, View> getSharedElementMap(SceneView scene) {
+    HashMap<String, SharedElementView> getSharedElementMap(SceneView scene) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP)
             return null;
-        HashMap<String, View> sharedElementMap = new HashMap<>();
-        for(View sharedElement : scene.sharedElements) {
+        HashMap<String, SharedElementView> sharedElementMap = new HashMap<>();
+        for(SharedElementView sharedElement : scene.sharedElements) {
             sharedElementMap.put(sharedElement.getTransitionName(), sharedElement);
         }
         return sharedElementMap;
     }
 
-    Pair[] getSharedElements(HashMap<String, View> sharedElementMap, ReadableArray sharedElementNames) {
+    Pair[] getSharedElements(HashMap<String, SharedElementView> sharedElementMap, ReadableArray sharedElementNames) {
         if (sharedElementMap == null || sharedElementNames == null)
             return null;
         ArrayList<Pair> sharedElementPairs = new ArrayList<>();
@@ -198,15 +198,14 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
     }
 
     private Pair[] getOldSharedElements(int currentCrumb, int crumb, SceneFragment sceneFragment, final Activity activity) {
-        final HashMap<String, View> oldSharedElementsMap = getSharedElementMap(sceneFragment.getScene());
+        final HashMap<String, SharedElementView> oldSharedElementsMap = getSharedElementMap(sceneFragment.getScene());
         final Pair[] oldSharedElements = currentCrumb - crumb == 1 ? getSharedElements(oldSharedElementsMap, oldSharedElementNames) : null;
         if (oldSharedElements != null && oldSharedElements.length != 0) {
             final SharedElementTransitioner transitioner = new SharedElementTransitioner(sceneFragment, getSharedElementSet(oldSharedElementNames));
             for(int i = 0; i < oldSharedElementNames.size(); i++) {
                 String name = oldSharedElementNames.getString(i);
                 if (oldSharedElementsMap.containsKey(name)) {
-                    View oldSharedElement = oldSharedElementsMap.get(name);
-                    SharedElementView oldSharedElementView = (SharedElementView) oldSharedElement.getParent();
+                    SharedElementView oldSharedElementView = oldSharedElementsMap.get(name);
                     transitioner.load(name, oldSharedElementView.exitTransition, activity);
                 }
             }
@@ -228,7 +227,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
     }
 
     private Pair[] getSharedElements(int currentCrumb, int crumb, SceneFragment sceneFragment) {
-        final HashMap<String, View> sharedElementsMap = getSharedElementMap(sceneFragment.getScene());
+        final HashMap<String, SharedElementView> sharedElementsMap = getSharedElementMap(sceneFragment.getScene());
         final Pair[] sharedElements = crumb - currentCrumb == 1 ? getSharedElements(sharedElementsMap, sharedElementNames) : null;
         if (sharedElements != null && sharedElements.length != 0) {
             sceneFragment.setExitSharedElementCallback(new SharedElementCallback() {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -203,8 +203,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
             for(int i = 0; i < oldSharedElementNames.size(); i++) {
                 String name = oldSharedElementNames.getString(i);
                 if (oldSharedElementsMap.containsKey(name)) {
-                    SharedElementView oldSharedElementView = oldSharedElementsMap.get(name);
-                    transitioner.load(name, oldSharedElementView.exitTransition, activity);
+                    transitioner.load(name);
                 }
             }
             sceneFragment.setEnterSharedElementCallback(new SharedElementCallback() {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -93,7 +93,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
         if (crumb < currentCrumb) {
             FragmentManager fragmentManager = fragment.getChildFragmentManager();
             SceneFragment fragment = (SceneFragment) fragmentManager.findFragmentByTag(oldKey);
-            Pair<SharedElementView, String> sharedElement = fragment != null ? getOldSharedElement(currentCrumb, crumb, fragment, currentActivity) : null;
+            Pair<SharedElementView, String> sharedElement = fragment != null ? getOldSharedElement(currentCrumb, crumb, fragment) : null;
             SceneFragment prevFragment = (SceneFragment) fragmentManager.findFragmentByTag(keys.getString(crumb));
             if (sharedElement != null && prevFragment != null && prevFragment.getScene() != null)
                 prevFragment.getScene().sharedElementMotion = new SharedElementMotion(fragment, prevFragment, oldSharedElementName);
@@ -121,7 +121,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                         sharedElement = getSharedElement(currentCrumb, crumb, prevFragment);
                 }
                 if (sharedElement != null) {
-                    fragmentTransaction.addSharedElement((View) sharedElement.first, (String) sharedElement.second);
+                    fragmentTransaction.addSharedElement(sharedElement.first, sharedElement.second);
                 }
                 fragmentTransaction.setCustomAnimations(oldCrumb != -1 ? enter : 0, exit, popEnter, popExit);
                 SceneFragment fragment = new SceneFragment(scene, sharedElementName);
@@ -174,7 +174,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
         return null;
     }
 
-    private Pair<SharedElementView, String> getOldSharedElement(int currentCrumb, int crumb, SceneFragment sceneFragment, final Activity activity) {
+    private Pair<SharedElementView, String> getOldSharedElement(int currentCrumb, int crumb, SceneFragment sceneFragment) {
         final HashMap<String, SharedElementView> oldSharedElementsMap = getSharedElementMap(sceneFragment.getScene());
         final Pair<SharedElementView, String> oldSharedElement = currentCrumb - crumb == 1 ? getSharedElement(oldSharedElementsMap, oldSharedElementName) : null;
         if (oldSharedElement != null) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -96,7 +96,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
             Pair<SharedElementView, String> sharedElement = fragment != null ? getOldSharedElement(currentCrumb, crumb, fragment, currentActivity) : null;
             SceneFragment prevFragment = (SceneFragment) fragmentManager.findFragmentByTag(keys.getString(crumb));
             if (sharedElement != null && prevFragment != null && prevFragment.getScene() != null)
-                prevFragment.getScene().transitioner = new SharedElementMotion(fragment, prevFragment, oldSharedElementName);
+                prevFragment.getScene().sharedElementMotion = new SharedElementMotion(fragment, prevFragment, oldSharedElementName);
             fragmentManager.popBackStack(String.valueOf(crumb), 0);
         }
         if (crumb > currentCrumb) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -55,8 +55,8 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
         activityStyle.recycle();
 
         activityStyle = context.getTheme().obtainStyledAttributes(windowAnimationStyleResId, new int[] {
-                android.R.attr.activityOpenEnterAnimation, android.R.attr.activityOpenExitAnimation,
-                android.R.attr.activityCloseEnterAnimation, android.R.attr.activityCloseExitAnimation
+            android.R.attr.activityOpenEnterAnimation, android.R.attr.activityOpenExitAnimation,
+            android.R.attr.activityCloseEnterAnimation, android.R.attr.activityCloseExitAnimation
         });
         defaultAnimation.put(android.R.attr.activityOpenEnterAnimation, activityStyle.getResourceId(0, 0));
         defaultAnimation.put(android.R.attr.activityOpenExitAnimation, activityStyle.getResourceId(1, 0));

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -75,6 +75,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
             if (uri != null) {
                 mainActivity.getIntent().setData(null);
                 DeviceEventManagerModule deviceEventManagerModule = ((ThemedReactContext) getContext()).getNativeModule(DeviceEventManagerModule.class);
+                assert deviceEventManagerModule != null;
                 deviceEventManagerModule.emitNewIntentReceived(uri);
             }
         }
@@ -109,6 +110,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                 int nextCrumb = currentCrumb + i + 1;
                 String key = keys.getString(nextCrumb);
                 SceneView scene = scenes.get(key);
+                assert scene != null : "Scene is null";
                 int popEnter = getAnimationResourceId(currentActivity, scene.enterAnim, android.R.attr.activityCloseEnterAnimation);
                 int popExit = getAnimationResourceId(currentActivity, scene.exitAnim, android.R.attr.activityCloseExitAnimation);
                 FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
@@ -135,6 +137,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
             int exit = getAnimationResourceId(currentActivity, exitAnim, android.R.attr.activityOpenExitAnimation);
             String key = keys.getString(crumb);
             SceneView scene = scenes.get(key);
+            assert scene != null : "Scene is null";
             int popEnter = getAnimationResourceId(currentActivity, scene.enterAnim, android.R.attr.activityCloseEnterAnimation);
             int popExit = getAnimationResourceId(currentActivity, scene.exitAnim, android.R.attr.activityCloseExitAnimation);
             FragmentManager fragmentManager = fragment.getChildFragmentManager();
@@ -229,6 +232,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
         }
         if (keys.size() == 1) {
             SceneView scene = scenes.get(keys.getString(0));
+            assert scene != null : "Scene is null";
             for (int i = 0; i < scene.getChildCount(); i++) {
                 if (scene.getChildAt(i) instanceof CoordinatorLayoutView)
                     ((CoordinatorLayoutView) scene.getChildAt(i)).scrollToTop();

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -20,7 +20,7 @@ public class SceneFragment extends Fragment {
         super();
         this.scene = scene;
         if (sharedElement != null )
-            scene.transitioner = new SharedElementMotion(this, this, sharedElement);
+            scene.sharedElementMotion = new SharedElementMotion(this, this, sharedElement);
     }
 
     @Nullable
@@ -29,7 +29,7 @@ public class SceneFragment extends Fragment {
         if (scene != null) {
             if (scene.getParent() != null)
                 ((ViewGroup) scene.getParent()).endViewTransition(scene);
-            if (scene.transitioner != null)
+            if (scene.sharedElementMotion != null)
                 postponeEnterTransition();
             return scene;
         }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -18,11 +18,11 @@ public class SceneFragment extends Fragment {
         super();
     }
 
-    SceneFragment(SceneView scene, HashSet<String> sharedElements) {
+    SceneFragment(SceneView scene, String sharedElement) {
         super();
         this.scene = scene;
-        if (sharedElements != null )
-            scene.transitioner = new SharedElementTransitioner(this, this, sharedElements);
+        if (sharedElement != null )
+            scene.transitioner = new SharedElementTransitioner(this, this, sharedElement);
     }
 
     @Nullable

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -9,8 +9,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
-import java.util.HashSet;
-
 public class SceneFragment extends Fragment {
     private SceneView scene;
 
@@ -22,7 +20,7 @@ public class SceneFragment extends Fragment {
         super();
         this.scene = scene;
         if (sharedElement != null )
-            scene.transitioner = new SharedElementTransitioner(this, this, sharedElement);
+            scene.transitioner = new SharedElementMotion(this, this, sharedElement);
     }
 
     @Nullable

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -22,7 +22,7 @@ public class SceneFragment extends Fragment {
         super();
         this.scene = scene;
         if (sharedElements != null )
-            scene.transitioner = new SharedElementTransitioner(this, sharedElements);
+            scene.transitioner = new SharedElementTransitioner(this, this, sharedElements);
     }
 
     @Nullable

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneView.java
@@ -13,7 +13,7 @@ public class SceneView extends ViewGroup {
     protected String enterAnim;
     protected String exitAnim;
     public HashSet<SharedElementView> sharedElements = new HashSet<>();
-    public SharedElementMotion transitioner;
+    public SharedElementMotion sharedElementMotion;
 
     public SceneView(Context context) {
         super(context);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneView.java
@@ -1,7 +1,6 @@
 package com.navigation.reactnative;
 
 import android.content.Context;
-import android.view.View;
 import android.view.ViewGroup;
 
 import com.facebook.react.bridge.ReactContext;
@@ -14,7 +13,7 @@ public class SceneView extends ViewGroup {
     protected String enterAnim;
     protected String exitAnim;
     public HashSet<SharedElementView> sharedElements = new HashSet<>();
-    public SharedElementTransitioner transitioner;
+    public SharedElementMotion transitioner;
 
     public SceneView(Context context) {
         super(context);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneView.java
@@ -13,7 +13,7 @@ public class SceneView extends ViewGroup {
     protected String sceneKey;
     protected String enterAnim;
     protected String exitAnim;
-    public HashSet<View> sharedElements = new HashSet<>();
+    public HashSet<SharedElementView> sharedElements = new HashSet<>();
     public SharedElementTransitioner transitioner;
 
     public SceneView(Context context) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementManager.java
@@ -22,7 +22,7 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
 
     @ReactProp(name = "name")
     public void setName(SharedElementView view, String name) {
-        view.setName(name);
+        view.setTransitionName(name);
     }
 
     @ReactProp(name = "enterTransition")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementManager.java
@@ -41,9 +41,4 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
         if (("cross").equals(fadeMode)) view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_CROSS);
         if (("through").equals(fadeMode)) view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_THROUGH);
     }
-
-    @ReactProp(name = "drawingViewId", defaultInt = View.NO_ID)
-    public void setDrawingViewId(SharedElementView view, int drawingViewId) {
-        view.transition.setDrawingViewId(drawingViewId);
-    }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementManager.java
@@ -36,10 +36,10 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
     @ReactProp(name = "fadeMode")
     public void setFadeMode(SharedElementView view, String fadeMode) {
         if (fadeMode == null) view.transition.setFadeMode(view.defaultFadeMode);
-        if (fadeMode == "in") view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_IN);
-        if (fadeMode == "out") view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_OUT);
-        if (fadeMode == "cross") view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_CROSS);
-        if (fadeMode == "through") view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_THROUGH);
+        if (("in").equals(fadeMode)) view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_IN);
+        if (("out").equals(fadeMode)) view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_OUT);
+        if (("cross").equals(fadeMode)) view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_CROSS);
+        if (("through").equals(fadeMode)) view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_THROUGH);
     }
 
     @ReactProp(name = "drawingViewId", defaultInt = View.NO_ID)

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementManager.java
@@ -1,7 +1,5 @@
 package com.navigation.reactnative;
 
-import android.view.View;
-
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementManager.java
@@ -1,8 +1,11 @@
 package com.navigation.reactnative;
 
+import android.view.View;
+
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.google.android.material.transition.MaterialContainerTransform;
 
 import javax.annotation.Nonnull;
 
@@ -23,5 +26,24 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
     @ReactProp(name = "name")
     public void setName(SharedElementView view, String name) {
         view.setTransitionName(name);
+    }
+
+    @ReactProp(name = "duration", defaultInt = -1)
+    public void setDuration(SharedElementView view, int duration) {
+        view.transition.setDuration(duration != -1 ? duration : view.defaultDuration);
+    }
+
+    @ReactProp(name = "fadeMode")
+    public void setFadeMode(SharedElementView view, String fadeMode) {
+        if (fadeMode == null) view.transition.setFadeMode(view.defaultFadeMode);
+        if (fadeMode == "in") view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_IN);
+        if (fadeMode == "out") view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_OUT);
+        if (fadeMode == "cross") view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_CROSS);
+        if (fadeMode == "through") view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_THROUGH);
+    }
+
+    @ReactProp(name = "drawingViewId", defaultInt = View.NO_ID)
+    public void setDrawingViewId(SharedElementView view, int drawingViewId) {
+        view.transition.setDrawingViewId(drawingViewId);
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementManager.java
@@ -24,14 +24,4 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
     public void setName(SharedElementView view, String name) {
         view.setTransitionName(name);
     }
-
-    @ReactProp(name = "enterTransition")
-    public void setEnterTransition(SharedElementView view, String enterTransition) {
-        view.enterTransition = enterTransition;
-    }
-
-    @ReactProp(name = "exitTransition")
-    public void setExitTransition(SharedElementView view, String exitTransition) {
-        view.exitTransition = exitTransition;
-    }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementMotion.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementMotion.java
@@ -22,7 +22,7 @@ class SharedElementMotion {
             enterScene.setSharedElementEnterTransition(transition);
             enterScene.setSharedElementReturnTransition(transition);
             scene.startPostponedEnterTransition();
-            scene.getScene().transitioner = null;
+            scene.getScene().sharedElementMotion = null;
         }
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementMotion.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementMotion.java
@@ -14,11 +14,10 @@ class SharedElementMotion {
     }
 
     void load(SharedElementView sharedElementView) {
-        String sharedElement = sharedElementView.getTransitionName();
-        if (sharedElementName.equals(sharedElement)) {
+        if (sharedElementName.equals(sharedElementView.getTransitionName())) {
             MaterialContainerTransform transition = sharedElementView.transition;
             transition.setTransitionDirection(enterScene == scene ? MaterialContainerTransform.TRANSITION_DIRECTION_ENTER : MaterialContainerTransform.TRANSITION_DIRECTION_RETURN);
-            transition.addTarget(sharedElement);
+            transition.addTarget(sharedElementView.getTransitionName());
             enterScene.setSharedElementEnterTransition(transition);
             enterScene.setSharedElementReturnTransition(transition);
             scene.startPostponedEnterTransition();

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementMotion.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementMotion.java
@@ -2,12 +2,12 @@ package com.navigation.reactnative;
 
 import com.google.android.material.transition.MaterialContainerTransform;
 
-class SharedElementTransitioner {
+class SharedElementMotion {
     private final SceneFragment enterScene;
     private final SceneFragment scene;
     private final String sharedElementName;
 
-    SharedElementTransitioner(SceneFragment enterScene, SceneFragment scene, String sharedElementName) {
+    SharedElementMotion(SceneFragment enterScene, SceneFragment scene, String sharedElementName) {
         this.sharedElementName = sharedElementName;
         this.enterScene = enterScene;
         this.scene = scene;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementMotion.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementMotion.java
@@ -5,16 +5,16 @@ import com.google.android.material.transition.MaterialContainerTransform;
 class SharedElementMotion {
     private final SceneFragment enterScene;
     private final SceneFragment scene;
-    private final String sharedElementName;
+    private final String sharedElement;
 
-    SharedElementMotion(SceneFragment enterScene, SceneFragment scene, String sharedElementName) {
-        this.sharedElementName = sharedElementName;
+    SharedElementMotion(SceneFragment enterScene, SceneFragment scene, String sharedElement) {
+        this.sharedElement = sharedElement;
         this.enterScene = enterScene;
         this.scene = scene;
     }
 
     void load(SharedElementView sharedElementView) {
-        if (sharedElementName.equals(sharedElementView.getTransitionName())) {
+        if (sharedElement.equals(sharedElementView.getTransitionName())) {
             MaterialContainerTransform transition = sharedElementView.transition;
             transition.setTransitionDirection(enterScene == scene ? MaterialContainerTransform.TRANSITION_DIRECTION_ENTER : MaterialContainerTransform.TRANSITION_DIRECTION_RETURN);
             transition.addTarget(sharedElementView.getTransitionName());

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
@@ -8,16 +8,16 @@ import com.google.android.material.transition.MaterialContainerTransform;
 import java.util.HashSet;
 
 class SharedElementTransitioner {
-    private final SceneFragment transitionScene;
-    private final SceneFragment postponedScene;
+    private final SceneFragment enterScene;
+    private final SceneFragment scene;
     private final HashSet<String> sharedElements;
     private final HashSet<String> loadedSharedElements = new HashSet<>();
     private final HashSet<Transition> transitions = new HashSet<>();
 
-    SharedElementTransitioner(SceneFragment transitionScene, SceneFragment postponedScene, HashSet<String> sharedElements) {
+    SharedElementTransitioner(SceneFragment enterScene, SceneFragment scene, HashSet<String> sharedElements) {
         this.sharedElements = sharedElements;
-        this.transitionScene = transitionScene;
-        this.postponedScene = postponedScene;
+        this.enterScene = enterScene;
+        this.scene = scene;
     }
 
     void load(SharedElementView sharedElementView) {
@@ -25,7 +25,7 @@ class SharedElementTransitioner {
         if (sharedElements.contains(sharedElement) && !loadedSharedElements.contains(sharedElement)) {
             loadedSharedElements.add(sharedElement);
             MaterialContainerTransform transition = sharedElementView.transition;
-            transition.setTransitionDirection(transitionScene == postponedScene ? MaterialContainerTransform.TRANSITION_DIRECTION_ENTER : MaterialContainerTransform.TRANSITION_DIRECTION_RETURN);
+            transition.setTransitionDirection(enterScene == scene ? MaterialContainerTransform.TRANSITION_DIRECTION_ENTER : MaterialContainerTransform.TRANSITION_DIRECTION_RETURN);
             transition.addTarget(sharedElement);
             transitions.add(transition);
         }
@@ -34,10 +34,10 @@ class SharedElementTransitioner {
             for(Transition transition : transitions) {
                 transitionSet.addTransition(transition);
             }
-            transitionScene.setSharedElementEnterTransition(transitionSet);
-            transitionScene.setSharedElementReturnTransition(transitionSet);
-            postponedScene.startPostponedEnterTransition();
-            postponedScene.getScene().transitioner = null;
+            enterScene.setSharedElementEnterTransition(transitionSet);
+            enterScene.setSharedElementReturnTransition(transitionSet);
+            scene.startPostponedEnterTransition();
+            scene.getScene().transitioner = null;
         }
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
@@ -3,7 +3,6 @@ package com.navigation.reactnative;
 import android.content.Context;
 import android.os.Build;
 import androidx.transition.Transition;
-import androidx.transition.TransitionInflater;
 import androidx.transition.TransitionSet;
 
 import com.google.android.material.transition.MaterialContainerTransform;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
@@ -7,33 +7,32 @@ import androidx.transition.TransitionSet;
 
 import com.google.android.material.transition.MaterialContainerTransform;
 
-import java.util.HashMap;
 import java.util.HashSet;
 
 class SharedElementTransitioner {
     private SceneFragment sceneFragment;
     private HashSet<String> sharedElements;
     private HashSet<String> loadedSharedElements = new HashSet<>();
-    private HashMap<String, Transition> transitions = new HashMap<>();
+    private HashSet<Transition> transitions = new HashSet<>();
 
     SharedElementTransitioner(SceneFragment sceneFragment, HashSet<String> sharedElements) {
         this.sharedElements = sharedElements;
         this.sceneFragment = sceneFragment;
     }
 
-    void load(String sharedElement, String transitionKey, Context context) {
+    void load(String sharedElement) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP)
             return;
         if (sharedElements.contains(sharedElement) && !loadedSharedElements.contains(sharedElement)) {
             loadedSharedElements.add(sharedElement);
             MaterialContainerTransform transition = new MaterialContainerTransform();
             transition.addTarget(sharedElement);
-            transitions.put(transitionKey, transition);
+            transitions.add(transition);
         }
         if(sharedElements.size() == loadedSharedElements.size()) {
             TransitionSet transitionSet = new TransitionSet();
-            for(String key : transitions.keySet()) {
-                transitionSet.addTransition(transitions.get(key));
+            for(Transition transition : transitions) {
+                transitionSet.addTransition(transition);
             }
             sceneFragment.setSharedElementEnterTransition(transitionSet);
             sceneFragment.setSharedElementReturnTransition(transitionSet);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
@@ -8,14 +8,16 @@ import com.google.android.material.transition.MaterialContainerTransform;
 import java.util.HashSet;
 
 class SharedElementTransitioner {
-    private final SceneFragment sceneFragment;
+    private final SceneFragment transitionScene;
+    private final SceneFragment postponedScene;
     private final HashSet<String> sharedElements;
     private final HashSet<String> loadedSharedElements = new HashSet<>();
     private final HashSet<Transition> transitions = new HashSet<>();
 
-    SharedElementTransitioner(SceneFragment sceneFragment, HashSet<String> sharedElements) {
+    SharedElementTransitioner(SceneFragment transitionScene, SceneFragment postponedScene, HashSet<String> sharedElements) {
         this.sharedElements = sharedElements;
-        this.sceneFragment = sceneFragment;
+        this.transitionScene = transitionScene;
+        this.postponedScene = postponedScene;
     }
 
     void load(String sharedElement) {
@@ -30,10 +32,10 @@ class SharedElementTransitioner {
             for(Transition transition : transitions) {
                 transitionSet.addTransition(transition);
             }
-            sceneFragment.setSharedElementEnterTransition(transitionSet);
-            sceneFragment.setSharedElementReturnTransition(transitionSet);
-            sceneFragment.startPostponedEnterTransition();
-            sceneFragment.getScene().transitioner = null;
+            transitionScene.setSharedElementEnterTransition(transitionSet);
+            transitionScene.setSharedElementReturnTransition(transitionSet);
+            postponedScene.startPostponedEnterTransition();
+            postponedScene.getScene().transitioner = null;
         }
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
@@ -1,41 +1,26 @@
 package com.navigation.reactnative;
 
-import androidx.transition.Transition;
-import androidx.transition.TransitionSet;
-
 import com.google.android.material.transition.MaterialContainerTransform;
-
-import java.util.HashSet;
 
 class SharedElementTransitioner {
     private final SceneFragment enterScene;
     private final SceneFragment scene;
-    private final HashSet<String> sharedElements;
-    private final HashSet<String> loadedSharedElements = new HashSet<>();
-    private final HashSet<Transition> transitions = new HashSet<>();
+    private final String sharedElementName;
 
-    SharedElementTransitioner(SceneFragment enterScene, SceneFragment scene, HashSet<String> sharedElements) {
-        this.sharedElements = sharedElements;
+    SharedElementTransitioner(SceneFragment enterScene, SceneFragment scene, String sharedElementName) {
+        this.sharedElementName = sharedElementName;
         this.enterScene = enterScene;
         this.scene = scene;
     }
 
     void load(SharedElementView sharedElementView) {
         String sharedElement = sharedElementView.getTransitionName();
-        if (sharedElements.contains(sharedElement) && !loadedSharedElements.contains(sharedElement)) {
-            loadedSharedElements.add(sharedElement);
+        if (sharedElementName.equals(sharedElement)) {
             MaterialContainerTransform transition = sharedElementView.transition;
             transition.setTransitionDirection(enterScene == scene ? MaterialContainerTransform.TRANSITION_DIRECTION_ENTER : MaterialContainerTransform.TRANSITION_DIRECTION_RETURN);
             transition.addTarget(sharedElement);
-            transitions.add(transition);
-        }
-        if(sharedElements.size() == loadedSharedElements.size()) {
-            TransitionSet transitionSet = new TransitionSet();
-            for(Transition transition : transitions) {
-                transitionSet.addTransition(transition);
-            }
-            enterScene.setSharedElementEnterTransition(transitionSet);
-            enterScene.setSharedElementReturnTransition(transitionSet);
+            enterScene.setSharedElementEnterTransition(transition);
+            enterScene.setSharedElementReturnTransition(transition);
             scene.startPostponedEnterTransition();
             scene.getScene().transitioner = null;
         }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
@@ -1,7 +1,5 @@
 package com.navigation.reactnative;
 
-import android.content.Context;
-import android.os.Build;
 import androidx.transition.Transition;
 import androidx.transition.TransitionSet;
 
@@ -10,10 +8,10 @@ import com.google.android.material.transition.MaterialContainerTransform;
 import java.util.HashSet;
 
 class SharedElementTransitioner {
-    private SceneFragment sceneFragment;
-    private HashSet<String> sharedElements;
-    private HashSet<String> loadedSharedElements = new HashSet<>();
-    private HashSet<Transition> transitions = new HashSet<>();
+    private final SceneFragment sceneFragment;
+    private final HashSet<String> sharedElements;
+    private final HashSet<String> loadedSharedElements = new HashSet<>();
+    private final HashSet<Transition> transitions = new HashSet<>();
 
     SharedElementTransitioner(SceneFragment sceneFragment, HashSet<String> sharedElements) {
         this.sharedElements = sharedElements;
@@ -21,8 +19,6 @@ class SharedElementTransitioner {
     }
 
     void load(String sharedElement) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP)
-            return;
         if (sharedElements.contains(sharedElement) && !loadedSharedElements.contains(sharedElement)) {
             loadedSharedElements.add(sharedElement);
             MaterialContainerTransform transition = new MaterialContainerTransform();

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
@@ -24,7 +24,8 @@ class SharedElementTransitioner {
         String sharedElement = sharedElementView.getTransitionName();
         if (sharedElements.contains(sharedElement) && !loadedSharedElements.contains(sharedElement)) {
             loadedSharedElements.add(sharedElement);
-            MaterialContainerTransform transition = new MaterialContainerTransform();
+            MaterialContainerTransform transition = sharedElementView.transition;
+            transition.setTransitionDirection(transitionScene == postponedScene ? MaterialContainerTransform.TRANSITION_DIRECTION_ENTER : MaterialContainerTransform.TRANSITION_DIRECTION_RETURN);
             transition.addTarget(sharedElement);
             transitions.add(transition);
         }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
@@ -2,9 +2,11 @@ package com.navigation.reactnative;
 
 import android.content.Context;
 import android.os.Build;
-import android.transition.Transition;
-import android.transition.TransitionInflater;
-import android.transition.TransitionSet;
+import androidx.transition.Transition;
+import androidx.transition.TransitionInflater;
+import androidx.transition.TransitionSet;
+
+import com.google.android.material.transition.MaterialContainerTransform;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -25,21 +27,9 @@ class SharedElementTransitioner {
             return;
         if (sharedElements.contains(sharedElement) && !loadedSharedElements.contains(sharedElement)) {
             loadedSharedElements.add(sharedElement);
-            if (transitionKey == null)
-                transitionKey = "move";
-            Transition transition;
-            if (transitions.containsKey(transitionKey))
-                transition = transitions.get(transitionKey);
-            else {
-                String packageName = context.getPackageName();
-                int transitionId = context.getResources().getIdentifier(transitionKey, "transition", packageName);
-                if (transitionId == 0)
-                    transitionId = context.getResources().getIdentifier("move", "transition", packageName);
-                transition = TransitionInflater.from(context).inflateTransition(transitionId);
-                transitions.put(transitionKey, transition);
-            }
-            if (transition != null)
-                transition.addTarget(sharedElement);
+            MaterialContainerTransform transition = new MaterialContainerTransform();
+            transition.addTarget(sharedElement);
+            transitions.put(transitionKey, transition);
         }
         if(sharedElements.size() == loadedSharedElements.size()) {
             TransitionSet transitionSet = new TransitionSet();

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementTransitioner.java
@@ -20,7 +20,8 @@ class SharedElementTransitioner {
         this.postponedScene = postponedScene;
     }
 
-    void load(String sharedElement) {
+    void load(SharedElementView sharedElementView) {
+        String sharedElement = sharedElementView.getTransitionName();
         if (sharedElements.contains(sharedElement) && !loadedSharedElements.contains(sharedElement)) {
             loadedSharedElements.add(sharedElement);
             MaterialContainerTransform transition = new MaterialContainerTransform();

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -29,8 +29,8 @@ public class SharedElementView extends ViewGroup {
             @Override
             public boolean onPreDraw() {
                 getViewTreeObserver().removeOnPreDrawListener(this);
-                if (scene.transitioner != null)
-                    scene.transitioner.load(SharedElementView.this);
+                if (scene.sharedElementMotion != null)
+                    scene.sharedElementMotion.load(SharedElementView.this);
                 return true;
             }
         });

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -34,12 +34,12 @@ public class SharedElementView extends ViewGroup {
     }
 
     @Override
-    protected void onLayout(boolean b, int i, int i1, int i2, int i3) {
-    }
-
-    @Override
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
         scene = null;
+    }
+
+    @Override
+    protected void onLayout(boolean b, int i, int i1, int i2, int i3) {
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -9,8 +9,6 @@ import android.view.ViewTreeObserver;
 import android.widget.FrameLayout;
 
 public class SharedElementView extends ViewGroup {
-    protected String enterTransition;
-    protected String exitTransition;
     private SceneView scene;
 
     public SharedElementView(Context context) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -9,11 +9,15 @@ import com.google.android.material.transition.MaterialContainerTransform;
 
 public class SharedElementView extends ViewGroup {
     private SceneView scene;
-    MaterialContainerTransform transition;
+    final MaterialContainerTransform transition;
+    final long defaultDuration;
+    final int defaultFadeMode;
 
     public SharedElementView(Context context) {
         super(context);
         transition = new MaterialContainerTransform(context, false);
+        defaultDuration = transition.getDuration();
+        defaultFadeMode = transition.getFadeMode();
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -3,51 +3,18 @@ package com.navigation.reactnative;
 import android.content.Context;
 import android.os.Build;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.ViewParent;
 import android.view.ViewTreeObserver;
 import android.widget.FrameLayout;
 
-public class SharedElementView extends FrameLayout {
-    private String name;
+public class SharedElementView extends ViewGroup {
     protected String enterTransition;
     protected String exitTransition;
     private SceneView scene;
 
     public SharedElementView(Context context) {
         super(context);
-    }
-
-    public void setName(String name) {
-        this.name = name;
-        setTransitionName(getChildAt(0), name);
-    }
-
-    @Override
-    public void addView(View child, int index) {
-        super.addView(child, index);
-        if (scene != null) {
-            if (!scene.sharedElements.contains(child)) {
-                setTransitionName(child, name);
-                scene.sharedElements.add(child);
-            }
-        }
-    }
-
-    @Override
-    public void removeViewAt(int index) {
-        View sharedElement = getChildAt(index);
-        if (scene != null) {
-            if (scene.sharedElements.contains(sharedElement)) {
-                setTransitionName(sharedElement, null);
-                scene.sharedElements.remove(sharedElement);
-            }
-            super.removeViewAt(index);
-        }
-    }
-
-    protected void setTransitionName(View sharedElement, String name) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && sharedElement != null)
-            sharedElement.setTransitionName(name);
     }
 
     @Override
@@ -59,20 +26,20 @@ public class SharedElementView extends FrameLayout {
         if (ancestor == null)
             return;
         scene = (SceneView) ancestor;
-        View sharedElement = getChildAt(0);
-        if (!scene.sharedElements.contains(sharedElement)) {
-            setTransitionName(sharedElement, name);
-            scene.sharedElements.add(sharedElement);
-        }
+        scene.sharedElements.add(this);
         getViewTreeObserver().addOnPreDrawListener(new ViewTreeObserver.OnPreDrawListener() {
             @Override
             public boolean onPreDraw() {
                 getViewTreeObserver().removeOnPreDrawListener(this);
                 if (scene.transitioner != null)
-                    scene.transitioner.load(name, enterTransition, getContext());
+                    scene.transitioner.load(getTransitionName(), enterTransition, getContext());
                 return true;
             }
         });
+    }
+
+    @Override
+    protected void onLayout(boolean b, int i, int i1, int i2, int i3) {
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -1,12 +1,9 @@
 package com.navigation.reactnative;
 
 import android.content.Context;
-import android.os.Build;
-import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
 import android.view.ViewTreeObserver;
-import android.widget.FrameLayout;
 
 public class SharedElementView extends ViewGroup {
     private SceneView scene;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -32,7 +32,7 @@ public class SharedElementView extends ViewGroup {
             public boolean onPreDraw() {
                 getViewTreeObserver().removeOnPreDrawListener(this);
                 if (scene.transitioner != null)
-                    scene.transitioner.load(getTransitionName(), enterTransition, getContext());
+                    scene.transitioner.load(getTransitionName());
                 return true;
             }
         });

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -8,7 +8,6 @@ import android.view.ViewTreeObserver;
 import com.google.android.material.transition.MaterialContainerTransform;
 
 public class SharedElementView extends ViewGroup {
-    private SceneView scene;
     final MaterialContainerTransform transition;
     final long defaultDuration;
     final int defaultFadeMode;
@@ -28,7 +27,7 @@ public class SharedElementView extends ViewGroup {
             ancestor = ancestor.getParent();
         if (ancestor == null)
             return;
-        scene = (SceneView) ancestor;
+        final SceneView scene = (SceneView) ancestor;
         scene.sharedElements.add(this);
         getViewTreeObserver().addOnPreDrawListener(new ViewTreeObserver.OnPreDrawListener() {
             @Override
@@ -39,12 +38,6 @@ public class SharedElementView extends ViewGroup {
                 return true;
             }
         });
-    }
-
-    @Override
-    protected void onDetachedFromWindow() {
-        super.onDetachedFromWindow();
-        scene = null;
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -27,7 +27,7 @@ public class SharedElementView extends ViewGroup {
             public boolean onPreDraw() {
                 getViewTreeObserver().removeOnPreDrawListener(this);
                 if (scene.transitioner != null)
-                    scene.transitioner.load(getTransitionName());
+                    scene.transitioner.load(SharedElementView.this);
                 return true;
             }
         });

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -22,12 +22,8 @@ public class SharedElementView extends ViewGroup {
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
-        ViewParent ancestor = getParent();
-        while (ancestor != null && !(ancestor instanceof SceneView))
-            ancestor = ancestor.getParent();
-        if (ancestor == null)
-            return;
-        final SceneView scene = (SceneView) ancestor;
+        final SceneView scene = getScene();
+        if (scene == null) return;
         scene.sharedElements.add(this);
         getViewTreeObserver().addOnPreDrawListener(new ViewTreeObserver.OnPreDrawListener() {
             @Override
@@ -38,6 +34,22 @@ public class SharedElementView extends ViewGroup {
                 return true;
             }
         });
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        SceneView scene = getScene();
+        if (scene != null) scene.sharedElements.remove(this);
+    }
+
+    private SceneView getScene() {
+        ViewParent ancestor = getParent();
+        while (ancestor != null && !(ancestor instanceof SceneView))
+            ancestor = ancestor.getParent();
+        if (ancestor == null)
+            return null;
+        return (SceneView) ancestor;
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -5,11 +5,15 @@ import android.view.ViewGroup;
 import android.view.ViewParent;
 import android.view.ViewTreeObserver;
 
+import com.google.android.material.transition.MaterialContainerTransform;
+
 public class SharedElementView extends ViewGroup {
     private SceneView scene;
+    MaterialContainerTransform transition;
 
     public SharedElementView(Context context) {
         super(context);
+        transition = new MaterialContainerTransform(context, false);
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/res/transition/move.xml
+++ b/NavigationReactNative/src/android/src/main/res/transition/move.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<transitionSet xmlns:android="http://schemas.android.com/apk/res/android">
-    <changeBounds/>
-    <changeTransform/>
-    <changeClipBounds/>
-</transitionSet>

--- a/NavigationReactNative/test/navigation-react-native-tests.tsx
+++ b/NavigationReactNative/test/navigation-react-native-tests.tsx
@@ -73,7 +73,7 @@ var Person = () => {
                 </RightBar>
             </NavigationBar>
             <View>
-                <SharedElement name={name} transition="bounce">
+                <SharedElement name={name}>
                     <Text>{name}</Text>
                 </SharedElement>
             </View>

--- a/NavigationReactNative/test/navigation-react-native-tests.tsx
+++ b/NavigationReactNative/test/navigation-react-native-tests.tsx
@@ -89,7 +89,7 @@ stateNavigator.navigate('people');
 
 const App = () => (
     <NavigationHandler stateNavigator={stateNavigator}>
-      <NavigationStack />
+      <NavigationStack sharedElement={(_, { name }) => name} />
     </NavigationHandler>
   );
   

--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -359,7 +359,7 @@ export interface SharedElementProps {
      */
     duration?: number;
     /**
-     * The fade mode used to swap the content of two views
+     * The fade mode used to swap the content of the two views
      */
     fadeMode?: 'in' | 'out' | 'cross' | 'through';
     /**

--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -27,9 +27,9 @@ export interface NavigationStackProps {
      */
     hidesTabBar?: (state: State, data: any, crumbs: Crumb[]) => boolean;
     /**
-     * A scene's shared elements
+     * A scene's shared element
      */
-    sharedElements?: (state: State, data: any, crumbs: Crumb[]) => string[];
+    sharedElement?: (state: State, data: any, crumbs: Crumb[]) => string;
     /**
      * Renders the scene for the State and data
      */

--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -351,13 +351,17 @@ export class StatusBar extends Component<StatusBarProps> {}
  */
 export interface SharedElementProps {
     /**
-     * The name shared across scenes by the two elements
+     * The name shared across scenes by the two views
      */
     name: string;
     /**
-     * The resource for the transition
+     * The duration of the transition
      */
-    transition?: string | ((mount: boolean) => string);
+    duration?: number;
+    /**
+     * The fade mode used to swap the content of two views
+     */
+    fadeMode?: 'in' | 'out' | 'cross' | 'through';
     /**
      * The style
      */

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -359,7 +359,7 @@ export interface SharedElementProps {
      */
     duration?: number;
     /**
-     * The fade mode used to swap the content of two views
+     * The fade mode used to swap the content of the two views
      */
     fadeMode?: 'in' | 'out' | 'cross' | 'through';
     /**

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -27,9 +27,9 @@ export interface NavigationStackProps {
      */
     hidesTabBar?: (state: State, data: any, crumbs: Crumb[]) => boolean;
     /**
-     * A scene's shared elements
+     * A scene's shared element
      */
-    sharedElements?: (state: State, data: any, crumbs: Crumb[]) => string[];
+    sharedElement?: (state: State, data: any, crumbs: Crumb[]) => string;
     /**
      * Renders the scene for the State and data
      */

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -351,13 +351,17 @@ export class StatusBar extends Component<StatusBarProps> {}
  */
 export interface SharedElementProps {
     /**
-     * The name shared across scenes by the two elements
+     * The name shared across scenes by the two views
      */
     name: string;
     /**
-     * The resource for the transition
+     * The duration of the transition
      */
-    transition?: string | ((mount: boolean) => string);
+    duration?: number;
+    /**
+     * The fade mode used to swap the content of two views
+     */
+    fadeMode?: 'in' | 'out' | 'cross' | 'through';
     /**
      * The style
      */


### PR DESCRIPTION
[A container transform](https://material.io/develop/android/theming/motion#container-transform) is a shared element transition that supports containers like ViewGroups.

Updated Android material components to v1.4.0.

Dropped support for traditional Android shared element transitions because they only support single elements like an image. Think the only loss of functionality is there can only be one container transform at a time. But only needed multiple for traditional shared elements because they couldn’t handle containers. For example, sharing a photo and description would’ve required 2 shared elements but can now share the parent view container instead.
