### PR TITLE
Went back in browser history until the right scene is reached

### DIFF
--- a/NavigationReactMobile/src/MobileHistoryManager.ts
+++ b/NavigationReactMobile/src/MobileHistoryManager.ts
@@ -87,6 +87,12 @@ class MobileHistoryManager extends HTML5HistoryManager {
             url = this.buildCurrentUrl(url);
         return url;
     }
+    
+    stop() {
+        if (this.navigateHistory)
+            window.removeEventListener('popstate', this.navigateHistory);
+        this.navigateHistory = null;
+    }
 }
 
 export default MobileHistoryManager;


### PR DESCRIPTION
Take the example of navigating from A to A → B. There’s 1 item in the stack and 1 in browser history. The stack and browser history are in step. Then navigate without adding to the stack while adding to history. For example, opening a modal would stay on scene B but add to browser history. Now there’s still 1 item in the stack but 2 in browser history. The stack and browser history are out of step. Pressing the back button will go back 1 to scene A and 1 in browser history. So the browser url will point at B but the UI will show A.

Changed to go back in browser history until the right scene is reached. Can work out the right scene by checking the number of crumbs in the browser url match the number of crumbs in `StateContext`. Can’t keep calling `history.back()` in `addHistory` of the `HistoryManager` because `history.back` is asynchronous - the url doesn’t update immediately. Instead, put this logic into the `popstate` listener. Keep popping state until the scene is reached.
