### PR TITLE
Supported autocapitalize prop on SearchView component (Android >= 28)

### DIFF
--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarManager.java
@@ -1,5 +1,6 @@
 package com.navigation.reactnative;
 
+import android.os.Build;
 import android.text.InputType;
 
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
@@ -39,7 +40,10 @@ public class SearchBarManager extends ViewGroupManager<SearchBarView> {
 
     @ReactProp(name = "autoCapitalize")
     public void setAutoCapitalize(SearchBarView view, String autoCapitalize) {
-        view.searchView.setInputType(Integer.parseInt(autoCapitalize));
+        int inputType = Integer.parseInt(autoCapitalize);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
+            inputType = InputType.TYPE_CLASS_TEXT | inputType;
+        view.searchView.setInputType(inputType);
     }
 
     @ReactProp(name = "barTintColor", customType = "Color", defaultInt = Integer.MAX_VALUE)


### PR DESCRIPTION
`searchView.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS)` instead of 
`searchView.setInputType(InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS)`
