### PR TITLE
Prevented large titles from starting small (iOS 14)

### DIFF
--- a/NavigationReactNative/src/ios/NVSceneController.m
+++ b/NavigationReactNative/src/ios/NVSceneController.m
@@ -24,6 +24,21 @@
     self.view = _view;
 }
 
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    NVNavigationBarView *navigationBar = (NVNavigationBarView *) [self.view viewWithTag:NAVIGATION_BAR];
+    NVSearchBarView *searchBar = (NVSearchBarView *) [navigationBar viewWithTag:SEARCH_BAR];
+    self.definesPresentationContext = true;
+    if (!!searchBar && !navigationBar.hidden)
+    {
+        if (@available(iOS 11.0, *)) {
+            [self.navigationItem setSearchController:searchBar.searchController];
+            [self.navigationItem setHidesSearchBarWhenScrolling:searchBar.hideWhenScrolling];
+        }
+    }
+}
+
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];


### PR DESCRIPTION
In #543, moved the search controller initialisation out of `viewDidLoad` and into `viewWillAppear` but this is too late for iOS 14 (works on iOS 15). So moved it back into `viewDidLoad`. But also kept it in `viewWillAppear`. It needs to be in `viewWillAppear` because in #543 found out that when fluently navigating from A to A -> B -> C and hitting the back button fast then the `viewDidLoad` of B fires even when the back button is blocked (before subviews have loaded).

This means there is a problem on iOS 14 but is unlikely to occur. Have to fluently navigate over a scene with large titles. Then have to hit the back button fast before the fluent scene has loaded its subviews. In that case the large title doesn't show properly (scrolling the view fixes it).
