### PR TITLE
Supported `NavgationStack` and `NavigationBar` events missing from Fabric (Android)

### DIFF
--- a/NavigationReactNative/src/NavigationBarNativeComponent.js
+++ b/NavigationReactNative/src/NavigationBarNativeComponent.js
@@ -30,6 +30,9 @@ type NativeProps = $ReadOnly<{|
   backTitleOn: boolean,
   backTestID: string,
   barHeight: Double,
+  onOffsetChanged: DirectEventHandler<$ReadOnly<{|
+    offset: Double
+  |}>>,
 |}>;
 
 export default (codegenNativeComponent<NativeProps>(

--- a/NavigationReactNative/src/NavigationStackNativeComponent.js
+++ b/NavigationReactNative/src/NavigationStackNativeComponent.js
@@ -13,6 +13,7 @@ type NativeProps = $ReadOnly<{|
   sharedElement: string,
   oldSharedElement: string,
   mostRecentEventCount: Int32,
+  onNavigateToTop: DirectEventHandler<null>,
   onWillNavigateBack: DirectEventHandler<$ReadOnly<{|
     crumb: Int32
   |}>>,

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarManager.java
@@ -59,7 +59,7 @@ public class NavigationBarManager extends ViewGroupManager<NavigationBarView> {
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("onOffsetChanged", MapBuilder.of("registrationName", "onOffsetChanged"))
+            .put("topOnOffsetChanged", MapBuilder.of("registrationName", "onOffsetChanged"))
             .build();
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarView.java
@@ -12,8 +12,10 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.i18nmanager.I18nUtil;
 import com.facebook.react.uimanager.PixelUtil;
+import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.google.android.material.appbar.AppBarLayout;
 
@@ -30,9 +32,10 @@ public class NavigationBarView extends AppBarLayout {
         addOnOffsetChangedListener(new OnOffsetChangedListener() {
             @Override
             public void onOffsetChanged(AppBarLayout appBarLayout, int offset) {
-                OffsetChangedEvent event = OffsetChangedEvent.obtain(getId(), offset);
                 ReactContext reactContext = (ReactContext) getContext();
-                reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+                EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
+                OffsetChangedEvent event = OffsetChangedEvent.obtain(getId(), offset);
+                eventDispatcher.dispatchEvent(event);
             }
         });
     }
@@ -70,7 +73,7 @@ public class NavigationBarView extends AppBarLayout {
 
         @Override
         public String getEventName() {
-            return "onOffsetChanged";
+            return "topOnOffsetChanged";
         }
 
         @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarView.java
@@ -13,7 +13,6 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.i18nmanager.I18nUtil;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.UIManagerHelper;
-import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
@@ -29,14 +28,10 @@ public class NavigationBarView extends AppBarLayout {
         setLayoutParams(new AppBarLayout.LayoutParams(AppBarLayout.LayoutParams.MATCH_PARENT, AppBarLayout.LayoutParams.WRAP_CONTENT));
         defaultOutlineProvider = getOutlineProvider();
         defaultBackground = getBackground();
-        addOnOffsetChangedListener(new OnOffsetChangedListener() {
-            @Override
-            public void onOffsetChanged(AppBarLayout appBarLayout, int offset) {
-                ReactContext reactContext = (ReactContext) getContext();
-                EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
-                OffsetChangedEvent event = OffsetChangedEvent.obtain(getId(), offset);
-                eventDispatcher.dispatchEvent(event);
-            }
+        addOnOffsetChangedListener((appBarLayout, offset) -> {
+            ReactContext reactContext = (ReactContext) getContext();
+            EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
+            eventDispatcher.dispatchEvent(OffsetChangedEvent.obtain(getId(), offset));
         });
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarViewManager.java
@@ -167,7 +167,7 @@ public class NavigationBarViewManager extends ViewGroupManager<NavigationBarView
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("onOffsetChanged", MapBuilder.of("registrationName", "onOffsetChanged"))
+            .put("topOnOffsetChanged", MapBuilder.of("registrationName", "onOffsetChanged"))
             .build();
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -95,8 +95,8 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("onNavigateToTop", MapBuilder.of("registrationName", "onNavigateToTop"))
-            .put("onRest", MapBuilder.of("registrationName", "onRest"))
+            .put("topOnNavigateToTop", MapBuilder.of("registrationName", "onNavigateToTop"))
+            .put("topOnRest", MapBuilder.of("registrationName", "onRest"))
             .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -28,6 +28,9 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.UIManagerHelper;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 
 import java.util.ArrayList;
@@ -259,10 +262,9 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
     }
 
     void onRest(int crumb) {
-        WritableMap event = Arguments.createMap();
-        event.putInt("crumb", crumb);
         ReactContext reactContext = (ReactContext) getContext();
-        reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "onRest", event);
+        EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
+        eventDispatcher.dispatchEvent(new NavigationStackView.RestEvent(getId(), crumb));
     }
 
     @Override
@@ -298,6 +300,27 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
         @Override
         public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
             return stack != null ? stack : new View(getContext());
+        }
+    }
+
+    static class RestEvent extends Event<NavigationStackView.RestEvent> {
+        private final int crumb;
+
+        public RestEvent(int viewId, int crumb) {
+            super(viewId);
+            this.crumb = crumb;
+        }
+
+        @Override
+        public String getEventName() {
+            return "topOnRest";
+        }
+
+        @Override
+        public void dispatch(RCTEventEmitter rctEventEmitter) {
+            WritableMap event = Arguments.createMap();
+            event.putInt("crumb", this.crumb);
+            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), event);
         }
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -232,7 +232,8 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
     void scrollToTop() {
         if (keys.size() > 1) {
             ReactContext reactContext = (ReactContext) getContext();
-            reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "onNavigateToTop", null);
+            EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
+            eventDispatcher.dispatchEvent(new NavigationStackView.NavigateToTopEvent(getId()));
         }
         if (keys.size() == 1) {
             SceneView scene = scenes.get(keys.getString(0));
@@ -300,6 +301,22 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
         @Override
         public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
             return stack != null ? stack : new View(getContext());
+        }
+    }
+
+    static class NavigateToTopEvent extends Event<NavigationStackView.NavigateToTopEvent> {
+        public NavigateToTopEvent(int viewId) {
+            super(viewId);
+        }
+
+        @Override
+        public String getEventName() {
+            return "topOnNavigateToTop";
+        }
+
+        @Override
+        public void dispatch(RCTEventEmitter rctEventEmitter) {
+            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), null);
         }
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackViewManager.java
@@ -121,8 +121,8 @@ public class NavigationStackViewManager extends ViewGroupManager<NavigationStack
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-                .put("onNavigateToTop", MapBuilder.of("registrationName", "onNavigateToTop"))
-                .put("onRest", MapBuilder.of("registrationName", "onRest"))
-                .build();
+            .put("topOnNavigateToTop", MapBuilder.of("registrationName", "onNavigateToTop"))
+            .put("topOnRest", MapBuilder.of("registrationName", "onRest"))
+            .build();
     }
 }


### PR DESCRIPTION
Overlooked these events when migrating to Fabric. Followed the standard cross-architecture event pattern.

Noticed that `useNativeDriver` (from the Timeline component in the Twitter example) doesn't work with the `offsetChanged` event on the `NavigationBar`. Will do a release then create an example repo and raise a bug on the new architecture.