### PR TITLE
Stayed on the same scene when refresh navigating

### DIFF
--- a/Navigation/src/FluentNavigator.ts
+++ b/Navigation/src/FluentNavigator.ts
@@ -11,7 +11,7 @@ interface FluentNavigator {
 }
 
 function createFluentNavigator(states: { [index: string]: State }, stateHandler: StateHandler, stateContext = new StateContext()): FluentNavigator {
-    function getCrumbTrail(state: State, navigationData: any, crumbs: Crumb[], nextCrumb: Crumb): Crumb[] {
+    function getCrumbTrail(state: State, navigationData: any, crumbs: Crumb[], nextCrumb?: Crumb): Crumb[] {
         if (!state.trackCrumbTrail)
             return [];
         crumbs = crumbs.slice();
@@ -56,14 +56,14 @@ function createFluentNavigator(states: { [index: string]: State }, stateHandler:
             return navigateLink(state, data, null, crumbs, url);
         },
         refresh: function(navigationData?: any, hash?: string): FluentNavigator {
-            var {state, crumbs, nextCrumb} = stateContext;
+            var {state, crumbs} = stateContext;
             if (typeof navigationData === 'function')
                 navigationData = navigationData(stateContext.data);
-            var url = stateHandler.getLink(state, navigationData, hash, crumbs, nextCrumb);
+            var url = stateHandler.getLink(state, navigationData, hash, crumbs);
             if (url == null)
                 throw new Error('Invalid route data, a mandatory route parameter has not been supplied a value');
             var data = { ...state.defaults, ...navigationData };
-            var crumbs = getCrumbTrail(state, data, crumbs, nextCrumb);
+            var crumbs = getCrumbTrail(state, data, crumbs);
             return navigateLink(state, data, hash, crumbs, url);
         }
     }

--- a/Navigation/src/StateNavigator.ts
+++ b/Navigation/src/StateNavigator.ts
@@ -114,8 +114,8 @@ class StateNavigator {
     }
 
     getRefreshLink(navigationData?: any, hash?: string): string {
-        var { crumbs, nextCrumb } = this.stateContext;
-        return this.stateHandler.getLink(this.stateContext.state, navigationData, hash, crumbs, nextCrumb);
+        var { crumbs } = this.stateContext;
+        return this.stateHandler.getLink(this.stateContext.state, navigationData, hash, crumbs);
     }
 
     navigateLink(url: string, historyAction: 'add' | 'replace' | 'none' = 'add', history = false,

--- a/Navigation/src/StateNavigator.ts
+++ b/Navigation/src/StateNavigator.ts
@@ -64,9 +64,6 @@ class StateNavigator {
         stateContext.data = data;
         stateContext.hash = hash;
         stateContext.nextCrumb = new Crumb(data, state, url, this.stateHandler.getLink(state, data, hash), false, hash);
-        stateContext.previousState = null;
-        stateContext.previousData = {};
-        stateContext.previousUrl = null;
         if (stateContext.crumbs.length > 0) {
             var previousStateCrumb = stateContext.crumbs.slice(-1)[0];
             stateContext.previousState = previousStateCrumb.state;

--- a/Navigation/test/FluentNavigationTest.ts
+++ b/Navigation/test/FluentNavigationTest.ts
@@ -291,7 +291,7 @@ describe('Fluent', function () {
                 .navigate('s1')
                 .refresh()
                 .url;
-            assert.strictEqual(url, '/r1?crumb=%2Fr0&crumb=%2Fr1');
+            assert.strictEqual(url, '/r1?crumb=%2Fr0');
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
@@ -307,7 +307,7 @@ describe('Fluent', function () {
                 .navigate('s1')
                 .refresh(null, 'f')
                 .url;
-            assert.strictEqual(url, '/r1?crumb=%2Fr0&crumb=%2Fr1#f');
+            assert.strictEqual(url, '/r1?crumb=%2Fr0#f');
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
@@ -626,7 +626,7 @@ describe('Fluent', function () {
                 .navigateBack(1)
                 .refresh()
                 .url;
-            assert.strictEqual(url, '/r1?crumb=%2Fr0&crumb=%2Fr1');
+            assert.strictEqual(url, '/r1?crumb=%2Fr0');
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
@@ -666,7 +666,7 @@ describe('Fluent', function () {
                 .refresh()
                 .navigate('s3')
                 .url;
-            assert.strictEqual(url, '/r3?crumb=%2Fr0&crumb=%2Fr1&crumb=%2Fr1');
+            assert.strictEqual(url, '/r3?crumb=%2Fr0&crumb=%2Fr1');
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
@@ -947,7 +947,7 @@ describe('Fluent', function () {
                 .navigate('s1')
                 .refresh()
                 .url;
-            assert.strictEqual(url, '/r1?crumb=%2Fr0&crumb=%2Fr1');
+            assert.strictEqual(url, '/r1?crumb=%2Fr0');
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
@@ -1032,7 +1032,7 @@ describe('Fluent', function () {
                 .navigate('s1')
                 .refresh()
                 .url;
-            assert.strictEqual(url, '/r1?crumb=%2Fr0&crumb=%2Fr1');
+            assert.strictEqual(url, '/r1?crumb=%2Fr0');
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
@@ -1133,8 +1133,8 @@ describe('Fluent', function () {
             var url1 = fluent3
                 .refresh()
                 .url;
-            assert.strictEqual(url0, '/r1?crumb=%2Fr0&crumb=%2Fr1');
-            assert.strictEqual(url1, '/r3?crumb=%2Fr2&crumb=%2Fr3');
+            assert.strictEqual(url0, '/r1?crumb=%2Fr0');
+            assert.strictEqual(url1, '/r3?crumb=%2Fr2');
             assert.strictEqual(stateNavigator0.stateContext.url, null);
             assert.strictEqual(stateNavigator1.stateContext.url, null);
         });
@@ -1266,7 +1266,7 @@ describe('Fluent', function () {
                 .refresh()
                 .navigateBack(1)
                 .url;
-            assert.strictEqual(url, '/r1?crumb=%2Fr0');
+            assert.strictEqual(url, '/r0');
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });
@@ -1283,7 +1283,7 @@ describe('Fluent', function () {
                 .refresh(null, 'f1')
                 .navigateBack(1)
                 .url;
-            assert.strictEqual(url, '/r1?crumb=%2Fr0%23f0');
+            assert.strictEqual(url, '/r0#f0');
             assert.strictEqual(stateNavigator.stateContext.url, null);
         });
     });

--- a/Navigation/test/NavigationDataTest.ts
+++ b/Navigation/test/NavigationDataTest.ts
@@ -2156,9 +2156,9 @@ describe('Navigation Data', function () {
                 assert.strictEqual(stateNavigator.stateContext.previousData['s'], 'Hello');
                 assert.strictEqual(stateNavigator.stateContext.previousData['n'], 5);
                 assert.strictEqual(stateNavigator.stateContext.previousData['b'], true);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['s'], 'Hello');
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['n'], 5);
-                assert.strictEqual(stateNavigator.stateContext.crumbs[1].data['b'], true);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['s'], 'Hello');
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['n'], 5);
+                assert.strictEqual(stateNavigator.stateContext.crumbs[0].data['b'], true);
                 assert.strictEqual(stateNavigator.stateContext.data['s'], 'Hello');
                 assert.strictEqual(stateNavigator.stateContext.data['n'], 5);
                 assert.strictEqual(stateNavigator.stateContext.data['b'], true);
@@ -2561,7 +2561,7 @@ describe('Navigation Data', function () {
         }
     });
 
-    describe('Refresh Individual Data Custom Trail', function() {
+    describe('Navigate Individual Data Custom Trail', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {
             stateNavigator = new StateNavigator([
@@ -2584,8 +2584,8 @@ describe('Navigation Data', function () {
         describe('Navigate', function() {
             beforeEach(function() {
                 stateNavigator.navigate('s');
-                stateNavigator.refresh();
-                stateNavigator.refresh(individualNavigationData);
+                stateNavigator.navigate('s');
+                stateNavigator.navigate('s', individualNavigationData);
             });
             test();
         });
@@ -2594,9 +2594,9 @@ describe('Navigation Data', function () {
             beforeEach(function() {
                 var link = stateNavigator.getNavigationLink('s');
                 stateNavigator.navigateLink(link);
-                var link = stateNavigator.getRefreshLink();
+                var link = stateNavigator.getNavigationLink('s');
                 stateNavigator.navigateLink(link);
-                link = stateNavigator.getRefreshLink(individualNavigationData);
+                link = stateNavigator.getNavigationLink('s', individualNavigationData);
                 stateNavigator.navigateLink(link);
             });
             test();
@@ -2606,8 +2606,8 @@ describe('Navigation Data', function () {
             beforeEach(function() {
                 var link = stateNavigator.fluent()
                     .navigate('s')
-                    .refresh()
-                    .refresh(individualNavigationData)
+                    .navigate('s')
+                    .navigate('s', individualNavigationData)
                     .url;
                 stateNavigator.navigateLink(link);
             });
@@ -5285,8 +5285,8 @@ describe('Navigation Data', function () {
             it('should populate old and previous data', function () {
                 assert.strictEqual(stateNavigator.stateContext.oldData['s'], 'Hello');
                 assert.strictEqual(stateNavigator.stateContext.oldData['t'], 1);
-                assert.strictEqual(stateNavigator.stateContext.previousData['s'], 'Hello');
-                assert.strictEqual(stateNavigator.stateContext.previousData['t'], 1);
+                assert.strictEqual(stateNavigator.stateContext.previousData['s'], undefined);
+                assert.strictEqual(stateNavigator.stateContext.previousData['t'], undefined);
                 assert.strictEqual(stateNavigator.stateContext.data['s'], undefined);
                 assert.strictEqual(stateNavigator.stateContext.data['t'], undefined);
             });
@@ -7222,7 +7222,7 @@ describe('Navigation Data', function () {
         }
     });
     
-    describe('Refresh Data Back Custom Trail', function() {
+    describe('Navigate Data Back Custom Trail', function() {
         var stateNavigator: StateNavigator;
         beforeEach(function() {
             stateNavigator = new StateNavigator([
@@ -7242,7 +7242,7 @@ describe('Navigation Data', function () {
             beforeEach(function() {
                 stateNavigator.navigate('s0');
                 stateNavigator.navigate('s1', data);
-                stateNavigator.refresh();
+                stateNavigator.navigate('s1');
                 stateNavigator.navigateBack(1);
             });
             test();
@@ -7254,7 +7254,7 @@ describe('Navigation Data', function () {
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationLink('s1', data);
                 stateNavigator.navigateLink(link);
-                link = stateNavigator.getRefreshLink();
+                link = stateNavigator.getNavigationLink('s1');
                 stateNavigator.navigateLink(link);
                 link = stateNavigator.getNavigationBackLink(1);
                 stateNavigator.navigateLink(link);
@@ -7267,7 +7267,7 @@ describe('Navigation Data', function () {
                 var link = stateNavigator.fluent()
                     .navigate('s0')
                     .navigate('s1', data)
-                    .refresh()
+                    .navigate('s1')
                     .navigateBack(1)
                     .url;
                 stateNavigator.navigateLink(link);

--- a/Navigation/test/NavigationTest.ts
+++ b/Navigation/test/NavigationTest.ts
@@ -700,12 +700,10 @@ describe('Navigation', function () {
             it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.crumbs.length, 2);
+                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
+                assert.equal(stateNavigator.stateContext.crumbs.length, 1);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.crumbs[1].state, stateNavigator.states['s1']);
-                assert.ok(!stateNavigator.stateContext.crumbs[0].last);
-                assert.ok(stateNavigator.stateContext.crumbs[1].last);
+                assert.ok(stateNavigator.stateContext.crumbs[0].last);
             });
         }
     });
@@ -726,15 +724,12 @@ describe('Navigation', function () {
             assert.equal(stateNavigator.stateContext.hash, 'f');
             assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
             assert.strictEqual(stateNavigator.stateContext.oldHash, null);
-            assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s1']);
+            assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
             assert.strictEqual(stateNavigator.stateContext.previousHash, null);
-            assert.equal(stateNavigator.stateContext.crumbs.length, 2);
+            assert.equal(stateNavigator.stateContext.crumbs.length, 1);
             assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
             assert.strictEqual(stateNavigator.stateContext.crumbs[0].hash, null);
-            assert.equal(stateNavigator.stateContext.crumbs[1].state, stateNavigator.states['s1']);
-            assert.strictEqual(stateNavigator.stateContext.crumbs[1].hash, null);
-            assert.ok(!stateNavigator.stateContext.crumbs[0].last);
-            assert.ok(stateNavigator.stateContext.crumbs[1].last);
+            assert.ok(stateNavigator.stateContext.crumbs[0].last);
         });
     });
 
@@ -1565,12 +1560,10 @@ describe('Navigation', function () {
             it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.crumbs.length, 2);
+                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
+                assert.equal(stateNavigator.stateContext.crumbs.length, 1);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.crumbs[1].state, stateNavigator.states['s1']);
-                assert.ok(!stateNavigator.stateContext.crumbs[0].last);
-                assert.ok(stateNavigator.stateContext.crumbs[1].last);
+                assert.ok(stateNavigator.stateContext.crumbs[0].last);
             });
         }
     });
@@ -1668,13 +1661,11 @@ describe('Navigation', function () {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s3']);
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
                 assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.crumbs.length, 3);
+                assert.equal(stateNavigator.stateContext.crumbs.length, 2);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
                 assert.equal(stateNavigator.stateContext.crumbs[1].state, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.crumbs[2].state, stateNavigator.states['s1']);
                 assert.ok(!stateNavigator.stateContext.crumbs[0].last);
-                assert.ok(!stateNavigator.stateContext.crumbs[1].last);
-                assert.ok(stateNavigator.stateContext.crumbs[2].last);
+                assert.ok(stateNavigator.stateContext.crumbs[1].last);
             });
         }
     });
@@ -4809,12 +4800,10 @@ describe('Navigation', function () {
             it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.crumbs.length, 2);
+                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
+                assert.equal(stateNavigator.stateContext.crumbs.length, 1);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.crumbs[1].state, stateNavigator.states['s1']);
-                assert.ok(!stateNavigator.stateContext.crumbs[0].last);
-                assert.ok(stateNavigator.stateContext.crumbs[1].last);
+                assert.ok(stateNavigator.stateContext.crumbs[0].last);
             });
         }
     });
@@ -4992,12 +4981,10 @@ describe('Navigation', function () {
             it('should populate context', function() {
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.crumbs.length, 2);
+                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
+                assert.equal(stateNavigator.stateContext.crumbs.length, 1);
                 assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.crumbs[1].state, stateNavigator.states['s1']);
-                assert.ok(!stateNavigator.stateContext.crumbs[0].last);
-                assert.ok(stateNavigator.stateContext.crumbs[1].last);
+                assert.ok(stateNavigator.stateContext.crumbs[0].last);
             });
         }
     });
@@ -5200,18 +5187,14 @@ describe('Navigation', function () {
                 assert.equal(stateNavigator1.stateContext.state, stateNavigator1.states['s3']);
                 assert.equal(stateNavigator0.stateContext.oldState, stateNavigator0.states['s1']);
                 assert.equal(stateNavigator1.stateContext.oldState, stateNavigator1.states['s3']);
-                assert.equal(stateNavigator0.stateContext.previousState, stateNavigator0.states['s1']);
-                assert.equal(stateNavigator1.stateContext.previousState, stateNavigator1.states['s3']);
-                assert.equal(stateNavigator0.stateContext.crumbs.length, 2);
+                assert.equal(stateNavigator0.stateContext.previousState, stateNavigator0.states['s0']);
+                assert.equal(stateNavigator1.stateContext.previousState, stateNavigator1.states['s2']);
+                assert.equal(stateNavigator0.stateContext.crumbs.length, 1);
                 assert.equal(stateNavigator0.stateContext.crumbs[0].state, stateNavigator0.states['s0']);
-                assert.equal(stateNavigator0.stateContext.crumbs[1].state, stateNavigator0.states['s1']);
-                assert.ok(!stateNavigator0.stateContext.crumbs[0].last);
-                assert.ok(stateNavigator0.stateContext.crumbs[1].last);
-                assert.equal(stateNavigator1.stateContext.crumbs.length, 2);
+                assert.ok(stateNavigator0.stateContext.crumbs[0].last);
+                assert.equal(stateNavigator1.stateContext.crumbs.length, 1);
                 assert.equal(stateNavigator1.stateContext.crumbs[0].state, stateNavigator1.states['s2']);
-                assert.equal(stateNavigator1.stateContext.crumbs[1].state, stateNavigator1.states['s3']);
-                assert.ok(!stateNavigator1.stateContext.crumbs[0].last);
-                assert.ok(stateNavigator1.stateContext.crumbs[1].last);
+                assert.ok(stateNavigator1.stateContext.crumbs[0].last);
             });
         }
     });
@@ -5595,12 +5578,10 @@ describe('Navigation', function () {
         
         function test() {
             it('should populate context', function() {
-                assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
+                assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s0']);
                 assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
-                assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-                assert.equal(stateNavigator.stateContext.crumbs.length, 1);
-                assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
-                assert.ok(stateNavigator.stateContext.crumbs[0].last);
+                assert.equal(stateNavigator.stateContext.previousState, null);
+                assert.equal(stateNavigator.stateContext.crumbs.length, 0);
             });
         }
     });
@@ -5619,15 +5600,13 @@ describe('Navigation', function () {
             stateNavigator.navigateLink(link);
             link = stateNavigator.getNavigationBackLink(1);
             stateNavigator.navigateLink(link);
-            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s1']);
-            assert.equal(stateNavigator.stateContext.hash, null);
+            assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s0']);
+            assert.equal(stateNavigator.stateContext.hash, 'f0');
             assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s1']);
             assert.equal(stateNavigator.stateContext.oldHash, 'f1');
-            assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-            assert.equal(stateNavigator.stateContext.previousHash, 'f0');
-            assert.equal(stateNavigator.stateContext.crumbs.length, 1);
-            assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
-            assert.ok(stateNavigator.stateContext.crumbs[0].last);
+            assert.equal(stateNavigator.stateContext.previousState, null);
+            assert.equal(stateNavigator.stateContext.previousHash, null);
+            assert.equal(stateNavigator.stateContext.crumbs.length, 0);
         });
     });
 

--- a/NavigationReact/test/RefreshLinkTest.tsx
+++ b/NavigationReact/test/RefreshLinkTest.tsx
@@ -2332,7 +2332,7 @@ describe('RefreshLinkTest', function () {
             var link = container.querySelector<HTMLAnchorElement>('a');
             assert.equal(link.hash, '#/r0?x=a');
             stateNavigator.navigate('s1', {y: 'b'});
-            assert.equal(link.hash, '#/r1?y=b&x=a&crumb=%2Fr0&crumb=%2Fr1%3Fy%3Db');
+            assert.equal(link.hash, '#/r1?y=b&x=a&crumb=%2Fr0');
         })
     });
 
@@ -2409,7 +2409,7 @@ describe('RefreshLinkTest', function () {
             var link = container.querySelector<HTMLAnchorElement>('a');
             assert.equal(link.hash, '');
             stateNavigator.navigate('s1');
-            assert.equal(link.hash, '#/r1?x=a&crumb=%2Fr0%3Fx%3Da&crumb=%2Fr1');
+            assert.equal(link.hash, '#/r1?x=a&crumb=%2Fr0%3Fx%3Da');
         })
     });
 
@@ -2589,19 +2589,16 @@ describe('RefreshLinkTest', function () {
             stateNavigator.navigate('s1', {y: 'b'});
             var link = container.querySelector<HTMLAnchorElement>('a');
             Simulate.click(link);
-            assert.equal(stateNavigator.stateContext.url, '/r0?z=c&crumb=%2Fr0%3Fx%3Da');
+            assert.equal(stateNavigator.stateContext.url, '/r0?z=c');
             assert.equal(stateNavigator.stateContext.state, stateNavigator.states['s0']);
             assert.equal(stateNavigator.stateContext.data.z, 'c');
             assert.equal(stateNavigator.stateContext.oldUrl, '/r0?x=a');
             assert.equal(stateNavigator.stateContext.oldState, stateNavigator.states['s0']);
             assert.equal(stateNavigator.stateContext.oldData.x, 'a');
-            assert.equal(stateNavigator.stateContext.previousUrl, '/r0?x=a');
-            assert.equal(stateNavigator.stateContext.previousState, stateNavigator.states['s0']);
-            assert.equal(stateNavigator.stateContext.previousData.x, 'a');
-            assert.equal(stateNavigator.stateContext.crumbs.length, 1);
-            assert.equal(stateNavigator.stateContext.crumbs[0].url, '/r0?x=a');
-            assert.equal(stateNavigator.stateContext.crumbs[0].state, stateNavigator.states['s0']);
-            assert.equal(stateNavigator.stateContext.crumbs[0].data.x, 'a');
+            assert.equal(stateNavigator.stateContext.previousUrl, null);
+            assert.equal(stateNavigator.stateContext.previousState, null);
+            assert.equal(stateNavigator.stateContext.previousData.x, undefined);
+            assert.equal(stateNavigator.stateContext.crumbs.length, 0);
         })
     });
 


### PR DESCRIPTION
Refreshing when on scene A used to create the stack A → A. So it stayed on the same `State` but it didn’t stay on the same scene.
```js
stateNavigator.navigate('A');
stateNavigator.refresh();
```
A while back I updated the docs and changed `State` to scene throughout. The [Current Data doc](https://grahammendick.github.io/navigation/documentation/current-data.html) says
>> You can build Hyperlinks that change data without changing scene using the RefreshLink component

So the behaviour never matched the docs. Decided the docs are right. Refresh navigation should stay on the same scene and not just the same `State`. So now refreshing when on scene A keeps the stack as A. Can still create the stack A → A by navigating to A instead of refreshing.
```js
stateNavigator.navigate('A');
stateNavigator.navigate('A');
```
Interactions within a scene on mobile and native web can use refresh navigation without having to use `truncateCrumbTrail` anymore. Take the colour changer on the 'details' scene of the zoom sample - used to have to `truncateCrumbTrail` to prevent two 'details' scenes in the stack. Refresh navigation handles this automatically.
