### PR TITLE
android: remove backgroundColor from scene root view

### DIFF
--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -167,7 +167,6 @@ var NVScene = global.nativeFabricUIManager ? require('./SceneNativeComponent').d
 
 const styles = StyleSheet.create({
     scene: {
-        backgroundColor: '#fff',
         position: 'absolute',
         top: 0, right: 0,
         bottom: 0, left: 0,


### PR DESCRIPTION
`crumbStyle` `unmountStyle` transitions using alpha shown unwanted white color caused by hardcoded background color on Scene.

---

Fixes #639

before:

https://user-images.githubusercontent.com/1761227/189640131-d2f4e3bc-87bc-4843-9007-a90aefb4e507.mp4

after:

https://user-images.githubusercontent.com/1761227/189640004-05e14116-6f99-4a51-bf27-cea3847949fb.mp4


