### PR TITLE
Supported Material Design 3 for the BottomAppBar (Android) 

### DIFF
--- a/NavigationReactNative/src/BottomAppBar.tsx
+++ b/NavigationReactNative/src/BottomAppBar.tsx
@@ -1,9 +1,11 @@
 import React, { cloneElement, ReactElement } from 'react';
-import { Platform, Image, StyleSheet, requireNativeComponent } from 'react-native';
+import { Platform, Image, requireNativeComponent, NativeModules } from 'react-native';
 import SearchBar from './SearchBar';
 
 const BottomAppBar = ({ navigationImage, overflowImage, children, style, ...props }: any) => {
     if (Platform.OS === 'ios') return null;
+    const Material3 = global.__turboModuleProxy != null ? require("./NativeMaterial3Module").default : NativeModules.Material3;
+    const { on: material3 } = Platform.OS === 'android' ? Material3.getConstants() : { on: false };
     var childrenArray = (React.Children.toArray(children) as ReactElement<any>[]);
     var searchBar: any = childrenArray.find(({type}) => type === SearchBar);
     searchBar = searchBar && cloneElement(searchBar, { bottomBar: true });
@@ -12,8 +14,8 @@ const BottomAppBar = ({ navigationImage, overflowImage, children, style, ...prop
             <NVBottomAppBar
                 navigationImage={Image.resolveAssetSource(navigationImage)}
                 overflowImage={Image.resolveAssetSource(overflowImage)}
-                barHeight={56}
-                style={styles.toolbar}
+                barHeight={!material3 ? 56 : 80}
+                style={{height: !material3 ? 56 : 80}}
                 {...props}>
                 {childrenArray.filter(({type}) => type !== SearchBar)}
             </NVBottomAppBar>
@@ -23,11 +25,5 @@ const BottomAppBar = ({ navigationImage, overflowImage, children, style, ...prop
 }
 
 var NVBottomAppBar = global.nativeFabricUIManager ? require('./BottomAppBarNativeComponent').default : requireNativeComponent('NVBottomAppBar');
-
-const styles = StyleSheet.create({
-    toolbar: {
-        height: 56
-    },
-});
 
 export default BottomAppBar;

--- a/NavigationReactNative/src/android/build.gradle
+++ b/NavigationReactNative/src/android/build.gradle
@@ -61,7 +61,7 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.viewpager2:viewpager2:1.0.0'
 }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomAppBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomAppBarView.java
@@ -107,6 +107,12 @@ public class BottomAppBarView extends BottomAppBar implements ActionView {
         });
     }
 
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        requestLayout();
+    }
+
     void setNavIconSource(@Nullable ReadableMap source) {
         IconResolver.setIconSource(source, navIconResolverListener, getContext());
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CoordinatorLayoutView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CoordinatorLayoutView.java
@@ -70,6 +70,8 @@ public class CoordinatorLayoutView extends CoordinatorLayout implements ReactZIn
                 ((TabBarPagerView) getChildAt(i)).scrollToTop();
             if (getChildAt(i) instanceof ViewPager2)
                 TabBarPagerRTLManager.getAdapter((ViewPager2) getChildAt(i)).scrollToTop();
+            if (getChildAt(i) instanceof BottomAppBarView)
+                ((BottomAppBarView) getChildAt(i)).performShow();
         }
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLAdapter.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLAdapter.java
@@ -47,6 +47,8 @@ public class TabBarPagerRTLAdapter extends FragmentStateAdapter {
                     ((ScrollView) viewGroup.getChildAt(i)).smoothScrollTo(0,0);
                 if (viewGroup.getChildAt(i) instanceof ViewPager2)
                     TabBarPagerRTLManager.getAdapter((ViewPager2) viewGroup.getChildAt(i)).scrollToTop();
+                if (viewGroup.getChildAt(i) instanceof BottomAppBarView)
+                    ((BottomAppBarView) viewGroup.getChildAt(i)).performShow();
             }
         }
         if (tabBarItem instanceof ScrollView)

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
@@ -116,6 +116,8 @@ public class TabBarPagerView extends ViewPager implements TabBarItemView.ChangeL
                     ((ScrollView) viewGroup.getChildAt(i)).smoothScrollTo(0,0);
                 if (viewGroup.getChildAt(i) instanceof TabBarPagerView)
                     ((TabBarPagerView) viewGroup.getChildAt(i)).scrollToTop();
+                if (viewGroup.getChildAt(i) instanceof BottomAppBarView)
+                    ((BottomAppBarView) viewGroup.getChildAt(i)).performShow();
             }
         }
         if (tabBarItem instanceof ScrollView)

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -126,6 +126,8 @@ public class TabBarView extends ViewGroup implements TabBarItemView.ChangeListen
                     ((TabBarPagerView) viewGroup.getChildAt(i)).scrollToTop();
                 if (viewGroup.getChildAt(i) instanceof ViewPager2)
                     TabBarPagerRTLManager.getAdapter((ViewPager2) viewGroup.getChildAt(i)).scrollToTop();
+                if (viewGroup.getChildAt(i) instanceof BottomAppBarView)
+                    ((BottomAppBarView) viewGroup.getChildAt(i)).performShow();
             }
         }
         if (tabBarItem instanceof ScrollView)


### PR DESCRIPTION
Updated Android material components to v1.7.0 to support [Material Design 3 for the BottomAppBar](https://m3.material.io/components/bottom-app-bar/specs). Set height to 80dp to match the Material 3 specs if the user opts in by using a `Material3` Theme.

[Material components v1.7.0](https://github.com/material-components/material-components-android/releases/tag/1.7.0-beta01) updated the `compileSdkVersion` and `targetSdkVersion` to 32. Currently, React Native 0.70 has these at 31 so not going to merge this PR yet. It looks like [React Native 0.71 bumps these to 33](https://github.com/facebook/react-native/pull/35196) which would avoid having to add a manual bump step to the setup instructions.