### PR TITLE
Re-rendered a refreshed current Scene whenever the NavigationStack re-renders

### DIFF
--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -37,7 +37,8 @@ class NavigationStack extends React.Component<NavigationStackProps, NavigationSt
         var keys = prevKeys.slice(0, currentKeys.length).concat(newKeys);
         if (prevKeys.length === keys.length && prevState !== state)
             keys[keys.length - 1] = `${counter}-${keys.length - 1}`;
-        return {keys, stateNavigator, rest: history, counter: (counter + 1) % 1000};
+        const refresh = prevKeys.length === keys.length && prevState === state;
+        return {keys, stateNavigator, rest: history || refresh, counter: (counter + 1) % 1000};
     }
     onWillNavigateBack({nativeEvent}) {
         var {stateNavigator} = this.props;


### PR DESCRIPTION
After #556, re-rendering the `NavigationStack` should re-render the current scene. But after a refresh navigation this wasn’t working. After a refresh no animation happens so `onRest` wasn't called. Without setting `rest` to true the current scene won’t re-render.

So detected a refresh navigation and immediately set `rest` to true instead.
