### PR TITLE
Prevented rendering scenes while animating

### DIFF
--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -61,7 +61,8 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
     getStyle(mounted: boolean, {state, data, crumbs, nextState, nextData, mount}: SceneContext) {
         var {unmountedStyle, mountedStyle, crumbStyle} = this.props;
         var styleProp = !mounted ? unmountedStyle : (mount ? mountedStyle : crumbStyle);
-        return typeof styleProp === 'function' ? styleProp(state, data, crumbs, nextState, nextData) : styleProp;
+        var style = typeof styleProp === 'function' ? styleProp(state, data, crumbs, nextState, nextData) : styleProp;
+        return {...style, __marker: !mounted ? 1 : (mount ? 0 : -1)};
     }
     render() {
         var {children, duration, renderScene, sharedElementMotion, stateNavigator} = this.props;
@@ -77,7 +78,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
                     onRest={({key}) => this.clearScene(key)}
                     duration={duration}>
                     {styles => (
-                        styles.map(({data: {key, state, data}, style}) => {
+                        styles.map(({data: {key, state, data}, style: {__marker, ...style}}) => {
                             var crumb = +key.replace(/\++$/, '');
                             var {rest} = this.state;
                             var scene = <Scene crumb={crumb} rest={rest} renderScene={renderScene} /> ;


### PR DESCRIPTION
Take scenario where the mounted and crumb styles are the same. Then navigate from A --> B back to A. There's no styles to interpolate for A because it's moving from a crumb to mounted. So rest gets set to true immediately - even while scene B is still animating as it unmounts. But this causes scene A to render during the animation because the `shouldComponentUpdate` of a `Scene` returns true when `rest` is true.
```jsx
<NavigationStack
  unmountedStyle={{translate: 100}}
  mountedStyle={{translate: 0}}
  crumbStyle={{translate: 0}}>
```
Added a marker to style to ensure there's always something to interpolate. Ensures that `rest` isn't set before the animation duration elapses. The marker is 1 for unmounted, 0 for mounted and -1 for crumb