### PR TITLE
Added to history whenever the stack changes

### DIFF
--- a/Navigation/src/history/HTML5HistoryManager.ts
+++ b/Navigation/src/history/HTML5HistoryManager.ts
@@ -17,12 +17,11 @@ class HTML5HistoryManager implements HistoryManager {
     }
 
     addHistory(url: string, replace: boolean) {
-        var href = this.getHref(url);
-        if (!this.disabled && this.getHref(this.getUrl(window.location)) !== href) {
+        if (!this.disabled && (window.history.state?.navigationLink || this.getUrl(window.location)) !== url) {
             if (!replace)            
-                window.history.pushState({navigationLink: url}, null, href);
+                window.history.pushState({navigationLink: url}, null, this.getHref(url));
             else
-                window.history.replaceState({navigationLink: url}, null, href);
+                window.history.replaceState({navigationLink: url}, null, this.getHref(url));
         }
     }
 


### PR DESCRIPTION
Navigating from A to A → A on mobile should add to browser history because the stack has changed. It wasn’t being added because it was checking the unchanged href (both '/A').