### PR TITLE
Prevented wrong scene showing during unmount

### DIFF
--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -32,8 +32,9 @@ class Scene extends React.Component<SceneProps & {navigationEvent: NavigationEve
     render() {
         var {navigationEvent} = this.state;
         var {crumb, navigationEvent: {stateNavigator}} = this.props;
-        var {crumbs, nextCrumb} = stateNavigator.stateContext;
-        var {state, data} = (crumb < crumbs.length) ? crumbs[crumb] : nextCrumb;
+        var {crumbs} = stateNavigator.stateContext;
+        var stateContext = navigationEvent?.stateNavigator?.stateContext;
+        var {state, data} = stateContext || crumbs[crumb];
         return (
             <NavigationContext.Provider value={navigationEvent}>
                 {navigationEvent && this.props.renderScene(state, data)}

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -34,7 +34,7 @@ class Scene extends React.Component<SceneProps & {navigationEvent: NavigationEve
         var {crumb, navigationEvent: {stateNavigator}} = this.props;
         var {crumbs} = stateNavigator.stateContext;
         var stateContext = navigationEvent?.stateNavigator?.stateContext;
-        var {state, data} = stateContext || crumbs[crumb];
+        var {state, data} = stateContext || crumbs[crumb] || {};
         return (
             <NavigationContext.Provider value={navigationEvent}>
                 {navigationEvent && this.props.renderScene(state, data)}


### PR DESCRIPTION
When navigating from A to A → B then back to A, could get scene A showing in place of scene B. So scene A would show twice - both as the mounted and the unmounting scene. Scene B calculated its `state` and `data` from the global `stateNavigator` in props instead of the local stateNavigator in state. (This bug only showed up when the `mounted` and `crumb` styles were the same so that `onRest` fired before B unmounted and triggered B to rerender).

Was another bug when fluently navigating from A to A --> B --> C then navigate back 2 to A. Scene B would throw an error because it had no `navigationEvent` in React State and the `crumbs` from the global `stateNavigator` are less than B. Preventing the destructuring error is enough because the render won't do anything anyway.