### PR TITLE
Updated navigation dependencies to bring in the component api

### DIFF
--- a/NavigationReact/sample/app.html
+++ b/NavigationReact/sample/app.html
@@ -115,8 +115,8 @@
 
         ReactDOM.render(
             <NavigationHandler stateNavigator={stateNavigator}>
-                <SceneView stateKey="people"><List /></SceneView>
-                <SceneView stateKey="person"><Details /></SceneView>
+                <SceneView active="people"><List /></SceneView>
+                <SceneView active="person"><Details /></SceneView>
             </NavigationHandler>,
           document.getElementById('root')
         );

--- a/NavigationReactMobile/sample/twitter/package-lock.json
+++ b/NavigationReactMobile/sample/twitter/package-lock.json
@@ -2638,18 +2638,18 @@
       "integrity": "sha512-sp4/KqRRcd8XMKNtMbRfUiwOZqi5eJTC8pSJxkbTYj3CKhyNo37OpJlZVtOsfckdSdQP4Utl7+NUXQPwdJzZfA=="
     },
     "node_modules/navigation-react": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/navigation-react/-/navigation-react-4.0.0.tgz",
-      "integrity": "sha512-CqC67BtTFd6cvLfYb5Nj22vYsnwHix7Wj7Aj4+VzKB+hD81T4QsLiYKGZXY8QUtBL+C2w0UsLk7a6pCfT+zf3A==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/navigation-react/-/navigation-react-4.5.0.tgz",
+      "integrity": "sha512-EF7UmOqcR9GpjgPV7PjUOXhj55sNfvOAGnPXUO9nGTS7rtXHvUj93u83pGUgN7oZWBelFS/UX91okWps2CUPgw==",
       "peerDependencies": {
         "navigation": "*",
         "react": "*"
       }
     },
     "node_modules/navigation-react-mobile": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/navigation-react-mobile/-/navigation-react-mobile-3.6.0.tgz",
-      "integrity": "sha512-ZDCYmUvtRaoNe7PEJ+3K5lv3GshkveNZ+Ma2M5XLGfERBBvNr1aUIP0fPJNqgMMGo56c0nprO1NWhYM4hZY5vg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/navigation-react-mobile/-/navigation-react-mobile-3.8.0.tgz",
+      "integrity": "sha512-qF3+HhZZIxwaEtIMNQUWtqjRCxLy+28KPJhiy9Zj9AYI+mo8H+lj7g2OIdqpWPqQQQu0pcRG0DNn5yQLAonENQ==",
       "peerDependencies": {
         "navigation": "*",
         "navigation-react": "*",
@@ -5569,15 +5569,15 @@
       "integrity": "sha512-sp4/KqRRcd8XMKNtMbRfUiwOZqi5eJTC8pSJxkbTYj3CKhyNo37OpJlZVtOsfckdSdQP4Utl7+NUXQPwdJzZfA=="
     },
     "navigation-react": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/navigation-react/-/navigation-react-4.0.0.tgz",
-      "integrity": "sha512-CqC67BtTFd6cvLfYb5Nj22vYsnwHix7Wj7Aj4+VzKB+hD81T4QsLiYKGZXY8QUtBL+C2w0UsLk7a6pCfT+zf3A==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/navigation-react/-/navigation-react-4.5.0.tgz",
+      "integrity": "sha512-EF7UmOqcR9GpjgPV7PjUOXhj55sNfvOAGnPXUO9nGTS7rtXHvUj93u83pGUgN7oZWBelFS/UX91okWps2CUPgw==",
       "requires": {}
     },
     "navigation-react-mobile": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/navigation-react-mobile/-/navigation-react-mobile-3.6.0.tgz",
