### PR TITLE
Allowed extra render before freezing on tab change

### DIFF
--- a/NavigationReactNative/src/TabBarItem.tsx
+++ b/NavigationReactNative/src/TabBarItem.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { requireNativeComponent, Image, Platform, StyleSheet } from 'react-native';
 import BackButton from './BackButton';
 import TabBarItemContext from './TabBarItemContext';
@@ -8,14 +8,16 @@ import Freeze from './Freeze';
 
 const TabBarItem = ({selected, onPress, children, image, systemItem, badge, index, freezable, ...props}) => {
     const [loaded, setLoaded] = useState(selected);
+    const [freeze, setFreeze] = useState(false);
     const backHandler = useRef(createBackHandler());
     const onLoad = useRef({ onLoad: () => setLoaded(true)});
+    useEffect(() => setFreeze(freezable), [freezable]);
     if (!loaded && selected) setLoaded(true);
     image = typeof image === 'string' ? (Platform.OS === 'ios' ? null : {uri: image}) : image;
     return (
         <>
             <BackButton onPress={() => selected && backHandler.current.handleBack()} />
-            <Freeze enabled={loaded && freezable}>
+            <Freeze enabled={loaded && freeze}>
                 <NVTabBarItem
                     ref={(ref: any) => {
                         if (!!React.Suspense && ref?.viewConfig?.validAttributes?.style) {


### PR DESCRIPTION
Fixes #671

The Navigation router freezes inactive tabs for performance. There's no need to render invisible content. But this meant that changes to `TabBarItem` images on tab change weren't showing up. Ideally would move the `Freeze` around the children instead of around the `TabBarItem` but React Native sets the display to `none` which breaks things on Android. Instead, delayed the freeze for one render.
