### PR TITLE
Corrected scene animating away after replace and back (Android)

### DIFF
--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -147,6 +147,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
             int popExit = getAnimationResourceId(currentActivity, scene.exitAnim, android.R.attr.activityCloseExitAnimation);
             FragmentManager fragmentManager = fragment.getChildFragmentManager();
             FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+            fragmentTransaction.setReorderingAllowed(true);
             fragmentTransaction.setCustomAnimations(enter, exit, popEnter, popExit);
             fragmentTransaction.replace(getId(), new SceneFragment(scene, null), key);
             fragmentTransaction.addToBackStack(String.valueOf(crumb));


### PR DESCRIPTION
Fluently navigating from A →  B to A →  C then pressing back it would show B animating away instead of C. Allowing reordering corrects this