### PR TITLE
Survived live/reload when React Native may rerun useMemo and recreate state navigators

### DIFF
--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -86,12 +86,11 @@ const NavigationMotion = ({unmountedStyle, mountedStyle, crumbStyle, duration = 
         }
         return {rest: !moving, mountRest: !mountMoving, mountDuration, mountProgress};
     }
-    const {keys: prevKeys, stateNavigator: prevStateNavigator} = motionState;
-    if (prevStateNavigator !== stateNavigator) {
+    const {stateNavigator: prevStateNavigator} = motionState;
+    if (prevStateNavigator !== stateNavigator && stateNavigator.stateContext.state) {
         setMotionState((prevStackState) => {
+            const {keys: prevKeys, stateNavigator: prevStateNavigator} = prevStackState;
             const {state, crumbs, nextCrumb} = stateNavigator.stateContext;
-            if (!state)
-                return {...prevStackState, stateNavigator, keys: []};
             const prevState = prevStateNavigator && prevStateNavigator.stateContext.state;
             const currentKeys = crumbs.concat(nextCrumb).map((_, i) => '' + i);
             const newKeys = currentKeys.slice(prevKeys.length);

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -92,12 +92,10 @@ const NavigationStack = ({underlayColor = '#000', title, crumbStyle = () => null
         return {enterAnim, exitAnim, sharedElement, oldSharedElement};
     }
     const {stateNavigator: prevStateNavigator, keys, rest} = stackState;
-    if (prevStateNavigator !== stateNavigator) {
+    if (prevStateNavigator !== stateNavigator && stateNavigator.stateContext.state) {
         setStackState((prevStackState) => {
             const {keys: prevKeys, stateNavigator: prevStateNavigator, counter} = prevStackState;
             const {state, crumbs, nextCrumb, history} = stateNavigator.stateContext;
-            if (!state)
-                return {...prevStackState, stateNavigator, keys: []};
             const prevState = prevStateNavigator && prevStateNavigator.stateContext.state;
             const currentKeys = crumbs.concat(nextCrumb).map((_, i) => `${counter}-${i}`);
             const newKeys = currentKeys.slice(prevKeys.length);


### PR DESCRIPTION
When live editing the `Tabs` component in the native Twitter sample, React Native reruns the memos and recreates the state navigators for the tabs. This temporarily reset the keys to `[]` because the state context is empty. Then clicking a tweet throws an error when the `NavigationStack` tries to navigate back to 0.
```jsx
useMemo(() => new StateNavigator(stateNavigator), []);
```
This has come in with the new component api because the initial navigation doesn't happen until the `useEffect` runs. Changed to ignore an empty state context. This only happens in live/reload and only the first one (must be a timing thing, think subsequent live/reloads process the click fast enough that keys is never empty?!)