-      "integrity": "sha512-ZDCYmUvtRaoNe7PEJ+3K5lv3GshkveNZ+Ma2M5XLGfERBBvNr1aUIP0fPJNqgMMGo56c0nprO1NWhYM4hZY5vg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/navigation-react-mobile/-/navigation-react-mobile-3.8.0.tgz",
+      "integrity": "sha512-qF3+HhZZIxwaEtIMNQUWtqjRCxLy+28KPJhiy9Zj9AYI+mo8H+lj7g2OIdqpWPqQQQu0pcRG0DNn5yQLAonENQ==",
       "requires": {}
     },
     "node-libs-browser": {

--- a/NavigationReactNative/sample/twitter/ios/Podfile.lock
+++ b/NavigationReactNative/sample/twitter/ios/Podfile.lock
@@ -58,7 +58,7 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - glog (0.3.5)
   - libevent (2.1.12)
-  - navigation-react-native (8.1.1):
+  - navigation-react-native (8.9.0):
     - React-Core
   - OpenSSL-Universal (1.1.180)
   - RCT-Folly (2020.01.13.00):
@@ -464,7 +464,7 @@ SPEC CHECKSUMS:
   FlipperKit: 8a20b5c5fcf9436cac58551dc049867247f64b00
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  navigation-react-native: 45357e77573e1bd3da048d92dd908832e23aedb0
+  navigation-react-native: c05ced550ca8d1027512a490d316d08460f5fedc
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: ec2ebc96b7bfba3ca5c32740f5a0c6a014a274d2
@@ -492,6 +492,6 @@ SPEC CHECKSUMS:
   Yoga: a7de31c64fe738607e7a3803e3f591a4b1df7393
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 441ec4570026291b569e86528ede4d4421393662
+PODFILE CHECKSUM: 9242c130c7fcac5adbaa205c21db9a41268941b6
 
-COCOAPODS: 1.11.0
+COCOAPODS: 1.11.3

--- a/NavigationReactNative/sample/twitter/package-lock.json
+++ b/NavigationReactNative/sample/twitter/package-lock.json
@@ -7371,18 +7371,18 @@
       "integrity": "sha512-FlhpzwFBrWEqXx7kT9YJZ/b50r3XWQwGWnmTt22SGFNwwxDuGUYAHMMdqU0U21G62VNmG0h91FiydB22wsJAEA=="
     },
     "node_modules/navigation-react": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/navigation-react/-/navigation-react-4.3.0.tgz",
-      "integrity": "sha512-A2sqS4T8hgpvPQUcqhP3OAtUzVL/8RlWEprQPjX4UrGHXpsMJr+VnluZtxY32Y8HMnKezu5kBl8zVxivideO0g==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/navigation-react/-/navigation-react-4.5.0.tgz",
+      "integrity": "sha512-EF7UmOqcR9GpjgPV7PjUOXhj55sNfvOAGnPXUO9nGTS7rtXHvUj93u83pGUgN7oZWBelFS/UX91okWps2CUPgw==",
       "peerDependencies": {
         "navigation": "*",
         "react": "*"
       }
     },
     "node_modules/navigation-react-native": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/navigation-react-native/-/navigation-react-native-8.1.1.tgz",
-      "integrity": "sha512-ZMXvQJgFfBuQwcMkMYifUkiQZRRRq2Yg1udEN3i5eQgrIKwX1wr75gNZ0XCwYD6IZQ1EjDQtI2Qe80e68WQgig==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/navigation-react-native/-/navigation-react-native-8.9.0.tgz",
+      "integrity": "sha512-1K9U4KQPePFYI2KkyiBlLZBEQdKbiDE0JBAzCLhqdTxg52qjeqTeTvtq/V/DOiiLt60C2ZLWf5dHUo53Fk5FKA==",
       "peerDependencies": {
         "navigation": "*",
         "navigation-react": "*",
@@ -16603,15 +16603,15 @@
       "integrity": "sha512-FlhpzwFBrWEqXx7kT9YJZ/b50r3XWQwGWnmTt22SGFNwwxDuGUYAHMMdqU0U21G62VNmG0h91FiydB22wsJAEA=="
     },
     "navigation-react": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/navigation-react/-/navigation-react-4.3.0.tgz",
