### PR TITLE
Add info on custom expo development client support to docs

### DIFF
--- a/documentation/native/setup.html
+++ b/documentation/native/setup.html
@@ -51,8 +51,8 @@
           </div>
           <div id="article">
             <h1>Setup</h1>
-            <p>
-                The Navigation router for React Native uses the underlying native APIs to provide faithful navigation on Android and iOS. Because it contains native code you have to eject from Expo or create your application using <code>react-native init</code>.
+             <p>
+                The Navigation router for React Native uses the underlying native APIs to provide faithful navigation on Android and iOS. Because it contains native code, you have to create your application using <code>react-native init</code> or <a href="https://docs.expo.dev/development/introduction/">a custom development build of Expo</a>.
             </p>
             <p>
                 Install the three navigation packages from npm.


### PR DESCRIPTION
Adding the wording suggested in #553 (with minimal changes):

"The Navigation router for React Native uses the underlying native APIs to provide faithful navigation on Android and iOS. Because it contains native code, you have to create your application using react-native init or a custom development build of Expo."

Fixes #553 