### PR TITLE
Updated Fabric setup guide for Android (for c++ state)

### DIFF
--- a/documentation/native/setup.html
+++ b/documentation/native/setup.html
@@ -91,7 +91,7 @@ export default App;</code></pre>
               <p>
                   Currently React Native Fabric doesn't autolink 3rd party libraries on Android. The following steps go through how to manually link the <code>navigation-react-native</code> package. These steps are only needed on the new architecture.
               </p>
-              <p>Update the <code>android/app/build.gradle</code> file (note the trailing comma on the first line).</p>
+              <p>Update 2 lines in <code>android/app/build.gradle</code> file (note the trailing comma on the first line).</p>
               <pre><code class="language-xxx">    "REACT_ANDROID_BUILD_DIR=$rootDir/../node_modules/react-native/ReactAndroid/build"<span class="diff">,</span>
     <span class="diff">"NODE_MODULES_DIR=$rootDir/../node_modules"</span>
 cFlags "-Wall", "-Werror", "-fexceptions", "-frtti", "-DWITH_INSPECTOR=1"
@@ -101,17 +101,29 @@ cFlags "-Wall", "-Werror", "-fexceptions", "-frtti", "-DWITH_INSPECTOR=1"
 <span class="diff">include $(NODE_MODULES_DIR)/navigation-react-native/android/build/generated/source/codegen/jni/Android.mk</span>
 include $(CLEAR_VARS)
 </code></pre>
-              <p>Add another line to <code>android/app/src/main/jni/Android.mk</code>.</p>
+              <p>And update 2 lines in <code>android/app/src/main/jni/Android.mk</code>.</p>
+              <pre><code class="language-xxx">LOCAL_C_INCLUDES := $(LOCAL_PATH)<span class="diff"> $(NODE_MODULES_DIR)/navigation-react-native/cpp</span>
+LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)<span class="diff"> $(wildcard $(NODE_MODULES_DIR)/navigation-react-native/cpp/react/renderer/components/navigation-react-native/*.cpp)</span>
+LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)
+
+</code></pre>
+
+              <p>And add 3 lines to <code>android/app/src/main/jni/Android.mk</code>.</p>
               <pre><code class="language-xxx">libreact_codegen_rncore \
-<span class="diff">libreact_codegen_navigation-react-native \</span>
+<span class="diff">libreact_codegen_navigation-react-native \
+libreact_render_mapbuffer \
+libreact_render_imagemanager \</span>
 libreact_debug \
 </code></pre>
-              <p>Add a line to the <code>android/app/src/main/jni/MainComponentsRegistry.cpp</code> file.</p>
+              <p>Add 4 lines to the <code>android/app/src/main/jni/MainComponentsRegistry.cpp</code> file.</p>
               <pre><code class="language-xxx">#include &lt;react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
-<span class="diff">#include &lt;react/renderer/components/navigation-react-native/ComponentDescriptors.h></span>
+<span class="diff">#include &lt;react/renderer/components/navigation-react-native/ComponentDescriptors.h>
+#include &lt;react/renderer/components/navigation-react-native/NVBarButtonComponentDescriptor.h>
+#include &lt;react/renderer/components/navigation-react-native/NVSearchBarComponentDescriptor.h>
+#include &lt;react/renderer/components/navigation-react-native/NVTabBarItemComponentDescriptor.h></span>
 #include &lt;react/renderer/components/rncore/ComponentDescriptors.h>
 </code></pre>
-              <p>And these other lines to <code>android/app/src/main/jni/MainComponentsRegistry.cpp</code>. One for each component.</p>
+              <p>And add 23 lines to <code>android/app/src/main/jni/MainComponentsRegistry.cpp</code>. One for each component.</p>
               <pre><code class="language-xxx">// providerRegistry->add(concreteComponentDescriptorProvider&lt;
 //        AocViewerComponentDescriptor>());
 <span class="diff">providerRegistry->add(concreteComponentDescriptorProvider&lt;NVActionBarComponentDescriptor>());


### PR DESCRIPTION
The changes are due to the c++ state used for BarButton and TabBarItem (image props) and SearchBar (node size). These changes are for iOS but result in changes to the setup on Android