### PR TITLE
Smoothed navigation animation when new scene renders slowly

### DIFF
--- a/NavigationReactMobile/src/Motion.tsx
+++ b/NavigationReactMobile/src/Motion.tsx
@@ -47,7 +47,7 @@ class Motion<T> extends React.Component<MotionProps<T>, any> {
                 if (unchanged) {
                     nextItem.start = item.start;
                     nextItem.rest = item.progress === 1;
-                    var progressDelta = (nextItem.tick - item.tick) / duration;
+                    var progressDelta = Math.min(nextItem.tick - item.tick, 50) / duration;
                     nextItem.progress = Math.min(item.progress + progressDelta, 1);
                 } else {
                     nextItem.rest = false;


### PR DESCRIPTION
When navigating from A to B the animation would be jumpy if B takes a while to render. For example, if the animation duration is 300ms and B takes 150ms to render then the animation would start half way through.

Fixed by capping the time between ticks at 50ms. So even if B takes 150ms to render the animation will still start near the beginning. This matches the behaviour of native, where the transition animation pauses to allow time for the new scene to render. Only once the new scene has rendered does the transition begin.
