### PR TITLE
Added Floating Action Button Component (Android)

### DIFF
--- a/NavigationReactNative/src/BottomSheet.tsx
+++ b/NavigationReactNative/src/BottomSheet.tsx
@@ -37,6 +37,7 @@ class BottomSheet extends React.Component<any, any> {
         }
     }
     render() {
+        if (Platform.OS === 'ios') return null;
         var { expandedHeight, expandedOffset, peekHeight, halfExpandedRatio, hideable, skipCollapsed, draggable, children } = this.props
         const detents = (UIManager as any).getViewManagerConfig('NVBottomSheet').Constants.Detent
         return (
@@ -77,4 +78,4 @@ const styles = StyleSheet.create({
     },
 });
 
-export default Platform.OS === "android" ? BottomSheet : () => null;
+export default BottomSheet;

--- a/NavigationReactNative/src/FloatingActionButton.tsx
+++ b/NavigationReactNative/src/FloatingActionButton.tsx
@@ -3,11 +3,10 @@ import { Image, Platform, requireNativeComponent, Animated } from "react-native"
 
 class FloatingActionButton extends React.Component<any, any> {
     render() {
-        var { image, gravity, ...props } = this.props;
+        var { image, ...props } = this.props;
         return (
             <NVFloatingActionButton
                 image={Image.resolveAssetSource(image)}
-                gravity={gravity}
                 {...props}
             />
         );

--- a/NavigationReactNative/src/FloatingActionButton.tsx
+++ b/NavigationReactNative/src/FloatingActionButton.tsx
@@ -1,12 +1,13 @@
 import React from "react";
-import { Image, Platform, requireNativeComponent, Animated } from "react-native";
+import { Image, Platform, requireNativeComponent, Animated, StyleSheet } from "react-native";
 
 class FloatingActionButton extends React.Component<any, any> {
     render() {
-        var { image, ...props } = this.props;
+        var { image, style, ...props } = this.props;
         return (
             <NVFloatingActionButton
                 image={Image.resolveAssetSource(image)}
+                style={[ styles.floatingActionButton, style ]}
                 {...props}
             />
         );
@@ -14,5 +15,13 @@ class FloatingActionButton extends React.Component<any, any> {
 }
 
 const NVFloatingActionButton = requireNativeComponent<any>("NVFloatingActionButton", null);
+
+const styles = StyleSheet.create({
+    floatingActionButton: {
+        position: 'absolute',
+        height: 56,
+        width: 56
+    },
+});
 
 export default Platform.OS === 'android' ? Animated.createAnimatedComponent(FloatingActionButton) : null;

--- a/NavigationReactNative/src/FloatingActionButton.tsx
+++ b/NavigationReactNative/src/FloatingActionButton.tsx
@@ -20,8 +20,7 @@ const styles = StyleSheet.create({
     floatingActionButton: {
         position: 'absolute',
         height: 56,
-        width: 56,
-        zIndex: 78
+        width: 56
     },
 });
 

--- a/NavigationReactNative/src/FloatingActionButton.tsx
+++ b/NavigationReactNative/src/FloatingActionButton.tsx
@@ -20,7 +20,8 @@ const styles = StyleSheet.create({
     floatingActionButton: {
         position: 'absolute',
         height: 56,
-        width: 56
+        width: 56,
+        zIndex: 78
     },
 });
 

--- a/NavigationReactNative/src/FloatingActionButton.tsx
+++ b/NavigationReactNative/src/FloatingActionButton.tsx
@@ -1,9 +1,15 @@
 import React from "react";
-import { Platform, requireNativeComponent, Animated } from "react-native";
+import { Image, Platform, requireNativeComponent, Animated } from "react-native";
 
 class FloatingActionButton extends React.Component<any, any> {
     render() {
-        return <NVFloatingActionButton />        
+        var { image, ...props } = this.props;
+        return (
+            <NVFloatingActionButton
+                image={Image.resolveAssetSource(image)}
+                {...props}
+            />
+        );
     }
 }
 

--- a/NavigationReactNative/src/FloatingActionButton.tsx
+++ b/NavigationReactNative/src/FloatingActionButton.tsx
@@ -24,4 +24,4 @@ const styles = StyleSheet.create({
     },
 });
 
-export default Platform.OS === 'android' ? Animated.createAnimatedComponent(FloatingActionButton) : null;
+export default Platform.OS === 'android' ? Animated.createAnimatedComponent(FloatingActionButton) : () => null;

--- a/NavigationReactNative/src/FloatingActionButton.tsx
+++ b/NavigationReactNative/src/FloatingActionButton.tsx
@@ -3,10 +3,11 @@ import { Image, Platform, requireNativeComponent, Animated } from "react-native"
 
 class FloatingActionButton extends React.Component<any, any> {
     render() {
-        var { image, ...props } = this.props;
+        var { image, gravity, ...props } = this.props;
         return (
             <NVFloatingActionButton
                 image={Image.resolveAssetSource(image)}
+                gravity={gravity}
                 {...props}
             />
         );

--- a/NavigationReactNative/src/FloatingActionButton.tsx
+++ b/NavigationReactNative/src/FloatingActionButton.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Platform, requireNativeComponent, Animated } from "react-native";
+
+class FloatingActionButton extends React.Component<any, any> {
+    render() {
+        return <NVFloatingActionButton />        
+    }
+}
+
+const NVFloatingActionButton = requireNativeComponent<any>("NVFloatingActionButton", null);
+
+export default Platform.OS === 'android' ? Animated.createAnimatedComponent(FloatingActionButton) : null;

--- a/NavigationReactNative/src/NavigationReactNative.ts
+++ b/NavigationReactNative/src/NavigationReactNative.ts
@@ -14,9 +14,10 @@ import CoordinatorLayout from './CoordinatorLayout';
 import CollapsingBar from './CollapsingBar';
 import ActionBar from './ActionBar';
 import StatusBar from './StatusBar';
+import FloatingActionButton from './FloatingActionButton';
 import useNavigating from './useNavigating';
 import useNavigated from './useNavigated';
 import useUnloading from './useUnloading';
 import useUnloaded from './useUnloaded';
 
-export { NavigationStack, NavigationBar, LeftBar, RightBar, BarButton, TitleBar, SearchBar, TabBar, TabBarItem, SharedElement, BackHandlerContext, ModalBackHandler, CoordinatorLayout, CollapsingBar, ActionBar, StatusBar, useNavigating, useNavigated, useUnloading, useUnloaded };
+export { NavigationStack, NavigationBar, LeftBar, RightBar, BarButton, TitleBar, SearchBar, TabBar, TabBarItem, SharedElement, BackHandlerContext, ModalBackHandler, CoordinatorLayout, CollapsingBar, ActionBar, StatusBar, FloatingActionButton, useNavigating, useNavigated, useUnloading, useUnloaded };

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CoordinatorLayoutView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CoordinatorLayoutView.java
@@ -7,8 +7,10 @@ import android.view.ViewConfiguration;
 import android.widget.ScrollView;
 
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import androidx.core.view.ViewCompat;
 import androidx.viewpager2.widget.ViewPager2;
 
+import com.facebook.react.modules.i18nmanager.I18nUtil;
 import com.facebook.react.uimanager.events.NativeGestureUtil;
 
 public class CoordinatorLayoutView extends CoordinatorLayout {
@@ -23,6 +25,7 @@ public class CoordinatorLayoutView extends CoordinatorLayout {
 
     public CoordinatorLayoutView(Context context){
         super(context);
+        ViewCompat.setLayoutDirection(this, !I18nUtil.getInstance().isRTL(context) ? ViewCompat.LAYOUT_DIRECTION_LTR : ViewCompat.LAYOUT_DIRECTION_RTL);
         touchSlop = ViewConfiguration.get(context).getScaledTouchSlop();
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
@@ -113,6 +113,11 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
         requestCoordinatorLayout(view);
     }
 
+    @ReactProp(name = "elevation")
+    public void setElevation(FloatingActionButtonView view, int elevation) {
+        view.setCompatElevation(PixelUtil.toPixelFromDIP(elevation));
+    }
+
     @ReactProp(name = "contentDescription")
     public void setContentDescription(FloatingActionButtonView view, String contentDescription) {
         view.setContentDescription(contentDescription);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
@@ -7,9 +7,12 @@ import android.view.View;
 import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.annotations.ReactProp;
+
+import java.util.Map;
 
 public class FloatingActionButtonManager extends SimpleViewManager<FloatingActionButtonView> {
     @NonNull
@@ -118,5 +121,12 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
         view.params.setMargins(
             Math.max(view.marginLeft, view.margin), Math.max(view.marginTop, view.margin),
             Math.max(view.marginRight, view.margin), Math.max(view.marginBottom, view.margin));
+    }
+
+    @Override
+    public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
+        return MapBuilder.<String, Object>builder()
+            .put("onPress", MapBuilder.of("registrationName", "onPress"))
+            .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
@@ -149,6 +149,11 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
         else view.setSize(FloatingActionButton.SIZE_NORMAL);
     }
 
+    @ReactProp(name = "testID")
+    public void setTestID(FloatingActionButtonView view, String testID) {
+        view.setTag(testID);
+    }
+
     private void requestCoordinatorLayout(FloatingActionButtonView view) {
         if (view.getParent() instanceof CoordinatorLayoutView) {
             CoordinatorLayoutView coordinatorLayoutView = (CoordinatorLayoutView) view.getParent();

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
@@ -45,14 +45,6 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
         view.setImageTintList(color != Integer.MAX_VALUE ? ColorStateList.valueOf(color) : null);
     }
 
-    @ReactProp(name = "hide")
-    public void setHide(FloatingActionButtonView view, boolean hide) {
-        assert view.params.getBehavior() != null;
-        ((FloatingActionButton.Behavior) view.params.getBehavior()).setAutoHideEnabled(!hide);
-        if (hide) view.hide();
-        else view.show();
-    }
-
     @ReactProp(name = "anchor", defaultInt = View.NO_ID)
     public void setAnchor(FloatingActionButtonView view, int anchor) {
         view.params.setAnchorId(anchor);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
@@ -1,5 +1,7 @@
 package com.navigation.reactnative;
 
+import android.content.res.ColorStateList;
+
 import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.ReadableMap;
@@ -23,5 +25,10 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
     @ReactProp(name = "image")
     public void setImage(FloatingActionButtonView view, ReadableMap icon) {
         view.setIconSource(icon);
+    }
+
+    @ReactProp(name = "backgroundColor", customType = "Color", defaultInt = Integer.MAX_VALUE)
+    public void setBackgroundColor(FloatingActionButtonView view, int backgroundColor) {
+        view.setBackgroundTintList(ColorStateList.valueOf(backgroundColor != Integer.MAX_VALUE ? backgroundColor : view.defaultBackgroundColor));
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
@@ -2,6 +2,7 @@ package com.navigation.reactnative;
 
 import android.content.res.ColorStateList;
 import android.view.Gravity;
+import android.view.View;
 
 import androidx.annotation.NonNull;
 
@@ -36,6 +37,12 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
     @ReactProp(name = "color", customType = "Color", defaultInt = Integer.MAX_VALUE)
     public void setColor(FloatingActionButtonView view, int color) {
         view.setImageTintList(color != Integer.MAX_VALUE ? ColorStateList.valueOf(color) : null);
+    }
+
+    @ReactProp(name = "anchor", defaultInt = View.NO_ID)
+    public void setAnchor(FloatingActionButtonView view, int anchor) {
+        view.params.setAnchorId(anchor);
+        requestCoordinatorLayout(view);
     }
 
     @ReactProp(name = "gravity")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
@@ -8,9 +8,11 @@ import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
+import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import java.util.Map;
 
@@ -106,6 +108,13 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
     @ReactProp(name = "contentDescription")
     public void setContentDescription(FloatingActionButtonView view, String contentDescription) {
         view.setContentDescription(contentDescription);
+    }
+
+    @ReactProp(name = "size")
+    public void setSize(FloatingActionButtonView view, int size) {
+        view.clearCustomSize();
+        if (size > 0) view.setCustomSize((int) PixelUtil.toPixelFromDIP(size));
+        else view.setSize(FloatingActionButton.SIZE_NORMAL);
     }
 
     private void requestCoordinatorLayout(FloatingActionButtonView view) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
@@ -31,4 +31,9 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
     public void setBackgroundColor(FloatingActionButtonView view, int backgroundColor) {
         view.setBackgroundTintList(ColorStateList.valueOf(backgroundColor != Integer.MAX_VALUE ? backgroundColor : view.defaultBackgroundColor));
     }
+
+    @ReactProp(name = "color", customType = "Color", defaultInt = Integer.MAX_VALUE)
+    public void setColor(FloatingActionButtonView view, int color) {
+        view.setImageTintList(color != Integer.MAX_VALUE ? ColorStateList.valueOf(color) : null);
+    }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
@@ -8,6 +8,7 @@ import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
+import com.facebook.react.modules.i18nmanager.I18nUtil;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -71,15 +72,21 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
     }
 
     private int convertGravity(String gravity) {
-        if ("topLeft".equals(gravity)) return Gravity.TOP | Gravity.START;
+        if ("topLeft".equals(gravity)) return Gravity.TOP | Gravity.LEFT;
+        if ("topStart".equals(gravity)) return Gravity.TOP | Gravity.START;
         if ("top".equals(gravity)) return Gravity.TOP | Gravity.CENTER;
-        if ("topRight".equals(gravity)) return Gravity.TOP | Gravity.END;
-        if ("left".equals(gravity)) return Gravity.CENTER | Gravity.START;
+        if ("topRight".equals(gravity)) return Gravity.TOP | Gravity.RIGHT;
+        if ("topEnd".equals(gravity)) return Gravity.TOP | Gravity.END;
+        if ("left".equals(gravity)) return Gravity.CENTER | Gravity.LEFT;
+        if ("start".equals(gravity)) return Gravity.CENTER | Gravity.START;
         if ("center".equals(gravity)) return Gravity.CENTER;
-        if ("right".equals(gravity)) return Gravity.CENTER | Gravity.END;
-        if ("bottomLeft".equals(gravity)) return Gravity.BOTTOM | Gravity.START;
+        if ("right".equals(gravity)) return Gravity.CENTER | Gravity.RIGHT;
+        if ("end".equals(gravity)) return Gravity.CENTER | Gravity.END;
+        if ("bottomLeft".equals(gravity)) return Gravity.BOTTOM | Gravity.LEFT;
+        if ("bottomStart".equals(gravity)) return Gravity.BOTTOM | Gravity.START;
         if ("bottom".equals(gravity)) return Gravity.BOTTOM | Gravity.CENTER;
-        if ("bottomRight".equals(gravity)) return Gravity.BOTTOM | Gravity.END;
+        if ("bottomRight".equals(gravity)) return Gravity.BOTTOM | Gravity.RIGHT;
+        if ("bottomEnd".equals(gravity)) return Gravity.BOTTOM | Gravity.END;
         return Gravity.NO_GRAVITY;
     }
 
@@ -98,6 +105,18 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
     @ReactProp(name = "marginBottom")
     public void setMarginBottom(FloatingActionButtonView view, int marginBottom) {
         view.marginBottom = marginBottom;
+        requestCoordinatorLayout(view);
+    }
+
+    @ReactProp(name = "marginStart")
+    public void setMarginStart(FloatingActionButtonView view, int marginStart) {
+        view.marginStart = marginStart;
+        requestCoordinatorLayout(view);
+    }
+
+    @ReactProp(name = "marginEnd")
+    public void setMarginEnd(FloatingActionButtonView view, int marginEnd) {
+        view.marginEnd = marginEnd;
         requestCoordinatorLayout(view);
     }
 
@@ -140,9 +159,12 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
     @Override
     protected void onAfterUpdateTransaction(@NonNull FloatingActionButtonView view) {
         super.onAfterUpdateTransaction(view);
+        boolean rtl = I18nUtil.getInstance().isRTL(view.getContext());
+        int marginLeft = Math.max(view.marginLeft, !rtl ? view.marginStart : view.marginEnd);
+        int marginRight = Math.max(view.marginRight, !rtl ? view.marginEnd : view.marginStart);
         view.params.setMargins(
-            Math.max(view.marginLeft, view.margin), Math.max(view.marginTop, view.margin),
-            Math.max(view.marginRight, view.margin), Math.max(view.marginBottom, view.margin));
+            Math.max(marginLeft, view.margin), Math.max(view.marginTop, view.margin),
+            Math.max(marginRight, view.margin), Math.max(view.marginBottom, view.margin));
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
@@ -100,6 +100,11 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
         requestCoordinatorLayout(view);
     }
 
+    @ReactProp(name = "contentDescription")
+    public void setContentDescription(FloatingActionButtonView view, String contentDescription) {
+        view.setContentDescription(contentDescription);
+    }
+
     private void requestCoordinatorLayout(FloatingActionButtonView view) {
         if (view.getParent() instanceof CoordinatorLayoutView) {
             CoordinatorLayoutView coordinatorLayoutView = (CoordinatorLayoutView) view.getParent();

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
@@ -44,6 +44,14 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
         view.setImageTintList(color != Integer.MAX_VALUE ? ColorStateList.valueOf(color) : null);
     }
 
+    @ReactProp(name = "hide")
+    public void setHide(FloatingActionButtonView view, boolean hide) {
+        assert view.params.getBehavior() != null;
+        ((FloatingActionButton.Behavior) view.params.getBehavior()).setAutoHideEnabled(!hide);
+        if (hide) view.hide();
+        else view.show();
+    }
+
     @ReactProp(name = "anchor", defaultInt = View.NO_ID)
     public void setAnchor(FloatingActionButtonView view, int anchor) {
         view.params.setAnchorId(anchor);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
@@ -47,17 +47,27 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
 
     @ReactProp(name = "gravity")
     public void setGravity(FloatingActionButtonView view, String gravity) {
-        if ("topLeft".equals(gravity)) view.params.gravity = Gravity.TOP | Gravity.START;
-        else if ("top".equals(gravity)) view.params.gravity = Gravity.TOP | Gravity.CENTER;
-        else if ("topRight".equals(gravity)) view.params.gravity = Gravity.TOP | Gravity.END;
-        else if ("left".equals(gravity)) view.params.gravity = Gravity.CENTER | Gravity.START;
-        else if ("center".equals(gravity)) view.params.gravity = Gravity.CENTER;
-        else if ("right".equals(gravity)) view.params.gravity = Gravity.CENTER | Gravity.END;
-        else if ("bottomLeft".equals(gravity)) view.params.gravity = Gravity.BOTTOM | Gravity.START;
-        else if ("bottom".equals(gravity)) view.params.gravity = Gravity.BOTTOM | Gravity.CENTER;
-        else if ("bottomRight".equals(gravity)) view.params.gravity = Gravity.BOTTOM | Gravity.END;
-        else view.params.gravity = Gravity.NO_GRAVITY;
+        view.params.gravity = convertGravity(gravity);
         requestCoordinatorLayout(view);
+    }
+
+    @ReactProp(name = "anchorGravity")
+    public void setAnchorGravity(FloatingActionButtonView view, String anchorGravity) {
+        view.params.anchorGravity = convertGravity(anchorGravity);
+        requestCoordinatorLayout(view);
+    }
+
+    private int convertGravity(String gravity) {
+        if ("topLeft".equals(gravity)) return Gravity.TOP | Gravity.START;
+        if ("top".equals(gravity)) return Gravity.TOP | Gravity.CENTER;
+        if ("topRight".equals(gravity)) return Gravity.TOP | Gravity.END;
+        if ("left".equals(gravity)) return Gravity.CENTER | Gravity.START;
+        if ("center".equals(gravity)) return Gravity.CENTER;
+        if ("right".equals(gravity)) return Gravity.CENTER | Gravity.END;
+        if ("bottomLeft".equals(gravity)) return Gravity.BOTTOM | Gravity.START;
+        if ("bottom".equals(gravity)) return Gravity.BOTTOM | Gravity.CENTER;
+        if ("bottomRight".equals(gravity)) return Gravity.BOTTOM | Gravity.END;
+        return Gravity.NO_GRAVITY;
     }
 
     @ReactProp(name = "marginTop")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
@@ -92,43 +92,43 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
 
     @ReactProp(name = "marginTop")
     public void setMarginTop(FloatingActionButtonView view, int marginTop) {
-        view.marginTop = marginTop;
+        view.marginTop = (int) PixelUtil.toPixelFromDIP(marginTop);
         requestCoordinatorLayout(view);
     }
 
     @ReactProp(name = "marginRight")
     public void setMarginRight(FloatingActionButtonView view, int marginRight) {
-        view.marginRight = marginRight;
+        view.marginRight = (int) PixelUtil.toPixelFromDIP(marginRight);
         requestCoordinatorLayout(view);
     }
 
     @ReactProp(name = "marginBottom")
     public void setMarginBottom(FloatingActionButtonView view, int marginBottom) {
-        view.marginBottom = marginBottom;
+        view.marginBottom = (int) PixelUtil.toPixelFromDIP(marginBottom);
         requestCoordinatorLayout(view);
     }
 
     @ReactProp(name = "marginStart")
     public void setMarginStart(FloatingActionButtonView view, int marginStart) {
-        view.marginStart = marginStart;
+        view.marginStart = (int) PixelUtil.toPixelFromDIP(marginStart);
         requestCoordinatorLayout(view);
     }
 
     @ReactProp(name = "marginEnd")
     public void setMarginEnd(FloatingActionButtonView view, int marginEnd) {
-        view.marginEnd = marginEnd;
+        view.marginEnd = (int) PixelUtil.toPixelFromDIP(marginEnd);
         requestCoordinatorLayout(view);
     }
 
     @ReactProp(name = "marginLeft")
     public void setMarginLeft(FloatingActionButtonView view, int marginLeft) {
-        view.marginLeft = marginLeft;
+        view.marginLeft = (int) PixelUtil.toPixelFromDIP(marginLeft);
         requestCoordinatorLayout(view);
     }
 
     @ReactProp(name = "margin")
     public void setMargin(FloatingActionButtonView view, int margin) {
-        view.margin = margin;
+        view.margin = (int) PixelUtil.toPixelFromDIP(margin);
         requestCoordinatorLayout(view);
     }
 
@@ -163,10 +163,8 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
         int marginLeft = Math.max(view.marginLeft, !rtl ? view.marginStart : view.marginEnd);
         int marginRight = Math.max(view.marginRight, !rtl ? view.marginEnd : view.marginStart);
         view.params.setMargins(
-            (int) PixelUtil.toPixelFromDIP(Math.max(marginLeft, view.margin)),
-            (int) PixelUtil.toPixelFromDIP(Math.max(view.marginTop, view.margin)),
-            (int) PixelUtil.toPixelFromDIP(Math.max(marginRight, view.margin)),
-            (int) PixelUtil.toPixelFromDIP(Math.max(view.marginBottom, view.margin)
+            Math.max(marginLeft, view.margin), Math.max(view.marginTop, view.margin),
+            Math.max(marginRight, view.margin), Math.max(view.marginBottom, view.margin
         ));
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
@@ -1,8 +1,10 @@
 package com.navigation.reactnative;
 
 import android.content.res.ColorStateList;
+import android.view.Gravity;
 
 import androidx.annotation.NonNull;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.SimpleViewManager;
@@ -35,5 +37,23 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
     @ReactProp(name = "color", customType = "Color", defaultInt = Integer.MAX_VALUE)
     public void setColor(FloatingActionButtonView view, int color) {
         view.setImageTintList(color != Integer.MAX_VALUE ? ColorStateList.valueOf(color) : null);
+    }
+
+    @ReactProp(name = "gravity")
+    public void setGravity(FloatingActionButtonView view, String gravity) {
+        if ("topLeft".equals(gravity)) view.params.gravity = Gravity.TOP | Gravity.LEFT;
+        else if ("top".equals(gravity)) view.params.gravity = Gravity.TOP | Gravity.CENTER;
+        else if ("topRight".equals(gravity)) view.params.gravity = Gravity.TOP | Gravity.RIGHT;
+        else if ("left".equals(gravity)) view.params.gravity = Gravity.CENTER | Gravity.LEFT;
+        else if ("center".equals(gravity)) view.params.gravity = Gravity.CENTER;
+        else if ("right".equals(gravity)) view.params.gravity = Gravity.CENTER | Gravity.RIGHT;
+        else if ("bottomLeft".equals(gravity)) view.params.gravity = Gravity.BOTTOM | Gravity.LEFT;
+        else if ("bottom".equals(gravity)) view.params.gravity = Gravity.BOTTOM | Gravity.CENTER;
+        else if ("bottomRight".equals(gravity)) view.params.gravity = Gravity.BOTTOM | Gravity.RIGHT;
+        else view.params.gravity = Gravity.NO_GRAVITY;
+        if (view.getParent() instanceof CoordinatorLayoutView) {
+            CoordinatorLayoutView coordinatorLayoutView = (CoordinatorLayoutView) view.getParent();
+            coordinatorLayoutView.requestLayout();
+        }
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
@@ -48,19 +48,19 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
     @ReactProp(name = "anchor", defaultInt = View.NO_ID)
     public void setAnchor(FloatingActionButtonView view, int anchor) {
         view.params.setAnchorId(anchor);
-        requestCoordinatorLayout(view);
+        if (view.getParent() != null) view.getParent().requestLayout();
     }
 
     @ReactProp(name = "gravity")
     public void setGravity(FloatingActionButtonView view, String gravity) {
         view.params.gravity = convertGravity(gravity);
-        requestCoordinatorLayout(view);
+        if (view.getParent() != null) view.getParent().requestLayout();
     }
 
     @ReactProp(name = "anchorGravity")
     public void setAnchorGravity(FloatingActionButtonView view, String anchorGravity) {
         view.params.anchorGravity = convertGravity(anchorGravity);
-        requestCoordinatorLayout(view);
+        if (view.getParent() != null) view.getParent().requestLayout();
     }
 
     private int convertGravity(String gravity) {
@@ -85,43 +85,43 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
     @ReactProp(name = "marginTop")
     public void setMarginTop(FloatingActionButtonView view, int marginTop) {
         view.marginTop = (int) PixelUtil.toPixelFromDIP(marginTop);
-        requestCoordinatorLayout(view);
+        if (view.getParent() != null) view.getParent().requestLayout();
     }
 
     @ReactProp(name = "marginRight")
     public void setMarginRight(FloatingActionButtonView view, int marginRight) {
         view.marginRight = (int) PixelUtil.toPixelFromDIP(marginRight);
-        requestCoordinatorLayout(view);
+        if (view.getParent() != null) view.getParent().requestLayout();
     }
 
     @ReactProp(name = "marginBottom")
     public void setMarginBottom(FloatingActionButtonView view, int marginBottom) {
         view.marginBottom = (int) PixelUtil.toPixelFromDIP(marginBottom);
-        requestCoordinatorLayout(view);
+        if (view.getParent() != null) view.getParent().requestLayout();
     }
 
     @ReactProp(name = "marginStart")
     public void setMarginStart(FloatingActionButtonView view, int marginStart) {
         view.marginStart = (int) PixelUtil.toPixelFromDIP(marginStart);
-        requestCoordinatorLayout(view);
+        if (view.getParent() != null) view.getParent().requestLayout();
     }
 
     @ReactProp(name = "marginEnd")
     public void setMarginEnd(FloatingActionButtonView view, int marginEnd) {
         view.marginEnd = (int) PixelUtil.toPixelFromDIP(marginEnd);
-        requestCoordinatorLayout(view);
+        if (view.getParent() != null) view.getParent().requestLayout();
     }
 
     @ReactProp(name = "marginLeft")
     public void setMarginLeft(FloatingActionButtonView view, int marginLeft) {
         view.marginLeft = (int) PixelUtil.toPixelFromDIP(marginLeft);
-        requestCoordinatorLayout(view);
+        if (view.getParent() != null) view.getParent().requestLayout();
     }
 
     @ReactProp(name = "margin")
     public void setMargin(FloatingActionButtonView view, int margin) {
         view.margin = (int) PixelUtil.toPixelFromDIP(margin);
-        requestCoordinatorLayout(view);
+        if (view.getParent() != null) view.getParent().requestLayout();
     }
 
     @ReactProp(name = "elevation")
@@ -144,13 +144,6 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
     @ReactProp(name = "testID")
     public void setTestID(FloatingActionButtonView view, String testID) {
         view.setTag(testID);
-    }
-
-    private void requestCoordinatorLayout(FloatingActionButtonView view) {
-        if (view.getParent() instanceof CoordinatorLayoutView) {
-            CoordinatorLayoutView coordinatorLayoutView = (CoordinatorLayoutView) view.getParent();
-            coordinatorLayoutView.requestLayout();
-        }
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
@@ -163,8 +163,11 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
         int marginLeft = Math.max(view.marginLeft, !rtl ? view.marginStart : view.marginEnd);
         int marginRight = Math.max(view.marginRight, !rtl ? view.marginEnd : view.marginStart);
         view.params.setMargins(
-            Math.max(marginLeft, view.margin), Math.max(view.marginTop, view.margin),
-            Math.max(marginRight, view.margin), Math.max(view.marginBottom, view.margin));
+            (int) PixelUtil.toPixelFromDIP(Math.max(marginLeft, view.margin)),
+            (int) PixelUtil.toPixelFromDIP(Math.max(view.marginTop, view.margin)),
+            (int) PixelUtil.toPixelFromDIP(Math.max(marginRight, view.margin)),
+            (int) PixelUtil.toPixelFromDIP(Math.max(view.marginBottom, view.margin)
+        ));
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
@@ -2,8 +2,10 @@ package com.navigation.reactnative;
 
 import androidx.annotation.NonNull;
 
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.annotations.ReactProp;
 
 public class FloatingActionButtonManager extends SimpleViewManager<FloatingActionButtonView> {
     @NonNull
@@ -16,5 +18,10 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
     @Override
     protected FloatingActionButtonView createViewInstance(@NonNull ThemedReactContext reactContext) {
         return new FloatingActionButtonView(reactContext);
+    }
+
+    @ReactProp(name = "image")
+    public void setImage(FloatingActionButtonView view, ReadableMap icon) {
+        view.setIconSource(icon);
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
@@ -1,0 +1,20 @@
+package com.navigation.reactnative;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.uimanager.SimpleViewManager;
+import com.facebook.react.uimanager.ThemedReactContext;
+
+public class FloatingActionButtonManager extends SimpleViewManager<FloatingActionButtonView> {
+    @NonNull
+    @Override
+    public String getName() {
+        return "NVFloatingActionButton";
+    }
+
+    @NonNull
+    @Override
+    protected FloatingActionButtonView createViewInstance(@NonNull ThemedReactContext reactContext) {
+        return new FloatingActionButtonView(reactContext);
+    }
+}

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
@@ -50,9 +50,51 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
         else if ("bottom".equals(gravity)) view.params.gravity = Gravity.BOTTOM | Gravity.CENTER;
         else if ("bottomRight".equals(gravity)) view.params.gravity = Gravity.BOTTOM | Gravity.END;
         else view.params.gravity = Gravity.NO_GRAVITY;
+        requestCoordinatorLayout(view);
+    }
+
+    @ReactProp(name = "marginTop")
+    public void setMarginTop(FloatingActionButtonView view, int marginTop) {
+        view.marginTop = marginTop;
+        requestCoordinatorLayout(view);
+    }
+
+    @ReactProp(name = "marginRight")
+    public void setMarginRight(FloatingActionButtonView view, int marginRight) {
+        view.marginRight = marginRight;
+        requestCoordinatorLayout(view);
+    }
+
+    @ReactProp(name = "marginBottom")
+    public void setMarginBottom(FloatingActionButtonView view, int marginBottom) {
+        view.marginBottom = marginBottom;
+        requestCoordinatorLayout(view);
+    }
+
+    @ReactProp(name = "marginLeft")
+    public void setMarginLeft(FloatingActionButtonView view, int marginLeft) {
+        view.marginLeft = marginLeft;
+        requestCoordinatorLayout(view);
+    }
+
+    @ReactProp(name = "margin")
+    public void setMargin(FloatingActionButtonView view, int margin) {
+        view.margin = margin;
+        requestCoordinatorLayout(view);
+    }
+
+    private void requestCoordinatorLayout(FloatingActionButtonView view) {
         if (view.getParent() instanceof CoordinatorLayoutView) {
             CoordinatorLayoutView coordinatorLayoutView = (CoordinatorLayoutView) view.getParent();
             coordinatorLayoutView.requestLayout();
         }
+    }
+
+    @Override
+    protected void onAfterUpdateTransaction(@NonNull FloatingActionButtonView view) {
+        super.onAfterUpdateTransaction(view);
+        view.params.setMargins(
+            Math.max(view.marginLeft, view.margin), Math.max(view.marginTop, view.margin),
+            Math.max(view.marginRight, view.margin), Math.max(view.marginBottom, view.margin));
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
@@ -4,7 +4,6 @@ import android.content.res.ColorStateList;
 import android.view.Gravity;
 
 import androidx.annotation.NonNull;
-import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.SimpleViewManager;
@@ -41,15 +40,15 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
 
     @ReactProp(name = "gravity")
     public void setGravity(FloatingActionButtonView view, String gravity) {
-        if ("topLeft".equals(gravity)) view.params.gravity = Gravity.TOP | Gravity.LEFT;
+        if ("topLeft".equals(gravity)) view.params.gravity = Gravity.TOP | Gravity.START;
         else if ("top".equals(gravity)) view.params.gravity = Gravity.TOP | Gravity.CENTER;
-        else if ("topRight".equals(gravity)) view.params.gravity = Gravity.TOP | Gravity.RIGHT;
-        else if ("left".equals(gravity)) view.params.gravity = Gravity.CENTER | Gravity.LEFT;
+        else if ("topRight".equals(gravity)) view.params.gravity = Gravity.TOP | Gravity.END;
+        else if ("left".equals(gravity)) view.params.gravity = Gravity.CENTER | Gravity.START;
         else if ("center".equals(gravity)) view.params.gravity = Gravity.CENTER;
-        else if ("right".equals(gravity)) view.params.gravity = Gravity.CENTER | Gravity.RIGHT;
-        else if ("bottomLeft".equals(gravity)) view.params.gravity = Gravity.BOTTOM | Gravity.LEFT;
+        else if ("right".equals(gravity)) view.params.gravity = Gravity.CENTER | Gravity.END;
+        else if ("bottomLeft".equals(gravity)) view.params.gravity = Gravity.BOTTOM | Gravity.START;
         else if ("bottom".equals(gravity)) view.params.gravity = Gravity.BOTTOM | Gravity.CENTER;
-        else if ("bottomRight".equals(gravity)) view.params.gravity = Gravity.BOTTOM | Gravity.RIGHT;
+        else if ("bottomRight".equals(gravity)) view.params.gravity = Gravity.BOTTOM | Gravity.END;
         else view.params.gravity = Gravity.NO_GRAVITY;
         if (view.getParent() instanceof CoordinatorLayoutView) {
             CoordinatorLayoutView coordinatorLayoutView = (CoordinatorLayoutView) view.getParent();

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonView.java
@@ -2,19 +2,24 @@ package com.navigation.reactnative;
 
 import android.content.Context;
 import android.graphics.drawable.Drawable;
+import android.view.Gravity;
+import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
 import com.facebook.react.bridge.ReadableMap;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 public class FloatingActionButtonView extends FloatingActionButton {
     final int defaultBackgroundColor;
+    final CoordinatorLayout.LayoutParams params = new CoordinatorLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
     private final IconResolver.IconResolverListener iconResolverListener;
 
     public FloatingActionButtonView(@NonNull Context context) {
         super(context);
+        setLayoutParams(params);
         defaultBackgroundColor = getBackgroundTintList().getDefaultColor();
         iconResolverListener = new IconResolver.IconResolverListener() {
             @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonView.java
@@ -18,7 +18,7 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton;
 public class FloatingActionButtonView extends FloatingActionButton {
     final int defaultBackgroundColor;
     final CoordinatorLayout.LayoutParams params;
-    int marginTop, marginRight, marginBottom, marginLeft, margin;
+    int marginTop, marginRight, marginBottom, marginLeft, marginStart, marginEnd, margin;
     private final IconResolver.IconResolverListener iconResolverListener;
 
     public FloatingActionButtonView(@NonNull Context context) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonView.java
@@ -1,13 +1,28 @@
 package com.navigation.reactnative;
 
 import android.content.Context;
+import android.graphics.drawable.Drawable;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
+import com.facebook.react.bridge.ReadableMap;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 public class FloatingActionButtonView extends FloatingActionButton {
+    private final IconResolver.IconResolverListener iconResolverListener;
+
     public FloatingActionButtonView(@NonNull Context context) {
         super(context);
+        iconResolverListener = new IconResolver.IconResolverListener() {
+            @Override
+            public void setDrawable(Drawable d) {
+                setImageDrawable(d);
+            }
+        };
+    }
+
+    void setIconSource(@Nullable ReadableMap source) {
+        IconResolver.setIconSource(source, iconResolverListener, getContext());
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonView.java
@@ -10,10 +10,12 @@ import com.facebook.react.bridge.ReadableMap;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 public class FloatingActionButtonView extends FloatingActionButton {
+    final int defaultBackgroundColor;
     private final IconResolver.IconResolverListener iconResolverListener;
 
     public FloatingActionButtonView(@NonNull Context context) {
         super(context);
+        defaultBackgroundColor = getBackgroundTintList().getDefaultColor();
         iconResolverListener = new IconResolver.IconResolverListener() {
             @Override
             public void setDrawable(Drawable d) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonView.java
@@ -26,6 +26,7 @@ public class FloatingActionButtonView extends FloatingActionButton {
         setSize(SIZE_NORMAL);
         defaultBackgroundColor = getBackgroundTintList() != null ? getBackgroundTintList().getDefaultColor() : Color.BLACK;
         params = new CoordinatorLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        params.setBehavior(getBehavior());
         setLayoutParams(params);
         iconResolverListener = new IconResolver.IconResolverListener() {
             @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonView.java
@@ -23,6 +23,7 @@ public class FloatingActionButtonView extends FloatingActionButton {
 
     public FloatingActionButtonView(@NonNull Context context) {
         super(context);
+        setSize(SIZE_NORMAL);
         defaultBackgroundColor = getBackgroundTintList() != null ? getBackgroundTintList().getDefaultColor() : Color.BLACK;
         params = new CoordinatorLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         setLayoutParams(params);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonView.java
@@ -1,0 +1,13 @@
+package com.navigation.reactnative;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
+public class FloatingActionButtonView extends FloatingActionButton {
+    public FloatingActionButtonView(@NonNull Context context) {
+        super(context);
+    }
+}

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonView.java
@@ -14,13 +14,15 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 public class FloatingActionButtonView extends FloatingActionButton {
     final int defaultBackgroundColor;
-    final CoordinatorLayout.LayoutParams params = new CoordinatorLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+    final CoordinatorLayout.LayoutParams params;
+    int marginTop, marginRight, marginBottom, marginLeft, margin;
     private final IconResolver.IconResolverListener iconResolverListener;
 
     public FloatingActionButtonView(@NonNull Context context) {
         super(context);
-        setLayoutParams(params);
         defaultBackgroundColor = getBackgroundTintList() != null ? getBackgroundTintList().getDefaultColor() : Color.BLACK;
+        params = new CoordinatorLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        setLayoutParams(params);
         iconResolverListener = new IconResolver.IconResolverListener() {
             @Override
             public void setDrawable(Drawable d) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonView.java
@@ -3,13 +3,16 @@ package com.navigation.reactnative;
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
+import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
+import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 public class FloatingActionButtonView extends FloatingActionButton {
@@ -29,6 +32,13 @@ public class FloatingActionButtonView extends FloatingActionButton {
                 setImageDrawable(d);
             }
         };
+        setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                ReactContext reactContext = (ReactContext) getContext();
+                reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onPress", null);
+            }
+        });
     }
 
     void setIconSource(@Nullable ReadableMap source) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonView.java
@@ -1,8 +1,8 @@
 package com.navigation.reactnative;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.graphics.drawable.Drawable;
-import android.view.Gravity;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
@@ -20,7 +20,7 @@ public class FloatingActionButtonView extends FloatingActionButton {
     public FloatingActionButtonView(@NonNull Context context) {
         super(context);
         setLayoutParams(params);
-        defaultBackgroundColor = getBackgroundTintList().getDefaultColor();
+        defaultBackgroundColor = getBackgroundTintList() != null ? getBackgroundTintList().getDefaultColor() : Color.BLACK;
         iconResolverListener = new IconResolver.IconResolverListener() {
             @Override
             public void setDrawable(Drawable d) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationPackage.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationPackage.java
@@ -32,7 +32,8 @@ public class NavigationPackage implements ReactPackage {
             new CollapsingBarManager(),
             new BarButtonManager(),
             new ActionBarManager(),
-            new StatusBarManager()
+            new StatusBarManager(),
+            new FloatingActionButtonManager()
         );
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
@@ -13,6 +13,7 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.facebook.react.views.view.ReactViewGroup;
 import com.google.android.material.appbar.AppBarLayout;
@@ -101,14 +102,14 @@ public class SearchBarView extends ReactViewGroup {
 
                 @Override
                 public void onSearchExpand() {
-                    setZ(58);
+                    setElevation(PixelUtil.toPixelFromDIP(5));
                     ReactContext reactContext = (ReactContext) getContext();
                     reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onExpand", null);
                 }
 
                 @Override
                 public void onSearchCollapse() {
-                    setZ(-58);
+                    setElevation(PixelUtil.toPixelFromDIP(-5));
                     ReactContext reactContext = (ReactContext) getContext();
                     reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onCollapse", null);
                 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
@@ -13,7 +13,6 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.facebook.react.views.view.ReactViewGroup;
 import com.google.android.material.appbar.AppBarLayout;
@@ -102,14 +101,14 @@ public class SearchBarView extends ReactViewGroup {
 
                 @Override
                 public void onSearchExpand() {
-                    setElevation(PixelUtil.toPixelFromDIP(5));
+                    setZ(58);
                     ReactContext reactContext = (ReactContext) getContext();
                     reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onExpand", null);
                 }
 
                 @Override
                 public void onSearchCollapse() {
-                    setElevation(PixelUtil.toPixelFromDIP(-5));
+                    setZ(-58);
                     ReactContext reactContext = (ReactContext) getContext();
                     reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(),"onCollapse", null);
                 }

--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -491,7 +491,7 @@ export class TabBar extends Component<TabBarProps> {}
 /**
  * Defines the Bottom Sheet Props contract
  */
- export interface BottomSheetProps {
+export interface BottomSheetProps {
     /**
      * The height of the bottom sheet when it is collapsed
      */

--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -537,7 +537,7 @@ export class TabBar extends Component<TabBarProps> {}
 /**
  * Renders a bottom sheet
  */
- export class BottomSheet extends Component<BottomSheetProps> {}
+export class BottomSheet extends Component<BottomSheetProps> {}
 
 /**
  * Defines the Floating Action Button Props contract

--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -1,5 +1,9 @@
 import { Component, Context, ReactNode } from 'react';
-import { BackHandler, ImageRequireSource, ImageURISource, NativeSyntheticEvent, StyleProp, ViewStyle } from 'react-native';
+import { BackHandler, ImageRequireSource, ImageURISource, NativeSyntheticEvent,
+    StyleProp, ViewStyle, RotateTransform, RotateXTransform, RotateYTransform,
+    RotateZTransform, ScaleTransform, ScaleXTransform, ScaleYTransform,
+    TranslateXTransform, TranslateYTransform
+} from 'react-native';
 import { Crumb, State, StateContext } from 'navigation';
 
 declare global {
@@ -487,6 +491,63 @@ export interface TabBarProps {
  * Renders a tab bar
  */
 export class TabBar extends Component<TabBarProps> {}
+
+/**
+ * Defines the Floating Action Button Props contract
+ */
+export interface FloatingActionButtonProps {
+    image: ImageRequireSource | ImageURISource | string;
+    hide?: boolean;
+    anchor?: number;
+    gravity?: 'topLeft' | 'topStart' | 'top' | 'topRight' | 'topEnd'
+        | 'left' | 'start' | 'center' | 'right' | 'end' | 'bottomLeft'
+        | 'bottomStart' | 'bottom' | 'bottomRight' |  'bottomEnd';
+    anchorGravity?: 'topLeft' | 'topStart' | 'top' | 'topRight' | 'topEnd'
+        | 'left' | 'start' | 'center' | 'right' | 'end' | 'bottomLeft'
+        | 'bottomStart' | 'bottom' | 'bottomRight' |  'bottomEnd';
+    size?: number;
+    contentDescription?: string;
+    style?: StyleProp<FloatingActionButtonStyle>;
+    onPress?: () => void;
+}
+
+/**
+ * Defines the Floating Action Button Style Prop contract
+ */
+export interface FloatingActionButtonStyle {
+    backgroundColor?: string;
+    color?: string;
+    margin?: number | string;
+    marginBottom?: number | string;
+    marginEnd?: number | string;
+    marginHorizontal?: number | string;
+    marginLeft?: number | string;
+    marginRight?: number | string;
+    marginStart?: number | string;
+    marginTop?: number | string;
+    opacity?: number;
+    elevation?: number;
+    transform?: (
+        | RotateTransform
+        | RotateXTransform
+        | RotateYTransform
+        | RotateZTransform
+        | ScaleTransform
+        | ScaleXTransform
+        | ScaleYTransform
+        | TranslateXTransform
+        | TranslateYTransform)[];
+    rotation?: number;
+    scaleX?: number;
+    scaleY?: number;
+    translateX?: number;
+    translateY?: number;
+}
+
+/**
+ * Renders a floating action button
+ */
+export class FloatingActionButton extends Component<FloatingActionButtonProps> {}
 
 /**
  * Defines the Modal Back Handler Props contract

--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -1,9 +1,5 @@
 import { Component, Context, ReactNode } from 'react';
-import { BackHandler, ImageRequireSource, ImageURISource, NativeSyntheticEvent,
-    StyleProp, ViewStyle, RotateTransform, RotateXTransform, RotateYTransform,
-    RotateZTransform, ScaleTransform, ScaleXTransform, ScaleYTransform,
-    TranslateXTransform, TranslateYTransform
-} from 'react-native';
+import { BackHandler, ImageRequireSource, ImageURISource, NativeSyntheticEvent, StyleProp, ViewStyle, TransformsStyle } from 'react-native';
 import { Crumb, State, StateContext } from 'navigation';
 
 declare global {
@@ -544,16 +540,7 @@ export interface FloatingActionButtonProps {
         marginTop?: number | string;
         opacity?: number;
         elevation?: number;
-        transform?: (
-            | RotateTransform
-            | RotateXTransform
-            | RotateYTransform
-            | RotateZTransform
-            | ScaleTransform
-            | ScaleXTransform
-            | ScaleYTransform
-            | TranslateXTransform
-            | TranslateYTransform)[];
+        transform?: TransformsStyle;
         rotation?: number;
         scaleX?: number;
         scaleY?: number;

--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -527,7 +527,7 @@ export interface FloatingActionButtonProps {
     /**
      * The id of the floating action button in end-to-end tests
      */
-     testID?: string;
+    testID?: string;
      /**
      * The style
      */

--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -534,6 +534,9 @@ export interface FloatingActionButtonProps {
     onPress?: () => void;
 }
 
+/**
+ * Defines the Floating Action Button Style Prop contract
+ */
 export interface FloatingActionButtonStyle extends TransformsStyle {
     backgroundColor?: string;
     color?: string;

--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -497,10 +497,6 @@ export interface FloatingActionButtonProps {
      */
     image: ImageRequireSource | ImageURISource | string;
     /**
-     * Indicates whether to hide the floating action button
-     */
-    hide?: boolean;
-    /**
      * The view the floating action button is anchored to
      */
     anchor?: number | null;

--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -525,6 +525,10 @@ export interface FloatingActionButtonProps {
      */
     contentDescription?: string;
     /**
+     * The id of the floating action button in end-to-end tests
+     */
+     testID?: string;
+     /**
      * The style
      */
     style?: StyleProp<FloatingActionButtonStyle>;

--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -537,14 +537,14 @@ export interface FloatingActionButtonProps {
 export interface FloatingActionButtonStyle extends TransformsStyle {
     backgroundColor?: string;
     color?: string;
-    margin?: number | string;
-    marginBottom?: number | string;
-    marginEnd?: number | string;
-    marginHorizontal?: number | string;
-    marginLeft?: number | string;
-    marginRight?: number | string;
-    marginStart?: number | string;
-    marginTop?: number | string;
+    margin?: number;
+    marginBottom?: number;
+    marginEnd?: number;
+    marginHorizontal?: number;
+    marginLeft?: number;
+    marginRight?: number;
+    marginStart?: number;
+    marginTop?: number;
     opacity?: number;
     elevation?: number;
 }

--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -503,7 +503,7 @@ export interface FloatingActionButtonProps {
     /**
      * The view the floating action button is anchored to
      */
-    anchor?: number;
+    anchor?: number | null;
     /**
      * The layout position of the floating action button
      */
@@ -527,30 +527,26 @@ export interface FloatingActionButtonProps {
     /**
      * The style
      */
-    style?: StyleProp<{
-        backgroundColor?: string;
-        color?: string;
-        margin?: number | string;
-        marginBottom?: number | string;
-        marginEnd?: number | string;
-        marginHorizontal?: number | string;
-        marginLeft?: number | string;
-        marginRight?: number | string;
-        marginStart?: number | string;
-        marginTop?: number | string;
-        opacity?: number;
-        elevation?: number;
-        transform?: TransformsStyle;
-        rotation?: number;
-        scaleX?: number;
-        scaleY?: number;
-        translateX?: number;
-        translateY?: number;
-    }>;
+    style?: StyleProp<FloatingActionButtonStyle>;
     /**
      * Handles floating action button press events
      */
     onPress?: () => void;
+}
+
+export interface FloatingActionButtonStyle extends TransformsStyle {
+    backgroundColor?: string;
+    color?: string;
+    margin?: number | string;
+    marginBottom?: number | string;
+    marginEnd?: number | string;
+    marginHorizontal?: number | string;
+    marginLeft?: number | string;
+    marginRight?: number | string;
+    marginStart?: number | string;
+    marginTop?: number | string;
+    opacity?: number;
+    elevation?: number;
 }
 
 /**

--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -496,18 +496,45 @@ export class TabBar extends Component<TabBarProps> {}
  * Defines the Floating Action Button Props contract
  */
 export interface FloatingActionButtonProps {
+    /**
+     * The floating action button image
+     */
     image: ImageRequireSource | ImageURISource | string;
+    /**
+     * Indicates whether to hide the floating action button
+     */
     hide?: boolean;
+    /**
+     * The view the floating action button is anchored to
+     */
     anchor?: number;
+    /**
+     * The layout position of the floating action button
+     */
     gravity?: 'topLeft' | 'topStart' | 'top' | 'topRight' | 'topEnd'
         | 'left' | 'start' | 'center' | 'right' | 'end' | 'bottomLeft'
         | 'bottomStart' | 'bottom' | 'bottomRight' |  'bottomEnd';
+    /**
+     * The relative position of the floating action button within the anchor
+     */
     anchorGravity?: 'topLeft' | 'topStart' | 'top' | 'topRight' | 'topEnd'
         | 'left' | 'start' | 'center' | 'right' | 'end' | 'bottomLeft'
         | 'bottomStart' | 'bottom' | 'bottomRight' |  'bottomEnd';
+    /**
+     * The size of the floating action button
+     */
     size?: number;
+    /**
+     * The accessible description of the floating action button
+     */
     contentDescription?: string;
+    /**
+     * The style
+     */
     style?: StyleProp<FloatingActionButtonStyle>;
+    /**
+     * Handles floating action button press events
+     */
     onPress?: () => void;
 }
 

--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -531,44 +531,39 @@ export interface FloatingActionButtonProps {
     /**
      * The style
      */
-    style?: StyleProp<FloatingActionButtonStyle>;
+    style?: StyleProp<{
+        backgroundColor?: string;
+        color?: string;
+        margin?: number | string;
+        marginBottom?: number | string;
+        marginEnd?: number | string;
+        marginHorizontal?: number | string;
+        marginLeft?: number | string;
+        marginRight?: number | string;
+        marginStart?: number | string;
+        marginTop?: number | string;
+        opacity?: number;
+        elevation?: number;
+        transform?: (
+            | RotateTransform
+            | RotateXTransform
+            | RotateYTransform
+            | RotateZTransform
+            | ScaleTransform
+            | ScaleXTransform
+            | ScaleYTransform
+            | TranslateXTransform
+            | TranslateYTransform)[];
+        rotation?: number;
+        scaleX?: number;
+        scaleY?: number;
+        translateX?: number;
+        translateY?: number;
+    }>;
     /**
      * Handles floating action button press events
      */
     onPress?: () => void;
-}
-
-/**
- * Defines the Floating Action Button Style Prop contract
- */
-export interface FloatingActionButtonStyle {
-    backgroundColor?: string;
-    color?: string;
-    margin?: number | string;
-    marginBottom?: number | string;
-    marginEnd?: number | string;
-    marginHorizontal?: number | string;
-    marginLeft?: number | string;
-    marginRight?: number | string;
-    marginStart?: number | string;
-    marginTop?: number | string;
-    opacity?: number;
-    elevation?: number;
-    transform?: (
-        | RotateTransform
-        | RotateXTransform
-        | RotateYTransform
-        | RotateZTransform
-        | ScaleTransform
-        | ScaleXTransform
-        | ScaleYTransform
-        | TranslateXTransform
-        | TranslateYTransform)[];
-    rotation?: number;
-    scaleX?: number;
-    scaleY?: number;
-    translateX?: number;
-    translateY?: number;
 }
 
 /**

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -491,7 +491,7 @@ export class TabBar extends Component<TabBarProps> {}
 /**
  * Defines the Bottom Sheet Props contract
  */
- export interface BottomSheetProps {
+export interface BottomSheetProps {
     /**
      * The height of the bottom sheet when it is collapsed
      */

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -537,7 +537,7 @@ export class TabBar extends Component<TabBarProps> {}
 /**
  * Renders a bottom sheet
  */
- export class BottomSheet extends Component<BottomSheetProps> {}
+export class BottomSheet extends Component<BottomSheetProps> {}
 
 /**
  * Defines the Floating Action Button Props contract

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -527,7 +527,7 @@ export interface FloatingActionButtonProps {
     /**
      * The id of the floating action button in end-to-end tests
      */
-     testID?: string;
+    testID?: string;
      /**
      * The style
      */

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -534,6 +534,9 @@ export interface FloatingActionButtonProps {
     onPress?: () => void;
 }
 
+/**
+ * Defines the Floating Action Button Style Prop contract
+ */
 export interface FloatingActionButtonStyle extends TransformsStyle {
     backgroundColor?: string;
     color?: string;

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -497,10 +497,6 @@ export interface FloatingActionButtonProps {
      */
     image: ImageRequireSource | ImageURISource | string;
     /**
-     * Indicates whether to hide the floating action button
-     */
-    hide?: boolean;
-    /**
      * The view the floating action button is anchored to
      */
     anchor?: number | null;

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -525,6 +525,10 @@ export interface FloatingActionButtonProps {
      */
     contentDescription?: string;
     /**
+     * The id of the floating action button in end-to-end tests
+     */
+     testID?: string;
+     /**
      * The style
      */
     style?: StyleProp<FloatingActionButtonStyle>;

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -1,5 +1,5 @@
 import { Component, Context, ReactNode } from 'react';
-import { BackHandler, ImageRequireSource, ImageURISource, NativeSyntheticEvent, StyleProp, ViewStyle } from 'react-native';
+import { BackHandler, ImageRequireSource, ImageURISource, NativeSyntheticEvent, StyleProp, ViewStyle, TransformsStyle } from 'react-native';
 import { Crumb, State, StateContext } from 'navigation';
 
 declare global {
@@ -487,6 +487,72 @@ export interface TabBarProps {
  * Renders a tab bar
  */
 export class TabBar extends Component<TabBarProps> {}
+
+/**
+ * Defines the Floating Action Button Props contract
+ */
+export interface FloatingActionButtonProps {
+    /**
+     * The floating action button image
+     */
+    image: ImageRequireSource | ImageURISource | string;
+    /**
+     * Indicates whether to hide the floating action button
+     */
+    hide?: boolean;
+    /**
+     * The view the floating action button is anchored to
+     */
+    anchor?: number | null;
+    /**
+     * The layout position of the floating action button
+     */
+    gravity?: 'topLeft' | 'topStart' | 'top' | 'topRight' | 'topEnd'
+        | 'left' | 'start' | 'center' | 'right' | 'end' | 'bottomLeft'
+        | 'bottomStart' | 'bottom' | 'bottomRight' |  'bottomEnd';
+    /**
+     * The relative position of the floating action button within the anchor
+     */
+    anchorGravity?: 'topLeft' | 'topStart' | 'top' | 'topRight' | 'topEnd'
+        | 'left' | 'start' | 'center' | 'right' | 'end' | 'bottomLeft'
+        | 'bottomStart' | 'bottom' | 'bottomRight' |  'bottomEnd';
+    /**
+     * The size of the floating action button
+     */
+    size?: number;
+    /**
+     * The accessible description of the floating action button
+     */
+    contentDescription?: string;
+    /**
+     * The style
+     */
+    style?: StyleProp<FloatingActionButtonStyle>;
+    /**
+     * Handles floating action button press events
+     */
+    onPress?: () => void;
+}
+
+export interface FloatingActionButtonStyle extends TransformsStyle {
+    backgroundColor?: string;
+    color?: string;
+    margin?: number;
+    marginBottom?: number;
+    marginEnd?: number;
+    marginHorizontal?: number;
+    marginLeft?: number;
+    marginRight?: number;
+    marginStart?: number;
+    marginTop?: number;
+    opacity?: number;
+    elevation?: number;
+}
+
+/**
+ * Renders a floating action button
+ */
+export class FloatingActionButton extends Component<FloatingActionButtonProps> {}
 
 /**
  * Defines the Modal Back Handler Props contract


### PR DESCRIPTION
Wrapped the Android [FloatingActionButton View](https://developer.android.com/reference/com/google/android/material/floatingactionbutton/FloatingActionButton). A child of the `CoordinatorLayout`, it can be anchored to other views, like the `BottomSheet`, for example
```jsx
const [anchor, setAnchor] = useState(null);

<CoordinatorLayout>
  <FloatingActionButton anchor={anchor} image={require('./new.png')} />
  <BottomSheet ref={(ref) => setAnchor(findNodeHandle(ref))}>
  </BottomSheet>
</CoordinatorLayout>
```
Made the FAB (Floating Action Button) animated because the material guidelines talk about transforming the FAB, for example, into a menu when it’s clicked.
