### PR TITLE
Supported custom back button image (iOS)

### DIFF
--- a/NavigationReactNative/src/NavigationBar.tsx
+++ b/NavigationReactNative/src/NavigationBar.tsx
@@ -31,7 +31,7 @@ class NavigationBar extends React.Component<any, any> {
         }
     }
     render() {
-        var {bottomBar, hidden, logo, navigationImage, overflowImage, backTitle, titleCentered, children, style = {height: undefined}, ...otherProps} = this.props;
+        var {bottomBar, hidden, logo, navigationImage, overflowImage, backTitle, backImage, titleCentered, children, style = {height: undefined}, ...otherProps} = this.props;
         const Material3 = global.__turboModuleProxy != null ? require("./NativeMaterial3Module").default : NativeModules.Material3;
         const { on: material3 } = Platform.OS === 'android' ? Material3.getConstants() : { on: false };
         var scrollEdgeProps = this.getScrollEdgeProps()
@@ -49,6 +49,7 @@ class NavigationBar extends React.Component<any, any> {
                     hidden={hidden}
                     backTitle={backTitle}
                     backTitleOn={backTitle !== undefined}
+                    backImage={Image.resolveAssetSource(backImage)}
                     barHeight={!!collapsingBar ? style.height : 0}
                     style={{height: !!collapsingBar ? style.height : null}}
                     {...otherProps}

--- a/NavigationReactNative/src/NavigationBarNativeComponent.js
+++ b/NavigationReactNative/src/NavigationBarNativeComponent.js
@@ -28,6 +28,7 @@ type NativeProps = $ReadOnly<{|
   largeTitleColor: ColorValue,
   backTitle: string,
   backTitleOn: boolean,
+  backImage: ImageSource,
   backTestID: string,
   barHeight: Double,
   onOffsetChanged: DirectEventHandler<$ReadOnly<{|
@@ -37,4 +38,5 @@ type NativeProps = $ReadOnly<{|
 
 export default (codegenNativeComponent<NativeProps>(
    'NVNavigationBar',
+   {interfaceOnly: true}
 ): HostComponent<NativeProps>);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarViewManager.java
@@ -6,6 +6,7 @@ import android.view.MenuItem;
 
 import androidx.annotation.Nullable;
 
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.PixelUtil;
@@ -158,6 +159,10 @@ public class NavigationBarViewManager extends ViewGroupManager<NavigationBarView
 
     @Override
     public void setBackTitleOn(NavigationBarView view, boolean value) {
+    }
+
+    @Override
+    public void setBackImage(NavigationBarView view, @Nullable ReadableMap value) {
     }
 
     @Override

--- a/NavigationReactNative/src/cpp/navigationreactnative.h
+++ b/NavigationReactNative/src/cpp/navigationreactnative.h
@@ -15,6 +15,7 @@
 #include <jsi/jsi.h>
 #include <react/renderer/components/navigationreactnative/NVActionBarComponentDescriptor.h>
 #include <react/renderer/components/navigationreactnative/NVBarButtonComponentDescriptor.h>
+#include <react/renderer/components/navigationreactnative/NVNavigationBarComponentDescriptor.h>
 #include <react/renderer/components/navigationreactnative/NVSearchBarComponentDescriptor.h>
 #include <react/renderer/components/navigationreactnative/NVTabBarItemComponentDescriptor.h>
 #include <react/renderer/components/navigationreactnative/NVTitleBarComponentDescriptor.h>

--- a/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVNavigationBarComponentDescriptor.h
+++ b/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVNavigationBarComponentDescriptor.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "NVNavigationBarShadowNode.h"
+#include <react/renderer/core/ConcreteComponentDescriptor.h>
+
+namespace facebook {
+namespace react {
+
+class NVNavigationBarComponentDescriptor final
+    : public ConcreteComponentDescriptor<NVNavigationBarShadowNode> {
+ public:
+    NVNavigationBarComponentDescriptor(ComponentDescriptorParameters const &parameters)
+      : ConcreteComponentDescriptor(parameters),
+        imageManager_(std::make_shared<ImageManager>(contextContainer_)){}
+
+  void adopt(ShadowNode::Unshared const &shadowNode) const override {
+    ConcreteComponentDescriptor::adopt(shadowNode);
+
+    auto navigationBarShadowNode =
+        std::static_pointer_cast<NVNavigationBarShadowNode>(shadowNode);
+
+    navigationBarShadowNode->setImageManager(imageManager_);
+  }
+
+ private:
+  const SharedImageManager imageManager_;
+};
+
+} // namespace react
+} // namespace facebook

--- a/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVNavigationBarShadowNode.cpp
+++ b/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVNavigationBarShadowNode.cpp
@@ -1,0 +1,54 @@
+#include "NVNavigationBarShadowNode.h"
+#include <react/renderer/core/LayoutContext.h>
+
+namespace facebook {
+namespace react {
+
+extern const char NVNavigationBarComponentName[] = "NVNavigationBar";
+
+void NVNavigationBarShadowNode::setImageManager(const SharedImageManager &imageManager) {
+  ensureUnsealed();
+  imageManager_ = imageManager;
+}
+
+void NVNavigationBarShadowNode::updateStateIfNeeded() {
+  const auto &newImageSource = getImageSource();
+
+  auto const &currentState = getStateData();
+
+  auto imageSource = currentState.getImageSource();
+
+  bool anyChanged = newImageSource != imageSource;
+
+  if (!anyChanged) {
+    return;
+  }
+
+  ensureUnsealed();
+
+  auto state = NVNavigationBarState{
+      newImageSource,
+      imageManager_->requestImage(newImageSource, getSurfaceId()),
+    };
+  setStateData(std::move(state));
+}
+
+ImageSource NVNavigationBarShadowNode::getImageSource() const {
+  return getConcreteProps().image;
+}
+
+#pragma mark - LayoutableShadowNode
+
+Size NVNavigationBarShadowNode::measureContent(
+    LayoutContext const &layoutContext,
+    LayoutConstraints const &layoutConstraints) const {
+  return {};
+}
+
+void NVNavigationBarShadowNode::layout(LayoutContext layoutContext) {
+  updateStateIfNeeded();
+  ConcreteViewShadowNode::layout(layoutContext);
+}
+
+} // namespace react
+} // namespace facebook

--- a/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVNavigationBarShadowNode.cpp
+++ b/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVNavigationBarShadowNode.cpp
@@ -34,7 +34,7 @@ void NVNavigationBarShadowNode::updateStateIfNeeded() {
 }
 
 ImageSource NVNavigationBarShadowNode::getImageSource() const {
-  return getConcreteProps().image;
+  return getConcreteProps().backImage;
 }
 
 #pragma mark - LayoutableShadowNode

--- a/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVNavigationBarShadowNode.h
+++ b/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVNavigationBarShadowNode.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "NVNavigationBarState.h"
+#include <react/renderer/components/view/ConcreteViewShadowNode.h>
+#include <react/renderer/components/navigationreactnative/EventEmitters.h>
+#include <react/renderer/components/navigationreactnative/Props.h>
+#include <react/renderer/imagemanager/ImageManager.h>
+
+namespace facebook {
+namespace react {
+
+JSI_EXPORT extern const char NVNavigationBarComponentName[];
+
+class JSI_EXPORT NVNavigationBarShadowNode final: public ConcreteViewShadowNode<
+  NVNavigationBarComponentName,
+  NVNavigationBarProps,
+  NVNavigationBarEventEmitter,
+  NVNavigationBarState
+> {
+
+public:
+  using ConcreteViewShadowNode::ConcreteViewShadowNode;
+
+  void setImageManager(const SharedImageManager &imageManager);
+
+  static NVNavigationBarState initialStateData(
+                                           ShadowNodeFragment const &fragment,
+                                           ShadowNodeFamilyFragment const &familyFragment,
+                                           ComponentDescriptor const &componentDescriptor) {
+    auto imageSource = ImageSource{ImageSource::Type::Invalid};
+    return {
+      imageSource,
+      {imageSource, nullptr}};
+  }
+
+#pragma mark - LayoutableShadowNode
+
+  Size measureContent(
+                      LayoutContext const &layoutContext,
+                      LayoutConstraints const &layoutConstraints) const override;
+  void layout(LayoutContext layoutContext) override;
+
+private:
+  void updateStateIfNeeded();
+
+  ImageSource getImageSource() const;
+
+  SharedImageManager imageManager_;
+};
+
+} // namespace react
+} // namespace facebook

--- a/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVNavigationBarState.cpp
+++ b/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVNavigationBarState.cpp
@@ -1,0 +1,15 @@
+#include "NVNavigationBarState.h"
+
+namespace facebook {
+namespace react {
+
+ImageSource NVNavigationBarState::getImageSource() const {
+  return imageSource_;
+}
+
+ImageRequest const &NVNavigationBarState::getImageRequest() const {
+  return *imageRequest_;
+}
+
+} // namespace react
+} // namespace facebook

--- a/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVNavigationBarState.h
+++ b/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVNavigationBarState.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#ifdef ANDROID
+#include <folly/dynamic.h>
+#include <react/renderer/mapbuffer/MapBuffer.h>
+#include <react/renderer/mapbuffer/MapBufferBuilder.h>
+#endif
+
+#include <react/renderer/imagemanager/ImageRequest.h>
+#include <react/renderer/imagemanager/primitives.h>
+
+namespace facebook {
+namespace react {
+
+class NVNavigationBarState final {
+ public:
+  NVNavigationBarState(
+      ImageSource const &imageSource,
+      ImageRequest imageRequest)
+      : imageSource_(imageSource),
+        imageRequest_(
+            std::make_shared<ImageRequest>(std::move(imageRequest))){};
+
+  NVNavigationBarState() = default;
+
+  ImageSource getImageSource() const;
+  ImageRequest const &getImageRequest() const;
+
+#ifdef ANDROID
+  NVNavigationBarState(NVNavigationBarState const &previousState, folly::dynamic data){};
+
+  folly::dynamic getDynamic() const {
+    return {};
+  };
+  MapBuffer getMapBuffer() const {
+    return MapBufferBuilder::EMPTY();
+  };
+#endif
+
+ private:
+  ImageSource imageSource_;
+  std::shared_ptr<ImageRequest> imageRequest_;
+};
+
+} // namespace react
+} // namespace facebook

--- a/NavigationReactNative/src/ios/NVNavigationBarComponentView.h
+++ b/NavigationReactNative/src/ios/NVNavigationBarComponentView.h
@@ -30,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) UIColor *largeTitleColor;
 @property (nonatomic, copy) NSString *backTitle;
 @property (nonatomic, copy) NSString *backTestID;
+@property (nonatomic, assign) BOOL backImageOn;
 @property (nonatomic, copy)  void (^ _Nullable backImageDidLoadBlock)(void);
 
 @end

--- a/NavigationReactNative/src/ios/NVNavigationBarComponentView.h
+++ b/NavigationReactNative/src/ios/NVNavigationBarComponentView.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) UIColor *largeTitleColor;
 @property (nonatomic, copy) NSString *backTitle;
 @property (nonatomic, copy) NSString *backTestID;
-@property (nonatomic, copy) void (^backImageDidLoadBlock)(void);
+@property (nonatomic, copy)  void (^ _Nullable backImageDidLoadBlock)(void);
 
 @end
 

--- a/NavigationReactNative/src/ios/NVNavigationBarComponentView.h
+++ b/NavigationReactNative/src/ios/NVNavigationBarComponentView.h
@@ -30,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) UIColor *largeTitleColor;
 @property (nonatomic, copy) NSString *backTitle;
 @property (nonatomic, copy) NSString *backTestID;
+@property (nonatomic, copy) void (^backImageDidLoadBlock)(void);
 
 @end
 

--- a/NavigationReactNative/src/ios/NVNavigationBarComponentView.h
+++ b/NavigationReactNative/src/ios/NVNavigationBarComponentView.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) UIColor *largeTitleColor;
 @property (nonatomic, copy) NSString *backTitle;
 @property (nonatomic, copy) NSString *backTestID;
-@property (nonatomic, assign) BOOL backImageOn;
+@property (nonatomic, assign) BOOL backImageLoading;
 @property (nonatomic, copy) void (^ _Nullable backImageDidLoadBlock)(void);
 
 @end

--- a/NavigationReactNative/src/ios/NVNavigationBarComponentView.h
+++ b/NavigationReactNative/src/ios/NVNavigationBarComponentView.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) NSString *backTitle;
 @property (nonatomic, copy) NSString *backTestID;
 @property (nonatomic, assign) BOOL backImageOn;
