### PR TITLE
Supported SearchBar inside a CoordinatorLayout inside a TabBarItem

### DIFF
--- a/NavigationReactNative/src/CoordinatorLayout.tsx
+++ b/NavigationReactNative/src/CoordinatorLayout.tsx
@@ -1,26 +1,9 @@
 import React from 'react'
 import { requireNativeComponent, Platform } from 'react-native';
-import NavigationBar from './NavigationBar';
-import SearchBar from './SearchBar';
 
-const CoordinatorLayout = ({overlap, children}) => {
-    var {clonedChildren, searchBar} = React.Children.toArray(children)
-        .reduce((val: any, child: any) => {
-            if (child.type === NavigationBar) {
-                var barChildren = React.Children.toArray(child.props.children);
-                val.searchBar = barChildren.find(({type}: any) => type === SearchBar);
-                child = React.cloneElement(child, child.props, barChildren.filter(c => c !== val.searchBar))
-            }
-            val.clonedChildren.push(child);
-            return val;
-        }, {clonedChildren: [], searchBar: null});
-    return (
-        <>
-            <NVCoordinatorLayout overlap={overlap} style={{flex: 1}}>{clonedChildren}</NVCoordinatorLayout>
-            {searchBar}
-        </>
-    );
-};
+const CoordinatorLayout = ({overlap, children}) => (
+    <NVCoordinatorLayout overlap={overlap} style={{flex: 1}}>{children}</NVCoordinatorLayout>
+);
 const NVCoordinatorLayout = requireNativeComponent<any>('NVCoordinatorLayout', null)
 
 export default Platform.OS === 'android' ? CoordinatorLayout : ({children}) => children;

--- a/NavigationReactNative/src/SearchBar.tsx
+++ b/NavigationReactNative/src/SearchBar.tsx
@@ -37,7 +37,7 @@ class SearchBar extends React.Component<any, any> {
                 onChangeText={this.onChangeText}
                 onExpand={() => this.setState({show: true})}
                 onCollapse={() => this.setState({show: false})}
-                style={[styles.searchBar, show && showStyle]}>
+                style={[styles.searchBar, showStyle]}>
                 {Platform.OS === 'ios' || this.state.show ? children : null}
             </NVSearchBar>
         );

--- a/NavigationReactNative/src/SearchBar.tsx
+++ b/NavigationReactNative/src/SearchBar.tsx
@@ -49,7 +49,11 @@ var NVSearchBar = requireNativeComponent<any>('NVSearchBar', null);
 var styles = StyleSheet.create({
     searchBar: {
         position: 'absolute',
-        top: 0, right: 0, bottom: 0, left: 0,
+        ...Platform.select({
+            android: {
+                top: 0, right: 0, bottom: 0, left: 0,
+            },
+        })
     },
 });
 

