### PR TITLE
backIndicatorImage on iOS appearance

### DIFF
--- a/NavigationReactNative/src/ios/NVNavigationBarComponentView.mm
+++ b/NavigationReactNative/src/ios/NVNavigationBarComponentView.mm
@@ -157,7 +157,8 @@ API_AVAILABLE(ios(13.0)){
     [appearance setLargeTitleTextAttributes:[self largeTitleAttributes]];
     appearance.backButtonAppearance = [UIBarButtonItemAppearance new];
     appearance.backButtonAppearance.normal.titleTextAttributes = [self backAttributes];
-    [appearance setBackIndicatorImage:_backImage transitionMaskImage:_backImage];
+    UIImage* backIndicatorImage = [_backImage imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+    [appearance setBackIndicatorImage:backIndicatorImage transitionMaskImage:backIndicatorImage];
     return appearance;
 }
 

--- a/NavigationReactNative/src/ios/NVNavigationBarView.m
+++ b/NavigationReactNative/src/ios/NVNavigationBarView.m
@@ -124,7 +124,8 @@ API_AVAILABLE(ios(13.0)){
     [appearance setLargeTitleTextAttributes:[self largeTitleAttributes]];
     appearance.backButtonAppearance = [UIBarButtonItemAppearance new];
     appearance.backButtonAppearance.normal.titleTextAttributes = [self backAttributes];
-    [appearance setBackIndicatorImage:_backImage transitionMaskImage:_backImage];
+    UIImage* backIndicatorImage = [_backImage imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+    [appearance setBackIndicatorImage:backIndicatorImage transitionMaskImage:backIndicatorImage];
     return appearance;
 }
 


### PR DESCRIPTION
For some reason some native image icons (Images.xcassets) were displayed as a big white rounded button. This change sets to `UIImageRenderingModeAlwaysOriginal` the image rendering mode displaying the image as expected.