### PR TITLE
Updated SearchBar component size in native on Fabric (iOS)

### DIFF
--- a/NavigationReactNative/src/SearchBar.tsx
+++ b/NavigationReactNative/src/SearchBar.tsx
@@ -9,7 +9,6 @@ class SearchBar extends React.Component<any, any> {
         this.ref = React.createRef<View>();
         this.onChangeText = this.onChangeText.bind(this);
         this.onChangeScopeButton = this.onChangeScopeButton.bind(this);
-        this.onChangeBounds = this.onChangeBounds.bind(this);
     }
     static defaultProps = {
         obscureBackground: true,
@@ -32,12 +31,8 @@ class SearchBar extends React.Component<any, any> {
         if (onChangeScopeButton)
             onChangeScopeButton(scopeButtons[scopeButton])
     }
-    onChangeBounds({nativeEvent}) {
-        var {width, height} = nativeEvent;
-        this.setState({width, height});
-    }
     render() {
-        var {show, width, height, mostRecentEventCount, mostRecentButtonEventCount} = this.state;
+        var {show, mostRecentEventCount, mostRecentButtonEventCount} = this.state;
         var {autoCapitalize, children, bottomBar, scopeButton, scopeButtons, ...props} = this.props;
         var constants = (UIManager as any).getViewManagerConfig('NVSearchBar').Constants;
         autoCapitalize = Platform.OS === 'android' ? constants.AutoCapitalize[autoCapitalize] : autoCapitalize;
@@ -54,10 +49,9 @@ class SearchBar extends React.Component<any, any> {
                 mostRecentButtonEventCount={mostRecentButtonEventCount}
                 onChangeText={this.onChangeText}
                 onChangeScopeButton={this.onChangeScopeButton}
-                onChangeBounds={this.onChangeBounds}
                 onExpand={() => this.setState({show: true})}
                 onCollapse={() => this.setState({show: false})}
-                style={[styles.searchBar, showStyle, {width, height}]}>
+                style={[styles.searchBar, showStyle]}>
                 {Platform.OS === 'ios' || this.state.show ? children : null}
             </NVSearchBar>
         );

--- a/NavigationReactNative/src/SearchBarNativeComponent.js
+++ b/NavigationReactNative/src/SearchBarNativeComponent.js
@@ -26,14 +26,11 @@ type NativeProps = $ReadOnly<{|
     scopeButton: Int32,
     eventCount: Int32,
   |}>>,
-  onChangeBounds: DirectEventHandler<$ReadOnly<{|
-    width: Float,
-    height: Float,
-  |}>>,
   onExpand: DirectEventHandler<null>,
   onCollapse: DirectEventHandler<null>,
 |}>;
 
 export default (codegenNativeComponent<NativeProps>(
    'NVSearchBar',
+   {interfaceOnly: true}
 ): HostComponent<NativeProps>);

--- a/NavigationReactNative/src/cpp/react/renderer/components/navigation-react-native/NVSearchBarComponentDescriptor.h
+++ b/NavigationReactNative/src/cpp/react/renderer/components/navigation-react-native/NVSearchBarComponentDescriptor.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <react/debug/react_native_assert.h>
+#include "NVSearchBarShadowNode.h"
+#include <react/renderer/core/ConcreteComponentDescriptor.h>
+
+namespace facebook {
+namespace react {
+
+class NVSearchBarComponentDescriptor final
+    : public ConcreteComponentDescriptor<NVSearchBarShadowNode> {
+ public:
+  using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
+
+  void adopt(ShadowNode::Unshared const &shadowNode) const override {
+    react_native_assert(
+        std::dynamic_pointer_cast<NVSearchBarShadowNode>(shadowNode));
+    auto screenShadowNode =
+        std::static_pointer_cast<NVSearchBarShadowNode>(shadowNode);
+
+    react_native_assert(
+        std::dynamic_pointer_cast<YogaLayoutableShadowNode>(screenShadowNode));
+    auto layoutableShadowNode =
+        std::static_pointer_cast<YogaLayoutableShadowNode>(screenShadowNode);
+
+    auto state =
+        std::static_pointer_cast<const NVSearchBarShadowNode::ConcreteState>(
+            shadowNode->getState());
+    auto stateData = state->getData();
+
+    if (stateData.frameSize.width != 0 && stateData.frameSize.height != 0) {
+      layoutableShadowNode->setSize(
+          Size{stateData.frameSize.width, stateData.frameSize.height});
+    }
+
+    ConcreteComponentDescriptor::adopt(shadowNode);
+  }
+};
+
+} // namespace react
+} // namespace facebook

--- a/NavigationReactNative/src/cpp/react/renderer/components/navigation-react-native/NVSearchBarShadowNode.cpp
+++ b/NavigationReactNative/src/cpp/react/renderer/components/navigation-react-native/NVSearchBarShadowNode.cpp
@@ -1,0 +1,9 @@
+#include "NVSearchBarShadowNode.h"
+
+namespace facebook {
+namespace react {
+
+extern const char NVSearchBarComponentName[] = "NVSearchBar";
+
+} // namespace react
+} // namespace facebook

--- a/NavigationReactNative/src/cpp/react/renderer/components/navigation-react-native/NVSearchBarShadowNode.h
+++ b/NavigationReactNative/src/cpp/react/renderer/components/navigation-react-native/NVSearchBarShadowNode.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "NVSearchBarState.h"
+#include <react/renderer/components/navigation-react-native/EventEmitters.h>
+#include <react/renderer/components/navigation-react-native/Props.h>
+#include <react/renderer/components/view/ConcreteViewShadowNode.h>
+
+namespace facebook {
+namespace react {
+
+extern const char NVSearchBarComponentName[];
+
+class NVSearchBarShadowNode final : public ConcreteViewShadowNode<
+                                          NVSearchBarComponentName,
+                                          NVSearchBarProps,
+                                          NVSearchBarEventEmitter,
+                                          NVSearchBarState> {
+ public:
+  using ConcreteViewShadowNode::ConcreteViewShadowNode;
+
+  static ShadowNodeTraits BaseTraits() {
+    auto traits = ConcreteViewShadowNode::BaseTraits();
+    traits.set(ShadowNodeTraits::Trait::RootNodeKind);
+    return traits;
+  }
+};
+
+} // namespace react
+} // namespace facebook

--- a/NavigationReactNative/src/cpp/react/renderer/components/navigation-react-native/NVSearchBarState.cpp
+++ b/NavigationReactNative/src/cpp/react/renderer/components/navigation-react-native/NVSearchBarState.cpp
@@ -1,0 +1,14 @@
+#include "NVSearchBarState.h"
+
+namespace facebook {
+namespace react {
+
+#ifdef ANDROID
+folly::dynamic NVSearchBarState::getDynamic() const {
+  return folly::dynamic::object("frameWidth", frameSize.width)(
+      "frameHeight", frameSize.height);
+}
+#endif
+
+} // namespace react
+} // namespace facebook

--- a/NavigationReactNative/src/cpp/react/renderer/components/navigation-react-native/NVSearchBarState.h
+++ b/NavigationReactNative/src/cpp/react/renderer/components/navigation-react-native/NVSearchBarState.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <react/renderer/graphics/Float.h>
+#include <react/renderer/graphics/Geometry.h>
+#include <react/renderer/graphics/conversions.h>
+
+#ifdef ANDROID
+#include <folly/dynamic.h>
+#include <react/renderer/mapbuffer/MapBuffer.h>
+#include <react/renderer/mapbuffer/MapBufferBuilder.h>
+#endif
+
+namespace facebook {
+namespace react {
+
+class NVSearchBarState final {
+ public:
+  using Shared = std::shared_ptr<const NVSearchBarState>;
+
+  NVSearchBarState(){};
+  NVSearchBarState(Size frameSize_) : frameSize(frameSize_){};
+
+#ifdef ANDROID
+  NVSearchBarState(
+      NVSearchBarState const &previousState,
+      folly::dynamic data)
+      : frameSize(Size{
+            (Float)data["frameWidth"].getDouble(),
+            (Float)data["frameHeight"].getDouble()}){};
+#endif
+
+  const Size frameSize{};
+
+#ifdef ANDROID
+  folly::dynamic getDynamic() const;
+  MapBuffer getMapBuffer() const {
+    return MapBufferBuilder::EMPTY();
+  };
+
+#endif
+
+#pragma mark - Getters
+};
+
+} // namespace react
+} // namespace facebook

--- a/NavigationReactNative/src/ios/NVSearchBarManager.m
+++ b/NavigationReactNative/src/ios/NVSearchBarManager.m
@@ -28,6 +28,5 @@ RCT_EXPORT_VIEW_PROPERTY(scopeButton, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(mostRecentButtonEventCount, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(onChangeText, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onChangeScopeButton, RCTDirectEventBlock)
-RCT_EXPORT_VIEW_PROPERTY(onChangeBounds, RCTDirectEventBlock)
 
 @end

--- a/NavigationReactNative/src/ios/NVSearchBarView.h
+++ b/NavigationReactNative/src/ios/NVSearchBarView.h
@@ -11,7 +11,6 @@
 @property (nonatomic, assign) NSInteger mostRecentButtonEventCount;
 @property (nonatomic, copy) RCTBubblingEventBlock onChangeText;
 @property (nonatomic, copy) RCTDirectEventBlock onChangeScopeButton;
-@property (nonatomic, copy) RCTDirectEventBlock onChangeBounds;
 
 -(id)initWithBridge: (RCTBridge *)bridge;
 


### PR DESCRIPTION
The `setSize` on the UIManager isn't supported in Fabric. When first migrating to Fabric, tried to copy the React Native `Modal` way of changing size on native. But it uses c++ state which isn’t documented anywhere. So passed the new bounds back to JavaScript and set the width and height in React. But it was only a temp solution because noticed the odd UI glitch when changing orientation. This PR replaces the temp solution with the Modal's c++ implementation.

See #607 for general overview of how to use c++ state. But originally worked it out in the `native-nodesize` branch and these changes are copied over from there.
