### PR TITLE
Ensured re-rendering the NavigationStack uses the latest scene and props

### DIFF
--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -29,9 +29,10 @@ const NavigationMotion = ({unmountedStyle, mountedStyle, crumbStyle, duration = 
         }
     }
     findScenes();
-    let { current: allScenes } = useRef(scenes);
+    const prevScenes = useRef({});
+    const allScenes = {...prevScenes.current, ...scenes};
     useEffect(() => {
-        allScenes = {...allScenes, ...scenes};
+        prevScenes.current = allScenes;
         const {state, crumbs, nextCrumb} = stateNavigator.stateContext;
         const validate = ({key}) => !!scenes[key];
         if (firstLink) {
@@ -42,7 +43,7 @@ const NavigationMotion = ({unmountedStyle, mountedStyle, crumbStyle, duration = 
             if (resetLink != null) stateNavigator.navigateLink(resetLink);
         }
         return () => stateNavigator.offBeforeNavigate(validate);
-    }, [children, stateNavigator, scenes, stackInvalidatedLink]);
+    }, [children, stateNavigator, scenes, allScenes, stackInvalidatedLink]);
     const getSharedElements = () => {
         const {crumbs, oldUrl} = stateNavigator.stateContext;
         if (oldUrl !== null) {

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -26,9 +26,10 @@ const NavigationStack = ({underlayColor = '#000', title, crumbStyle = () => null
         }
     }
     findScenes();
-    let { current: allScenes } = useRef(scenes);
+    const prevScenes = useRef({});
+    const allScenes = {...prevScenes.current, ...scenes};
     useEffect(() => {
-        allScenes = {...allScenes, ...scenes};
+        prevScenes.current = allScenes;
         const {state, crumbs, nextCrumb} = stateNavigator.stateContext;
         const validate = ({key}) => !!scenes[key];
         if (firstLink) {
@@ -39,7 +40,7 @@ const NavigationStack = ({underlayColor = '#000', title, crumbStyle = () => null
             if (resetLink != null) stateNavigator.navigateLink(resetLink);
         }
         return () => stateNavigator.offBeforeNavigate(validate);
-    }, [children, stateNavigator, scenes, stackInvalidatedLink]);
+    }, [children, stateNavigator, scenes, allScenes, stackInvalidatedLink]);
     const onWillNavigateBack = ({nativeEvent}) => {
         const distance = stateNavigator.stateContext.crumbs.length - nativeEvent.crumb;
         resumeNavigationRef.current = null;


### PR DESCRIPTION
Fixes #635 

Was using `let { current: allScenes } = useRef` but this created a stale closure. It meant the `NavigationStack` didn't get the latest scene and props from its children. For example, conditional navigation, where dynamically configure the stack of scenes, didn't work. Changing to const `const allScenes = useRef` fixed it. 

But noticed another problem where `allScenes` was a tempo behind because it was updated in `useEffect`. So it would take an additional render for `NavigationStack` to have the latest scenes and props. For example, this wouldn't render 'true'.
```jsx
const [updated, setUpdated] = useState(false);
useEffect(() => {
  setTimeout(() => {
    setUpdated(true);
  });
}, []);
<NavigationHandler stateNavigator={stateNavigator}>
  <NavigationStack>
    <Scene stateKey="example"><Text>{updated}</Text></Scene>
  </NavigationStack>
</NavigationHandler>
```
Changed `allScenes` from `ref` to `const` and built it during render instead of waiting for `useEffect`. 

Strangely the same code in `NavigationMotion` didn't have the stale closure. Well, it was stale but by the time `renderScene` happened it had the latest scenes and props. But updated `NavigationMotion` to ensure it never has a stale closure.