### PR TITLE
Added defensive checks to prevent errors reported in the wild (Android)

### DIFF
--- a/NavigationReactNative/sample/twitter/android/build.gradle
+++ b/NavigationReactNative/sample/twitter/android/build.gradle
@@ -6,8 +6,8 @@ buildscript {
     ext {
         buildToolsVersion = "31.0.0"
         minSdkVersion = 21
-        compileSdkVersion = 31
-        targetSdkVersion = 31
+        compileSdkVersion = 33
+        targetSdkVersion = 33
 
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -60,7 +60,7 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
             scene.setElevation(getChildAt(parent, index - 1).getElevation() + 1);
         parent.sceneKeys.add(index, scene.sceneKey);
         parent.scenes.put(scene.sceneKey, scene);
-        if (parent.startNavigation && parent.keys.size() == parent.scenes.size())
+        if (parent.startNavigation != null && parent.startNavigation && parent.keys.size() == parent.scenes.size())
             parent.onAfterUpdateTransaction();
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -92,7 +92,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
             transaction.commitNowAllowingStateLoss();
         }
         startNavigation = startNavigation == null && keys.size() != 0;
-        if (scenes.size() == 0 || fragment.getChildFragmentManager().isStateSaved())
+        if (scenes.size() == 0 || !fragment.isAdded() || fragment.getChildFragmentManager().isStateSaved())
             return;
         int crumb = keys.size() - 1;
         int currentCrumb = oldCrumb;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackViewManager.java
@@ -86,7 +86,7 @@ public class NavigationStackViewManager extends ViewGroupManager<NavigationStack
             scene.setElevation(getChildAt(parent, index - 1).getElevation() + 1);
         parent.sceneKeys.add(index, scene.sceneKey);
         parent.scenes.put(scene.sceneKey, scene);
-        if (parent.startNavigation && parent.keys.size() == parent.scenes.size())
+        if (parent.startNavigation != null && parent.startNavigation && parent.keys.size() == parent.scenes.size())
             parent.onAfterUpdateTransaction();
     }
 


### PR DESCRIPTION
Fixes #627

Got sent 2 weird stack traces on android. One in #627 and 
```java
java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.Boolean.booleanValue()' on a null object reference
  at com.navigation.reactnative.NavigationStackManager.addView ([http://NavigationStackManager.java:63](https://t.co/TveCpzQnSc))
  at com.navigation.reactnative.NavigationStackManager.addView ([http://NavigationStackManager.java:17](https://t.co/OxUVtu9yOd))
  at com.facebook.react.uimanager.NativeViewHierarchyManager.manageChildren ([http://NativeViewHierarchyManager.java:533](https://t.co/4OQaEqWBTh))
  at com.swmansion.reanimated.layoutReanimation.ReanimatedNativeHierarchyManager.manageChildren (http://ReanimatedNativeHierarchyManager.java:279)
  at com.facebook
```
Was advising of fixes and waiting for feedback but this [isn't working so well](https://github.com/grahammendick/navigation/issues/627#issuecomment-1330784072). So going to fix instead. The fixes are harmless as they're just extra defensive checks. Think this is better approach because pretty much anything is possible on android in the wild.



