### PR TITLE
Prevented tabs overlapping after keyboard closes (Android on Fabric)

### DIFF
--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
 import android.widget.ScrollView;
 
 import androidx.annotation.NonNull;
@@ -60,6 +61,7 @@ public class TabBarPagerView extends ViewPager implements TabBarItemView.ChangeL
             }
         });
         setAdapter(adapter);
+        getViewTreeObserver().addOnGlobalLayoutListener(() -> requestLayout());
     }
 
     @Override


### PR DESCRIPTION
In Twitter example, on Fabric, added new m3 SearchBar to the home scene. Opened the search and switched to the notifications tab when the keyboard was open. Then the content from both 'All' and 'Mentions' tabs overlapped. Requesting layout when keyboard closes fixes it