--- a/NavigationReactNative/src/SearchBar.tsx
+++ b/NavigationReactNative/src/SearchBar.tsx
@@ -5,7 +5,7 @@ class SearchBar extends React.Component<any, any> {
     private ref: React.RefObject<View>;
     constructor(props) {
         super(props);
-        this.state = {show: false, top: 56};
+        this.state = {show: false};
         this.ref = React.createRef<View>();
         this.onChangeText = this.onChangeText.bind(this);
     }
@@ -24,18 +24,18 @@ class SearchBar extends React.Component<any, any> {
 
     }
     render() {
-        var {show, top} = this.state;
+        var {show} = this.state;
         var {autoCapitalize, children, ...props} = this.props;
         var constants = (UIManager as any).getViewManagerConfig('NVSearchBar').Constants;
         autoCapitalize = Platform.OS === 'android' ? constants.AutoCapitalize[autoCapitalize] : autoCapitalize;
-        var showStyle = Platform.OS == 'android' && {top, right: 0, bottom: 0, left: 0, zIndex: 58}
+        var showStyle = Platform.OS === 'android' && {top: 56, zIndex: show ? 58 : -58}
         return (
             <NVSearchBar
                 {...props}
                 ref={this.ref}
                 autoCapitalize={autoCapitalize}
                 onChangeText={this.onChangeText}
-                onExpand={({nativeEvent: {top}}) => this.setState({show: true, top})}
+                onExpand={() => this.setState({show: true})}
                 onCollapse={() => this.setState({show: false})}
                 style={[styles.searchBar, show && showStyle]}>
                 {Platform.OS === 'ios' || this.state.show ? children : null}
@@ -49,11 +49,7 @@ var NVSearchBar = requireNativeComponent<any>('NVSearchBar', null);
 var styles = StyleSheet.create({
     searchBar: {
         position: 'absolute',
-        ...Platform.select({
-            android: {
-                zIndex: -58,
-            },
-        })
+        top: 0, right: 0, bottom: 0, left: 0,
     },
 });
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CoordinatorLayoutManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CoordinatorLayoutManager.java
@@ -41,7 +41,7 @@ public class CoordinatorLayoutManager extends ViewGroupManager<CoordinatorLayout
     @Override
     public void addView(CoordinatorLayoutView parent, View child, int index) {
         super.addView(parent, child, index);
-        if (child instanceof ScrollView || child instanceof ViewPager || child instanceof ViewPager2 || child instanceof SearchBarView) {
+        if (child instanceof ScrollView || child instanceof ViewPager || child instanceof ViewPager2) {
             CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) child.getLayoutParams();
             AppBarLayout.ScrollingViewBehavior behavior = new AppBarLayout.ScrollingViewBehavior();
             behavior.setOverlayTop(parent.overlap);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CoordinatorLayoutManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CoordinatorLayoutManager.java
@@ -41,7 +41,7 @@ public class CoordinatorLayoutManager extends ViewGroupManager<CoordinatorLayout
     @Override
     public void addView(CoordinatorLayoutView parent, View child, int index) {
         super.addView(parent, child, index);
-        if (child instanceof ScrollView || child instanceof ViewPager || child instanceof ViewPager2) {
+        if (child instanceof ScrollView || child instanceof ViewPager || child instanceof ViewPager2 || child instanceof SearchBarView) {
             CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) child.getLayoutParams();
             AppBarLayout.ScrollingViewBehavior behavior = new AppBarLayout.ScrollingViewBehavior();
             behavior.setOverlayTop(parent.overlap);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CoordinatorLayoutView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CoordinatorLayoutView.java
@@ -10,7 +10,6 @@ import android.widget.ScrollView;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.viewpager2.widget.ViewPager2;
 
-import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.uimanager.ReactZIndexedViewGroup;
 import com.facebook.react.uimanager.ViewGroupDrawingOrderHelper;
 import com.facebook.react.uimanager.events.NativeGestureUtil;
@@ -24,12 +23,12 @@ public class CoordinatorLayoutView extends CoordinatorLayout implements ReactZIn
     private final int[] scrollOffset = new int[2];
     private final int[] scrollConsumed = new int[2];
     private boolean layoutRequested = false;
-    private final ViewGroupDrawingOrderHelper mDrawingOrderHelper;
+    private final ViewGroupDrawingOrderHelper drawingOrderHelper;
 
     public CoordinatorLayoutView(Context context){
         super(context);
         touchSlop = ViewConfiguration.get(context).getScaledTouchSlop();
-        mDrawingOrderHelper = new ViewGroupDrawingOrderHelper(this);
+        drawingOrderHelper = new ViewGroupDrawingOrderHelper(this);
     }
 
     @Override
@@ -146,34 +145,34 @@ public class CoordinatorLayoutView extends CoordinatorLayout implements ReactZIn
 
     @Override
     public void addView(View child, int index, ViewGroup.LayoutParams params) {
-        mDrawingOrderHelper.handleAddView(child);
-        setChildrenDrawingOrderEnabled(mDrawingOrderHelper.shouldEnableCustomDrawingOrder());
+        drawingOrderHelper.handleAddView(child);
+        setChildrenDrawingOrderEnabled(drawingOrderHelper.shouldEnableCustomDrawingOrder());
         super.addView(child, index, params);
     }
 
     @Override
     public void removeView(View view) {
-        mDrawingOrderHelper.handleRemoveView(view);
-        setChildrenDrawingOrderEnabled(mDrawingOrderHelper.shouldEnableCustomDrawingOrder());
+        drawingOrderHelper.handleRemoveView(view);
+        setChildrenDrawingOrderEnabled(drawingOrderHelper.shouldEnableCustomDrawingOrder());
         super.removeView(view);
     }
 
     @Override
     public void removeViewAt(int index) {
-        mDrawingOrderHelper.handleRemoveView(getChildAt(index));
-        setChildrenDrawingOrderEnabled(mDrawingOrderHelper.shouldEnableCustomDrawingOrder());
+        drawingOrderHelper.handleRemoveView(getChildAt(index));
+        setChildrenDrawingOrderEnabled(drawingOrderHelper.shouldEnableCustomDrawingOrder());
         super.removeViewAt(index);
     }
 
     @Override
     public int getZIndexMappedChildIndex(int index) {
-        return mDrawingOrderHelper.getChildDrawingOrder(getChildCount(), index);
+        return drawingOrderHelper.getChildDrawingOrder(getChildCount(), index);
     }
 
     @Override
     public void updateDrawingOrder() {
-        mDrawingOrderHelper.update();
-        setChildrenDrawingOrderEnabled(mDrawingOrderHelper.shouldEnableCustomDrawingOrder());
+        drawingOrderHelper.update();
+        setChildrenDrawingOrderEnabled(drawingOrderHelper.shouldEnableCustomDrawingOrder());
         invalidate();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneView.java
@@ -6,10 +6,11 @@ import android.view.ViewGroup;
 
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
+import com.facebook.react.views.view.ReactViewGroup;
 
 import java.util.HashSet;
 
-public class SceneView extends ViewGroup {
+public class SceneView extends ReactViewGroup {
     protected String sceneKey;
     protected String enterAnim;
     protected String exitAnim;
@@ -45,9 +46,5 @@ public class SceneView extends ViewGroup {
     protected void popped() {
         ReactContext reactContext = (ReactContext) getContext();
         reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onPopped", null);
-    }
-
-    @Override
-    protected void onLayout(boolean changed, int l, int t, int r, int b) {
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneView.java
@@ -2,7 +2,6 @@ package com.navigation.reactnative;
 
 import android.content.Context;
 import android.view.View;
-import android.view.ViewGroup;
 
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.uimanager.events.RCTEventEmitter;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
@@ -20,8 +20,6 @@ import com.google.android.material.appbar.AppBarLayout;
 
 public class SearchBarView extends ReactViewGroup {
     final SearchView searchView;
-    final AppBarLayout.OnOffsetChangedListener onOffsetChangedListener;
-    private int barOffset = 0;
     int nativeEventCount;
     int mostRecentEventCount;
 
@@ -55,12 +53,6 @@ public class SearchBarView extends ReactViewGroup {
                 }
             }
         });
-        onOffsetChangedListener = new AppBarLayout.OnOffsetChangedListener() {
-            @Override
-            public void onOffsetChanged(AppBarLayout appBarLayout, int offset) {
-                barOffset = offset;
-            }
-        };
     }
 
     void setQuery(String query) {
@@ -93,7 +85,6 @@ public class SearchBarView extends ReactViewGroup {
                 if (navigationBarView.getChildAt(i) instanceof ToolbarView)
                     toolbarView = (ToolbarView) navigationBarView.getChildAt(i);
             }
-            navigationBarView.addOnOffsetChangedListener(onOffsetChangedListener);
         }
         if (toolbarView != null) {
             toolbarView.setOnSearchListener(new ToolbarView.OnSearchListener() {
@@ -107,7 +98,7 @@ public class SearchBarView extends ReactViewGroup {
                     setZ(58);
                     ReactContext reactContext = (ReactContext) getContext();
                     WritableMap event = Arguments.createMap();
-                    event.putInt("top", 56 + (int) PixelUtil.toDIPFromPixel(barOffset));
+                    event.putInt("top", 56);
                     reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onExpand", event);
                 }
 
@@ -121,20 +112,8 @@ public class SearchBarView extends ReactViewGroup {
         }
     }
 
-    @Override
-    protected void onDetachedFromWindow() {
-        super.onDetachedFromWindow();
-        NavigationBarView navigationBarView = getNavigationBarView();
-        if (navigationBarView != null)
-            navigationBarView.removeOnOffsetChangedListener(onOffsetChangedListener);
-    }
-
     private NavigationBarView getNavigationBarView() {
         ViewGroup view = (ViewGroup) getParent();
-        for(int i = 0; i < view.getChildCount(); i++) {
-            if (view.getChildAt(i) instanceof  CoordinatorLayoutView)
-                view = (CoordinatorLayoutView) view.getChildAt(i);
-        }
         for(int i = 0; i < view.getChildCount(); i++) {
             if (view.getChildAt(i) instanceof NavigationBarView) {
                 return (NavigationBarView) view.getChildAt(i);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
@@ -2,7 +2,6 @@ package com.navigation.reactnative;
 
 import android.content.Context;
 import android.view.MenuItem;
-import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
@@ -13,10 +12,8 @@ import androidx.appcompat.widget.SearchView;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.facebook.react.views.view.ReactViewGroup;
-import com.google.android.material.appbar.AppBarLayout;
 
 public class SearchBarView extends ReactViewGroup {
     final SearchView searchView;
@@ -97,9 +94,7 @@ public class SearchBarView extends ReactViewGroup {
                 public void onSearchExpand() {
                     setZ(58);
                     ReactContext reactContext = (ReactContext) getContext();
-                    WritableMap event = Arguments.createMap();
-                    event.putInt("top", 56);
-                    reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onExpand", event);
+                    reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onExpand", null);
                 }
 
                 @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
@@ -8,12 +8,14 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.ImageButton;
 
 import androidx.appcompat.widget.SearchView;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.facebook.react.views.view.ReactViewGroup;
+import com.google.android.material.appbar.AppBarLayout;
 
 public class SearchBarView extends ReactViewGroup {
     final SearchView searchView;
@@ -23,6 +25,10 @@ public class SearchBarView extends ReactViewGroup {
     public SearchBarView(Context context) {
         super(context);
         searchView = new SearchView(context);
+        CoordinatorLayout.LayoutParams params = new CoordinatorLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
+        AppBarLayout.ScrollingViewBehavior behavior = new AppBarLayout.ScrollingViewBehavior();
+        params.setBehavior(behavior);
+        setLayoutParams(params);
         searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
             @Override
             public boolean onQueryTextSubmit(String query) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
@@ -76,11 +76,14 @@ public class SearchBarView extends ReactViewGroup {
                 inputMethodManager.showSoftInput(searchView.findFocus(), 0);
         }
         ToolbarView toolbarView = null;
-        final NavigationBarView navigationBarView = getNavigationBarView();
-        if (navigationBarView != null) {
-            for (int i = 0; i < navigationBarView.getChildCount(); i++) {
-                if (navigationBarView.getChildAt(i) instanceof ToolbarView)
-                    toolbarView = (ToolbarView) navigationBarView.getChildAt(i);
+        ViewGroup view = (ViewGroup) getParent();
+        for(int i = 0; i < view.getChildCount(); i++) {
+            if (view.getChildAt(i) instanceof NavigationBarView) {
+                NavigationBarView navigationBarView = (NavigationBarView) view.getChildAt(i);
+                for (int j = 0; j < navigationBarView.getChildCount(); j++) {
+                    if (navigationBarView.getChildAt(j) instanceof ToolbarView)
+                        toolbarView = (ToolbarView) navigationBarView.getChildAt(i);
+                }
             }
         }
         if (toolbarView != null) {
@@ -105,16 +108,6 @@ public class SearchBarView extends ReactViewGroup {
                 }
             });
         }
-    }
-
-    private NavigationBarView getNavigationBarView() {
-        ViewGroup view = (ViewGroup) getParent();
-        for(int i = 0; i < view.getChildCount(); i++) {
-            if (view.getChildAt(i) instanceof NavigationBarView) {
-                return (NavigationBarView) view.getChildAt(i);
-            }
-        }
-        return null;
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
@@ -2,6 +2,7 @@ package com.navigation.reactnative;
 
 import android.content.Context;
 import android.view.MenuItem;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
@@ -103,6 +104,7 @@ public class SearchBarView extends ReactViewGroup {
 
                 @Override
                 public void onSearchExpand() {
+                    setZ(58);
                     ReactContext reactContext = (ReactContext) getContext();
                     WritableMap event = Arguments.createMap();
                     event.putInt("top", 56 + (int) PixelUtil.toDIPFromPixel(barOffset));
@@ -111,6 +113,7 @@ public class SearchBarView extends ReactViewGroup {
 
                 @Override
                 public void onSearchCollapse() {
+                    setZ(-58);
                     ReactContext reactContext = (ReactContext) getContext();
                     reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onCollapse", null);
                 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
@@ -214,6 +214,7 @@ public class ToolbarView extends Toolbar {
                         @Override
                         public boolean onMenuItemActionExpand(MenuItem item) {
                             onSearchAddedListener.onSearchExpand();
+                            ((NavigationBarView) getParent()).setExpanded(true);
                             return true;
                         }
                     });


### PR DESCRIPTION
The `CoordinatorLayout` used to extract the `SearchBar` from inside the `NavigationBar` and render it as a sibling component. So the parent `TabBarItem` goes from having one child (CoordinatorLayout) to having 2 children (CoordinatorLayout + SearchBar). But `TabBarItems` on Android only support one child so the `SearchBar` isn’t visible.

I did it like this because I couldn’t work out how to display the `SearchBar` as a child of the `CoordinatorLayout`. This PR solves that by rendering the `SearchBar` with `ScrollingViewBehavior` so it shows up below the `NavigationBar`.

As well as supporting search inside a `TabBarItem`, PR also removes the `NavigationBar` dependency from the `CoordinatorLayout` on the React side. So the `NavigationBar` doesn’t have to be an immediate child on the React side (android demands it’s an immediate child on the native side).

Made the `CoordinatorLayoutView` implement `ReactZIndexedViewGroup` otherwise touch events would pass through the `SearchBarView` to the scene behind. This led to fixing #315 by making the `SceneView` also implement the interface (by inheriting from `ReactViewGroup` instead of `ViewGroup`).

Also simplified the `SearchBarView` by expanding the `AppBarLayout` when the search button is pressed. Means don't have to track the bar offset.

