### PR TITLE
Supported smooth opacity animations (Android)

### DIFF
--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -67,22 +67,22 @@ const NavigationStack = ({underlayColor = '#000', title, crumbStyle = () => null
             setStackState(prevStackState => ({...prevStackState, rest: true}));
         }
     }
-    unmountStyle = (from, state, ...rest) => (
+    unmountStyle = (from: boolean, state: State, ...rest: any) => (
         allScenes?.[state.key]?.unmountStyle ?
             allScenes?.[state.key]?.unmountStyle(from, rest) :
             unmountStyle(from, state, rest)
     );
-    crumbStyle = (from, state, ...rest) => (
+    crumbStyle = (from: boolean, state: State, ...rest: any) => (
         allScenes?.[state.key]?.crumbStyle ?
             allScenes?.[state.key]?.crumbStyle(from, ...rest) :
             crumbStyle(from, state, rest)
     );
-    hidesTabBar = (state, ...rest) => (
+    hidesTabBar = (state: State, ...rest: any) => (
         allScenes?.[state.key]?.hidesTabBar ?
             allScenes?.[state.key]?.hidesTabBar(...rest) :
             unmountStyle(state, ...rest)
     );
-    getSharedElement = (state, ...rest) => (
+    getSharedElement = (state: State, ...rest: any) => (
         allScenes?.[state.key]?.getSharedElement ?
             allScenes?.[state.key]?.getSharedElement(...rest) :
             getSharedElement(state, ...rest)

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -67,6 +67,26 @@ const NavigationStack = ({underlayColor = '#000', title, crumbStyle = () => null
             setStackState(prevStackState => ({...prevStackState, rest: true}));
         }
     }
+    unmountStyle = (from, state, ...rest) => (
+        allScenes?.[state.key]?.unmountStyle ?
+            allScenes?.[state.key]?.unmountStyle(from, rest) :
+            unmountStyle(from, state, rest)
+    );
+    crumbStyle = (from, state, ...rest) => (
+        allScenes?.[state.key]?.crumbStyle ?
+            allScenes?.[state.key]?.crumbStyle(from, ...rest) :
+            crumbStyle(from, state, rest)
+    );
+    hidesTabBar = (state, ...rest) => (
+        allScenes?.[state.key]?.hidesTabBar ?
+            allScenes?.[state.key]?.hidesTabBar(...rest) :
+            unmountStyle(state, ...rest)
+    );
+    getSharedElement = (state, ...rest) => (
+        allScenes?.[state.key]?.getSharedElement ?
+            allScenes?.[state.key]?.getSharedElement(...rest) :
+            getSharedElement(state, ...rest)
+    );
     const getAnimation = () => {
         let {state, data, oldState, oldData, oldUrl, crumbs, nextCrumb} = stateNavigator.stateContext;
         if (!oldState)

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -67,18 +67,10 @@ const NavigationStack = ({underlayColor = '#000', title, crumbStyle = () => null
             setStackState(prevStackState => ({...prevStackState, rest: true}));
         }
     }
-    unmountStyle = (from: boolean, state: State, ...rest: any) => (
-        allScenes?.[state.key]?.unmountStyle ? allScenes?.[state.key]?.unmountStyle(from, ...rest) : unmountStyle(from, state, ...rest)
-    );
-    crumbStyle = (from: boolean, state: State, ...rest: any) => (
-        allScenes?.[state.key]?.crumbStyle ? allScenes?.[state.key]?.crumbStyle(from, ...rest) : crumbStyle(from, state, ...rest)
-    );
-    hidesTabBar = (state: State, ...rest: any) => (
-        allScenes?.[state.key]?.hidesTabBar ? allScenes?.[state.key]?.hidesTabBar(...rest) : unmountStyle(state, ...rest)
-    );
-    getSharedElement = (state: State, ...rest: any) => (
-        allScenes?.[state.key]?.getSharedElement ? allScenes?.[state.key]?.getSharedElement(...rest) : getSharedElement(state, ...rest)
-    );
+    unmountStyle = (from, state, ...rest) => allScenes?.[state.key]?.unmountStyle ? allScenes?.[state.key]?.unmountStyle(from, ...rest) : unmountStyle(from, state, ...rest);
+    crumbStyle = (from, state, ...rest) => allScenes?.[state.key]?.crumbStyle ? allScenes?.[state.key]?.crumbStyle(from, ...rest) : crumbStyle(from, state, ...rest);
+    hidesTabBar = (state, ...rest) => allScenes?.[state.key]?.hidesTabBar ? allScenes?.[state.key]?.hidesTabBar(...rest) : unmountStyle(state, ...rest);
+    getSharedElement = (state, ...rest) => allScenes?.[state.key]?.getSharedElement ? allScenes?.[state.key]?.getSharedElement(...rest) : getSharedElement(state, ...rest);
     const getAnimation = () => {
         let {state, data, oldState, oldData, oldUrl, crumbs, nextCrumb} = stateNavigator.stateContext;
         if (!oldState)

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -70,7 +70,7 @@ const NavigationStack = ({underlayColor = '#000', title, crumbStyle = () => null
     const sceneProps = ({key}: State) => firstLink ? allScenes[key].props : null;
     unmountStyle = (from, state, ...rest) => sceneProps(state)?.unmountStyle ? sceneProps(state)?.unmountStyle(from, ...rest) : unmountStyle(from, state, ...rest);
     crumbStyle = (from, state, ...rest) => sceneProps(state)?.crumbStyle ? sceneProps(state)?.crumbStyle(from, ...rest) : crumbStyle(from, state, ...rest);
-    hidesTabBar = (state, ...rest) => sceneProps(state)?.hidesTabBar ? sceneProps(state)?.hidesTabBar(...rest) : unmountStyle(state, ...rest);
+    hidesTabBar = (state, ...rest) => sceneProps(state)?.hidesTabBar ? sceneProps(state)?.hidesTabBar(...rest) : hidesTabBar(state, ...rest);
     getSharedElement = (state, ...rest) => sceneProps(state)?.getSharedElement ? sceneProps(state)?.getSharedElement(...rest) : getSharedElement(state, ...rest);
     const getAnimation = () => {
         let {state, data, oldState, oldData, oldUrl, crumbs, nextCrumb} = stateNavigator.stateContext;

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -67,7 +67,7 @@ const NavigationStack = ({underlayColor = '#000', title, crumbStyle = () => null
             setStackState(prevStackState => ({...prevStackState, rest: true}));
         }
     }
-    const sceneProps = ({key}: State) => allScenes?.[key]?.props;
+    const sceneProps = ({key}: State) => firstLink ? allScenes[key].props : null;
     unmountStyle = (from, state, ...rest) => sceneProps(state)?.unmountStyle ? sceneProps(state)?.unmountStyle(from, ...rest) : unmountStyle(from, state, ...rest);
     crumbStyle = (from, state, ...rest) => sceneProps(state)?.crumbStyle ? sceneProps(state)?.crumbStyle(from, ...rest) : crumbStyle(from, state, ...rest);
     hidesTabBar = (state, ...rest) => sceneProps(state)?.hidesTabBar ? sceneProps(state)?.hidesTabBar(...rest) : unmountStyle(state, ...rest);

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -67,10 +67,11 @@ const NavigationStack = ({underlayColor = '#000', title, crumbStyle = () => null
             setStackState(prevStackState => ({...prevStackState, rest: true}));
         }
     }
-    unmountStyle = (from, state, ...rest) => allScenes?.[state.key]?.unmountStyle ? allScenes?.[state.key]?.unmountStyle(from, ...rest) : unmountStyle(from, state, ...rest);
-    crumbStyle = (from, state, ...rest) => allScenes?.[state.key]?.crumbStyle ? allScenes?.[state.key]?.crumbStyle(from, ...rest) : crumbStyle(from, state, ...rest);
-    hidesTabBar = (state, ...rest) => allScenes?.[state.key]?.hidesTabBar ? allScenes?.[state.key]?.hidesTabBar(...rest) : unmountStyle(state, ...rest);
-    getSharedElement = (state, ...rest) => allScenes?.[state.key]?.getSharedElement ? allScenes?.[state.key]?.getSharedElement(...rest) : getSharedElement(state, ...rest);
+    const sceneProps = ({key}: State) => allScenes?.[key]?.props;
+    unmountStyle = (from, state, ...rest) => sceneProps(state)?.unmountStyle ? sceneProps(state)?.unmountStyle(from, ...rest) : unmountStyle(from, state, ...rest);
+    crumbStyle = (from, state, ...rest) => sceneProps(state)?.crumbStyle ? sceneProps(state)?.crumbStyle(from, ...rest) : crumbStyle(from, state, ...rest);
+    hidesTabBar = (state, ...rest) => sceneProps(state)?.hidesTabBar ? sceneProps(state)?.hidesTabBar(...rest) : unmountStyle(state, ...rest);
+    getSharedElement = (state, ...rest) => sceneProps(state)?.getSharedElement ? sceneProps(state)?.getSharedElement(...rest) : getSharedElement(state, ...rest);
     const getAnimation = () => {
         let {state, data, oldState, oldData, oldUrl, crumbs, nextCrumb} = stateNavigator.stateContext;
         if (!oldState)

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -68,24 +68,16 @@ const NavigationStack = ({underlayColor = '#000', title, crumbStyle = () => null
         }
     }
     unmountStyle = (from: boolean, state: State, ...rest: any) => (
-        allScenes?.[state.key]?.unmountStyle ?
-            allScenes?.[state.key]?.unmountStyle(from, rest) :
-            unmountStyle(from, state, rest)
+        allScenes?.[state.key]?.unmountStyle ? allScenes?.[state.key]?.unmountStyle(from, ...rest) : unmountStyle(from, state, ...rest)
     );
     crumbStyle = (from: boolean, state: State, ...rest: any) => (
-        allScenes?.[state.key]?.crumbStyle ?
-            allScenes?.[state.key]?.crumbStyle(from, ...rest) :
-            crumbStyle(from, state, rest)
+        allScenes?.[state.key]?.crumbStyle ? allScenes?.[state.key]?.crumbStyle(from, ...rest) : crumbStyle(from, state, ...rest)
     );
     hidesTabBar = (state: State, ...rest: any) => (
-        allScenes?.[state.key]?.hidesTabBar ?
-            allScenes?.[state.key]?.hidesTabBar(...rest) :
-            unmountStyle(state, ...rest)
+        allScenes?.[state.key]?.hidesTabBar ? allScenes?.[state.key]?.hidesTabBar(...rest) : unmountStyle(state, ...rest)
     );
     getSharedElement = (state: State, ...rest: any) => (
-        allScenes?.[state.key]?.getSharedElement ?
-            allScenes?.[state.key]?.getSharedElement(...rest) :
-            getSharedElement(state, ...rest)
+        allScenes?.[state.key]?.getSharedElement ? allScenes?.[state.key]?.getSharedElement(...rest) : getSharedElement(state, ...rest)
     );
     const getAnimation = () => {
         let {state, data, oldState, oldData, oldUrl, crumbs, nextCrumb} = stateNavigator.stateContext;

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -73,7 +73,7 @@ const NavigationStack = ({underlayColor = '#000', title, crumbStyle: crumbStyleS
     const unmountStyle = (from, state, ...rest) => sceneProps(state)?.unmountStyle ? sceneProps(state)?.unmountStyle(from, ...rest) : unmountStyleStack(from, state, ...rest);
     const crumbStyle = (from, state, ...rest) => sceneProps(state)?.crumbStyle ? sceneProps(state)?.crumbStyle(from, ...rest) : crumbStyleStack(from, state, ...rest);
     const hidesTabBar = (state, ...rest) => sceneProps(state)?.hidesTabBar ? returnOrCall(sceneProps(state)?.hidesTabBar, ...rest) : hidesTabBarStack(state, ...rest);
-    const getSharedElement = (state, ...rest) => sceneProps(state)?.getSharedElement ? returnOrCall(sceneProps(state)?.getSharedElement, ...rest) : getSharedElementStack(state, ...rest);
+    const getSharedElement = (state, ...rest) => sceneProps(state)?.sharedElement ? returnOrCall(sceneProps(state)?.sharedElement, ...rest) : getSharedElementStack(state, ...rest);
     const backgroundColor = (state, ...rest) => sceneProps(state)?.backgroundColor ? returnOrCall(sceneProps(state)?.backgroundColor, ...rest) : backgroundColorStack(state, ...rest);
     const getAnimation = () => {
         let {state, data, oldState, oldData, oldUrl, crumbs, nextCrumb} = stateNavigator.stateContext;

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -7,8 +7,8 @@ import Scene from './Scene';
 type NavigationStackProps = {underlayColor: string, title: (state: State, data: any) => string, crumbStyle: any, unmountStyle: any, hidesTabBar: any, sharedElement: any, stackInvalidatedLink: string, renderScene: (state: State, data: any) => ReactNode, children: any};
 type NavigationStackState = {stateNavigator: StateNavigator, keys: string[], rest: boolean, counter: number, mostRecentEventCount: number};
 
-const NavigationStack = ({underlayColor = '#000', title, crumbStyle = () => null, unmountStyle = () => null,
-    hidesTabBar = () => false, sharedElement: getSharedElement = () => null, stackInvalidatedLink, renderScene, children}: NavigationStackProps) => {
+const NavigationStack = ({underlayColor = '#000', title, crumbStyle: crumbStyleStack = () => null, unmountStyle: unmountStyleStack = () => null,
+    hidesTabBar: hidesTabBarStack = () => false, sharedElement: getSharedElementStack = () => null, stackInvalidatedLink, renderScene, children}: NavigationStackProps) => {
     const resumeNavigationRef = useRef(null);
     const ref = useRef(null);
     const {stateNavigator} = useContext(NavigationContext);
@@ -68,10 +68,10 @@ const NavigationStack = ({underlayColor = '#000', title, crumbStyle = () => null
         }
     }
     const sceneProps = ({key}: State) => firstLink ? allScenes[key].props : null;
-    unmountStyle = (from, state, ...rest) => sceneProps(state)?.unmountStyle ? sceneProps(state)?.unmountStyle(from, ...rest) : unmountStyle(from, state, ...rest);
-    crumbStyle = (from, state, ...rest) => sceneProps(state)?.crumbStyle ? sceneProps(state)?.crumbStyle(from, ...rest) : crumbStyle(from, state, ...rest);
-    hidesTabBar = (state, ...rest) => sceneProps(state)?.hidesTabBar ? sceneProps(state)?.hidesTabBar(...rest) : hidesTabBar(state, ...rest);
-    getSharedElement = (state, ...rest) => sceneProps(state)?.getSharedElement ? sceneProps(state)?.getSharedElement(...rest) : getSharedElement(state, ...rest);
+    const unmountStyle = (from, state, ...rest) => sceneProps(state)?.unmountStyle ? sceneProps(state)?.unmountStyle(from, ...rest) : unmountStyleStack(from, state, ...rest);
+    const crumbStyle = (from, state, ...rest) => sceneProps(state)?.crumbStyle ? sceneProps(state)?.crumbStyle(from, ...rest) : crumbStyleStack(from, state, ...rest);
+    const hidesTabBar = (state, ...rest) => sceneProps(state)?.hidesTabBar ? sceneProps(state)?.hidesTabBar(...rest) : hidesTabBarStack(state, ...rest);
+    const getSharedElement = (state, ...rest) => sceneProps(state)?.getSharedElement ? sceneProps(state)?.getSharedElement(...rest) : getSharedElementStack(state, ...rest);
     const getAnimation = () => {
         let {state, data, oldState, oldData, oldUrl, crumbs, nextCrumb} = stateNavigator.stateContext;
         if (!oldState)

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -68,10 +68,11 @@ const NavigationStack = ({underlayColor = '#000', title, crumbStyle: crumbStyleS
         }
     }
     const sceneProps = ({key}: State) => firstLink ? allScenes[key].props : null;
+    const returnOrCall = (item, ...args) => typeof item !== 'function' ? item : item(...args);
     const unmountStyle = (from, state, ...rest) => sceneProps(state)?.unmountStyle ? sceneProps(state)?.unmountStyle(from, ...rest) : unmountStyleStack(from, state, ...rest);
     const crumbStyle = (from, state, ...rest) => sceneProps(state)?.crumbStyle ? sceneProps(state)?.crumbStyle(from, ...rest) : crumbStyleStack(from, state, ...rest);
-    const hidesTabBar = (state, ...rest) => sceneProps(state)?.hidesTabBar ? sceneProps(state)?.hidesTabBar(...rest) : hidesTabBarStack(state, ...rest);
-    const getSharedElement = (state, ...rest) => sceneProps(state)?.getSharedElement ? sceneProps(state)?.getSharedElement(...rest) : getSharedElementStack(state, ...rest);
+    const hidesTabBar = (state, ...rest) => sceneProps(state)?.hidesTabBar ? returnOrCall(sceneProps(state)?.hidesTabBar, ...rest) : hidesTabBarStack(state, ...rest);
+    const getSharedElement = (state, ...rest) => sceneProps(state)?.getSharedElement ? returnOrCall(sceneProps(state)?.getSharedElement, ...rest) : getSharedElementStack(state, ...rest);
     const getAnimation = () => {
         let {state, data, oldState, oldData, oldUrl, crumbs, nextCrumb} = stateNavigator.stateContext;
         if (!oldState)

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -4,11 +4,12 @@ import { StateNavigator, Crumb, State } from 'navigation';
 import { NavigationContext } from 'navigation-react';
 import PopSync from './PopSync';
 import Scene from './Scene';
-type NavigationStackProps = {underlayColor: string, title: (state: State, data: any) => string, crumbStyle: any, unmountStyle: any, hidesTabBar: any, sharedElement: any, stackInvalidatedLink: string, renderScene: (state: State, data: any) => ReactNode, children: any};
+type NavigationStackProps = {underlayColor: string, title: (state: State, data: any) => string, crumbStyle: any, unmountStyle: any, hidesTabBar: any, sharedElement: any, backgroundColor: any, stackInvalidatedLink: string, renderScene: (state: State, data: any) => ReactNode, children: any};
 type NavigationStackState = {stateNavigator: StateNavigator, keys: string[], rest: boolean, counter: number, mostRecentEventCount: number};
 
 const NavigationStack = ({underlayColor = '#000', title, crumbStyle: crumbStyleStack = () => null, unmountStyle: unmountStyleStack = () => null,
-    hidesTabBar: hidesTabBarStack = () => false, sharedElement: getSharedElementStack = () => null, stackInvalidatedLink, renderScene, children}: NavigationStackProps) => {
+    hidesTabBar: hidesTabBarStack = () => false, sharedElement: getSharedElementStack = () => null, backgroundColor: backgroundColorStack = () => null,
+    stackInvalidatedLink, renderScene, children}: NavigationStackProps) => {
     const resumeNavigationRef = useRef(null);
     const ref = useRef(null);
     const {stateNavigator} = useContext(NavigationContext);
@@ -73,6 +74,7 @@ const NavigationStack = ({underlayColor = '#000', title, crumbStyle: crumbStyleS
     const crumbStyle = (from, state, ...rest) => sceneProps(state)?.crumbStyle ? sceneProps(state)?.crumbStyle(from, ...rest) : crumbStyleStack(from, state, ...rest);
     const hidesTabBar = (state, ...rest) => sceneProps(state)?.hidesTabBar ? returnOrCall(sceneProps(state)?.hidesTabBar, ...rest) : hidesTabBarStack(state, ...rest);
     const getSharedElement = (state, ...rest) => sceneProps(state)?.getSharedElement ? returnOrCall(sceneProps(state)?.getSharedElement, ...rest) : getSharedElementStack(state, ...rest);
+    const backgroundColor = (state, ...rest) => sceneProps(state)?.backgroundColor ? returnOrCall(sceneProps(state)?.backgroundColor, ...rest) : backgroundColorStack(state, ...rest);
     const getAnimation = () => {
         let {state, data, oldState, oldData, oldUrl, crumbs, nextCrumb} = stateNavigator.stateContext;
         if (!oldState)
@@ -137,6 +139,7 @@ const NavigationStack = ({underlayColor = '#000', title, crumbStyle: crumbStyleS
                         unmountStyle={unmountStyle}
                         crumbStyle={crumbStyle}
                         hidesTabBar={hidesTabBar}
+                        backgroundColor={backgroundColor}
                         title={title}
                         popped={popNative}
                         renderScene={firstLink ? ({key}) => allScenes[key] : renderScene} />

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -4,7 +4,7 @@ import { StateNavigator, StateContext, State, Crumb } from 'navigation';
 import { NavigationContext, NavigationEvent } from 'navigation-react';
 import BackButton from './BackButton';
 import Freeze from './Freeze';
-type SceneProps = { crumb: number, sceneKey: string, rest: boolean, renderScene: (state: State, data: any) => ReactNode, crumbStyle: any, unmountStyle: any, hidesTabBar: any, title: (state: State, data: any) => string, popped: (key: string) => void, navigationEvent: NavigationEvent };
+type SceneProps = { crumb: number, sceneKey: string, rest: boolean, renderScene: (state: State, data: any) => ReactNode, crumbStyle: any, unmountStyle: any, hidesTabBar: any, backgroundColor: any, title: (state: State, data: any) => string, popped: (key: string) => void, navigationEvent: NavigationEvent };
 type SceneState = { navigationEvent: NavigationEvent };
 
 class Scene extends React.Component<SceneProps, SceneState> {
@@ -114,7 +114,7 @@ class Scene extends React.Component<SceneProps, SceneState> {
         return stateContext;
     }
     getAnimation() {
-        var {crumb, navigationEvent: {stateNavigator}, unmountStyle, crumbStyle, hidesTabBar} = this.props;
+        var {crumb, navigationEvent: {stateNavigator}, unmountStyle, crumbStyle, hidesTabBar, backgroundColor} = this.props;
         var {crumbs, nextCrumb} = stateNavigator.stateContext;
         var {state, data} = crumbs[crumb] || nextCrumb;
         var currentCrumbs = crumbs.slice(0, crumb);
@@ -126,7 +126,8 @@ class Scene extends React.Component<SceneProps, SceneState> {
         }
         var exitAnim = unmountStyle(false, state, data, currentCrumbs);
         var hidesTabBar = hidesTabBar(state, data, currentCrumbs);
-        return {enterAnim, exitAnim, hidesTabBar};
+        var backgroundColor = backgroundColor(state, data, currentCrumbs) || '#fff';
+        return {enterAnim, exitAnim, hidesTabBar, backgroundColor};
     }
     render() {
         var {navigationEvent} = this.state;
@@ -167,7 +168,6 @@ var NVScene = global.nativeFabricUIManager ? require('./SceneNativeComponent').d
 
 const styles = StyleSheet.create({
     scene: {
-        backgroundColor: '#fff',
         position: 'absolute',
         top: 0, right: 0,
         bottom: 0, left: 0,

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -12,9 +12,13 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, sharedElem
         duration={duration}
         renderScene={renderScene}
         renderMotion={typeof children !== 'function' ? renderTransition || renderMotion : undefined}>
-        {children || renderMotion}
+        {typeof children !== 'function' ? (
+          React.Children.map(children, child => (
+            React.cloneElement(child, { crumbStyle: child.props.crumbedStyle })
+          ))
+        ) : (children || renderMotion)}
     </NavigationMotion>
-)
+);
 
 const renderMotion = ({translate}, scene, key) => (
   <View key={key}

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -7,7 +7,7 @@ const cloneScenes = (children, nested = false) => (
   React.Children.map(children, scene => (
     (scene.type === Scene || nested)
       ? React.cloneElement(scene, { crumbStyle: scene.props.crumbedStyle })
-      : React.cloneElement(scene, null, cloneScenes(scene.props.children, true) as any)
+      : React.cloneElement(scene, null, cloneScenes(scene.props.children, true))
   ))
 );
 

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -3,6 +3,14 @@ import { View } from 'react-native';
 import { NavigationMotion, Scene, SharedElementMotion } from 'navigation-react-mobile';
 import { MobileHistoryManager } from 'navigation-react-mobile';
 
+const cloneScenes = (children, nested = false) => (
+  React.Children.map(children, scene => (
+    (scene.type === Scene || nested)
+      ? React.cloneElement(scene, { crumbStyle: scene.props.crumbedStyle })
+      : React.cloneElement(scene, null, cloneScenes(scene.props.children, true) as any)
+  ))
+);
+
 const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, sharedElementTransition, duration, renderScene, renderTransition, children}) => (
     <NavigationMotion
         unmountedStyle={unmountedStyle || {translate: 100}}
@@ -12,11 +20,7 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, sharedElem
         duration={duration}
         renderScene={renderScene}
         renderMotion={typeof children !== 'function' ? renderTransition || renderMotion : undefined}>
-        {typeof children !== 'function' ? (
-          React.Children.map(children, child => (
-            React.cloneElement(child, { crumbStyle: child.props.crumbedStyle })
-          ))
-        ) : (children || renderMotion)}
+        {typeof children !== 'function' ? cloneScenes(children) : (children || renderMotion)}
     </NavigationMotion>
 );
 

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -3,14 +3,6 @@ import { View } from 'react-native';
 import { NavigationMotion, Scene, SharedElementMotion } from 'navigation-react-mobile';
 import { MobileHistoryManager } from 'navigation-react-mobile';
 
-const cloneScenes = (children, nested = false) => (
-  React.Children.map(children, scene => (
-    (scene.type === Scene || nested)
-      ? React.cloneElement(scene, { crumbStyle: scene.props.crumbedStyle })
-      : React.cloneElement(scene, null, cloneScenes(scene.props.children, true))
-  ))
-);
-
 const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, sharedElementTransition, duration, renderScene, renderTransition, children}) => (
     <NavigationMotion
         unmountedStyle={unmountedStyle || {translate: 100}}
@@ -35,6 +27,14 @@ const renderMotion = ({translate}, scene, key) => (
     }}>
     {scene}
   </View>
+);
+
+const cloneScenes = (children, nested = false) => (
+  React.Children.map(children, scene => (
+    (scene.type === Scene || nested)
+      ? React.cloneElement(scene, { crumbStyle: scene.props.crumbedStyle })
+      : React.cloneElement(scene, null, cloneScenes(scene.props.children, true))
+  ))
 );
 
 NavigationStack.Scene = Scene;

--- a/build/npm/navigation-react-mobile/navigation.react.mobile.d.ts
+++ b/build/npm/navigation-react-mobile/navigation.react.mobile.d.ts
@@ -132,6 +132,18 @@ export interface NavigationMotionProps {
      */
     stateKey: keyof NavigationInfo & string;
     /**
+     * The Scene's unmounted style
+     */
+     unmountedStyle?: any;
+     /**
+      * The Scene's mounted style
+      */
+     mountedStyle?: any;
+     /**
+      * The Scene's crumb trail style
+      */
+     crumbStyle?: any;
+     /**
      * The Scene content
      */
     children: ReactNode;

--- a/build/npm/navigation-react-mobile/navigation.react.mobile.d.ts
+++ b/build/npm/navigation-react-mobile/navigation.react.mobile.d.ts
@@ -134,15 +134,15 @@ export interface NavigationMotionProps {
     /**
      * The Scene's unmounted style
      */
-     unmountedStyle?: any;
-     /**
-      * The Scene's mounted style
-      */
-     mountedStyle?: any;
-     /**
-      * The Scene's crumb trail style
-      */
-     crumbStyle?: any;
+    unmountedStyle?: any;
+    /**
+     * The Scene's mounted style
+     */
+    mountedStyle?: any;
+    /**
+     * The Scene's crumb trail style
+     */
+    crumbStyle?: any;
      /**
      * The Scene content
      */

--- a/build/npm/navigation-react-native-web/navigation.react.native.web.d.ts
+++ b/build/npm/navigation-react-native-web/navigation.react.native.web.d.ts
@@ -42,6 +42,24 @@ declare module 'navigation-react-native' {
         renderTransition?: (style: any, scene: ReactElement<any>, key: string, active: boolean, state: State, data: any) => ReactElement<any>;
     }
 
+    /**
+     * Defines the Scene Props contract
+     */
+    export interface SceneProps<NavigationInfo extends { [index: string]: any } = any> {
+        /**
+         * The Scene's unmounted style
+         */
+        unmountedStyle?: any;
+        /**
+         * The Scene's mounted style
+         */
+        mountedStyle?: any;
+        /**
+         * The Scene's crumb trail style
+         */
+        crumbedStyle?: any;
+    }
+
     interface TabBarItemProps {
         /**
          * The tab hyperlink

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -68,23 +68,23 @@ export class NavigationStack extends Component<NavigationStackProps> { }
     /**
      * A Scene's to and from crumb trail style
      */
-     crumbStyle?: (from: boolean, data: any, crumbs: Crumb[], nextState?: State, nextData?: any) => string;
-     /**
-      * A Scene's to and from unmount style
-      */
-     unmountStyle?: (from: boolean, data: any, crumbs: Crumb[]) => string;
-     /**
-      * Indicates whether a Scene should display the tab bar
-      */
-     hidesTabBar?: boolean | ((data: any, crumbs: Crumb[]) => boolean);
-     /**
-      * A Scene's shared element
-      */
-     sharedElement?: string | ((data: any, crumbs: Crumb[]) => string);
-     /**
-      * The color of a Scene's background
-      */
-     backgroundColor?: ColorValue | ((data: any, crumbs: Crumb[]) => ColorValue);
+    crumbStyle?: (from: boolean, data: any, crumbs: Crumb[], nextState?: State, nextData?: any) => string;
+    /**
+     * A Scene's to and from unmount style
+     */
+    unmountStyle?: (from: boolean, data: any, crumbs: Crumb[]) => string;
+    /**
+     * Indicates whether a Scene should display the tab bar
+     */
+    hidesTabBar?: boolean | ((data: any, crumbs: Crumb[]) => boolean);
+    /**
+     * A Scene's shared element
+     */
+    sharedElement?: string | ((data: any, crumbs: Crumb[]) => string);
+    /**
+     * The color of a Scene's background
+     */
+    backgroundColor?: ColorValue | ((data: any, crumbs: Crumb[]) => ColorValue);
      /**
      * The Scene content
      */

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -19,27 +19,27 @@ export interface NavigationStackProps {
      */
     stackInvalidatedLink?: string;
      /**
-     * A Scene's title
+     * The Scene's title
      */
     title?: (state: State, data: any) => string;
     /**
-     * A Scene's to and from crumb trail style
+     * The Scene's to and from crumb trail style
      */
     crumbStyle?: (from: boolean, state: State, data: any, crumbs: Crumb[], nextState?: State, nextData?: any) => string;
     /**
-     * A Scene's to and from unmount style
+     * The Scene's to and from unmount style
      */
     unmountStyle?: (from: boolean, state: State, data: any, crumbs: Crumb[]) => string;
     /**
-     * Indicates whether a Scene should display the tab bar
+     * Indicates whether the Scene should display the tab bar
      */
     hidesTabBar?: (state: State, data: any, crumbs: Crumb[]) => boolean;
     /**
-     * A Scene's shared element
+     * The Scene's shared element
      */
     sharedElement?: (state: State, data: any, crumbs: Crumb[]) => string;
     /**
-     * The color of a Scene's background
+     * The color of the Scene's background
      */
     backgroundColor?: (state: State, data: any, crumbs: Crumb[]) => ColorValue;
     /**

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -35,15 +35,19 @@ export interface NavigationStackProps {
      */
     hidesTabBar?: (state: State, data: any, crumbs: Crumb[]) => boolean;
     /**
-     * A scene's shared element
+     * A Scene's shared element
      */
     sharedElement?: (state: State, data: any, crumbs: Crumb[]) => string;
     /**
-     * Renders the scene for the State and data
+     * The color of a Scene's background
+     */
+    backgroundColor?: (state: State, data: any, crumbs: Crumb[]) => ColorValue;
+    /**
+     * Renders the Scene for the State and data
      */
     renderScene?: (state: State, data: any) => ReactNode;
     /**
-     * The scenes
+     * The Scenes
      */
     children?: any;
 }
@@ -62,6 +66,26 @@ export class NavigationStack extends Component<NavigationStackProps> { }
      */
     stateKey: keyof NavigationInfo & string;
     /**
+     * A Scene's to and from crumb trail style
+     */
+     crumbStyle?: (from: boolean, data: any, crumbs: Crumb[], nextState?: State, nextData?: any) => string;
+     /**
+      * A Scene's to and from unmount style
+      */
+     unmountStyle?: (from: boolean, data: any, crumbs: Crumb[]) => string;
+     /**
+      * Indicates whether a Scene should display the tab bar
+      */
+     hidesTabBar?: boolean | ((data: any, crumbs: Crumb[]) => boolean);
+     /**
+      * A Scene's shared element
+      */
+     sharedElement?: string | ((data: any, crumbs: Crumb[]) => string);
+     /**
+      * The color of a Scene's background
+      */
+     backgroundColor?: ColorValue | ((data: any, crumbs: Crumb[]) => ColorValue);
+     /**
      * The Scene content
      */
     children: ReactNode;
@@ -486,7 +510,7 @@ export class StatusBar extends Component<StatusBarProps> {}
  */
 export interface SharedElementProps {
     /**
-     * The name shared across scenes by the two views
+     * The name shared across Scenes by the two views
      */
     name: string;
     /**

--- a/types/navigation-react-mobile.d.ts
+++ b/types/navigation-react-mobile.d.ts
@@ -132,6 +132,18 @@ export interface NavigationMotionProps {
      */
     stateKey: keyof NavigationInfo & string;
     /**
+     * The Scene's unmounted style
+     */
+     unmountedStyle?: any;
+     /**
+      * The Scene's mounted style
+      */
+     mountedStyle?: any;
+     /**
+      * The Scene's crumb trail style
+      */
+     crumbStyle?: any;
+     /**
      * The Scene content
      */
     children: ReactNode;

--- a/types/navigation-react-mobile.d.ts
+++ b/types/navigation-react-mobile.d.ts
@@ -134,15 +134,15 @@ export interface NavigationMotionProps {
     /**
      * The Scene's unmounted style
      */
-     unmountedStyle?: any;
-     /**
-      * The Scene's mounted style
-      */
-     mountedStyle?: any;
-     /**
-      * The Scene's crumb trail style
-      */
-     crumbStyle?: any;
+    unmountedStyle?: any;
+    /**
+     * The Scene's mounted style
+     */
+    mountedStyle?: any;
+    /**
+     * The Scene's crumb trail style
+     */
+    crumbStyle?: any;
      /**
      * The Scene content
      */

--- a/types/navigation-react-native-web.d.ts
+++ b/types/navigation-react-native-web.d.ts
@@ -42,6 +42,24 @@ declare module 'navigation-react-native' {
         renderTransition?: (style: any, scene: ReactElement<any>, key: string, active: boolean, state: State, data: any) => ReactElement<any>;
     }
 
+    /**
+     * Defines the Scene Props contract
+     */
+    export interface SceneProps<NavigationInfo extends { [index: string]: any } = any> {
+        /**
+         * The Scene's unmounted style
+         */
+        unmountedStyle?: any;
+        /**
+         * The Scene's mounted style
+         */
+        mountedStyle?: any;
+        /**
+         * The Scene's crumb trail style
+         */
+        crumbedStyle?: any;
+    }
+
     interface TabBarItemProps {
         /**
          * The tab hyperlink

--- a/types/navigation-react-native.d.ts
+++ b/types/navigation-react-native.d.ts
@@ -68,23 +68,23 @@ export class NavigationStack extends Component<NavigationStackProps> { }
     /**
      * A Scene's to and from crumb trail style
      */
-     crumbStyle?: (from: boolean, data: any, crumbs: Crumb[], nextState?: State, nextData?: any) => string;
-     /**
-      * A Scene's to and from unmount style
-      */
-     unmountStyle?: (from: boolean, data: any, crumbs: Crumb[]) => string;
-     /**
-      * Indicates whether a Scene should display the tab bar
-      */
-     hidesTabBar?: boolean | ((data: any, crumbs: Crumb[]) => boolean);
-     /**
-      * A Scene's shared element
-      */
-     sharedElement?: string | ((data: any, crumbs: Crumb[]) => string);
-     /**
-      * The color of a Scene's background
-      */
-     backgroundColor?: ColorValue | ((data: any, crumbs: Crumb[]) => ColorValue);
+    crumbStyle?: (from: boolean, data: any, crumbs: Crumb[], nextState?: State, nextData?: any) => string;
+    /**
+     * A Scene's to and from unmount style
+     */
+    unmountStyle?: (from: boolean, data: any, crumbs: Crumb[]) => string;
+    /**
+     * Indicates whether a Scene should display the tab bar
+     */
+    hidesTabBar?: boolean | ((data: any, crumbs: Crumb[]) => boolean);
+    /**
+     * A Scene's shared element
+     */
+    sharedElement?: string | ((data: any, crumbs: Crumb[]) => string);
+    /**
+     * The color of a Scene's background
+     */
+    backgroundColor?: ColorValue | ((data: any, crumbs: Crumb[]) => ColorValue);
      /**
      * The Scene content
      */

--- a/types/navigation-react-native.d.ts
+++ b/types/navigation-react-native.d.ts
@@ -19,27 +19,27 @@ export interface NavigationStackProps {
      */
     stackInvalidatedLink?: string;
      /**
-     * A Scene's title
+     * The Scene's title
      */
     title?: (state: State, data: any) => string;
     /**
-     * A Scene's to and from crumb trail style
+     * The Scene's to and from crumb trail style
      */
     crumbStyle?: (from: boolean, state: State, data: any, crumbs: Crumb[], nextState?: State, nextData?: any) => string;
     /**
-     * A Scene's to and from unmount style
+     * The Scene's to and from unmount style
      */
     unmountStyle?: (from: boolean, state: State, data: any, crumbs: Crumb[]) => string;
     /**
-     * Indicates whether a Scene should display the tab bar
+     * Indicates whether the Scene should display the tab bar
      */
     hidesTabBar?: (state: State, data: any, crumbs: Crumb[]) => boolean;
     /**
-     * A Scene's shared element
+     * The Scene's shared element
      */
     sharedElement?: (state: State, data: any, crumbs: Crumb[]) => string;
     /**
-     * The color of a Scene's background
+     * The color of the Scene's background
      */
     backgroundColor?: (state: State, data: any, crumbs: Crumb[]) => ColorValue;
     /**

--- a/types/navigation-react-native.d.ts
+++ b/types/navigation-react-native.d.ts
@@ -35,15 +35,19 @@ export interface NavigationStackProps {
      */
     hidesTabBar?: (state: State, data: any, crumbs: Crumb[]) => boolean;
     /**
-     * A scene's shared element
+     * A Scene's shared element
      */
     sharedElement?: (state: State, data: any, crumbs: Crumb[]) => string;
     /**
-     * Renders the scene for the State and data
+     * The color of a Scene's background
+     */
+    backgroundColor?: (state: State, data: any, crumbs: Crumb[]) => ColorValue;
+    /**
+     * Renders the Scene for the State and data
      */
     renderScene?: (state: State, data: any) => ReactNode;
     /**
-     * The scenes
+     * The Scenes
      */
     children?: any;
 }
@@ -62,6 +66,26 @@ export class NavigationStack extends Component<NavigationStackProps> { }
      */
     stateKey: keyof NavigationInfo & string;
     /**
+     * A Scene's to and from crumb trail style
+     */
+     crumbStyle?: (from: boolean, data: any, crumbs: Crumb[], nextState?: State, nextData?: any) => string;
+     /**
+      * A Scene's to and from unmount style
+      */
+     unmountStyle?: (from: boolean, data: any, crumbs: Crumb[]) => string;
+     /**
+      * Indicates whether a Scene should display the tab bar
+      */
+     hidesTabBar?: boolean | ((data: any, crumbs: Crumb[]) => boolean);
+     /**
+      * A Scene's shared element
+      */
+     sharedElement?: string | ((data: any, crumbs: Crumb[]) => string);
+     /**
+      * The color of a Scene's background
+      */
+     backgroundColor?: ColorValue | ((data: any, crumbs: Crumb[]) => ColorValue);
+     /**
      * The Scene content
      */
     children: ReactNode;
@@ -486,7 +510,7 @@ export class StatusBar extends Component<StatusBarProps> {}
  */
 export interface SharedElementProps {
     /**
-     * The name shared across scenes by the two views
+     * The name shared across Scenes by the two views
      */
     name: string;
     /**

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "baseUrl": "."
+    }
+}


### PR DESCRIPTION
Fixes #639

When animating a scene's opacity on Android, the white scene background color shows through. If the scene content is dark then it ends up gray when navigating. Added a `backgroundColor` prop to the `NavigationStack`. Setting a transparent background on Android prevents the scene going gray.
```jsx
<NavigationStack
  backgroundColor={() => Platform.OS === 'android' ? 'rgba(255,255,255,0)' : 'white'}>
```

Also added `backgroundColor` prop to the `Scene` so it can be changed per scene.

```jsx
<NavigationStack
  backgroundColor={() => Platform.OS === 'android' ? 'rgba(255,255,255,0)' : 'white'}>
  <Scene backgroundColor="black" />
```
Made other stack-level props, like `unmountStyle` and `hidesTabBar`, available at the scene-level for consistency.

```jsx
<NavigationStack>
  <Scene hidesTabBar />
```
Did this for stack-level props on NavigationReactMobile and NavigationReactNativeWeb too, for example, `unmountedStyle`.