-@property (nonatomic, copy)  void (^ _Nullable backImageDidLoadBlock)(void);
+@property (nonatomic, copy) void (^ _Nullable backImageDidLoadBlock)(void);
 
 @end
 

--- a/NavigationReactNative/src/ios/NVNavigationBarComponentView.mm
+++ b/NavigationReactNative/src/ios/NVNavigationBarComponentView.mm
@@ -5,10 +5,14 @@
 #import <react/renderer/components/navigationreactnative/EventEmitters.h>
 #import <react/renderer/components/navigationreactnative/Props.h>
 #import <react/renderer/components/navigationreactnative/RCTComponentViewHelpers.h>
+#import <react/renderer/imagemanager/ImageResponseObserverCoordinator.h>
+#import <NVNavigationBarComponentDescriptor.h>
 
 #import "RCTFabricComponentsPlugins.h"
 #import <React/RCTConversions.h>
 #import <React/RCTFont.h>
+#import <React/RCTImageResponseDelegate.h>
+#import <React/RCTImageResponseObserverProxy.h>
 #import <React/UIView+React.h>
 
 using namespace facebook::react;
@@ -16,7 +20,11 @@ using namespace facebook::react;
 @interface NVNavigationBarComponentView () <RCTNVNavigationBarViewProtocol>
 @end
 
