### PR TITLE
Documented Material Design 3 support

### DIFF
--- a/documentation/native/floating-action-button.html
+++ b/documentation/native/floating-action-button.html
@@ -68,17 +68,17 @@
                 If you anchor the <code>FloatingActionButton</code> to another component then they will move in tandem. When the user opens an email in our example application, we anchor the floating compose button to the contact details <a href="bottom-sheet.html"><code>BottomSheet</code></a>. This prevents the sheet from obscuring the compose button. When the user expands the sheet to see the contact information then the compose button moves up, too.
             </p>
             <pre><code class="language-jsx">&lt;CoordinatorLayout>
-  &lt;FloatingActionButton anchor="bottomSheet" />
   &lt;BottomSheet />
+  &lt;FloatingActionButton anchor="bottomSheet" />
 &lt;/CoordinatorLayout></code></pre>
             <h2>Cradling a Floating Action Button</h2>
             <p>
                 When a <code>FloatingActionButton</code> is anchored to a bottom <code>NavigationBar</code>, then the navigation bar changes its shape. It creates a cradle for the floating action button to nestle into. You create a bottom <code>NavigationBar</code> by setting the <code>bottomBar</code> prop to true. Any scrollable content that sits above a bottom navigation bar has to be padded to make room. Unless you make the bottom navigation bar scroll out of the way by setting its <code>hideOnScroll</code> prop to true.
             </p>
             <pre><code class="language-jsx">&lt;CoordinatorLayout>
-  &lt;FloatingActionButton anchor="bottomNavigationBar" />
   &lt;ScrollView nestedScrollEnabled={true} contentContainerStyle={{paddingBottom: 56}} />
   &lt;NavigationBar bottomBar={true} />
+  &lt;FloatingActionButton anchor="bottomNavigationBar" />
 &lt;/CoordinatorLayout></code></pre>
             <h2>Extending a Floating Action Button</h2>
             <p>

--- a/documentation/native/setup.html
+++ b/documentation/native/setup.html
@@ -52,7 +52,7 @@
           <div id="article">
             <h1>Setup</h1>
              <p>
-                The Navigation router for React Native uses the underlying native APIs to provide faithful navigation on Android and iOS. Because it contains native code, you have to create your application using <code>react-native init</code> or <a href="https://docs.expo.dev/development/introduction/">a custom development build of Expo</a>.
+                The Navigation router is a 100% native navigation library for React Native. It provides the same out-of-the-box experience that you'd get if you were building a native app without React Native. For example, the <code>TabBar</code> component renders to the <code>UITabBarController</code> from UIKit or the <code>BottomNavigationView</code> from Android's Material Design library. Because the Navigation router contains native code, you have to create your application using <code>react-native init</code> or <a href="https://docs.expo.dev/development/introduction/">a custom development build of Expo</a>.
             </p>
             <p>
                 Install the three navigation packages from npm.
@@ -79,6 +79,11 @@ const App = () => (
 );
 
 export default App;</code></pre>
+            <p>
+                If you want to use Android's <a href="https://m3.material.io/">Material Design 3</a> then configure a <code>Material3</code> theme in styles.xml. For example,
+            </p>
+            <pre><code class="language-jsx">&lt;style name="AppTheme" parent="Theme.Material3.DayNight.NoActionBar"></code></pre>
+
               <p>
                   That's all the setup you need in the current React Native architecture. The next section goes through the setup for the new architecture (Fabric).
               </p>

--- a/documentation/native/setup.html
+++ b/documentation/native/setup.html
@@ -80,7 +80,7 @@ const App = () => (
 
 export default App;</code></pre>
             <p>
-                If you want to use Android's <a href="https://m3.material.io/">Material Design 3</a> then configure a <code>Material3</code> theme in styles.xml. For example,
+                If you want to use <a href="https://m3.material.io/">Material Design 3</a> on Android then configure a <code>Material3</code> theme in styles.xml. For example,
             </p>
             <pre><code class="language-jsx">&lt;style name="AppTheme" parent="Theme.Material3.DayNight.NoActionBar"></code></pre>
 

--- a/documentation/native/setup.html
+++ b/documentation/native/setup.html
@@ -158,6 +158,17 @@ providerRegistry->add(concreteComponentDescriptorProvider&lt;NVTitleBarComponent
 providerRegistry->add(concreteComponentDescriptorProvider&lt;NVToolbarComponentDescriptor>());</span>
 return providerRegistry;
 </code></pre>
+              <p>Add a line to the <code>android/app/src/main/jni/MainApplicationModuleProvider.cpp</code> file.</p>
+              <pre><code class="language-xxx">#include &lt;rncore.h>
+<span class="diff">#include &lt;navigation-react-native.h></span></code></pre>
+              <p>And add 4 lines to the <code>android/app/src/main/jni/MainApplicationModuleProvider.cpp</code> file.</p>
+              <pre><code class="language-xxx"><span class="diff">auto module = navigation_react_native_ModuleProvider(moduleName, params);
+if (module != nullptr) {
+    return module;
+}</span>
+
+return rncore_ModuleProvider(moduleName, params);
+</code></pre>
           </div>
     </div>
     <script type="text/javascript" src="../../js/prism.js"></script>

--- a/documentation/native/tab-bar.html
+++ b/documentation/native/tab-bar.html
@@ -116,7 +116,7 @@ const Contacts = () => (
 &lt;/NavigationStack></code></pre>
             <div class="Note">
                 <h2>Note</h2>
-                We could assign the number of unread emails to the <code>badge</code> prop of the 'inbox' <code>TabBarItem</code>. But the badge won't display on Android unless we change to a <code>MaterialComponents</code> theme in the styles.xml, for example, <code>Theme.MaterialComponents.Light.NoActionBar.Bridge</code>
+                We could assign the number of unread emails to the <code>badge</code> prop of the 'inbox' <code>TabBarItem</code>. But the badge won't display on Android unless we change to a <code>MaterialComponents</code> theme in the styles.xml, for example, <code>Theme.MaterialComponents.Light.NoActionBar</code> or <code>Theme.Material3.Light.NoActionBar</code>
             </div>
             <h2>Scrolling the Navigation Bar on Android</h2>
             <p>


### PR DESCRIPTION
Also moved FABs to the end so that React Native gives them precedence for presses before the background components