### PR TITLE
Ensured pod installs on React Native < 0.70

### DIFF
--- a/NavigationReactNative/src/react-native.config.js
+++ b/NavigationReactNative/src/react-native.config.js
@@ -1,7 +1,16 @@
+let supportsCodegenConfig = false;
+try {
+  const rnCliAndroidVersion =
+    require('@react-native-community/cli-platform-android/package.json').version;
+  const [major] = rnCliAndroidVersion.split('.');
+  supportsCodegenConfig = major >= 9;
+} catch (e) {
+}
+
 module.exports = {
   dependency: {
     platforms: {
-      android: {
+      android: supportsCodegenConfig ? {
         componentDescriptors: [
           'NVActionBarComponentDescriptor',
           'NVBarButtonComponentDescriptor',
@@ -28,7 +37,7 @@ module.exports = {
           'NVToolbarComponentDescriptor',
         ],
         cmakeListsPath: "../cpp/CMakeLists.txt"
-      },
+      } : {},
     },
   },
 };


### PR DESCRIPTION
Fixes #651 

Only configured the android codegen if the `react-native-cli` version supports it. Copied this from [react-native-screens](https://github.com/software-mansion/react-native-screens/pull/1615), which copied it from [react-native-safe-area-context](https://github.com/th3rdwave/react-native-safe-area-context/commit/c4a3ad17c09b7c20887d05f51ea339811fe3e93c). 