-@implementation NVNavigationBarComponentView
+@implementation NVNavigationBarComponentView {
+    ImageResponseObserverCoordinator const *_imageCoordinator;
+    RCTImageResponseObserverProxy _imageResponseObserverProxy;
+    UIImage *_backImage;
+}
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
@@ -78,6 +86,11 @@ using namespace facebook::react;
         }
     }
     _backTestID = [[NSString alloc] initWithUTF8String: newViewProps.backTestID.c_str()];
+    NSString *uri = [[NSString alloc] initWithUTF8String:newViewProps.backImage.uri.c_str()];
+    _backImageOn = !![uri length];
+    if (![uri length]) {
+        _backImage = nil;
+    }
     [self updateStyle];
     [super updateProps:props oldProps:oldProps];
 }
@@ -195,6 +208,61 @@ API_AVAILABLE(ios(13.0)){
         attributes[NSFontAttributeName] = font;
     }
     return attributes;
+}
+
+- (void)prepareForRecycle
+{
+    [super prepareForRecycle];
+    self.imageCoordinator = nullptr;
+}
+
+- (void)updateState:(const facebook::react::State::Shared &)state oldState:(const facebook::react::State::Shared &)oldState
+{
+  auto _state = std::static_pointer_cast<NVNavigationBarShadowNode::ConcreteState const>(state);
+  auto _oldState = std::static_pointer_cast<NVNavigationBarShadowNode::ConcreteState const>(oldState);
+  auto data = _state->getData();
+  bool havePreviousData = _oldState != nullptr;
+  auto getCoordinator = [](ImageRequest const *request) -> ImageResponseObserverCoordinator const * {
+    if (request) {
+      return &request->getObserverCoordinator();
+    } else {
+      return nullptr;
+    }
+  };
+  if (!havePreviousData || data.getImageSource() != _oldState->getData().getImageSource()) {
+    self.imageCoordinator = getCoordinator(&data.getImageRequest());
+  }
+}
+
+- (void)setImageCoordinator:(const ImageResponseObserverCoordinator *)coordinator
+{
+  if (_imageCoordinator) {
+    _imageCoordinator->removeObserver(_imageResponseObserverProxy);
+  }
+  _imageCoordinator = coordinator;
+  if (_imageCoordinator) {
+    _imageCoordinator->addObserver(_imageResponseObserverProxy);
+  }
+}
+
+#pragma mark - RCTImageResponseDelegate
+
+- (void)didReceiveImage:(UIImage *)image metadata:(id)metadata fromObserver:(void const *)observer
+{
+  if (observer == &_imageResponseObserverProxy) {
+      if ([image isEqual:_backImage]) {
+        return;
+      }
+      _backImage = image;
+  }
+}
+
+- (void)didReceiveProgress:(float)progress fromObserver:(void const *)observer
+{
+}
+
+- (void)didReceiveFailureFromObserver:(void const *)observer
+{
 }
 
 #pragma mark - RCTComponentViewProtocol