-      "integrity": "sha512-A2sqS4T8hgpvPQUcqhP3OAtUzVL/8RlWEprQPjX4UrGHXpsMJr+VnluZtxY32Y8HMnKezu5kBl8zVxivideO0g==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/navigation-react/-/navigation-react-4.5.0.tgz",
+      "integrity": "sha512-EF7UmOqcR9GpjgPV7PjUOXhj55sNfvOAGnPXUO9nGTS7rtXHvUj93u83pGUgN7oZWBelFS/UX91okWps2CUPgw==",
       "requires": {}
     },
     "navigation-react-native": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/navigation-react-native/-/navigation-react-native-8.1.1.tgz",
-      "integrity": "sha512-ZMXvQJgFfBuQwcMkMYifUkiQZRRRq2Yg1udEN3i5eQgrIKwX1wr75gNZ0XCwYD6IZQ1EjDQtI2Qe80e68WQgig==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/navigation-react-native/-/navigation-react-native-8.9.0.tgz",
+      "integrity": "sha512-1K9U4KQPePFYI2KkyiBlLZBEQdKbiDE0JBAzCLhqdTxg52qjeqTeTvtq/V/DOiiLt60C2ZLWf5dHUo53Fk5FKA==",
       "requires": {}
     },
     "negotiator": {

--- a/NavigationReactNative/sample/twitter/yarn.lock
+++ b/NavigationReactNative/sample/twitter/yarn.lock
@@ -4694,14 +4694,14 @@
   "version" "1.4.0"
 
 "navigation-react-native@^8.0.0":
-  "integrity" "sha512-ZMXvQJgFfBuQwcMkMYifUkiQZRRRq2Yg1udEN3i5eQgrIKwX1wr75gNZ0XCwYD6IZQ1EjDQtI2Qe80e68WQgig=="
-  "resolved" "https://registry.npmjs.org/navigation-react-native/-/navigation-react-native-8.1.1.tgz"
-  "version" "8.1.1"
+  "integrity" "sha512-1K9U4KQPePFYI2KkyiBlLZBEQdKbiDE0JBAzCLhqdTxg52qjeqTeTvtq/V/DOiiLt60C2ZLWf5dHUo53Fk5FKA=="
+  "resolved" "https://registry.npmjs.org/navigation-react-native/-/navigation-react-native-8.9.0.tgz"
+  "version" "8.9.0"
 
 "navigation-react@*", "navigation-react@^4.3.0":
-  "integrity" "sha512-A2sqS4T8hgpvPQUcqhP3OAtUzVL/8RlWEprQPjX4UrGHXpsMJr+VnluZtxY32Y8HMnKezu5kBl8zVxivideO0g=="
-  "resolved" "https://registry.npmjs.org/navigation-react/-/navigation-react-4.3.0.tgz"
-  "version" "4.3.0"
+  "integrity" "sha512-EF7UmOqcR9GpjgPV7PjUOXhj55sNfvOAGnPXUO9nGTS7rtXHvUj93u83pGUgN7oZWBelFS/UX91okWps2CUPgw=="
+  "resolved" "https://registry.npmjs.org/navigation-react/-/navigation-react-4.5.0.tgz"
+  "version" "4.5.0"
 
 "navigation@*", "navigation@^5.5.0":
   "integrity" "sha512-FlhpzwFBrWEqXx7kT9YJZ/b50r3XWQwGWnmTt22SGFNwwxDuGUYAHMMdqU0U21G62VNmG0h91FiydB22wsJAEA=="

--- a/NavigationReactNativeWeb/sample/twitter/ios/Podfile.lock
+++ b/NavigationReactNativeWeb/sample/twitter/ios/Podfile.lock
@@ -58,7 +58,7 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - glog (0.3.5)
   - libevent (2.1.12)
-  - navigation-react-native (8.7.1):
+  - navigation-react-native (8.9.0):
     - React-Core
   - OpenSSL-Universal (1.1.180)
   - RCT-Folly (2020.01.13.00):
@@ -464,7 +464,7 @@ SPEC CHECKSUMS:
   FlipperKit: 8a20b5c5fcf9436cac58551dc049867247f64b00
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  navigation-react-native: 4327503284671eab51516e2c024f57a9fdcfe20c
+  navigation-react-native: c05ced550ca8d1027512a490d316d08460f5fedc
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: ec2ebc96b7bfba3ca5c32740f5a0c6a014a274d2
@@ -492,6 +492,6 @@ SPEC CHECKSUMS:
   Yoga: a7de31c64fe738607e7a3803e3f591a4b1df7393
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 441ec4570026291b569e86528ede4d4421393662
+PODFILE CHECKSUM: c61b6ed6a27dfdef63829750bf6648323d44b420
 
-COCOAPODS: 1.11.0
+COCOAPODS: 1.11.3

--- a/NavigationReactNativeWeb/sample/twitter/package-lock.json
+++ b/NavigationReactNativeWeb/sample/twitter/package-lock.json
@@ -7791,18 +7791,18 @@
       "integrity": "sha512-FlhpzwFBrWEqXx7kT9YJZ/b50r3XWQwGWnmTt22SGFNwwxDuGUYAHMMdqU0U21G62VNmG0h91FiydB22wsJAEA=="
     },
     "node_modules/navigation-react": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/navigation-react/-/navigation-react-4.3.0.tgz",
