### PR TITLE
Revert "android: remove backgroundColor from scene root view"

### DIFF
--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -167,6 +167,7 @@ var NVScene = global.nativeFabricUIManager ? require('./SceneNativeComponent').d
 
 const styles = StyleSheet.create({
     scene: {
+        backgroundColor: '#fff',
         position: 'absolute',
         top: 0, right: 0,
         bottom: 0, left: 0,


### PR DESCRIPTION
Reverts grahammendick/navigation#641

Need a way to bring this in as a non-breaking change. Also large titles on iOS doesn't work with a transparent background. Backing it out to give us more time to think about it cc @iamyellow 