### PR TITLE
Ensured keyboard stays open when search focused (Android)

### DIFF
--- a/NavigationReactNative/src/SearchBar.tsx
+++ b/NavigationReactNative/src/SearchBar.tsx
@@ -36,7 +36,7 @@ class SearchBar extends React.Component<any, any> {
         var {autoCapitalize, children, bottomBar, scopeButton, scopeButtons, ...props} = this.props;
         var constants = (UIManager as any).getViewManagerConfig('NVSearchBar').Constants;
         autoCapitalize = Platform.OS === 'android' ? constants.AutoCapitalize[autoCapitalize] : autoCapitalize;
-        var showStyle = Platform.OS === 'android' && {top: !bottomBar ? 56 : 0, bottom: !bottomBar ? 0: 56, zIndex: show ? 58 : -58}
+        var showStyle = Platform.OS === 'android' && {top: !bottomBar ? 56 : 0, bottom: !bottomBar ? 0: 56, height: show ? 'auto' : 0}
         return (
             <NVSearchBar
                 {...props}
@@ -65,6 +65,7 @@ var styles = StyleSheet.create({
         position: 'absolute',
         ...Platform.select({
             android: {
+                zIndex: 58,
                 right: 0, left: 0,
             },
         })

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
@@ -29,7 +29,6 @@ public class SearchBarView extends ReactViewGroup {
     public SearchBarView(Context context) {
         super(context);
         searchView = new SearchView(context);
-        setZ(-58);
         CoordinatorLayout.LayoutParams params = new CoordinatorLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
         AppBarLayout.ScrollingViewBehavior behavior = new AppBarLayout.ScrollingViewBehavior();
         params.setBehavior(behavior);
@@ -79,11 +78,7 @@ public class SearchBarView extends ReactViewGroup {
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
-        if (searchView.requestFocusFromTouch()) {
-            InputMethodManager inputMethodManager = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
-            if (inputMethodManager != null)
-                inputMethodManager.showSoftInput(searchView.findFocus(), 0);
-        }
+        post(focusAndKeyboard);
         ActionView actionView = null;
         ViewGroup view = (ViewGroup) getParent();
         for(int i = 0; i < view.getChildCount() && actionView == null; i++) {
@@ -106,7 +101,6 @@ public class SearchBarView extends ReactViewGroup {
 
                 @Override
                 public void onSearchExpand() {
-                    setZ(58);
                     ReactContext reactContext = (ReactContext) getContext();
                     EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
                     eventDispatcher.dispatchEvent(new ExpandEvent(getId()));
@@ -114,7 +108,6 @@ public class SearchBarView extends ReactViewGroup {
 
                 @Override
                 public void onSearchCollapse() {
-                    setZ(-58);
                     ReactContext reactContext = (ReactContext) getContext();
                     EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
                     eventDispatcher.dispatchEvent(new CollapseEvent(getId()));
@@ -122,6 +115,17 @@ public class SearchBarView extends ReactViewGroup {
             });
         }
     }
+
+    private final Runnable focusAndKeyboard = new Runnable() {
+        @Override
+        public void run() {
+            if (searchView.requestFocus()) {
+                InputMethodManager inputMethodManager = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+                if (inputMethodManager != null)
+                    inputMethodManager.showSoftInput(searchView.findFocus(), 0);
+            }
+        }
+    };
 
     @Override
     protected void onLayout(boolean changed, int l, int t, int r, int b) {


### PR DESCRIPTION
The keyboard would open and immediately close when navigating back on the zoom sample. Changed to request focus async instead of when attached to window.

On the new React Native architecture, the keyboard would open and immediately close when focused. Changed to use height (auto/0) instead of zIndex (58/-58) to show and hide the search results.

