### PR TITLE
Re-rendered the current Scene whenever the NavigationStack re-renders

### DIFF
--- a/NavigationReactMobile/src/Freeze.tsx
+++ b/NavigationReactMobile/src/Freeze.tsx
@@ -40,7 +40,7 @@ var Suspender = ({freeze, children}) => {
 };
 
 var Freeze = ({enabled, children}) => {
-    const suspendable = typeof React.Suspense !== 'undefined' && typeof window !== 'undefined';
+    const suspendable = !!React.Suspense && typeof window !== 'undefined';
     const suspender = <Suspender freeze={enabled && suspendable}>{children}</Suspender>;
     return suspendable ? <Suspense fallback={null}>{suspender}</Suspense> : suspender;
 };

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -79,9 +79,10 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
                     {styles => (
                         styles.map(({data: {key, state, data}, style}) => {
                             var crumb = +key.replace(/\++$/, '');
-                            var scene = <Scene crumb={crumb} renderScene={renderScene} /> ;
+                            var rest = this.state;
+                            var scene = <Scene crumb={crumb} rest={rest} renderScene={renderScene} /> ;
                             return (
-                                <Freeze key={key} enabled={this.state.rest && crumb < this.getScenes().length - 1}>
+                                <Freeze key={key} enabled={rest && crumb < this.getScenes().length - 1}>
                                     {children(style, scene, key, crumbs.length === crumb, state, data)}
                                 </Freeze>
                             );

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -79,7 +79,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
                     {styles => (
                         styles.map(({data: {key, state, data}, style}) => {
                             var crumb = +key.replace(/\++$/, '');
-                            var rest = this.state;
+                            var {rest} = this.state;
                             var scene = <Scene crumb={crumb} rest={rest} renderScene={renderScene} /> ;
                             return (
                                 <Freeze key={key} enabled={rest && crumb < this.getScenes().length - 1}>

--- a/NavigationReactMobile/src/Props.ts
+++ b/NavigationReactMobile/src/Props.ts
@@ -59,6 +59,7 @@ interface NavigationMotionProps {
 
 interface SceneProps {
     crumb: number;
+    rest: boolean;
     renderScene?: (state: State, data: any) => ReactNode;
 }
 

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -24,8 +24,10 @@ class Scene extends React.Component<SceneProps & {navigationEvent: NavigationEve
         var replace = oldCrumbs.length === crumb && oldState !== state;
         return !replace ? {navigationEvent} : null;
     }
-    shouldComponentUpdate(_nextProps, nextState) {
-        return nextState.navigationEvent !== this.state.navigationEvent;
+    shouldComponentUpdate({crumb, rest, navigationEvent: {stateNavigator}}, nextState) {
+        var {crumbs} = stateNavigator.stateContext;
+        var freezableOrCurrent = rest && (!!React.Suspense || crumbs.length === crumb);
+        return freezableOrCurrent || nextState.navigationEvent !== this.state.navigationEvent;
     }
     render() {
         var {navigationEvent} = this.state;

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -1110,42 +1110,7 @@ describe('NavigationMotion', function () {
     });
 
     describe('Re-render NavigationStack', function () {
-        it('should re-render current scene', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA} = stateNavigator.states;
-            var SceneA = ({updated}) => <div id='sceneA' data-updated={updated} />;
-            sceneA.renderScene = (updated) => <SceneA updated={updated} />;
-            var container = document.createElement('div');
-            var update;
-            var App = () => {
-                var [updated, setUpdated] = useState(false);
-                update = setUpdated;
-                return (
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion renderScene={(state) => state.renderScene(updated)}>
-                            {(_style, scene, key) =>  (
-                                <div id={key} key={key}>{scene}</div>
-                            )}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            }
-            ReactDOM.render(<App />, container);
-            update(true);
-            try {
-                var scene = container.querySelector<HTMLDivElement>("#sceneA");                
-                assert.strictEqual(scene.dataset.updated, 'true');
-            } finally {
-                ReactDOM.unmountComponentAtNode(container);
-            }
-        })
-    });
-
-    describe('Re-render NavigationStack', function () {
-        it('should not re-render crumb', function(){
+        it('should only re-render current scene', function(){
             var stateNavigator = new StateNavigator([
                 { key: 'sceneA' },
                 { key: 'sceneB', trackCrumbTrail: true },
@@ -1153,9 +1118,9 @@ describe('NavigationMotion', function () {
             stateNavigator.navigate('sceneA');
             var {sceneA, sceneB} = stateNavigator.states;
             var SceneA = ({updated}) => <div id='sceneA' data-updated={updated} />;
-            var SceneB = () => <div id='sceneB' />;
+            var SceneB = ({updated}) => <div id='sceneB' data-updated={updated} />;
             sceneA.renderScene = (updated) => <SceneA updated={updated} />;
-            sceneB.renderScene = () => <SceneB />;
+            sceneB.renderScene = (updated) => <SceneB updated={updated} />;
             var container = document.createElement('div');
             var update;
             var App = () => {
@@ -1175,8 +1140,10 @@ describe('NavigationMotion', function () {
             stateNavigator.navigate('sceneB');
             update(true);
             try {
-                var scene = container.querySelector<HTMLDivElement>("#sceneA");                
+                var scene = container.querySelector<HTMLDivElement>("#sceneA");
                 assert.strictEqual(scene.dataset.updated, 'false');
+                scene = container.querySelector<HTMLDivElement>("#sceneB");
+                assert.strictEqual(scene.dataset.updated, 'true');
             } finally {
                 ReactDOM.unmountComponentAtNode(container);
             }

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -1108,4 +1108,39 @@ describe('NavigationMotion', function () {
             }
         })
     });
+
+    describe('Re-render NavigationStack', function () {
+        it('should re-render current scene', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+            ]);
+            stateNavigator.navigate('sceneA');
+            var {sceneA} = stateNavigator.states;
+            var SceneA = ({updated}) => <div id='sceneA' data-updated={updated} />;
+            sceneA.renderScene = (updated) => <SceneA updated={updated} />;
+            var container = document.createElement('div');
+            var update;
+            var App = () => {
+                var [updated, setUpdated] = useState(false);
+                update = setUpdated;
+                return (
+                    <NavigationHandler stateNavigator={stateNavigator}>
+                        <NavigationMotion renderScene={(state) => state.renderScene(updated)}>
+                            {(_style, scene, key) =>  (
+                                <div id={key} key={key}>{scene}</div>
+                            )}
+                        </NavigationMotion>
+                    </NavigationHandler>
+                );
+            }
+            ReactDOM.render(<App />, container);
+            update(true);
+            try {
+                var scene = container.querySelector<HTMLDivElement>("#sceneA");                
+                assert.strictEqual(scene.dataset.updated, 'true');
+            } finally {
+                ReactDOM.unmountComponentAtNode(container);
+            }
+        })
+    });
 });

--- a/NavigationReactNative/src/Freeze.tsx
+++ b/NavigationReactNative/src/Freeze.tsx
@@ -40,8 +40,9 @@ var Suspender = ({freeze, children}) => {
 };
 
 var Freeze = ({enabled, children}) => {
-    const suspender = <Suspender freeze={enabled && !!React.Suspense}>{children}</Suspender>;
-    return !!React.Suspense ? <Suspense fallback={null}>{suspender}</Suspense> : suspender;
+    const suspendable = !!React.Suspense;
+    const suspender = <Suspender freeze={enabled && suspendable}>{children}</Suspender>;
+    return suspendable ? <Suspense fallback={null}>{suspender}</Suspense> : suspender;
 };
 
 export default Freeze;

--- a/NavigationReactNative/src/Freeze.tsx
+++ b/NavigationReactNative/src/Freeze.tsx
@@ -40,9 +40,8 @@ var Suspender = ({freeze, children}) => {
 };
 
 var Freeze = ({enabled, children}) => {
-    const suspendable = typeof React.Suspense !== 'undefined';
-    const suspender = <Suspender freeze={enabled && suspendable}>{children}</Suspender>;
-    return suspendable ? <Suspense fallback={null}>{suspender}</Suspense> : suspender;
+    const suspender = <Suspender freeze={enabled && !!React.Suspense}>{children}</Suspender>;
+    return !!React.Suspense ? <Suspense fallback={null}>{suspender}</Suspense> : suspender;
 };
 
 export default Freeze;

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -113,7 +113,7 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
                             key={key}
                             crumb={crumb}
                             sceneKey={key}
-                            freezable={typeof React.Suspense !== 'undefined' && rest}
+                            rest={rest}
                             unmountStyle={unmountStyle}
                             crumbStyle={crumbStyle}
                             hidesTabBar={hidesTabBar}

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -35,8 +35,7 @@ class Scene extends React.Component<SceneProps, SceneState> {
         var replace = oldCrumbs.length === crumb && oldState !== state;
         return !replace ? {navigationEvent} : null;
     }
-    shouldComponentUpdate({rest}: SceneProps, {navigationEvent}: SceneState) {
-        var {crumb, navigationEvent: {stateNavigator}} = this.props;
+    shouldComponentUpdate({crumb, rest, navigationEvent: {stateNavigator}}: SceneProps, {navigationEvent}: SceneState) {
         var {crumbs} = stateNavigator.stateContext;
         var freezableOrCurrent = rest && (!!React.Suspense || crumbs.length === crumb);
         return freezableOrCurrent || navigationEvent !== this.state.navigationEvent || (this.fluentPeekable() && !this.timer);

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -4,7 +4,7 @@ import { StateNavigator, StateContext, State, Crumb } from 'navigation';
 import { NavigationContext, NavigationEvent } from 'navigation-react';
 import BackButton from './BackButton';
 import Freeze from './Freeze';
-type SceneProps = { crumb: number, sceneKey: string, freezable: boolean, renderScene: (state: State, data: any) => ReactNode, crumbStyle: any, unmountStyle: any, hidesTabBar: any, title: (state: State, data: any) => string, popped: (key: string) => void, navigationEvent: NavigationEvent };
+type SceneProps = { crumb: number, sceneKey: string, rest: boolean, renderScene: (state: State, data: any) => ReactNode, crumbStyle: any, unmountStyle: any, hidesTabBar: any, title: (state: State, data: any) => string, popped: (key: string) => void, navigationEvent: NavigationEvent };
 type SceneState = { navigationEvent: NavigationEvent };
 
 class Scene extends React.Component<SceneProps, SceneState> {
@@ -35,8 +35,11 @@ class Scene extends React.Component<SceneProps, SceneState> {
         var replace = oldCrumbs.length === crumb && oldState !== state;
         return !replace ? {navigationEvent} : null;
     }
-    shouldComponentUpdate({freezable}, {navigationEvent}: SceneState) {
-        return freezable || navigationEvent !== this.state.navigationEvent || (this.fluentPeekable() && !this.timer);
+    shouldComponentUpdate({rest}: SceneProps, {navigationEvent}: SceneState) {
+        var {crumb, navigationEvent: {stateNavigator}} = this.props;
+        var {crumbs} = stateNavigator.stateContext;
+        var freezableOrCurrent = rest && (!!React.Suspense || crumbs.length === crumb);
+        return freezableOrCurrent || navigationEvent !== this.state.navigationEvent || (this.fluentPeekable() && !this.timer);
     }
     componentDidUpdate() {
         this.backgroundPeekNavigate();
@@ -128,7 +131,8 @@ class Scene extends React.Component<SceneProps, SceneState> {
     }
     render() {
         var {navigationEvent} = this.state;
-        var {crumb, title, sceneKey, freezable, popped, navigationEvent: {stateNavigator}} = this.props;
+        var {crumb, title, sceneKey, rest, popped, navigationEvent: {stateNavigator}} = this.props;
+        var freezable = rest && !!React.Suspense;
         var {crumbs} = stateNavigator.stateContext;
         var stateContext = navigationEvent?.stateNavigator?.stateContext;
         var {state, data} = stateContext || crumbs[crumb];
@@ -137,7 +141,7 @@ class Scene extends React.Component<SceneProps, SceneState> {
                 && (!stateContext['peek'] || stateContext['peek'] !== this.props.navigationEvent)}>
                 <NVScene
                     ref={(ref: any) => {
-                        if (typeof React.Suspense !== 'undefined' && ref?.viewConfig?.validAttributes?.style) {
+                        if (!!React.Suspense && ref?.viewConfig?.validAttributes?.style) {
                             ref.viewConfig.validAttributes.style = {
                                 ...ref.viewConfig.validAttributes.style,
                                 display: false

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -60,7 +60,7 @@ public class SceneFragment extends Fragment {
             });
             return anim;
         }
-        if (nextAnim == 0 && enter && getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.RESUMED)) {
+        if (nextAnim == 0 && enter && getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED)) {
             ((NavigationStackView) scene.getParent()).onRest(scene.crumb);
         }
         return super.onCreateAnimation(transit, enter, nextAnim);


### PR DESCRIPTION
Fixes #554

Thanks to @salockhart for raising such an interesting issue and with so much detail, too.

Take the scenario of a parent scene that opens a `Modal` with its own `NavigationStack`. The parent scene wants to pass data to the modal scene. Although it can do this using React Context it should be possible to do this using props, too. The example below uses the `renderScene` prop on the modal navigation stack to pass props to the `renderScene` on the State.

```jsx
const Wrapper = ({state, ...props}) => state.renderScene(props);

const ParentScene = ({progress, onSubmit}) => {
  const modalNavigator = useMemo(() => {
    const navigator = new StateNavigator([{key: 'scene'}])
    const {scene} = stateNavigator.states;
    screen.renderScene = (props) => <Scene {...props} />;
    navigator.navigate('scene');
    return navigator;
  });

  return (
    <NavigationHandler stateNavigator={modalNavigator}>
      <NavigationStack renderScene={(state) => (
        <Wrapper state={state} progress={progress} onSubmit={onSubmit} />
      )} />
    </NavigationHandler>
  );
}
```

The reason this didn’t work was because the Navigation router was overzealous in preventing re-renders. It stopped the scene from re-rendering if a navigation hadn’t happened. But the scene needs to re-render because the `renderScene` of the `NavigationStack` has changed.

A quick fix was to change the [lifecycle state check from RESUMED to STARTED](https://github.com/grahammendick/navigation/blob/50ca4c96728b5584e0e5b26c58c07f0bfd806ba2/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java#L63). Changing to STARTED ensures that the `onRest` is called when the modal scene opens. In turn, this means the `shouldComponentUpdate` returns true. On iOS the `onRest` was called correctly already which explains why #554 showed the example working on iOS and not Android.

This quick fix only works if React Suspense is available. The Freeze logic added in v8.6.0 means that `shouldComponentUpdate` returns true. Before v8.6.0 the `shouldComponentUpdate` always returns false unless there’s a navigation. This explains why #554 showed the example doesn’t work on iOS or Android in < 8.6.0.

Decided not to settle for this quick fix alone. Not (just) because React Suspense might not be available but because the Freeze logic relies on some React Native internals. So there’s no way to guarantee that future versions of React Native will work with the current Freeze implementation.

In short, re-rendering the `NavigationStack` will re-render the current (topmost) scene.
