### PR TITLE
Supported different durations per scene animation

### DIFF
--- a/NavigationReactMobile/src/Motion.tsx
+++ b/NavigationReactMobile/src/Motion.tsx
@@ -47,7 +47,7 @@ class Motion<T> extends React.Component<MotionProps<T>, any> {
                 if (unchanged) {
                     nextItem.start = item.start;
                     nextItem.rest = item.progress === 1;
-                    var progressDelta = Math.min(nextItem.tick - item.tick, 50) / duration;
+                    var progressDelta = Math.min(nextItem.tick - item.tick, 50) / (nextItem.end.duration ?? duration);
                     nextItem.progress = Math.min(item.progress + progressDelta, 1);
                 } else {
                     nextItem.rest = false;
@@ -75,7 +75,7 @@ class Motion<T> extends React.Component<MotionProps<T>, any> {
             .sort((a, b) => a.index !== b.index ? a.index - b.index : a.key.length - b.key.length);
         return {items, moving: items.filter(({rest}) => !rest).length !== 0};
     }
-    static areEqual(from = {}, to = {}) {
+    static areEqual({duration = 0, ...from} = {}, {duration: toDuration = 0, ...to} = {}) {
         if (Object.keys(from).length !== Object.keys(to).length)
             return false;
         for(var key in from) {
@@ -86,8 +86,10 @@ class Motion<T> extends React.Component<MotionProps<T>, any> {
     }
     static interpolateStyle({start, end, progress}) {
         var style = {};
-        for(var key in end)
-            style[key] = start[key] + (progress * (end[key] - start[key]));
+        for(var key in end) {
+            if (key !== 'duration')
+                style[key] = start[key] + (progress * (end[key] - start[key]));
+        }
         return style;
     }
     render() {

--- a/NavigationReactMobile/src/Motion.tsx
+++ b/NavigationReactMobile/src/Motion.tsx
@@ -89,9 +89,8 @@ class Motion<T> extends React.Component<MotionProps<T>, any> {
         for(var key in end) {
             if (key !== 'duration')
                 style[key] = start[key] + (progress * (end[key] - start[key]));
-            else
-                style[key] = end[key];
         }
+        style['duration'] = end['duration'];
         return style;
     }
     render() {

--- a/NavigationReactMobile/src/Motion.tsx
+++ b/NavigationReactMobile/src/Motion.tsx
@@ -47,7 +47,8 @@ class Motion<T> extends React.Component<MotionProps<T>, any> {
                 if (unchanged) {
                     nextItem.start = item.start;
                     nextItem.rest = item.progress === 1;
-                    var progressDelta = Math.min(nextItem.tick - item.tick, 50) / (nextItem.end.duration ?? duration);
+                    var itemDuration = nextItem.end.duration ?? duration;
+                    var progressDelta = itemDuration > 0 ? Math.min(nextItem.tick - item.tick, 50) / itemDuration : 1;
                     nextItem.progress = Math.min(item.progress + progressDelta, 1);
                 } else {
                     nextItem.rest = false;

--- a/NavigationReactMobile/src/Motion.tsx
+++ b/NavigationReactMobile/src/Motion.tsx
@@ -68,7 +68,7 @@ class Motion<T> extends React.Component<MotionProps<T>, any> {
                     var newItem: any = {key: getKey(item), data: item, tick, rest: false, index};
                     newItem.start = newItem.style = enter(item);
                     newItem.end = update(item);
-                    newItem.progress = Motion.areEqual(newItem.start, newItem.end) ? 1 : 0;
+                    newItem.progress = Motion.areEqual(newItem.start, newItem.end) ? 1 : progress;
                     return newItem;
                 })
             )

--- a/NavigationReactMobile/src/Motion.tsx
+++ b/NavigationReactMobile/src/Motion.tsx
@@ -89,6 +89,8 @@ class Motion<T> extends React.Component<MotionProps<T>, any> {
         for(var key in end) {
             if (key !== 'duration')
                 style[key] = start[key] + (progress * (end[key] - start[key]));
+            else
+                style[key] = end[key];
         }
         return style;
     }

--- a/NavigationReactMobile/src/Motion.tsx
+++ b/NavigationReactMobile/src/Motion.tsx
@@ -85,12 +85,12 @@ class Motion<T> extends React.Component<MotionProps<T>, any> {
         return true;
     }
     static interpolateStyle({start, end, progress}) {
-        var style = {};
+        var style: any = {};
         for(var key in end) {
             if (key !== 'duration')
                 style[key] = start[key] + (progress * (end[key] - start[key]));
         }
-        style['duration'] = end['duration'];
+        style.duration = end.duration;
         return style;
     }
     render() {

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -61,7 +61,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
         var style = typeof styleProp === 'function' ? styleProp(state, data, crumbs, nextState, nextData) : styleProp;
         return {...style, __marker: !mounted ? 1 : (mount ? 0 : -1)};
     }
-    static getRest(styles: MotionStyle[]) {
+    static getMotion(styles: MotionStyle[]) {
         var moving = false, mountMoving = false, mountDuration: number, mountProgress: number;
         for(var {rest, progress, data: {mount}, style: {duration}} of styles) {
             if (mount) {
@@ -87,7 +87,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
                     onRest={({key}) => this.clearScene(key)}
                     duration={duration}>
                     {styles => {
-                        var {rest, mountRest, mountDuration, mountProgress} = NavigationMotion.getRest(styles);
+                        var {rest, mountRest, mountDuration, mountProgress} = NavigationMotion.getMotion(styles);
                         return (
                             styles.map(({data: {key, state, data}, style: {__marker, duration, ...style}}) => {
                                 var crumb = +key.replace(/\++$/, '');

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -87,9 +87,9 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
                                     </Freeze>
                                 );
                             }).concat(
-                                mountMoving && sharedElementMotion && sharedElementMotion({
+                                sharedElementMotion && sharedElementMotion({
                                     key: 'sharedElements',
-                                    sharedElements: this.getSharedElements(),
+                                    sharedElements: mountMoving ? this.getSharedElements() : [],
                                     progress: styles[crumbs.length] && styles[crumbs.length].progress,
                                     duration,
                                 })

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -62,8 +62,9 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
         return {...style, __marker: !mounted ? 1 : (mount ? 0 : -1)};
     }
     getRest(styles: MotionStyle[]) {
-        var moving, mountMoving = false;
-        var mountDuration;
+        var moving = false;
+        var mountMoving = false;
+        var mountDuration: number;
         for(var {rest, data: {mount}, style: {duration}} of styles) {
             if (mount) {
                 mountMoving = !rest;

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -74,9 +74,14 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
                     onRest={({key}) => this.clearScene(key)}
                     duration={duration}>
                     {styles => {
-                        var {moving, mountMoving} = styles.reduce(({moving, mountMoving}, {rest, data: {mount}}) => (
-                            {moving: moving || !rest, mountMoving: !mount ? mountMoving : !rest}
-                        ), {moving: false, mountMoving: false})
+                        var {moving, mountMoving, mountDuration} = styles.reduce(
+                            ({moving, mountMoving, mountDuration}, {rest, data: {mount}, style: {duration}}) => (
+                                {
+                                    moving: moving || !rest,
+                                    mountMoving: !mount ? mountMoving : !rest,
+                                    mountDuration: !mount ? mountDuration : duration
+                                }
+                            ), {moving: false, mountMoving: false, mountDuration: 0});
                         return (
                             styles.map(({data: {key, state, data}, style: {__marker, duration, ...style}, rest: sceneRest}) => {
                                 var crumb = +key.replace(/\++$/, '');
@@ -91,7 +96,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
                                     key: 'sharedElements',
                                     sharedElements: mountMoving ? this.getSharedElements() : [],
                                     progress: styles[crumbs.length] && styles[crumbs.length].progress,
-                                    duration,
+                                    duration: mountDuration ?? duration,
                                 })
                             )
                         )}

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -90,7 +90,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
                     {styles => {
                         var {rest, mountRest, mountDuration} = NavigationMotion.getRest(styles);
                         return (
-                            styles.map(({data: {key, state, data}, style: {__marker, duration, ...style}, rest: sceneRest}) => {
+                            styles.map(({data: {key, state, data}, style: {__marker, duration, ...style}}) => {
                                 var crumb = +key.replace(/\++$/, '');
                                 var scene = <Scene crumb={crumb} rest={rest} renderScene={renderScene} />;
                                 return (

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -78,10 +78,10 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
                     onRest={({key}) => this.clearScene(key)}
                     duration={duration}>
                     {styles => (
-                        styles.map(({data: {key, state, data}, style: {__marker, ...style}}) => {
+                        styles.map(({data: {key, state, data}, style: {__marker, duration, ...style}, rest: sceneRest}) => {
                             var crumb = +key.replace(/\++$/, '');
-                            var {rest} = this.state;
-                            var scene = <Scene crumb={crumb} rest={rest} renderScene={renderScene} /> ;
+                            var rest = sceneRest && this.state.rest;
+                            var scene = <Scene crumb={crumb} rest={rest} renderScene={renderScene} />;
                             return (
                                 <Freeze key={key} enabled={rest && crumb < this.getScenes().length - 1}>
                                     {children(style, scene, key, crumbs.length === crumb, state, data)}

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -7,14 +7,14 @@ import SharedElementRegistry from './SharedElementRegistry';
 import withStateNavigator from './withStateNavigator';
 import Freeze from './Freeze';
 import { NavigationMotionProps } from './Props';
-type NavigationMotionState = {stateNavigator: StateNavigator, keys: string[], rest: boolean};
+type NavigationMotionState = {stateNavigator: StateNavigator, keys: string[]};
 type SceneContext = {key: string, state: State, data: any, url: string, crumbs: Crumb[], nextState: State, nextData: any, mount: boolean};
 
 class NavigationMotion extends React.Component<NavigationMotionProps, NavigationMotionState> {
     private sharedElementRegistry = new SharedElementRegistry();
     constructor(props: NavigationMotionProps) {
         super(props);
-        this.state = {stateNavigator: null, keys: [], rest: false};
+        this.state = {stateNavigator: null, keys: []};
     }
     static defaultProps = {
         duration: 300,
@@ -29,24 +29,20 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
         var keys = prevKeys.slice(0, currentKeys.length).concat(newKeys);
         if (prevKeys.length === keys.length && prevState !== state)
             keys[keys.length - 1] += '+';
-        return {keys, rest: false, stateNavigator};
+        return {keys, stateNavigator};
     }
     getSharedElements() {
         var {crumbs, oldUrl} = this.props.stateNavigator.stateContext;
-        if (oldUrl !== null && !this.state.rest) {
+        if (oldUrl !== null) {
             var oldScene = oldUrl.split('crumb=').length - 1;
             return this.sharedElementRegistry.getSharedElements(crumbs.length, oldScene);
         }
         return [];
     }
     clearScene(index) {
-        this.setState(({rest: prevRest}) => {
-            var scene = this.getScenes().filter(scene => scene.key === index)[0];
-            if (!scene)
-                this.sharedElementRegistry.unregisterSharedElement(index);
-            var rest = prevRest || (scene && scene.mount);
-            return (rest !== prevRest) ? {rest} : null;
-        });
+        var scene = this.getScenes().filter(scene => scene.key === index)[0];
+        if (!scene)
+            this.sharedElementRegistry.unregisterSharedElement(index);
     }
     getScenes(): SceneContext[]{
         var {stateNavigator} = this.props;

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -77,25 +77,29 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
                     leave={scene => this.getStyle(false, scene)}
                     onRest={({key}) => this.clearScene(key)}
                     duration={duration}>
-                    {styles => (
-                        styles.map(({data: {key, state, data}, style: {__marker, duration, ...style}, rest: sceneRest}) => {
-                            var crumb = +key.replace(/\++$/, '');
-                            var rest = sceneRest && this.state.rest;
-                            var scene = <Scene crumb={crumb} rest={rest} renderScene={renderScene} />;
-                            return (
-                                <Freeze key={key} enabled={rest && crumb < this.getScenes().length - 1}>
-                                    {children(style, scene, key, crumbs.length === crumb, state, data)}
-                                </Freeze>
-                            );
-                        }).concat(
-                            sharedElementMotion && sharedElementMotion({
-                                key: 'sharedElements',
-                                sharedElements: this.getSharedElements(),
-                                progress: styles[crumbs.length] && styles[crumbs.length].progress,
-                                duration,
-                            })
-                        )
-                    )}
+                    {styles => {
+                        var {moving, mountMoving} = styles.reduce(({moving, mountMoving}, {rest, data: {mount}}) => (
+                            {moving: moving || !rest, mountMoving: !mount ? mountMoving : !rest}
+                        ), {moving: false, mountMoving: false})
+                        return (
+                            styles.map(({data: {key, state, data}, style: {__marker, duration, ...style}, rest: sceneRest}) => {
+                                var crumb = +key.replace(/\++$/, '');
+                                var scene = <Scene crumb={crumb} rest={!moving} renderScene={renderScene} />;
+                                return (
+                                    <Freeze key={key} enabled={!moving && crumb < this.getScenes().length - 1}>
+                                        {children(style, scene, key, crumbs.length === crumb, state, data)}
+                                    </Freeze>
+                                );
+                            }).concat(
+                                mountMoving && sharedElementMotion && sharedElementMotion({
+                                    key: 'sharedElements',
+                                    sharedElements: this.getSharedElements(),
+                                    progress: styles[crumbs.length] && styles[crumbs.length].progress,
+                                    duration,
+                                })
+                            )
+                        )}
+                    }
                 </Motion>
             </SharedElementContext.Provider>
         );

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -61,7 +61,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
         var style = typeof styleProp === 'function' ? styleProp(state, data, crumbs, nextState, nextData) : styleProp;
         return {...style, __marker: !mounted ? 1 : (mount ? 0 : -1)};
     }
-    getRest(styles: MotionStyle[]) {
+    static getRest(styles: MotionStyle[]) {
         var moving = false;
         var mountMoving = false;
         var mountDuration: number;
@@ -88,7 +88,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
                     onRest={({key}) => this.clearScene(key)}
                     duration={duration}>
                     {styles => {
-                        var {rest, mountRest, mountDuration} = this.getRest(styles);
+                        var {rest, mountRest, mountDuration} = NavigationMotion.getRest(styles);
                         return (
                             styles.map(({data: {key, state, data}, style: {__marker, duration, ...style}, rest: sceneRest}) => {
                                 var crumb = +key.replace(/\++$/, '');

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -49,7 +49,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
         var {stateNavigator} = this.props;
         var {keys} = this.state;
         var {crumbs, nextCrumb, oldUrl} = stateNavigator.stateContext;
-        var backward = oldUrl && oldUrl.split('crumb=').length > crumbs.length;
+        var backward = oldUrl && oldUrl.split('crumb=').length > crumbs.length + 1;
         return crumbs.concat(nextCrumb).map(({state, data, url}, index, crumbsAndNext) => {
             var preCrumbs = crumbsAndNext.slice(0, index);
             var {state: nextState, data: nextData} = crumbsAndNext[index + 1] || {state: undefined, data: undefined};

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -62,17 +62,16 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
         return {...style, __marker: !mounted ? 1 : (mount ? 0 : -1)};
     }
     static getRest(styles: MotionStyle[]) {
-        var moving = false;
-        var mountMoving = false;
-        var mountDuration: number;
-        for(var {rest, data: {mount}, style: {duration}} of styles) {
+        var moving = false, mountMoving = false, mountDuration: number, mountProgress: number;
+        for(var {rest, progress, data: {mount}, style: {duration}} of styles) {
             if (mount) {
                 mountMoving = !rest;
                 mountDuration = duration;
+                mountProgress = progress;
             }
             moving = moving || !rest;
         }
-        return {rest: !moving, mountRest: !mountMoving, mountDuration};
+        return {rest: !moving, mountRest: !mountMoving, mountDuration, mountProgress};
     }
     render() {
         var {children, duration, renderScene, sharedElementMotion, stateNavigator} = this.props;
@@ -88,7 +87,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
                     onRest={({key}) => this.clearScene(key)}
                     duration={duration}>
                     {styles => {
-                        var {rest, mountRest, mountDuration} = NavigationMotion.getRest(styles);
+                        var {rest, mountRest, mountDuration, mountProgress} = NavigationMotion.getRest(styles);
                         return (
                             styles.map(({data: {key, state, data}, style: {__marker, duration, ...style}}) => {
                                 var crumb = +key.replace(/\++$/, '');
@@ -102,7 +101,7 @@ class NavigationMotion extends React.Component<NavigationMotionProps, Navigation
                                 sharedElementMotion && sharedElementMotion({
                                     key: 'sharedElements',
                                     sharedElements: !mountRest ? this.getSharedElements() : [],
-                                    progress: styles[crumbs.length] && styles[crumbs.length].progress,
+                                    progress: mountProgress,
                                     duration: mountDuration ?? duration,
                                 })
                             )

--- a/NavigationReactMobile/src/Props.ts
+++ b/NavigationReactMobile/src/Props.ts
@@ -13,7 +13,7 @@ interface MotionProps<T> {
     leave?: (item: T) => any;
     onRest?: (item: T) => void;
     progress?: number;
-    children: (items: {style: any, data: T, key: string, progress: number, start: any, end: any }[]) => ReactElement<any>[];
+    children: (items: {style: any, data: T, key: string, rest: boolean, progress: number, start: any, end: any }[]) => ReactElement<any>[];
 }
 
 interface SharedElementProps {


### PR DESCRIPTION
The `NavigationMotion` uses the duration passed in the style when animating to that position. For example, with a duration of 1000 in the `unmountedStyle` the unmounting animation will take a second to complete. 

Checked if all scenes are at rest before freezing and allowing current scene to update. Used to only check if the mount scene was at rest but this can over-render.  For example, if mount animation completes after 300ms and unmount after 800ms then, for the 500ms gap, the mount scene would keep rendering because it was at rest.

Here's how to make all animations of a Tweet scene take twice as long as animations of all other scenes,
```jsx
<NavigationMotion
  unmountedStyle={(state) => ({translate: 100, duration: state === tweet ? 600 : 300})}
  mountedStyle={(state) => ({translate: 0, duration: state === tweet ? 600 : 300})}
  crumbStyle={(state) => ({translate: -100, duration: state === tweet ? 600 : 300})}>
```

A scene can mount either when navigating forward to it for the first time, or when navigating back to revisit it. There’s a new `fromUnmounted` parameter passed to the `mountedStyle` prop to indicate the direction. Here's how to make the unmounted ←→ mounted animations take twice as long as the crumb ←→ remounted animations,
```jsx
<NavigationMotion
  unmountedStyle={{translate: 100, duration: 600}}
  mountedStyle={(state, data, crumbs, newState, newData, fromUnmounted) => (
    {translate: 0, duration: fromUnmounted ? 600 : 300}
  )}
  crumbStyle={{translate: -100, duration: 300}}>
```

Also fixed a couple of other bugs
1. Supported a duration of 0 for scene animation - if the duration is zero then set the progress to 1 (avoids the divide by 0)
2. Smoothed the animation of a delayed shared element render - if the shared element isn't rendered straight away then started its progress at the progress of the overall navigation. It was set at 0 which made it jump at the end to catch up

