### PR TITLE
Prevented blank screen when navigations and animations overlap

### DIFF
--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -32,11 +32,11 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
         if (!state)
             return {keys: []};
         var prevState = prevStateNavigator && prevStateNavigator.stateContext.state;
-        var currentKeys = crumbs.concat(nextCrumb).map((_, i) => `${counter}-${i}}`);
+        var currentKeys = crumbs.concat(nextCrumb).map((_, i) => `${counter}-${i}`);
         var newKeys = currentKeys.slice(prevKeys.length);
         var keys = prevKeys.slice(0, currentKeys.length).concat(newKeys);
         if (prevKeys.length === keys.length && prevState !== state)
-            keys[keys.length - 1] = `${counter}-${keys.length - 1}}`;
+            keys[keys.length - 1] = `${counter}-${keys.length - 1}`;
         return {keys, stateNavigator, rest: history, counter: (counter + 1) % 1000};
     }
     onWillNavigateBack({nativeEvent}) {

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -5,14 +5,14 @@ import { NavigationContext, AsyncStateNavigator } from 'navigation-react';
 import PopSync from './PopSync';
 import Scene from './Scene';
 type NavigationStackProps = {stateNavigator: AsyncStateNavigator, underlayColor: string, title: (state: State, data: any) => string, crumbStyle: any, unmountStyle: any, hidesTabBar: any, sharedElement: any, renderScene: (state: State, data: any) => ReactNode};
-type NavigationStackState = {stateNavigator: AsyncStateNavigator, keys: string[], rest: boolean};
+type NavigationStackState = {stateNavigator: AsyncStateNavigator, keys: string[], rest: boolean, counter: number};
 
 class NavigationStack extends React.Component<NavigationStackProps, NavigationStackState> {
     private ref: React.RefObject<View>;
     private resumeNavigation: () => void;
     constructor(props) {
         super(props);
-        this.state = {stateNavigator: null, keys: [], rest: true};
+        this.state = {stateNavigator: null, keys: [], rest: true, counter: 0};
         this.ref = React.createRef<View>();
         this.onWillNavigateBack = this.onWillNavigateBack.bind(this);
         this.onNavigateToTop = this.onNavigateToTop.bind(this);
@@ -25,19 +25,19 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
         hidesTabBar: () => false,
         sharedElement: () => null,
     }
-    static getDerivedStateFromProps({stateNavigator}: NavigationStackProps, {keys: prevKeys, stateNavigator: prevStateNavigator}: NavigationStackState) {
+    static getDerivedStateFromProps({stateNavigator}: NavigationStackProps, {keys: prevKeys, stateNavigator: prevStateNavigator, counter}: NavigationStackState) {
         if (stateNavigator === prevStateNavigator)
             return null;
         var {state, crumbs, nextCrumb, history} = stateNavigator.stateContext;
         if (!state)
             return {keys: []};
         var prevState = prevStateNavigator && prevStateNavigator.stateContext.state;
-        var currentKeys = crumbs.concat(nextCrumb).map((_, i) => '' + i);
+        var currentKeys = crumbs.concat(nextCrumb).map((_, i) => `${counter}-${i}}`);
         var newKeys = currentKeys.slice(prevKeys.length);
         var keys = prevKeys.slice(0, currentKeys.length).concat(newKeys);
         if (prevKeys.length === keys.length && prevState !== state)
-            keys[keys.length - 1] += '+';
-        return {keys, stateNavigator, rest: history};
+            keys[keys.length - 1] = `${counter}-${keys.length - 1}}`;
+        return {keys, stateNavigator, rest: history, counter: (counter + 1) % 1000};
     }
     onWillNavigateBack({nativeEvent}) {
         var {stateNavigator} = this.props;

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -134,8 +134,8 @@ class Scene extends React.Component<SceneProps, SceneState> {
         var freezable = rest && !!React.Suspense;
         var {crumbs} = stateNavigator.stateContext;
         var stateContext = navigationEvent?.stateNavigator?.stateContext;
-        var {state, data} = stateContext || crumbs[crumb] || {};
-        return (
+        var {state, data} = stateContext || crumbs[crumb];
+        return !!state && (
             <Freeze enabled={freezable && crumb < crumbs.length && navigationEvent
                 && (!stateContext['peek'] || stateContext['peek'] !== this.props.navigationEvent)}>
                 <NVScene

--- a/NavigationReactNative/src/ios/NVNavigationStackView.m
+++ b/NavigationReactNative/src/ios/NVNavigationStackView.m
@@ -115,7 +115,7 @@
 - (void)checkPeekability:(NSInteger)crumb
 {
     NVSceneView *scene;
-    if (crumb > 1 && self.keys.count > crumb - 1) {
+    if (crumb > 1) {
         scene = (NVSceneView *) [_scenes objectForKey:[self.keys objectAtIndex:crumb - 1]];
     }
     _navigationController.interactivePopGestureRecognizer.enabled = scene ? scene.subviews.count > 0 : YES;
@@ -134,7 +134,8 @@
 
 - (void)navigationController:(UINavigationController *)navigationController willShowViewController:(UIViewController *)viewController animated:(BOOL)animated
 {
-    NSInteger crumb = [((NVSceneView *) viewController.view).sceneKey intValue];
+    NSString *sceneKey = ((NVSceneView *) viewController.view).sceneKey;
+    NSInteger crumb = [[[sceneKey componentsSeparatedByString:@"-"] objectAtIndex:1] intValue];
     if (crumb < [self.keys count] - 1) {
         self.onWillNavigateBack(@{ @"crumb": @(crumb) });
     }

--- a/NavigationReactNative/src/ios/NVNavigationStackView.m
+++ b/NavigationReactNative/src/ios/NVNavigationStackView.m
@@ -115,7 +115,7 @@
 - (void)checkPeekability:(NSInteger)crumb
 {
     NVSceneView *scene;
-    if (crumb > 1) {
+    if (crumb > 1 && self.keys.count > crumb - 1) {
         scene = (NVSceneView *) [_scenes objectForKey:[self.keys objectAtIndex:crumb - 1]];
     }
     _navigationController.interactivePopGestureRecognizer.enabled = scene ? scene.subviews.count > 0 : YES;

--- a/NavigationReactNative/src/ios/NVNavigationStackView.m
+++ b/NavigationReactNative/src/ios/NVNavigationStackView.m
@@ -115,7 +115,7 @@
 - (void)checkPeekability:(NSInteger)crumb
 {
     NVSceneView *scene;
-    if (crumb > 1) {
+    if (crumb > 1 && self.keys.count > crumb - 1) {
         scene = (NVSceneView *) [_scenes objectForKey:[self.keys objectAtIndex:crumb - 1]];
     }
     _navigationController.interactivePopGestureRecognizer.enabled = scene ? scene.subviews.count > 0 : YES;
@@ -170,9 +170,11 @@
 
 - (BOOL)navigationBar:(UINavigationBar *)navigationBar shouldPopItem:(UINavigationItem *)item
 {
+    NVSceneView *scene;
     NSInteger crumb = [[navigationBar items] indexOfObject:item];
-    NVSceneView *scene = ((NVSceneView *) [self.viewControllers objectAtIndex:crumb - 1].view);
-    return scene.subviews.count > 0;
+    if (self.viewControllers.count > crumb - 1)
+        scene = ((NVSceneView *) [self.viewControllers objectAtIndex:crumb - 1].view);
+    return scene ? scene.subviews.count > 0 : YES;
 }
 
 @end


### PR DESCRIPTION
This is a redo of #584. Forgot that [iOS was relying on the old key format](https://github.com/grahammendick/navigation/blob/8ecee5b68e99afe03658a61595b6a36b860705bb/NavigationReactNative/src/ios/NVNavigationStackView.m#L137).

Take the scenario A → B. Inside A, there's a 4 second timer that navigates back to A.
```jsx
useEffect(() => {
  const timer = setInterval(() => {
    stateNavigator.navigate('A');
}, 4000);
  return () => clearInterval(timer);
})
```
Then click a button on B that navigates to A → B → C.

Time it right so that the button click happens just before the timer runs. So it first navigates back to A and then navigates to A → B → C. Then press back from C and scene B will be blank!

This happens because scenes were keyed by position, so scene B has the same key whenever it appears. When the animation back to A completes then scene B is popped. It should only pop the first scene B but it pops both B's because they share a key.

Fixed by giving scenes unique keys using a counter every that increments every navigation. So the first set of keys are 0-0 → 1-1 then when navigate back to A the counter increments and when navigate to C it increments again and gives 0-0 → 3–1 → 3-2. When animation back to A completes then scene 1-1 (first B) pops. When going back to second B it's not blank anymore because it's still there in React.

Note, that on the old MacBook Air the error happened but it didn't on the M1 MacBook. It was just too fast. So created fake slowdowns after each navigation to force the backup and then it failed on the M1 MacBook, too. For example,
```jsx
stateNavigator.navigate('A');
const date = Date.now();
let currentDate = null;
do {
  currentDate = Date.now();
} while (currentDate - date < 1000);
```