--- a/NavigationReactNative/src/ios/NVNavigationBarComponentView.mm
+++ b/NavigationReactNative/src/ios/NVNavigationBarComponentView.mm
@@ -17,7 +17,7 @@
 
 using namespace facebook::react;
 
-@interface NVNavigationBarComponentView () <RCTNVNavigationBarViewProtocol>
+@interface NVNavigationBarComponentView () <RCTNVNavigationBarViewProtocol, RCTImageResponseDelegate>
 @end
 
 @implementation NVNavigationBarComponentView {
@@ -31,6 +31,7 @@ using namespace facebook::react;
     if (self = [super initWithFrame:frame]) {
         static const auto defaultProps = std::make_shared<const NVNavigationBarProps>();
         _props = defaultProps;
+        _imageResponseObserverProxy = RCTImageResponseObserverProxy(self);
     }
     return self;
 }
@@ -156,6 +157,7 @@ API_AVAILABLE(ios(13.0)){
     [appearance setLargeTitleTextAttributes:[self largeTitleAttributes]];
     appearance.backButtonAppearance = [UIBarButtonItemAppearance new];
     appearance.backButtonAppearance.normal.titleTextAttributes = [self backAttributes];
+    [appearance setBackIndicatorImage:_backImage transitionMaskImage:_backImage];
     return appearance;
 }
 
@@ -254,6 +256,9 @@ API_AVAILABLE(ios(13.0)){
         return;
       }
       _backImage = image;
+      if (self.backImageDidLoadBlock) {
+          self.backImageDidLoadBlock();
+      }
   }
 }
 

--- a/NavigationReactNative/src/ios/NVNavigationBarComponentView.mm
+++ b/NavigationReactNative/src/ios/NVNavigationBarComponentView.mm
@@ -88,7 +88,7 @@ using namespace facebook::react;
     }
     _backTestID = [[NSString alloc] initWithUTF8String: newViewProps.backTestID.c_str()];
     NSString *uri = [[NSString alloc] initWithUTF8String:newViewProps.backImage.uri.c_str()];
-    _backImageOn = !![uri length];
+    _backImageLoading = !![uri length];
     if (![uri length]) {
         _backImage = nil;
     }
