### PR TITLE
Kept browser history in step with the stack when navigating back

### DIFF
--- a/NavigationReactMobile/src/MobileHistoryManager.ts
+++ b/NavigationReactMobile/src/MobileHistoryManager.ts
@@ -12,17 +12,22 @@ class MobileHistoryManager extends HTML5HistoryManager {
 
     addHistory(url: string, replace: boolean, stateContext?: StateContext) {
         var title = typeof document !== 'undefined' && document.title;
+        var distance = 0;
         if (!!stateContext && !stateContext.history) {
             var {oldUrl, crumbs} = stateContext;
             var start = !oldUrl ? 0 : oldUrl.split('crumb=').length;
+            distance = crumbs.length - start + 1;
             for(var i = start; i < crumbs.length; i++) {
                 let {url, state} = crumbs[i];
                 super.addHistory(url, i === 0);
                 if (typeof document !== 'undefined' && state.title)
                     document.title = state.title;
             }
+            if (distance < 0)
+                history.go(distance);
         }
-        super.addHistory(url, replace);
+        if (distance >= 0)
+            super.addHistory(url, replace);
         if (title)
             document.title = title;
     }


### PR DESCRIPTION
Instead of requiring the developer to intercept the `NavigationBackLink` press, made the history back call automatic by moving it into the `MobileHistoryManager`.  A plain `NavigationBackLink` now triggers a `history.go(-distance)`.
```jsx
<NavigationBackLink distance={1} />
```
The `MobileHistoryManager` works out the distance by comparing the old Url to the current crumbs. There was already logic in there to add the right number of browser history records when fluently navigating forwards. This is the symmetric condition when navigating back.