-      "integrity": "sha512-A2sqS4T8hgpvPQUcqhP3OAtUzVL/8RlWEprQPjX4UrGHXpsMJr+VnluZtxY32Y8HMnKezu5kBl8zVxivideO0g==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/navigation-react/-/navigation-react-4.5.0.tgz",
+      "integrity": "sha512-EF7UmOqcR9GpjgPV7PjUOXhj55sNfvOAGnPXUO9nGTS7rtXHvUj93u83pGUgN7oZWBelFS/UX91okWps2CUPgw==",
       "peerDependencies": {
         "navigation": "*",
         "react": "*"
       }
     },
     "node_modules/navigation-react-mobile": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/navigation-react-mobile/-/navigation-react-mobile-3.6.0.tgz",
-      "integrity": "sha512-ZDCYmUvtRaoNe7PEJ+3K5lv3GshkveNZ+Ma2M5XLGfERBBvNr1aUIP0fPJNqgMMGo56c0nprO1NWhYM4hZY5vg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/navigation-react-mobile/-/navigation-react-mobile-3.8.0.tgz",
+      "integrity": "sha512-qF3+HhZZIxwaEtIMNQUWtqjRCxLy+28KPJhiy9Zj9AYI+mo8H+lj7g2OIdqpWPqQQQu0pcRG0DNn5yQLAonENQ==",
       "peerDependencies": {
         "navigation": "*",
         "navigation-react": "*",
@@ -7810,9 +7810,9 @@
       }
     },
     "node_modules/navigation-react-native": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/navigation-react-native/-/navigation-react-native-8.7.1.tgz",
-      "integrity": "sha512-so+i1Abe0x62r6orXSEoP6LBh12d8d4Xb7YoXbE8ToU8lhCeTNjxM7Uy2zAxX/243qzZ4366rhfQNMaO4j/e9Q==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/navigation-react-native/-/navigation-react-native-8.9.0.tgz",
+      "integrity": "sha512-1K9U4KQPePFYI2KkyiBlLZBEQdKbiDE0JBAzCLhqdTxg52qjeqTeTvtq/V/DOiiLt60C2ZLWf5dHUo53Fk5FKA==",
       "peerDependencies": {
         "navigation": "*",
         "navigation-react": "*",
@@ -7821,9 +7821,9 @@
       }
     },
     "node_modules/navigation-react-native-web": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/navigation-react-native-web/-/navigation-react-native-web-1.0.0.tgz",
