### PR TITLE
Displayed TabBar unselected tint color prop (iOS >= 13)

### DIFF
--- a/NavigationReactNative/src/ios/NVTabBarComponentView.mm
+++ b/NavigationReactNative/src/ios/NVTabBarComponentView.mm
@@ -58,10 +58,6 @@ using namespace facebook::react;
     UIColor *selectedTintColor = RCTUIColorFromSharedColor(newViewProps.selectedTintColor);
     UIColor *unselectedTintColor = RCTUIColorFromSharedColor(newViewProps.unselectedTintColor);
     UIColor *barTintColor = RCTUIColorFromSharedColor(newViewProps.barTintColor);
-    if ([_tabBarController.tabBar tintColor] != selectedTintColor)
-        [_tabBarController.tabBar setTintColor: selectedTintColor];
-    if ([_tabBarController.tabBar unselectedItemTintColor] != unselectedTintColor)
-        [_tabBarController.tabBar setUnselectedItemTintColor: unselectedTintColor];
     if (@available(iOS 13.0, *)) {
         UITabBarAppearance *appearance = [UITabBarAppearance new];
         [appearance configureWithDefaultBackground];
@@ -84,23 +80,31 @@ using namespace facebook::react;
         NSNumber *size = !self.fontSize ? @10 : self.fontSize;
         NSString *weight = !self.fontWeight ? @"500" : self.fontWeight;
         UIFont *font = [RCTFont updateFont:baseFont withFamily:self.fontFamily size:size weight:weight style:self.fontStyle variant:nil scaleMultiplier:1];
-        NSMutableDictionary *attributes = [NSMutableDictionary new];
-        if (self.fontFamily || self.fontWeight || self.fontStyle || self.fontSize) {
-            attributes[NSFontAttributeName] = font;
+        NSMutableDictionary *unselectedAttributes = [NSMutableDictionary new];
+        NSMutableDictionary *selectedAttributes = [NSMutableDictionary new];
+        unselectedAttributes[NSForegroundColorAttributeName] = unselectedTintColor;
+        selectedAttributes[NSForegroundColorAttributeName] = selectedTintColor;        if (self.fontFamily || self.fontWeight || self.fontStyle || self.fontSize) {
+            unselectedAttributes[NSFontAttributeName] = font;
+            selectedAttributes[NSFontAttributeName] = font;
         }
         UITabBarItemAppearance *itemAppearance = [UITabBarItemAppearance new];
         UIColor *badgeColor = RCTUIColorFromSharedColor(newViewProps.badgeColor);
         [itemAppearance.normal setBadgeBackgroundColor:badgeColor];
         [itemAppearance.selected setBadgeBackgroundColor:badgeColor];
-        [itemAppearance.normal setTitleTextAttributes:attributes];
-        [itemAppearance.selected setTitleTextAttributes:attributes];
+        [itemAppearance.normal setTitleTextAttributes:unselectedAttributes];
+        [itemAppearance.selected setTitleTextAttributes:selectedAttributes];
+        [itemAppearance.normal setIconColor:unselectedTintColor];
+        [itemAppearance.selected setIconColor:selectedTintColor];
         appearance.stackedLayoutAppearance = itemAppearance;
         appearance.compactInlineLayoutAppearance = itemAppearance;
         _tabBarController.tabBar.standardAppearance = appearance;
+        [_tabBarController.tabBar setNeedsLayout];
         if (@available(iOS 15.0, *))
             _tabBarController.tabBar.scrollEdgeAppearance = appearance;
     } else {
         [_tabBarController.tabBar setBarTintColor:barTintColor];
+        [_tabBarController.tabBar setTintColor: selectedTintColor];
+        [_tabBarController.tabBar setUnselectedItemTintColor: unselectedTintColor];
     }
     _mostRecentEventCount = newViewProps.mostRecentEventCount;
     NSInteger eventLag = _nativeEventCount - _mostRecentEventCount;

--- a/NavigationReactNative/src/ios/NVTabBarView.h
+++ b/NavigationReactNative/src/ios/NVTabBarView.h
@@ -5,6 +5,8 @@
 
 @property (nonatomic, assign) NSInteger tabCount;
 @property (nonatomic, copy) UIColor *barTintColor;
+@property (nonatomic, copy) UIColor *selectedTintColor;
+@property (nonatomic, copy) UIColor *unselectedTintColor;
 @property (nonatomic, copy) UIColor *badgeColor;
 @property (nonatomic, assign) BOOL scrollsToTop;
 @property (nonatomic, copy) NSString *fontFamily;

--- a/NavigationReactNative/src/ios/NVTabBarView.m
+++ b/NavigationReactNative/src/ios/NVTabBarView.m
@@ -35,18 +35,6 @@
     }
 }
 
