### PR TITLE
Prevented flash when opening Modal containing a NavigationStack (Android)

### DIFF
--- a/NavigationReactNative/sample/medley/Direction.js
+++ b/NavigationReactNative/sample/medley/Direction.js
@@ -60,6 +60,7 @@ export default ({direction, color}) => {
           <ModalBackHandler>
             {handleBack => (
               <Modal
+                transparent={true}
                 visible={modalVisible}
                 onRequestClose={() => {
                   if (!handleBack())
@@ -68,6 +69,7 @@ export default ({direction, color}) => {
                 <ModalContext.Provider value={() => setModalVisible(false)}>
                   <NavigationHandler stateNavigator={modalNavigator}>
                     <NavigationStack
+                      underlayColor="rgba(0,0,0,0)"
                       crumbStyle={(from, state) => state.getCrumbStyle(from)}
                       unmountStyle={(from, state) => state.getUnmountStyle(from)} />
                   </NavigationHandler>

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -4,7 +4,7 @@ import { Crumb, State } from 'navigation';
 import { NavigationContext, AsyncStateNavigator } from 'navigation-react';
 import PopSync from './PopSync';
 import Scene from './Scene';
-type NavigationStackProps = {stateNavigator: AsyncStateNavigator, title: (state: State, data: any) => string, crumbStyle: any, unmountStyle: any, hidesTabBar: any, sharedElement: any, underlayColor: string, renderScene: (state: State, data: any) => ReactNode};
+type NavigationStackProps = {stateNavigator: AsyncStateNavigator, underlayColor: string, title: (state: State, data: any) => string, crumbStyle: any, unmountStyle: any, hidesTabBar: any, sharedElement: any, renderScene: (state: State, data: any) => ReactNode};
 type NavigationStackState = {stateNavigator: AsyncStateNavigator, keys: string[], rest: boolean};
 
 class NavigationStack extends React.Component<NavigationStackProps, NavigationStackState> {
@@ -19,11 +19,11 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
         this.onRest = this.onRest.bind(this);
     }
     static defaultProps = {
+        underlayColor: '#000',
         unmountStyle: () => null,
         crumbStyle: () => null,
         hidesTabBar: () => false,
         sharedElement: () => null,
-        underlayColor: '#000'
     }
     static getDerivedStateFromProps({stateNavigator}: NavigationStackProps, {keys: prevKeys, stateNavigator: prevStateNavigator}: NavigationStackState) {
         if (stateNavigator === prevStateNavigator)
@@ -95,7 +95,7 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
     }
     render() {
         var {keys, rest} = this.state;
-        var {stateNavigator, unmountStyle, crumbStyle, hidesTabBar, title, underlayColor, renderScene} = this.props;
+        var {stateNavigator, underlayColor, unmountStyle, crumbStyle, hidesTabBar, title, renderScene} = this.props;
         var {crumbs, nextCrumb} = stateNavigator.stateContext;
         return (
             <NVNavigationStack

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -4,7 +4,7 @@ import { Crumb, State } from 'navigation';
 import { NavigationContext, AsyncStateNavigator } from 'navigation-react';
 import PopSync from './PopSync';
 import Scene from './Scene';
-type NavigationStackProps = {stateNavigator: AsyncStateNavigator, title: (state: State, data: any) => string, crumbStyle: any, unmountStyle: any, hidesTabBar: any, sharedElement: any, renderScene: (state: State, data: any) => ReactNode};
+type NavigationStackProps = {stateNavigator: AsyncStateNavigator, title: (state: State, data: any) => string, crumbStyle: any, unmountStyle: any, hidesTabBar: any, sharedElement: any, underlayColor: string, renderScene: (state: State, data: any) => ReactNode};
 type NavigationStackState = {stateNavigator: AsyncStateNavigator, keys: string[], rest: boolean};
 
 class NavigationStack extends React.Component<NavigationStackProps, NavigationStackState> {
@@ -22,7 +22,8 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
         unmountStyle: () => null,
         crumbStyle: () => null,
         hidesTabBar: () => false,
-        sharedElement: () => null
+        sharedElement: () => null,
+        underlayColor: '#000'
     }
     static getDerivedStateFromProps({stateNavigator}: NavigationStackProps, {keys: prevKeys, stateNavigator: prevStateNavigator}: NavigationStackState) {
         if (stateNavigator === prevStateNavigator)
@@ -94,13 +95,13 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
     }
     render() {
         var {keys, rest} = this.state;
-        var {stateNavigator, unmountStyle, crumbStyle, hidesTabBar, title, renderScene} = this.props;
+        var {stateNavigator, unmountStyle, crumbStyle, hidesTabBar, title, underlayColor, renderScene} = this.props;
         var {crumbs, nextCrumb} = stateNavigator.stateContext;
         return (
             <NVNavigationStack
                 ref={this.ref}
                 keys={keys}
-                style={styles.stack}
+                style={[styles.stack, {backgroundColor: underlayColor}]}
                 {...this.getAnimation()}
                 onWillNavigateBack={this.onWillNavigateBack}
                 onNavigateToTop={this.onNavigateToTop}
@@ -132,7 +133,6 @@ var NVNavigationStack = requireNativeComponent<any>('NVNavigationStack', null);
 const styles = StyleSheet.create({
     stack: {
         flex: 1,
-        backgroundColor: '#000',
     },
 });
 

--- a/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
+++ b/NavigationReactNative/test/node_modules/@types/navigation-react-native.d.ts
@@ -11,6 +11,10 @@ declare global {
  */
 export interface NavigationStackProps {
     /**
+     * The color of the background behind the Scenes
+     */
+    underlayColor?: string;
+    /**
      * A Scene's title
      */
     title?: (state: State, data: any) => string;

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -11,6 +11,10 @@ declare global {
  */
 export interface NavigationStackProps {
     /**
+     * The color of the background behind the Scenes
+     */
+    underlayColor?: string;
+    /**
      * A Scene's title
      */
     title?: (state: State, data: any) => string;


### PR DESCRIPTION
The `NavigationStack` background is briefly visible when opening a `Modal`. It was hard-coded to black which caused a flash.

Added an `underlayColor` prop to the `NavigationStack`. Setting this to a transparent color and the `Modal` to transparent prevents this flash.

```jsx
<Modal transparent={true}>
  <NavigationHandler stateNavigator={contactNavigator}>
    <NavigationStack underlayColor=”rgba(0,0,0,0)” />
  </NavigationHandler>
</Modal> 
```
Allowing the containing Scene to show through makes it feel more like a modal.