-      "integrity": "sha512-Afxqk3bYoOfpvsce1oQk7rOAueUidXUpQfz243/nl1eBppTxTJjRjsmH/A6E10Ra2UaSoTeiiNOYqBUhAzt+Fg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/navigation-react-native-web/-/navigation-react-native-web-1.1.0.tgz",
+      "integrity": "sha512-f49yx/b8pMyOiY5jwuqe1pCSwaNSdNuATHf1St1/NLojQndxksi0LV2IcOleXg9Xmf6SPKWzhuNkw8HWVXH4pw==",
       "dependencies": {
         "navigation-react-mobile": "*"
       },
@@ -17892,27 +17892,27 @@
       "integrity": "sha512-FlhpzwFBrWEqXx7kT9YJZ/b50r3XWQwGWnmTt22SGFNwwxDuGUYAHMMdqU0U21G62VNmG0h91FiydB22wsJAEA=="
     },
     "navigation-react": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/navigation-react/-/navigation-react-4.3.0.tgz",
-      "integrity": "sha512-A2sqS4T8hgpvPQUcqhP3OAtUzVL/8RlWEprQPjX4UrGHXpsMJr+VnluZtxY32Y8HMnKezu5kBl8zVxivideO0g==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/navigation-react/-/navigation-react-4.5.0.tgz",
+      "integrity": "sha512-EF7UmOqcR9GpjgPV7PjUOXhj55sNfvOAGnPXUO9nGTS7rtXHvUj93u83pGUgN7oZWBelFS/UX91okWps2CUPgw==",
       "requires": {}
     },
     "navigation-react-mobile": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/navigation-react-mobile/-/navigation-react-mobile-3.6.0.tgz",
-      "integrity": "sha512-ZDCYmUvtRaoNe7PEJ+3K5lv3GshkveNZ+Ma2M5XLGfERBBvNr1aUIP0fPJNqgMMGo56c0nprO1NWhYM4hZY5vg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/navigation-react-mobile/-/navigation-react-mobile-3.8.0.tgz",
+      "integrity": "sha512-qF3+HhZZIxwaEtIMNQUWtqjRCxLy+28KPJhiy9Zj9AYI+mo8H+lj7g2OIdqpWPqQQQu0pcRG0DNn5yQLAonENQ==",
       "requires": {}
     },
     "navigation-react-native": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/navigation-react-native/-/navigation-react-native-8.7.1.tgz",
-      "integrity": "sha512-so+i1Abe0x62r6orXSEoP6LBh12d8d4Xb7YoXbE8ToU8lhCeTNjxM7Uy2zAxX/243qzZ4366rhfQNMaO4j/e9Q==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/navigation-react-native/-/navigation-react-native-8.9.0.tgz",
+      "integrity": "sha512-1K9U4KQPePFYI2KkyiBlLZBEQdKbiDE0JBAzCLhqdTxg52qjeqTeTvtq/V/DOiiLt60C2ZLWf5dHUo53Fk5FKA==",
       "requires": {}
     },
     "navigation-react-native-web": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/navigation-react-native-web/-/navigation-react-native-web-1.0.0.tgz",
-      "integrity": "sha512-Afxqk3bYoOfpvsce1oQk7rOAueUidXUpQfz243/nl1eBppTxTJjRjsmH/A6E10Ra2UaSoTeiiNOYqBUhAzt+Fg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/navigation-react-native-web/-/navigation-react-native-web-1.1.0.tgz",
+      "integrity": "sha512-f49yx/b8pMyOiY5jwuqe1pCSwaNSdNuATHf1St1/NLojQndxksi0LV2IcOleXg9Xmf6SPKWzhuNkw8HWVXH4pw==",
       "requires": {
         "navigation-react-mobile": "*"
       }

--- a/NavigationReactNativeWeb/sample/twitter/yarn.lock
+++ b/NavigationReactNativeWeb/sample/twitter/yarn.lock
@@ -5070,26 +5070,26 @@
   "version" "1.4.0"
 
 "navigation-react-mobile@*":