@@ -216,6 +216,8 @@ API_AVAILABLE(ios(13.0)){
 {
     [super prepareForRecycle];
     self.imageCoordinator = nullptr;
+    _backImage = nil;
+    self.backImageDidLoadBlock = nil;
 }
 
 - (void)updateState:(const facebook::react::State::Shared &)state oldState:(const facebook::react::State::Shared &)oldState
@@ -258,6 +260,7 @@ API_AVAILABLE(ios(13.0)){
       if (self.backImageDidLoadBlock) {
           self.backImageDidLoadBlock();
       }
+      _backImageLoading = NO;
       _backImage = image;
       [self updateStyle];
   }

--- a/NavigationReactNative/src/ios/NVNavigationBarComponentView.mm
+++ b/NavigationReactNative/src/ios/NVNavigationBarComponentView.mm
@@ -255,10 +255,11 @@ API_AVAILABLE(ios(13.0)){
       if ([image isEqual:_backImage]) {
         return;
       }
-      _backImage = image;
       if (self.backImageDidLoadBlock) {
           self.backImageDidLoadBlock();
       }
+      _backImage = image;
+      [self updateStyle];
   }
 }
 

--- a/NavigationReactNative/src/ios/NVNavigationBarComponentView.mm
+++ b/NavigationReactNative/src/ios/NVNavigationBarComponentView.mm
@@ -216,6 +216,7 @@ API_AVAILABLE(ios(13.0)){
 {
     [super prepareForRecycle];
     self.imageCoordinator = nullptr;
+    _backImageLoading = NO;
     _backImage = nil;
 }
 

--- a/NavigationReactNative/src/ios/NVNavigationBarComponentView.mm
+++ b/NavigationReactNative/src/ios/NVNavigationBarComponentView.mm
@@ -217,7 +217,6 @@ API_AVAILABLE(ios(13.0)){
     [super prepareForRecycle];
     self.imageCoordinator = nullptr;
     _backImage = nil;
-    self.backImageDidLoadBlock = nil;
 }
 
 - (void)updateState:(const facebook::react::State::Shared &)state oldState:(const facebook::react::State::Shared &)oldState
@@ -259,6 +258,7 @@ API_AVAILABLE(ios(13.0)){
       }
       if (self.backImageDidLoadBlock) {
           self.backImageDidLoadBlock();
+          self.backImageDidLoadBlock = nil;
       }
       _backImageLoading = NO;
       _backImage = image;

--- a/NavigationReactNative/src/ios/NVNavigationBarManager.m
+++ b/NavigationReactNative/src/ios/NVNavigationBarManager.m
@@ -10,7 +10,7 @@ RCT_EXPORT_MODULE()
 
 - (UIView *)view
 {
-    return [[NVNavigationBarView alloc] init];
+    return [[NVNavigationBarView alloc] initWithBridge:self.bridge];
 }
 
 RCT_EXPORT_VIEW_PROPERTY(hidden, BOOL)
@@ -35,6 +35,7 @@ RCT_EXPORT_VIEW_PROPERTY(titleColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(largeTitleColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(backTitle, NSString)
 RCT_EXPORT_VIEW_PROPERTY(backTitleOn, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(backImage, RCTImageSource)
 RCT_EXPORT_VIEW_PROPERTY(backTestID, NSString)
 
 

--- a/NavigationReactNative/src/ios/NVNavigationBarView.h
+++ b/NavigationReactNative/src/ios/NVNavigationBarView.h
@@ -28,7 +28,7 @@
 @property (nonatomic, copy) NSString *backTitle;
 @property (nonatomic, assign) BOOL backTitleOn;
 @property (nonatomic, copy) NSString *backTestID;
-@property (nonatomic, assign) BOOL backImageOn;
+@property (nonatomic, assign) BOOL backImageLoading;
 @property (nonatomic, copy) void (^backImageDidLoadBlock)(void);
 
 -(id)initWithBridge: (RCTBridge *)bridge;

--- a/NavigationReactNative/src/ios/NVNavigationBarView.h
+++ b/NavigationReactNative/src/ios/NVNavigationBarView.h
@@ -1,4 +1,5 @@
 #import <UIKit/UIKit.h>
+#import <React/RCTBridge.h>
 #import "NVSceneController.h"
 
 @interface NVNavigationBarView : UIView <NVNavigationBar>
@@ -27,7 +28,10 @@
 @property (nonatomic, copy) NSString *backTitle;
 @property (nonatomic, assign) BOOL backTitleOn;
 @property (nonatomic, copy) NSString *backTestID;
+@property (nonatomic, assign) BOOL backImageOn;
+@property (nonatomic, copy) void (^backImageDidLoadBlock)(void);
 
+-(id)initWithBridge: (RCTBridge *)bridge;
 -(void)updateStyle;
 
 @end

--- a/NavigationReactNative/src/ios/NVNavigationBarView.m
+++ b/NavigationReactNative/src/ios/NVNavigationBarView.m
@@ -33,12 +33,13 @@
                     self.backImageDidLoadBlock();
                 }
                 self ->_backImage = image;
+                [self updateStyle];
             });
         }];
     } else {
         _backImage = nil;
+        [self updateStyle];
     }
