### PR TITLE
Prevented crumb animation when replacing screnes (Android)

### DIFF
--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -143,10 +143,9 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
             int popEnter = getAnimationResourceId(currentActivity, scene.enterAnim, android.R.attr.activityCloseEnterAnimation);
             int popExit = getAnimationResourceId(currentActivity, scene.exitAnim, android.R.attr.activityCloseExitAnimation);
             FragmentManager fragmentManager = fragment.getChildFragmentManager();
-            fragmentManager.popBackStack();
             FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
             fragmentTransaction.setCustomAnimations(enter, exit, popEnter, popExit);
-            fragmentTransaction.add(getId(), new SceneFragment(scene, null), key);
+            fragmentTransaction.replace(getId(), new SceneFragment(scene, null), key);
             fragmentTransaction.addToBackStack(String.valueOf(crumb));
             fragmentTransaction.commit();
         }


### PR DESCRIPTION
When navigating from A → B → C to A → B → D then would see B's crumb animation. Then when navigating from D back to B no animation would happen (because it had already run).

Changed Fragment navigation from `popBackStack/add` combination to `replace`. Seems obvious that `replace` is the right choice but, [looking back](https://github.com/grahammendick/navigation/commit/0a4c361d79c9ab7ea43f00f8661ffd3bb5cfc4b8), it seems that replace wasn't working properly. Would see B animating in the background. But have tested again and replace now only animates C and D.