-  "integrity" "sha512-ZDCYmUvtRaoNe7PEJ+3K5lv3GshkveNZ+Ma2M5XLGfERBBvNr1aUIP0fPJNqgMMGo56c0nprO1NWhYM4hZY5vg=="
-  "resolved" "https://registry.npmjs.org/navigation-react-mobile/-/navigation-react-mobile-3.6.0.tgz"
-  "version" "3.6.0"
+  "integrity" "sha512-qF3+HhZZIxwaEtIMNQUWtqjRCxLy+28KPJhiy9Zj9AYI+mo8H+lj7g2OIdqpWPqQQQu0pcRG0DNn5yQLAonENQ=="
+  "resolved" "https://registry.npmjs.org/navigation-react-mobile/-/navigation-react-mobile-3.8.0.tgz"
+  "version" "3.8.0"
 
 "navigation-react-native-web@^1.0.0":
-  "integrity" "sha512-Afxqk3bYoOfpvsce1oQk7rOAueUidXUpQfz243/nl1eBppTxTJjRjsmH/A6E10Ra2UaSoTeiiNOYqBUhAzt+Fg=="
-  "resolved" "https://registry.npmjs.org/navigation-react-native-web/-/navigation-react-native-web-1.0.0.tgz"
-  "version" "1.0.0"
+  "integrity" "sha512-f49yx/b8pMyOiY5jwuqe1pCSwaNSdNuATHf1St1/NLojQndxksi0LV2IcOleXg9Xmf6SPKWzhuNkw8HWVXH4pw=="
+  "resolved" "https://registry.npmjs.org/navigation-react-native-web/-/navigation-react-native-web-1.1.0.tgz"
+  "version" "1.1.0"
   dependencies:
     "navigation-react-mobile" "*"
 
 "navigation-react-native@^8.7.1":
-  "integrity" "sha512-so+i1Abe0x62r6orXSEoP6LBh12d8d4Xb7YoXbE8ToU8lhCeTNjxM7Uy2zAxX/243qzZ4366rhfQNMaO4j/e9Q=="
-  "resolved" "https://registry.npmjs.org/navigation-react-native/-/navigation-react-native-8.7.1.tgz"
-  "version" "8.7.1"
+  "integrity" "sha512-1K9U4KQPePFYI2KkyiBlLZBEQdKbiDE0JBAzCLhqdTxg52qjeqTeTvtq/V/DOiiLt60C2ZLWf5dHUo53Fk5FKA=="
+  "resolved" "https://registry.npmjs.org/navigation-react-native/-/navigation-react-native-8.9.0.tgz"
+  "version" "8.9.0"
 
 "navigation-react@*", "navigation-react@^4.3.0":
-  "integrity" "sha512-A2sqS4T8hgpvPQUcqhP3OAtUzVL/8RlWEprQPjX4UrGHXpsMJr+VnluZtxY32Y8HMnKezu5kBl8zVxivideO0g=="
-  "resolved" "https://registry.npmjs.org/navigation-react/-/navigation-react-4.3.0.tgz"
-  "version" "4.3.0"
+  "integrity" "sha512-EF7UmOqcR9GpjgPV7PjUOXhj55sNfvOAGnPXUO9nGTS7rtXHvUj93u83pGUgN7oZWBelFS/UX91okWps2CUPgw=="
+  "resolved" "https://registry.npmjs.org/navigation-react/-/navigation-react-4.5.0.tgz"
+  "version" "4.5.0"
 
 "navigation@*", "navigation@^5.5.0":
   "integrity" "sha512-FlhpzwFBrWEqXx7kT9YJZ/b50r3XWQwGWnmTt22SGFNwwxDuGUYAHMMdqU0U21G62VNmG0h91FiydB22wsJAEA=="


### PR DESCRIPTION
Fixes #595 and #596

Updated the navigation dependencies of the Twitter samples, now the component api is released, so that they work from `npm install` again