-    [self updateStyle];
 }
 
 - (void)didSetProps:(NSArray<NSString *> *)changedProps

--- a/NavigationReactNative/src/ios/NVNavigationBarView.m
+++ b/NavigationReactNative/src/ios/NVNavigationBarView.m
@@ -1,15 +1,44 @@
 #import "NVNavigationBarView.h"
 
+#import <React/RCTBridge.h>
 #import <React/RCTFont.h>
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullability-completeness"
+#import <React/RCTImageLoaderProtocol.h>
+#pragma clang diagnostic pop
+#import <React/RCTImageSource.h>
 #import <React/UIView+React.h>
 
 @implementation NVNavigationBarView
+{
+    __weak RCTBridge *_bridge;
+    UIImage *_backImage;
+}
 
-- (id)init
+- (id)initWithBridge:(RCTBridge *)bridge
 {
     if (self = [super init]) {
+        _bridge = bridge;
     }
     return self;
+}
+
+- (void)setBackImage:(RCTImageSource *)source
+{
+    _backImageOn = !!source;
+    if (!!source) {
+        [[_bridge moduleForName:@"ImageLoader"] loadImageWithURLRequest:source.request size:source.size scale:source.scale clipped:NO resizeMode:RCTResizeModeCover progressBlock:nil partialLoadBlock:nil completionBlock:^(NSError *error, UIImage *image) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (self.backImageDidLoadBlock) {
+                    self.backImageDidLoadBlock();
+                }
+                self ->_backImage = image;
+            });
+        }];
+    } else {
+        _backImage = nil;
+    }
+    [self updateStyle];
 }
 
 - (void)didSetProps:(NSArray<NSString *> *)changedProps
@@ -92,6 +121,7 @@ API_AVAILABLE(ios(13.0)){
     [appearance setLargeTitleTextAttributes:[self largeTitleAttributes]];
     appearance.backButtonAppearance = [UIBarButtonItemAppearance new];
     appearance.backButtonAppearance.normal.titleTextAttributes = [self backAttributes];
+    [appearance setBackIndicatorImage:_backImage transitionMaskImage:_backImage];
     return appearance;
 }
 

--- a/NavigationReactNative/src/ios/NVNavigationBarView.m
+++ b/NavigationReactNative/src/ios/NVNavigationBarView.m
@@ -25,13 +25,15 @@
 
 - (void)setBackImage:(RCTImageSource *)source
 {
-    _backImageOn = !!source;
+    _backImageLoading = !!source;
     if (!!source) {
         [[_bridge moduleForName:@"ImageLoader"] loadImageWithURLRequest:source.request size:source.size scale:source.scale clipped:NO resizeMode:RCTResizeModeCover progressBlock:nil partialLoadBlock:nil completionBlock:^(NSError *error, UIImage *image) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 if (self.backImageDidLoadBlock) {
                     self.backImageDidLoadBlock();
+                    self.backImageDidLoadBlock = nil;
                 }
+                self ->_backImageLoading = NO;
                 self ->_backImage = image;
                 [self updateStyle];
             });

--- a/NavigationReactNative/src/ios/NVNavigationStackComponentView.mm
+++ b/NavigationReactNative/src/ios/NVNavigationStackComponentView.mm
@@ -115,7 +115,12 @@ using namespace facebook::react;
         NVSceneController *controller = [[NVSceneController alloc] initWithScene:scene];
         NSMutableArray *controllers = [NSMutableArray arrayWithArray:_navigationController.viewControllers];
         [controllers replaceObjectAtIndex:crumb withObject:controller];
-        [_navigationController setViewControllers:controllers animated:animate];
+        __block BOOL completed = NO;
+        [self completeNavigation:^{
+            if (completed) return;
+            completed = YES;
+            [self->_navigationController setViewControllers:controllers animated:animate];
+        } waitOn:scene];
     }
 }
 