-- (void)setSelectedTintColor:(UIColor *)selectedTintColor
-{
-    [_tabBarController.tabBar setTintColor: selectedTintColor];
-}
-
-- (void)setUnselectedTintColor:(UIColor *)unselectedTintColor
-{
-    if (@available(iOS 10.0, *)) {
-        [_tabBarController.tabBar setUnselectedItemTintColor: unselectedTintColor];
-    }
-}
-
 - (void)insertReactSubview:(UIView *)subview atIndex:(NSInteger)atIndex
 {
     [super insertReactSubview:subview atIndex:atIndex];
@@ -97,22 +85,31 @@
         NSNumber *size = !self.fontSize ? @10 : self.fontSize;
         NSString *weight = !self.fontWeight ? @"500" : self.fontWeight;
         UIFont *font = [RCTFont updateFont:baseFont withFamily:self.fontFamily size:size weight:weight style:self.fontStyle variant:nil scaleMultiplier:1];
-        NSMutableDictionary *attributes = [NSMutableDictionary new];
+        NSMutableDictionary *unselectedAttributes = [NSMutableDictionary new];
+        NSMutableDictionary *selectedAttributes = [NSMutableDictionary new];
+        unselectedAttributes[NSForegroundColorAttributeName] = _unselectedTintColor;
+        selectedAttributes[NSForegroundColorAttributeName] = _selectedTintColor;
         if (self.fontFamily || self.fontWeight || self.fontStyle || self.fontSize) {
-            attributes[NSFontAttributeName] = font;
+            unselectedAttributes[NSFontAttributeName] = font;
+            selectedAttributes[NSFontAttributeName] = font;
         }
         UITabBarItemAppearance *itemAppearance = [UITabBarItemAppearance new];
         [itemAppearance.normal setBadgeBackgroundColor:_badgeColor];
         [itemAppearance.selected setBadgeBackgroundColor:_badgeColor];
-        [itemAppearance.normal setTitleTextAttributes:attributes];
-        [itemAppearance.selected setTitleTextAttributes:attributes];
+        [itemAppearance.normal setTitleTextAttributes:unselectedAttributes];
+        [itemAppearance.selected setTitleTextAttributes:selectedAttributes];
+        [itemAppearance.normal setIconColor:_unselectedTintColor];
+        [itemAppearance.selected setIconColor:_selectedTintColor];
         appearance.stackedLayoutAppearance = itemAppearance;
         appearance.compactInlineLayoutAppearance = itemAppearance;
         _tabBarController.tabBar.standardAppearance = appearance;
+        [_tabBarController.tabBar setNeedsLayout];
         if (@available(iOS 15.0, *))
             _tabBarController.tabBar.scrollEdgeAppearance = appearance;
     } else {
         [_tabBarController.tabBar setBarTintColor:_barTintColor];
+        [_tabBarController.tabBar setUnselectedItemTintColor: _unselectedTintColor];
+        [_tabBarController.tabBar setTintColor: _selectedTintColor];
     }
 }
 


### PR DESCRIPTION
Fixes #682

Like in #613, used `TabBarItemAppearance` introduced in iOS 13 because the old way doesn't work for unselected tint color prop
