### PR TITLE
Documented setup for the new React Native Architecture (Fabric)

### DIFF
--- a/css/prism.css
+++ b/css/prism.css
@@ -109,5 +109,5 @@ pre[class*="language-"] {
 }
 .diff {
 	background-color: rgb(218, 251, 225);
-    color: rgb(17, 99, 41);	
+	color: rgb(17, 99, 41);	
 }

--- a/css/prism.css
+++ b/css/prism.css
@@ -107,3 +107,7 @@ pre[class*="language-"] {
 .token.entity {
 	cursor: help;
 }
+.diff {
+	background-color: rgb(218, 251, 225);
+    color: rgb(17, 99, 41);	
+}

--- a/documentation/native/floating-action-button.html
+++ b/documentation/native/floating-action-button.html
@@ -67,20 +67,18 @@
             <p>
                 If you anchor the <code>FloatingActionButton</code> to another component then they will move in tandem. When the user opens an email in our example application, we anchor the floating compose button to the contact details <a href="bottom-sheet.html"><code>BottomSheet</code></a>. This prevents the sheet from obscuring the compose button. When the user expands the sheet to see the contact information then the compose button moves up, too.
             </p>
-            <pre><code class="language-jsx">const [anchor, setAnchor] = useState(null);
-
-&lt;CoordinatorLayout>
-  &lt;FloatingActionButton anchor={anchor} />
-  &lt;BottomSheet ref={(ref) => setAnchor(findNodeHandle(ref))} />
+            <pre><code class="language-jsx">&lt;CoordinatorLayout>
+  &lt;FloatingActionButton anchor="bottomSheet" />
+  &lt;BottomSheet />
 &lt;/CoordinatorLayout></code></pre>
             <h2>Cradling a Floating Action Button</h2>
             <p>
                 When a <code>FloatingActionButton</code> is anchored to a bottom <code>NavigationBar</code>, then the navigation bar changes its shape. It creates a cradle for the floating action button to nestle into. You create a bottom <code>NavigationBar</code> by setting the <code>bottomBar</code> prop to true. Any scrollable content that sits above a bottom navigation bar has to be padded to make room. Unless you make the bottom navigation bar scroll out of the way by setting its <code>hideOnScroll</code> prop to true.
             </p>
             <pre><code class="language-jsx">&lt;CoordinatorLayout>
-  &lt;FloatingActionButton anchor={anchor} />
+  &lt;FloatingActionButton anchor="bottomNavigationBar" />
   &lt;ScrollView nestedScrollEnabled={true} contentContainerStyle={{paddingBottom: 56}} />
-  &lt;NavigationBar bottomBar={true} ref={(ref) => setAnchor(findNodeHandle(ref))} />
+  &lt;NavigationBar bottomBar={true} />
 &lt;/CoordinatorLayout></code></pre>
             <h2>Extending a Floating Action Button</h2>
             <p>

--- a/documentation/native/setup.html
+++ b/documentation/native/setup.html
@@ -78,6 +78,9 @@ const App = () => (
 );
 
 export default App;</code></pre>
+              <p>
+                  That's all the setup you need in the current React Native architecture. The next section goes through the setup for the new architecture (Fabric).
+              </p>
               <h2>The New Architecture (Fabric)</h2>
               <p>
                   The Navigation router supports the new React Native architecture. 

--- a/documentation/native/setup.html
+++ b/documentation/native/setup.html
@@ -98,29 +98,29 @@ libreact_debug \
 </code></pre>
               <pre><code class="language-xxx">// providerRegistry->add(concreteComponentDescriptorProvider<
 //        AocViewerComponentDescriptor>());
-<span class="diff">providerRegistry->add(concreteComponentDescriptorProvider<NVActionBarComponentDescriptor>());
-providerRegistry->add(concreteComponentDescriptorProvider<NVBarButtonComponentDescriptor>());
-providerRegistry->add(concreteComponentDescriptorProvider<NVBottomAppBarComponentDescriptor>());
-providerRegistry->add(concreteComponentDescriptorProvider<NVBottomSheetComponentDescriptor>());
-providerRegistry->add(concreteComponentDescriptorProvider<NVCollapsingBarComponentDescriptor>());
-providerRegistry->add(concreteComponentDescriptorProvider<NVCoordinatorLayoutComponentDescriptor>());
-providerRegistry->add(concreteComponentDescriptorProvider<NVExtendedFloatingActionButtonComponentDescriptor>());
-providerRegistry->add(concreteComponentDescriptorProvider<NVFloatingActionButtonComponentDescriptor>());
-providerRegistry->add(concreteComponentDescriptorProvider<NVNavigationBarComponentDescriptor>());
-providerRegistry->add(concreteComponentDescriptorProvider<NVNavigationStackComponentDescriptor>());
-providerRegistry->add(concreteComponentDescriptorProvider<NVSceneComponentDescriptor>());
-providerRegistry->add(concreteComponentDescriptorProvider<NVSearchBarComponentDescriptor>());
-providerRegistry->add(concreteComponentDescriptorProvider<NVSharedElementComponentDescriptor>());
-providerRegistry->add(concreteComponentDescriptorProvider<NVStatusBarComponentDescriptor>());
-providerRegistry->add(concreteComponentDescriptorProvider<NVTabBarItemComponentDescriptor>());
-providerRegistry->add(concreteComponentDescriptorProvider<NVTabBarComponentDescriptor>());
-providerRegistry->add(concreteComponentDescriptorProvider<NVTabBarPagerComponentDescriptor>());
-providerRegistry->add(concreteComponentDescriptorProvider<NVTabBarPagerRTLComponentDescriptor>());
-providerRegistry->add(concreteComponentDescriptorProvider<NVTabLayoutComponentDescriptor>());
-providerRegistry->add(concreteComponentDescriptorProvider<NVTabLayoutRTLComponentDescriptor>());
-providerRegistry->add(concreteComponentDescriptorProvider<NVTabNavigationComponentDescriptor>());
-providerRegistry->add(concreteComponentDescriptorProvider<NVTitleBarComponentDescriptor>());
-providerRegistry->add(concreteComponentDescriptorProvider<NVToolbarComponentDescriptor>());</span>
+<span class="diff">providerRegistry->add(concreteComponentDescriptorProvider&lt;NVActionBarComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider&lt;NVBarButtonComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider&lt;NVBottomAppBarComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider&lt;NVBottomSheetComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider&lt;NVCollapsingBarComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider&lt;NVCoordinatorLayoutComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider&lt;NVExtendedFloatingActionButtonComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider&lt;NVFloatingActionButtonComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider&lt;NVNavigationBarComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider&lt;NVNavigationStackComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider&lt;NVSceneComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider&lt;NVSearchBarComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider&lt;NVSharedElementComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider&lt;NVStatusBarComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider&lt;NVTabBarItemComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider&lt;NVTabBarComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider&lt;NVTabBarPagerComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider&lt;NVTabBarPagerRTLComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider&lt;NVTabLayoutComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider&lt;NVTabLayoutRTLComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider&lt;NVTabNavigationComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider&lt;NVTitleBarComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider&lt;NVToolbarComponentDescriptor>());</span>
 return providerRegistry;
 </code></pre>
           </div>

--- a/documentation/native/setup.html
+++ b/documentation/native/setup.html
@@ -79,10 +79,11 @@ const App = () => (
 
 export default App;</code></pre>
               <h2>The New Architecture (Fabric)</h2>
-              <pre><code class="language-js">cd ios && RCT_NEW_ARCH_ENABLED=1 pod install && cd ..</code></pre>
-              <pre><code class="language-xxx"># to write custom TurboModules/Fabric components OR use libraries that
-# are providing them.
-newArchEnabled=<span class="diff">true</span></code></pre>
+              <p>
+                <code>cd ios && RCT_NEW_ARCH_ENABLED=1 pod install && cd ..</code>
+                <code>newArchEnabled=true</code>
+              </p>
+              <h3>Autolinking on Android</h3>
               <pre><code class="language-xxx">    "REACT_ANDROID_BUILD_DIR=$rootDir/../node_modules/react-native/ReactAndroid/build"<span class="diff">,</span>
     <span class="diff">"NODE_MODULES_DIR=$rootDir/../node_modules"</span>
 cFlags "-Wall", "-Werror", "-fexceptions", "-frtti", "-DWITH_INSPECTOR=1"

--- a/documentation/native/setup.html
+++ b/documentation/native/setup.html
@@ -80,6 +80,9 @@ const App = () => (
 export default App;</code></pre>
               <h2>The New Architecture (Fabric)</h2>
               <pre><code class="language-js">cd ios && RCT_NEW_ARCH_ENABLED=1 pod install && cd ..</code></pre>
+              <pre><code class="language-xxx"># to write custom TurboModules/Fabric components OR use libraries that
+# are providing them.
+newArchEnabled=<span class="diff">true</span></code></pre>
               <pre><code class="language-xxx">    "REACT_ANDROID_BUILD_DIR=$rootDir/../node_modules/react-native/ReactAndroid/build"<span class="diff">,</span>
     <span class="diff">"NODE_MODULES_DIR=$rootDir/../node_modules"</span>
 cFlags "-Wall", "-Werror", "-fexceptions", "-frtti", "-DWITH_INSPECTOR=1"

--- a/documentation/native/setup.html
+++ b/documentation/native/setup.html
@@ -80,27 +80,35 @@ const App = () => (
 export default App;</code></pre>
               <h2>The New Architecture (Fabric)</h2>
               <p>
-                <code>cd ios && RCT_NEW_ARCH_ENABLED=1 pod install && cd ..</code>
-                <code>newArchEnabled=true</code>
+                  The Navigation router supports the new React Native architecture. 
+                  Enable it on Android by setting <code>newArchEnabled=true</code> in the <code>android/gradle.properties</code> file. Enable it on iOS by running <code>cd ios && RCT_NEW_ARCH_ENABLED=1 pod install && cd ..</code>
               </p>
               <h3>Autolinking on Android</h3>
+              <p>
+                  Currently React Native doesn't autolink 3rd party libraries on Android. The following steps go through how to manually link the <code>navigation-react-native</code> package.
+              </p>
+              <p>Update the <code>android/app/build.gradle</code> file (note the additional trailing comma on the preceding line).</p>
               <pre><code class="language-xxx">    "REACT_ANDROID_BUILD_DIR=$rootDir/../node_modules/react-native/ReactAndroid/build"<span class="diff">,</span>
     <span class="diff">"NODE_MODULES_DIR=$rootDir/../node_modules"</span>
 cFlags "-Wall", "-Werror", "-fexceptions", "-frtti", "-DWITH_INSPECTOR=1"
 </code></pre>
+              <p>Add a line to the <code>android/app/src/main/jni/Android.mk</code> file.</p>
               <pre><code class="language-xxx"># include $(GENERATED_SRC_DIR)/codegen/jni/Android.mk
 <span class="diff">include $(NODE_MODULES_DIR)/navigation-react-native/android/build/generated/source/codegen/jni/Android.mk</span>
 include $(CLEAR_VARS)
 </code></pre>
+              <p>Add another line to <code>android/app/src/main/jni/Android.mk</code>.</p>
               <pre><code class="language-xxx">libreact_codegen_rncore \
 <span class="diff">libreact_codegen_navigation-react-native \</span>
 libreact_debug \
 </code></pre>
+              <p>Add a line to the <code>android/app/src/main/jni/MainComponentsRegistry.cpp</code> file.</p>
               <pre><code class="language-xxx">#include &lt;react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
 <span class="diff">#include &lt;react/renderer/components/navigation-react-native/ComponentDescriptors.h></span>
 #include &lt;react/renderer/components/rncore/ComponentDescriptors.h>
 </code></pre>
-              <pre><code class="language-xxx">// providerRegistry->add(concreteComponentDescriptorProvider<
+              <p>And these other lines to <code>android/app/src/main/jni/MainComponentsRegistry.cpp</code>. One for each component.</p>
+              <pre><code class="language-xxx">// providerRegistry->add(concreteComponentDescriptorProvider&lt;
 //        AocViewerComponentDescriptor>());
 <span class="diff">providerRegistry->add(concreteComponentDescriptorProvider&lt;NVActionBarComponentDescriptor>());
 providerRegistry->add(concreteComponentDescriptorProvider&lt;NVBarButtonComponentDescriptor>());

--- a/documentation/native/setup.html
+++ b/documentation/native/setup.html
@@ -87,7 +87,7 @@ export default App;</code></pre>
               <p>
                   Currently React Native Fabric doesn't autolink 3rd party libraries on Android. The following steps go through how to manually link the <code>navigation-react-native</code> package. These steps are only needed on the new architecture.
               </p>
-              <p>Update the <code>android/app/build.gradle</code> file (note the additional trailing comma on the first line).</p>
+              <p>Update the <code>android/app/build.gradle</code> file (note the trailing comma on the first line).</p>
               <pre><code class="language-xxx">    "REACT_ANDROID_BUILD_DIR=$rootDir/../node_modules/react-native/ReactAndroid/build"<span class="diff">,</span>
     <span class="diff">"NODE_MODULES_DIR=$rootDir/../node_modules"</span>
 cFlags "-Wall", "-Werror", "-fexceptions", "-frtti", "-DWITH_INSPECTOR=1"

--- a/documentation/native/setup.html
+++ b/documentation/native/setup.html
@@ -78,6 +78,51 @@ const App = () => (
 );
 
 export default App;</code></pre>
+              <h2>The New Architecture (Fabric)</h2>
+              <pre><code class="language-js">cd ios && RCT_NEW_ARCH_ENABLED=1 pod install && cd ..</code></pre>
+              <pre><code class="language-xxx">    "REACT_ANDROID_BUILD_DIR=$rootDir/../node_modules/react-native/ReactAndroid/build"<span class="diff">,</span>
+    <span class="diff">"NODE_MODULES_DIR=$rootDir/../node_modules"</span>
+cFlags "-Wall", "-Werror", "-fexceptions", "-frtti", "-DWITH_INSPECTOR=1"
+</code></pre>
+              <pre><code class="language-xxx"># include $(GENERATED_SRC_DIR)/codegen/jni/Android.mk
+<span class="diff">include $(NODE_MODULES_DIR)/navigation-react-native/android/build/generated/source/codegen/jni/Android.mk</span>
+include $(CLEAR_VARS)
+</code></pre>
+              <pre><code class="language-xxx">libreact_codegen_rncore \
+<span class="diff">libreact_codegen_navigation-react-native \</span>
+libreact_debug \
+</code></pre>
+              <pre><code class="language-xxx">#include &lt;react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
+<span class="diff">#include &lt;react/renderer/components/navigation-react-native/ComponentDescriptors.h></span>
+#include &lt;react/renderer/components/rncore/ComponentDescriptors.h>
+</code></pre>
+              <pre><code class="language-xxx">// providerRegistry->add(concreteComponentDescriptorProvider<
+//        AocViewerComponentDescriptor>());
+<span class="diff">providerRegistry->add(concreteComponentDescriptorProvider<NVActionBarComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider<NVBarButtonComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider<NVBottomAppBarComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider<NVBottomSheetComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider<NVCollapsingBarComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider<NVCoordinatorLayoutComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider<NVExtendedFloatingActionButtonComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider<NVFloatingActionButtonComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider<NVNavigationBarComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider<NVNavigationStackComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider<NVSceneComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider<NVSearchBarComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider<NVSharedElementComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider<NVStatusBarComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider<NVTabBarItemComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider<NVTabBarComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider<NVTabBarPagerComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider<NVTabBarPagerRTLComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider<NVTabLayoutComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider<NVTabLayoutRTLComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider<NVTabNavigationComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider<NVTitleBarComponentDescriptor>());
+providerRegistry->add(concreteComponentDescriptorProvider<NVToolbarComponentDescriptor>());</span>
+return providerRegistry;
+</code></pre>
           </div>
     </div>
     <script type="text/javascript" src="../../js/prism.js"></script>

--- a/documentation/native/setup.html
+++ b/documentation/native/setup.html
@@ -85,7 +85,7 @@ export default App;</code></pre>
               </p>
               <h3>Autolinking on Android</h3>
               <p>
-                  Currently React Native doesn't autolink 3rd party libraries on Android. The following steps go through how to manually link the <code>navigation-react-native</code> package.
+                  Currently React Native Fabric doesn't autolink 3rd party libraries on Android. The following steps go through how to manually link the <code>navigation-react-native</code> package. These steps are only needed on the new architecture.
               </p>
               <p>Update the <code>android/app/build.gradle</code> file (note the additional trailing comma on the preceding line).</p>
               <pre><code class="language-xxx">    "REACT_ANDROID_BUILD_DIR=$rootDir/../node_modules/react-native/ReactAndroid/build"<span class="diff">,</span>

--- a/documentation/native/setup.html
+++ b/documentation/native/setup.html
@@ -87,7 +87,7 @@ export default App;</code></pre>
               <p>
                   Currently React Native Fabric doesn't autolink 3rd party libraries on Android. The following steps go through how to manually link the <code>navigation-react-native</code> package. These steps are only needed on the new architecture.
               </p>
-              <p>Update the <code>android/app/build.gradle</code> file (note the additional trailing comma on the preceding line).</p>
+              <p>Update the <code>android/app/build.gradle</code> file (note the additional trailing comma on the first line).</p>
               <pre><code class="language-xxx">    "REACT_ANDROID_BUILD_DIR=$rootDir/../node_modules/react-native/ReactAndroid/build"<span class="diff">,</span>
     <span class="diff">"NODE_MODULES_DIR=$rootDir/../node_modules"</span>
 cFlags "-Wall", "-Werror", "-fexceptions", "-frtti", "-DWITH_INSPECTOR=1"


### PR DESCRIPTION
And updated FAB anchoring to use strings instead of `findNodeHandle` so it works in both old and new architecture.