--- a/NavigationReactNative/src/ios/NVNavigationStackView.m
+++ b/NavigationReactNative/src/ios/NVNavigationStackView.m
@@ -86,13 +86,13 @@
         }
         NVNavigationBarView *navigationBar = [self findNavigationBar:((UIViewController *) [controllers lastObject]).view];
         void (^completeNavigation)(void) = ^{
+            navigationBar.backImageDidLoadBlock = nil;
             if (crumb - currentCrumb == 1) {
                 [self->_navigationController pushViewController:controllers[0] animated:animate];
             } else {
                 NSArray *allControllers = [self->_navigationController.viewControllers arrayByAddingObjectsFromArray:controllers];
                 [self->_navigationController setViewControllers:allControllers animated:animate];
             }
-            navigationBar.backImageDidLoadBlock = nil;
         };
         if (!navigationBar.backImageOn) {
             completeNavigation();

--- a/NavigationReactNative/src/ios/NVNavigationStackView.m
+++ b/NavigationReactNative/src/ios/NVNavigationStackView.m
@@ -85,7 +85,7 @@
             [controllers addObject:controller];
         }
         NVNavigationBarView *navigationBar = [self findNavigationBar:((UIViewController *) [controllers lastObject]).view];
-        void (^completeNavigation)(void) = ^{
+        void (^startTransition)(void) = ^{
             if (crumb - currentCrumb == 1) {
                 [self->_navigationController pushViewController:controllers[0] animated:animate];
             } else {
@@ -95,12 +95,12 @@
             navigationBar.backImageDidLoadBlock = nil;
         };
         if (!navigationBar.backImageOn) {
-            completeNavigation();
+            startTransition();
         } else {
-            navigationBar.backImageDidLoadBlock = completeNavigation;
+            navigationBar.backImageDidLoadBlock = startTransition;
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, .1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
                 if (navigationBar.backImageDidLoadBlock)
-                    completeNavigation();
+                    startTransition();
             });
         }
     }

--- a/NavigationReactNative/src/ios/NVNavigationStackView.m
+++ b/NavigationReactNative/src/ios/NVNavigationStackView.m
@@ -84,7 +84,7 @@
             controller.navigationItem.title = scene.title;
             [controllers addObject:controller];
         }
-        UIView<NVNavigationBar> *navigationBar = [self findNavigationBar:((UIViewController *) [controllers lastObject]).view];
+        NVNavigationBarView *navigationBar = [self findNavigationBar:((UIViewController *) [controllers lastObject]).view];
         void (^completeNavigation)(void) = ^{
             if (crumb - currentCrumb == 1) {
                 [self->_navigationController pushViewController:controllers[0] animated:animate];

--- a/NavigationReactNative/src/ios/NVNavigationStackView.m
+++ b/NavigationReactNative/src/ios/NVNavigationStackView.m
@@ -85,7 +85,7 @@
             [controllers addObject:controller];
         }
         NVNavigationBarView *navigationBar = [self findNavigationBar:((UIViewController *) [controllers lastObject]).view];
-        void (^startTransition)(void) = ^{
+        void (^completeNavigation)(void) = ^{
             if (crumb - currentCrumb == 1) {
                 [self->_navigationController pushViewController:controllers[0] animated:animate];
             } else {
@@ -95,12 +95,12 @@
             navigationBar.backImageDidLoadBlock = nil;
         };
         if (!navigationBar.backImageOn) {
-            startTransition();
+            completeNavigation();
         } else {
-            navigationBar.backImageDidLoadBlock = startTransition;
+            navigationBar.backImageDidLoadBlock = completeNavigation;
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, .1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
                 if (navigationBar.backImageDidLoadBlock)
-                    startTransition();
+                    completeNavigation();
             });
         }
     }

--- a/NavigationReactNative/src/ios/NVSceneController.h
+++ b/NavigationReactNative/src/ios/NVSceneController.h
@@ -23,6 +23,7 @@
 @property (nonatomic, assign) BOOL largeTitle;
 @property (nonatomic, copy) NSString* title;
 @property (nonatomic, copy) NSString *backTitle;
+@property (nonatomic, copy) void (^backImageDidLoadBlock)(void);
 - (void)updateStyle;
 
 @end

--- a/NavigationReactNative/src/ios/NVSceneController.h
+++ b/NavigationReactNative/src/ios/NVSceneController.h
@@ -1,5 +1,15 @@
 #import <UIKit/UIKit.h>
 
+@interface NVSceneController : UIViewController
+
+@property (nonatomic, copy) void (^boundsDidChangeBlock)(NVSceneController *controller);
+@property (nonatomic, assign) UIStatusBarStyle statusBarStyle;
+@property (nonatomic, assign) BOOL statusBarHidden;
+
+- (id)initWithScene:(UIView *)view;
+
+@end
+
 @protocol NVNavigationBar
 
 @property (nonatomic, assign) BOOL isHidden;
@@ -10,17 +20,6 @@
 @property (nonatomic, copy) void (^backImageDidLoadBlock)(void);
 
 - (void)updateStyle;
-
-@end
-
-@interface NVSceneController : UIViewController
-
-@property (nonatomic, copy) void (^boundsDidChangeBlock)(NVSceneController *controller);
-@property (nonatomic, assign) UIStatusBarStyle statusBarStyle;
-@property (nonatomic, assign) BOOL statusBarHidden;
-
-- (id)initWithScene:(UIView *)view;
-- (UIView<NVNavigationBar> *) findNavigationBar:(UIView *)parent;
 
 @end
 

