### PR TITLE
Removed visual delay when rendering stack inside sliding Modal

### DIFF
--- a/NavigationReactNative/src/ios/NVNavigationStackComponentView.mm
+++ b/NavigationReactNative/src/ios/NVNavigationStackComponentView.mm
@@ -26,6 +26,7 @@ using namespace facebook::react;
     NSMutableDictionary *_scenes;
     NSInteger _nativeEventCount;
     UINavigationController *_oldNavigationController;
+    BOOL _navigated;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -64,9 +65,14 @@ using namespace facebook::react;
     self.keys = [keysArr copy];
     _enterAnimOff = newViewProps.enterAnimOff;
     _mostRecentEventCount = newViewProps.mostRecentEventCount;
-    dispatch_async(dispatch_get_main_queue(), ^{
+    if (!_navigated) {
         [self navigate];
-    });
+        _navigated = YES;
+    } else {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self navigate];
+        });
+    }
     [super updateProps:props oldProps:oldProps];
 }
 
@@ -209,6 +215,7 @@ using namespace facebook::react;
     _scenes = [[NSMutableDictionary alloc] init];
     _oldNavigationController = _navigationController;
     _navigationController = nil;
+    _navigated = NO;
 }
 
 #pragma mark - RCTComponentViewProtocol

--- a/NavigationReactNative/src/ios/NVNavigationStackView.m
+++ b/NavigationReactNative/src/ios/NVNavigationStackView.m
@@ -15,6 +15,7 @@
     __weak RCTBridge *_bridge;
     NSMutableDictionary *_scenes;
     NSInteger _nativeEventCount;
+    BOOL _navigated;
 }
 
 - (id)initWithBridge:(RCTBridge *)bridge
@@ -50,9 +51,14 @@
 - (void)didSetProps:(NSArray<NSString *> *)changedProps
 {
     [super didSetProps:changedProps];
-    dispatch_async(dispatch_get_main_queue(), ^{
+    if (!_navigated) {
         [self navigate];
-    });
+        _navigated = YES;
+    } else {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self navigate];
+        });
+    }
 }
 
 - (void)navigate

--- a/NavigationReactNative/src/ios/NVSceneComponentView.mm
+++ b/NavigationReactNative/src/ios/NVSceneComponentView.mm
@@ -17,6 +17,7 @@ using namespace facebook::react;
 @implementation NVSceneComponentView
 {
     BOOL _notifiedPeekable;
+    UIViewController *_oldViewController;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -28,8 +29,17 @@ using namespace facebook::react;
     return self;
 }
 
+
+- (void)ensureViewController
+{
+    [_oldViewController willMoveToParentViewController:nil];
+    [_oldViewController.view removeFromSuperview];
+    [_oldViewController removeFromParentViewController];
+}
+
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
+    [self ensureViewController];
     const auto &newViewProps = *std::static_pointer_cast<NVSceneProps const>(props);
     _sceneKey = [[NSString alloc] initWithUTF8String: newViewProps.sceneKey.c_str()];
     _crumb = newViewProps.crumb;
@@ -62,7 +72,7 @@ using namespace facebook::react;
 - (void)prepareForRecycle
 {
     [super prepareForRecycle];
-    self.reactViewController.view = nil;
+    _oldViewController = self.reactViewController;
     _notifiedPeekable = NO;
 }
 

--- a/NavigationReactNative/src/ios/NVSceneComponentView.mm
+++ b/NavigationReactNative/src/ios/NVSceneComponentView.mm
@@ -32,10 +32,13 @@ using namespace facebook::react;
 
 - (void)ensureViewController
 {
-    [_oldViewController willMoveToParentViewController:nil];
-    [_oldViewController.view removeFromSuperview];
-    [_oldViewController removeFromParentViewController];
-    _oldViewController.view = nil;
+    if (!!_oldViewController) {
+        [_oldViewController willMoveToParentViewController:nil];
+        [_oldViewController.view removeFromSuperview];
+        [_oldViewController removeFromParentViewController];
+        _oldViewController.view = nil;
+        _oldViewController = nil;
+    }
 }
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps

--- a/NavigationReactNative/src/ios/NVSceneComponentView.mm
+++ b/NavigationReactNative/src/ios/NVSceneComponentView.mm
@@ -35,6 +35,7 @@ using namespace facebook::react;
     [_oldViewController willMoveToParentViewController:nil];
     [_oldViewController.view removeFromSuperview];
     [_oldViewController removeFromParentViewController];
+    _oldViewController.view = nil;
 }
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps


### PR DESCRIPTION
When opening `Modal` with a sliding animation, the `NavigationStack` didn't appear until after the animation completes. Thanks @RichardLindhout for letting me know about this.

This regression was introduced when adding [support for custom back button image on iOS](https://github.com/grahammendick/navigation/pull/648). This PR changed the navigation from sync to async so that the full view hierarchy was built and any back button image could be found. Making it async meant the stack didn't render in time for it to show while the Modal slides in.

Changed the navigation from async back to sync for the very first render - don't need the delay on the first render because there won't be a back button. Got a bit lucky because the scenes are mounted before the props are updated for the first render on both the old and new architectures (after the first render, the order is reversed on the new architecture).

While testing, found a bug with `Scene` recycling on the new architecture when opening and closing the modal in the medley sample. Recycled the scene `UIViewController` using the same pattern already in place for other controllers (like `UINavigationController` and `UITabBarController`).