--- a/NavigationReactNative/src/ios/NVSceneController.h
+++ b/NavigationReactNative/src/ios/NVSceneController.h
@@ -23,7 +23,6 @@
 @property (nonatomic, assign) BOOL largeTitle;
 @property (nonatomic, copy) NSString* title;
 @property (nonatomic, copy) NSString *backTitle;
-
 - (void)updateStyle;
 
 @end

--- a/NavigationReactNative/src/ios/NVSceneController.h
+++ b/NavigationReactNative/src/ios/NVSceneController.h
@@ -10,23 +10,21 @@
 
 @end
 
+@protocol NVScene
+
+@property (nonatomic, assign) BOOL hidesTabBar;
+- (void)didPop;
+
+@end
+
 @protocol NVNavigationBar
 
 @property (nonatomic, assign) BOOL isHidden;
 @property (nonatomic, assign) BOOL largeTitle;
 @property (nonatomic, copy) NSString* title;
 @property (nonatomic, copy) NSString *backTitle;
-@property (nonatomic, assign) BOOL backImageOn;
-@property (nonatomic, copy) void (^backImageDidLoadBlock)(void);
 
 - (void)updateStyle;
-
-@end
-
-@protocol NVScene
-
-@property (nonatomic, assign) BOOL hidesTabBar;
-- (void)didPop;
 
 @end
 

--- a/NavigationReactNative/src/ios/NVSceneController.h
+++ b/NavigationReactNative/src/ios/NVSceneController.h
@@ -1,5 +1,18 @@
 #import <UIKit/UIKit.h>
 
+@protocol NVNavigationBar
+
+@property (nonatomic, assign) BOOL isHidden;
+@property (nonatomic, assign) BOOL largeTitle;
+@property (nonatomic, copy) NSString* title;
+@property (nonatomic, copy) NSString *backTitle;
+@property (nonatomic, assign) BOOL backImageOn;
+@property (nonatomic, copy) void (^backImageDidLoadBlock)(void);
+
+- (void)updateStyle;
+
+@end
+
 @interface NVSceneController : UIViewController
 
 @property (nonatomic, copy) void (^boundsDidChangeBlock)(NVSceneController *controller);
@@ -7,6 +20,7 @@
 @property (nonatomic, assign) BOOL statusBarHidden;
 
 - (id)initWithScene:(UIView *)view;
+- (UIView<NVNavigationBar> *) findNavigationBar:(UIView *)parent;
 
 @end
 
@@ -14,16 +28,6 @@
 
 @property (nonatomic, assign) BOOL hidesTabBar;
 - (void)didPop;
-
-@end
-
-@protocol NVNavigationBar
-
-@property (nonatomic, assign) BOOL isHidden;
-@property (nonatomic, assign) BOOL largeTitle;
-@property (nonatomic, copy) NSString* title;
-@property (nonatomic, copy) NSString *backTitle;
-- (void)updateStyle;
 
 @end
 

--- a/NavigationReactNative/src/ios/NVSceneController.m
+++ b/NavigationReactNative/src/ios/NVSceneController.m
@@ -44,6 +44,7 @@
     NSInteger crumb = [self.navigationController.viewControllers indexOfObject:self];
     UIViewController *previousController = crumb > 0 ? [self.navigationController.viewControllers objectAtIndex:crumb - 1] : nil;
     UIView<NVNavigationBar> *navigationBar = [self findNavigationBar:self.view];
+    navigationBar.backImageDidLoadBlock = nil;
     BOOL hidden = navigationBar.isHidden;
     if (@available(iOS 13.0, *)) {
     } else {

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -133,6 +133,10 @@ export interface NavigationBarProps {
      */
     backTitle?: string;
     /**
+     * The back button image
+     */
+    backImage?: ImageRequireSource | ImageURISource;
+    /**
      * The logo
      */
     logo?: ImageRequireSource | ImageURISource;

--- a/types/navigation-react-native.d.ts
+++ b/types/navigation-react-native.d.ts
@@ -133,6 +133,10 @@ export interface NavigationBarProps {
      */
     backTitle?: string;
     /**
+     * The back button image
+     */
+    backImage?: ImageRequireSource | ImageURISource;
+    /**
      * The logo
      */
     logo?: ImageRequireSource | ImageURISource;


### PR DESCRIPTION
Fixes #640

Added a `backImage` prop to the `NavigationBar` component.
```jsx
<NavigationBar backImage={require('./arrow.png')} >
```

The tricky part was that React Native loads images async but iOS expects the back image to be provided in `viewWillAppear`. Had to wait for the back image to load before pushing the next `UIViewController`.

Interestingly, in Fabric the back image usually loaded before `viewWillAppear` even without waiting, but on the old architecture it never did.
