### PR TITLE
Ensured event lag tracked without setNativeProps

### DIFF
--- a/NavigationReactNative/src/BottomSheet.tsx
+++ b/NavigationReactNative/src/BottomSheet.tsx
@@ -21,11 +21,13 @@ class BottomSheet extends React.Component<any, any> {
     }
     onDetentChanged({nativeEvent}) {
         var {eventCount: mostRecentEventCount, detent: nativeDetent} = nativeEvent;
-        this.setState({mostRecentEventCount});
         var detents = (UIManager as any).getViewManagerConfig('NVBottomSheet').Constants.Detent
         var detent = Object.keys(detents).find(name => detents[name] === nativeDetent)
         this.dragging = !detent
-        if (detent) this.changeDetent(detent);
+        if (detent) {
+            this.changeDetent(detent);
+            this.setState({mostRecentEventCount});
+        }
     }
     changeDetent(selectedDetent) {
         var {detent, onChangeDetent} = this.props;

--- a/NavigationReactNative/src/SearchBar.tsx
+++ b/NavigationReactNative/src/SearchBar.tsx
@@ -10,26 +10,26 @@ const SearchBar = ({obscureBackground = true, hideNavigationBar= true, hideWhenS
     const [mostRecentActiveEventCount, setMostRecentActiveEventCount] = useState(0);
     const changeText = ({nativeEvent}) => {
         const {eventCount: mostRecentEventCount, text} = nativeEvent;
-        setMostRecentEventCount(mostRecentEventCount);
         if (onChangeText)
-            onChangeText(text)
+            onChangeText(text);
+        setMostRecentEventCount(mostRecentEventCount);
     }
     if (active != null && show !== active) setShow(active);
     const onChangeShow = ({nativeEvent}) => {
         const {eventCount: mostRecentActiveCount, active: newActive} = nativeEvent;
-        setMostRecentActiveEventCount(mostRecentActiveCount);
         if (show !== newActive) {
             if (active == null)
                 setShow(newActive);
             if (!!onChangeActive)
                 onChangeActive(newActive);
         }
+        setMostRecentActiveEventCount(mostRecentActiveCount);
     }
     const changeScopeButton = ({nativeEvent}) => {
         var {eventCount: mostRecentButtonEventCount, scopeButton} = nativeEvent;
-        setMostRecentButtonEventCount(mostRecentButtonEventCount);
         if (onChangeScopeButton)
             onChangeScopeButton(scopeButtons[scopeButton])
+        setMostRecentButtonEventCount(mostRecentButtonEventCount);
     }
     const Material3 = global.__turboModuleProxy != null ? require("./NativeMaterial3Module").default : NativeModules.Material3;
     const { on: material3 } = Platform.OS === 'android' ? Material3.getConstants() : { on: false };

--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -26,8 +26,8 @@ class TabBar extends React.Component<any, any> {
     }
     onTabSelected({nativeEvent}) {
         var {eventCount: mostRecentEventCount, tab} = nativeEvent;
-        this.setState({mostRecentEventCount});
         this.changeTab(tab);
+        this.setState({mostRecentEventCount});
     }
     onTabSwipeStateChanged({nativeEvent}) {
         this.swiping = nativeEvent.swiping;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetManager.java
@@ -29,10 +29,7 @@ public class BottomSheetManager extends ViewGroupManager<BottomSheetView> {
 
     @ReactProp(name = "detent")
     public void setDetent(BottomSheetView view, int detent) {
-        int eventLag = view.nativeEventCount - view.mostRecentEventCount;
-        if (eventLag == 0) {
-            view.detent = detent;
-        }
+        view.pendingDetent = detent;
     }
 
     @ReactProp(name = "mostRecentEventCount")
@@ -88,8 +85,7 @@ public class BottomSheetManager extends ViewGroupManager<BottomSheetView> {
     @Override
     protected void onAfterUpdateTransaction(@NonNull BottomSheetView view) {
         super.onAfterUpdateTransaction(view);
-        if (view.bottomSheetBehavior.getState() != view.detent)
-            view.bottomSheetBehavior.setState(view.detent);
+        view.onAfterUpdateTransaction();
     }
 
     @Nullable

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetView.java
@@ -20,6 +20,7 @@ public class BottomSheetView extends ReactViewGroup {
     BottomSheetBehavior<BottomSheetView> bottomSheetBehavior;
     BottomSheetBehavior.BottomSheetCallback bottomSheetCallback;
     float defaultHalfExpandedRatio;
+    int pendingDetent;
     int detent;
     int nativeEventCount;
     int mostRecentEventCount;
@@ -54,6 +55,15 @@ public class BottomSheetView extends ReactViewGroup {
             }
         };
         bottomSheetBehavior.addBottomSheetCallback(bottomSheetCallback);
+    }
+
+    void onAfterUpdateTransaction() {
+        int eventLag = nativeEventCount - mostRecentEventCount;
+        if (eventLag == 0) {
+            detent = pendingDetent;
+        }
+        if (bottomSheetBehavior.getState() != detent)
+            bottomSheetBehavior.setState(detent);
     }
 
     static class DetentChangedEvent extends Event<BottomSheetView.DetentChangedEvent> {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetViewManager.java
@@ -44,10 +44,7 @@ public class BottomSheetViewManager extends ViewGroupManager<BottomSheetView> im
 
     @ReactProp(name = "detent")
     public void setDetent(BottomSheetView view, int detent) {
-        int eventLag = view.nativeEventCount - view.mostRecentEventCount;
-        if (eventLag == 0) {
-            view.detent = detent;
-        }
+        view.pendingDetent = detent;
     }
 
     @ReactProp(name = "mostRecentEventCount")
@@ -103,8 +100,7 @@ public class BottomSheetViewManager extends ViewGroupManager<BottomSheetView> im
     @Override
     protected void onAfterUpdateTransaction(@NonNull BottomSheetView view) {
         super.onAfterUpdateTransaction(view);
-        if (view.bottomSheetBehavior.getState() != view.detent)
-            view.bottomSheetBehavior.setState(view.detent);
+        view.onAfterUpdateTransaction();
     }
 
     @Nullable

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarViewManager.java
@@ -78,7 +78,12 @@ public class NavigationBarViewManager extends ViewGroupManager<NavigationBarView
     }
 
     @Override
-    public void setHidden(NavigationBarView view, boolean value) {
+    public void setCrumb(NavigationBarView view, int value) {
+    }
+
+    @Override
+    public void setIsHidden(NavigationBarView view, boolean value) {
+
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarManager.java
@@ -3,6 +3,7 @@ package com.navigation.reactnative;
 import android.os.Build;
 import android.text.InputType;
 
+import androidx.annotation.NonNull;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
 import com.facebook.react.common.MapBuilder;
@@ -73,6 +74,12 @@ public class SearchBarManager extends ViewGroupManager<SearchBarView> {
             params.bottomMargin = (int) PixelUtil.toPixelFromDIP(56);
             params.setBehavior(null);
         }
+    }
+
+    @Override
+    protected void onAfterUpdateTransaction(@NonNull SearchBarView view) {
+        super.onAfterUpdateTransaction(view);
+        view.onAfterUpdateTransaction();
     }
 
     @Nonnull

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
@@ -25,6 +25,7 @@ public class SearchBarView extends ReactViewGroup {
     final SearchView searchView;
     private MenuItem menuItem;
     boolean bottomBar = false;
+    String pendingText;
     int nativeEventCount;
     int mostRecentEventCount;
     int nativeActiveEventCount;
@@ -68,9 +69,7 @@ public class SearchBarView extends ReactViewGroup {
     }
 
     void setQuery(String query) {
-        int eventLag = nativeEventCount - mostRecentEventCount;
-        if (eventLag == 0 && !searchView.getQuery().toString().equals(query))
-            searchView.setQuery(query, true);
+        pendingText = query;
     }
 
     void setActive(boolean active) {
@@ -133,6 +132,12 @@ public class SearchBarView extends ReactViewGroup {
                 }
             });
         }
+    }
+
+    void onAfterUpdateTransaction() {
+        int eventLag = nativeEventCount - mostRecentEventCount;
+        if (eventLag == 0 && !searchView.getQuery().toString().equals(pendingText))
+            searchView.setQuery(pendingText, true);
     }
 
     private final Runnable focusAndKeyboard = new Runnable() {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
@@ -108,8 +108,6 @@ public class SearchBarView extends ReactViewGroup {
                 public void onSearchAdd(MenuItem searchMenuItem) {
                     menuItem = searchMenuItem;
                     searchMenuItem.setActionView(searchView);
-                    if (pendingActive)
-                        menuItem.expandActionView();
                 }
 
                 @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
@@ -136,7 +136,7 @@ public class SearchBarView extends ReactViewGroup {
 
     void onAfterUpdateTransaction() {
         int eventLag = nativeEventCount - mostRecentEventCount;
-        if (eventLag == 0 && !searchView.getQuery().toString().equals(pendingText))
+        if (eventLag == 0 && pendingText != null && !searchView.getQuery().toString().equals(pendingText))
             searchView.setQuery(pendingText, true);
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
@@ -1,7 +1,6 @@
 package com.navigation.reactnative;
 
 import android.content.Context;
-import android.content.ContextWrapper;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
@@ -26,6 +25,7 @@ public class SearchBarView extends ReactViewGroup {
     private MenuItem menuItem;
     boolean bottomBar = false;
     String pendingText;
+    boolean pendingActive;
     int nativeEventCount;
     int mostRecentEventCount;
     int nativeActiveEventCount;
@@ -73,12 +73,7 @@ public class SearchBarView extends ReactViewGroup {
     }
 
     void setActive(boolean active) {
-        int eventLag = nativeActiveEventCount - mostRecentActiveEventCount;
-        if (eventLag == 0 && menuItem != null && menuItem.isActionViewExpanded() != active)
-            if (active)
-                menuItem.expandActionView();
-            else
-                menuItem.collapseActionView();
+        pendingActive = active;
     }
 
     void setBarTintColor(Integer barTintColor) {
@@ -113,6 +108,8 @@ public class SearchBarView extends ReactViewGroup {
                 public void onSearchAdd(MenuItem searchMenuItem) {
                     menuItem = searchMenuItem;
                     searchMenuItem.setActionView(searchView);
+                    if (pendingActive)
+                        menuItem.expandActionView();
                 }
 
                 @Override
@@ -138,6 +135,12 @@ public class SearchBarView extends ReactViewGroup {
         int eventLag = nativeEventCount - mostRecentEventCount;
         if (eventLag == 0 && pendingText != null && !searchView.getQuery().toString().equals(pendingText))
             searchView.setQuery(pendingText, true);
+        int activeEventLag = nativeActiveEventCount - mostRecentActiveEventCount;
+        if (activeEventLag == 0 && menuItem != null && menuItem.isActionViewExpanded() != pendingActive)
+            if (pendingActive)
+                menuItem.expandActionView();
+            else
+                menuItem.collapseActionView();
     }
 
     private final Runnable focusAndKeyboard = new Runnable() {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarViewManager.java
@@ -2,6 +2,7 @@ package com.navigation.reactnative;
 
 import android.text.InputType;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
@@ -115,6 +116,12 @@ public class SearchBarViewManager extends ViewGroupManager<SearchBarView> implem
             params.bottomMargin = (int) PixelUtil.toPixelFromDIP(56);
             params.setBehavior(null);
         }
+    }
+
+    @Override
+    protected void onAfterUpdateTransaction(@NonNull SearchBarView view) {
+        super.onAfterUpdateTransaction(view);
+        view.onAfterUpdateTransaction();
     }
 
     @Nonnull

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchResultsManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchResultsManager.java
@@ -1,5 +1,7 @@
 package com.navigation.reactnative;
 
+import androidx.annotation.NonNull;
+
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
@@ -47,6 +49,12 @@ public class SearchResultsManager extends ViewGroupManager<SearchResultsView> {
     @ReactProp(name = "mostRecentActiveEventCount")
     public void setMostRecentActiveEventCount(SearchResultsView view, int mostRecentActiveEventCount) {
         view.mostRecentActiveEventCount = mostRecentActiveEventCount;
+    }
+
+    @Override
+    protected void onAfterUpdateTransaction(@NonNull SearchResultsView view) {
+        super.onAfterUpdateTransaction(view);
+        view.onAfterUpdateTransaction();
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchResultsView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchResultsView.java
@@ -23,6 +23,8 @@ import com.google.android.material.search.SearchView;
 public class SearchResultsView extends SearchView {
     Drawable defaultBackground;
     private boolean layoutRequested = false;
+
+    private String pendingText;
     int nativeEventCount;
     int mostRecentEventCount;
     int nativeActiveEventCount;
@@ -70,10 +72,7 @@ public class SearchResultsView extends SearchView {
     }
 
     void setText(String text) {
-        int eventLag = nativeEventCount - mostRecentEventCount;
-        if (eventLag == 0 && !getEditText().getText().toString().equals(text)) {
-            getEditText().setText(text);
-        }
+        pendingText = text;
     }
 
     void setActive(boolean active) {
@@ -92,6 +91,13 @@ public class SearchResultsView extends SearchView {
             if (view.getChildAt(i) instanceof NavigationBarView) {
                 setupWithSearchBar((SearchToolbarView) ((NavigationBarView) view.getChildAt(i)).getChildAt(0));
             }
+        }
+    }
+
+    void onAfterUpdateTransaction() {
+        int eventLag = nativeEventCount - mostRecentEventCount;
+        if (eventLag == 0 && !getEditText().getText().toString().equals(pendingText)) {
+            getEditText().setText(pendingText);
         }
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchResultsView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchResultsView.java
@@ -95,7 +95,7 @@ public class SearchResultsView extends SearchView {
 
     void onAfterUpdateTransaction() {
         int eventLag = nativeEventCount - mostRecentEventCount;
-        if (eventLag == 0 && !getEditText().getText().toString().equals(pendingText)) {
+        if (eventLag == 0 && pendingText != null && !getEditText().getText().toString().equals(pendingText)) {
             getEditText().setText(pendingText);
         }
         int activeEventLag = nativeActiveEventCount - mostRecentActiveEventCount;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchResultsViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchResultsViewManager.java
@@ -80,6 +80,12 @@ public class SearchResultsViewManager extends ViewGroupManager<SearchResultsView
     }
 
     @Override
+    protected void onAfterUpdateTransaction(@NonNull SearchResultsView view) {
+        super.onAfterUpdateTransaction(view);
+        view.onAfterUpdateTransaction();
+    }
+
+    @Override
     public boolean needsCustomLayoutForChildren() {
         return true;
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarManager.java
@@ -27,12 +27,7 @@ public class TabBarManager extends ViewGroupManager<TabBarView> {
 
     @ReactProp(name = "selectedTab")
     public void setSelectedTab(TabBarView view, int selectedTab) {
-        int eventLag = view.nativeEventCount - view.mostRecentEventCount;
-        if (eventLag == 0 && view.selectedTab != selectedTab) {
-            view.selectedTab = selectedTab;
-            if (view.tabFragments.size() > selectedTab)
-                view.setCurrentTab(selectedTab);
-        }
+        view.pendingSelectedTab = selectedTab;
     }
 
     @ReactProp(name = "mostRecentEventCount")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerManager.java
@@ -29,12 +29,7 @@ public class TabBarPagerManager extends ViewGroupManager<TabBarPagerView> {
 
     @ReactProp(name = "selectedTab")
     public void setSelectedTab(TabBarPagerView view, int selectedTab) {
-        int eventLag = view.nativeEventCount - view.mostRecentEventCount;
-        if (eventLag == 0 && view.getCurrentItem() != selectedTab) {
-            view.selectedTab = selectedTab;
-            if (view.getTabsCount() > selectedTab)
-                view.setCurrentItem(selectedTab, false);
-        }
+        view.pendingSelectedTab = selectedTab;
     }
 
     @ReactProp(name = "mostRecentEventCount")
@@ -84,7 +79,7 @@ public class TabBarPagerManager extends ViewGroupManager<TabBarPagerView> {
     @Override
     protected void onAfterUpdateTransaction(@Nonnull TabBarPagerView view) {
         super.onAfterUpdateTransaction(view);
-        view.populateTabs();
+        view.onAfterUpdateTransaction();
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLAdapter.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLAdapter.java
@@ -15,6 +15,7 @@ import java.util.List;
 public class TabBarPagerRTLAdapter extends FragmentStateAdapter {
     private final List<TabBarItemView> tabBarItems = new ArrayList<>();
     final Fragment fragment;
+    int pendingSelectedTab = 0;
     int selectedTab = 0;
     boolean scrollsToTop;
     int nativeEventCount;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLManager.java
@@ -110,12 +110,7 @@ public class TabBarPagerRTLManager extends ViewGroupManager<ViewPager2> {
 
     @ReactProp(name = "selectedTab")
     public void setSelectedTab(ViewPager2 view, int selectedTab) {
-        int eventLag = getAdapter(view).nativeEventCount - getAdapter(view).mostRecentEventCount;
-        if (eventLag == 0 && view.getCurrentItem() != selectedTab) {
-            getAdapter(view).selectedTab = selectedTab;
-            if (getAdapter(view).getTabsCount() > selectedTab)
-                setCurrentItem(view, selectedTab);
-        }
+        getAdapter(view).pendingSelectedTab = selectedTab;
     }
 
     private void setCurrentItem(final ViewPager2 view, int selectedTab) {
@@ -173,6 +168,12 @@ public class TabBarPagerRTLManager extends ViewGroupManager<ViewPager2> {
     @Override
     protected void onAfterUpdateTransaction(@Nonnull ViewPager2 view) {
         super.onAfterUpdateTransaction(view);
+        int eventLag = getAdapter(view).nativeEventCount - getAdapter(view).mostRecentEventCount;
+        if (eventLag == 0 && view.getCurrentItem() != getAdapter(view).pendingSelectedTab) {
+            getAdapter(view).selectedTab = getAdapter(view).pendingSelectedTab;
+            if (getAdapter(view).getTabsCount() > getAdapter(view).selectedTab)
+                setCurrentItem(view, getAdapter(view).selectedTab);
+        }
         getAdapter(view).populateTabs(getTabLayout(view));
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLViewManager.java
@@ -130,12 +130,7 @@ public class TabBarPagerRTLViewManager extends ViewGroupManager<ViewPager2> impl
 
     @ReactProp(name = "selectedTab")
     public void setSelectedTab(ViewPager2 view, int selectedTab) {
-        int eventLag = getAdapter(view).nativeEventCount - getAdapter(view).mostRecentEventCount;
-        if (eventLag == 0 && view.getCurrentItem() != selectedTab) {
-            getAdapter(view).selectedTab = selectedTab;
-            if (getAdapter(view).getTabsCount() > selectedTab)
-                setCurrentItem(view, selectedTab);
-        }
+        getAdapter(view).pendingSelectedTab = selectedTab;
     }
 
     private void setCurrentItem(final ViewPager2 view, int selectedTab) {
@@ -194,6 +189,12 @@ public class TabBarPagerRTLViewManager extends ViewGroupManager<ViewPager2> impl
     @Override
     protected void onAfterUpdateTransaction(@Nonnull ViewPager2 view) {
         super.onAfterUpdateTransaction(view);
+        int eventLag = getAdapter(view).nativeEventCount - getAdapter(view).mostRecentEventCount;
+        if (eventLag == 0 && view.getCurrentItem() != getAdapter(view).pendingSelectedTab) {
+            getAdapter(view).selectedTab = getAdapter(view).pendingSelectedTab;
+            if (getAdapter(view).getTabsCount() > getAdapter(view).selectedTab)
+                setCurrentItem(view, getAdapter(view).selectedTab);
+        }
         getAdapter(view).populateTabs(getTabLayout(view));
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
@@ -32,6 +32,7 @@ import java.util.List;
 
 public class TabBarPagerView extends ViewPager implements TabBarItemView.ChangeListener {
     private final Fragment fragment;
+    int pendingSelectedTab = 0;
     int selectedTab = 0;
     boolean scrollsToTop;
     private boolean layoutRequested = false;
@@ -78,6 +79,16 @@ public class TabBarPagerView extends ViewPager implements TabBarItemView.ChangeL
             measured = true;
             getAdapter().notifyDataSetChanged();
         }
+    }
+
+    void onAfterUpdateTransaction() {
+        int eventLag = nativeEventCount - mostRecentEventCount;
+        if (eventLag == 0 && getCurrentItem() != pendingSelectedTab) {
+            selectedTab = pendingSelectedTab;
+            if (getTabsCount() > selectedTab)
+                setCurrentItem(selectedTab, false);
+        }
+        populateTabs();
     }
 
     void populateTabs() {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerViewManager.java
@@ -44,12 +44,7 @@ public class TabBarPagerViewManager extends ViewGroupManager<TabBarPagerView> im
 
     @ReactProp(name = "selectedTab")
     public void setSelectedTab(TabBarPagerView view, int selectedTab) {
-        int eventLag = view.nativeEventCount - view.mostRecentEventCount;
-        if (eventLag == 0 && view.getCurrentItem() != selectedTab) {
-            view.selectedTab = selectedTab;
-            if (view.getTabsCount() > selectedTab)
-                view.setCurrentItem(selectedTab, false);
-        }
+        view.pendingSelectedTab = selectedTab;
     }
 
     @ReactProp(name = "mostRecentEventCount")
@@ -100,7 +95,7 @@ public class TabBarPagerViewManager extends ViewGroupManager<TabBarPagerView> im
     @Override
     protected void onAfterUpdateTransaction(@Nonnull TabBarPagerView view) {
         super.onAfterUpdateTransaction(view);
-        view.populateTabs();
+        view.onAfterUpdateTransaction();
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -32,6 +32,7 @@ public class TabBarView extends ViewGroup implements TabBarItemView.ChangeListen
     private TabFragment selectedTabFragment;
     private Fragment fragment;
     boolean tabsChanged = false;
+    int pendingSelectedTab = 0;
     int selectedTab = 0;
     boolean scrollsToTop;
     int nativeEventCount;
@@ -81,6 +82,12 @@ public class TabBarView extends ViewGroup implements TabBarItemView.ChangeListen
     }
 
     void onAfterUpdateTransaction() {
+        int eventLag = nativeEventCount - mostRecentEventCount;
+        if (eventLag == 0 && pendingSelectedTab != selectedTab) {
+            selectedTab = pendingSelectedTab;
+            if (tabFragments.size() > selectedTab)
+                setCurrentTab(selectedTab);
+        }
         if (tabFragments.size() == 0)
             return;
         populateTabs();

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarViewManager.java
@@ -42,12 +42,7 @@ public class TabBarViewManager extends ViewGroupManager<TabBarView> implements N
 
     @ReactProp(name = "selectedTab")
     public void setSelectedTab(TabBarView view, int selectedTab) {
-        int eventLag = view.nativeEventCount - view.mostRecentEventCount;
-        if (eventLag == 0 && view.selectedTab != selectedTab) {
-            view.selectedTab = selectedTab;
-            if (view.tabFragments.size() > selectedTab)
-                view.setCurrentTab(selectedTab);
-        }
+        view.pendingSelectedTab = selectedTab;
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
@@ -43,15 +43,11 @@ public class TabNavigationView extends BottomNavigationView implements TabView {
     }
 
     void setTitles() {
-        int selectedIndex = getSelectedItemId();
         getMenu().clear();
         TabBarView tabBar = getTabBar();
         for (int i = 0; tabBar != null && i < tabBar.tabFragments.size(); i++) {
             getMenu().add(Menu.NONE, i, i, getTabBar().tabFragments.get(i).tabBarItem.styledTitle);
         }
-        autoSelected = true;
-        setSelectedItemId(selectedIndex);
-        autoSelected = false;
     }
 
     @Override

--- a/NavigationReactNative/src/ios/NVSearchBarView.h
+++ b/NavigationReactNative/src/ios/NVSearchBarView.h
@@ -6,6 +6,7 @@
 @interface NVSearchBarView : UIView <UISearchResultsUpdating, UISearchBarDelegate, NVSearchBar>
 
 @property UISearchController *searchController;
+@property (nonatomic, copy) NSString *text;
 @property (nonatomic, assign) BOOL active;
 @property (nonatomic, assign) BOOL hideWhenScrolling;
 @property (nonatomic, assign) NSInteger mostRecentEventCount;

--- a/NavigationReactNative/src/ios/NVSearchBarView.h
+++ b/NavigationReactNative/src/ios/NVSearchBarView.h
@@ -8,6 +8,7 @@
 @property UISearchController *searchController;
 @property (nonatomic, copy) NSString *text;
 @property (nonatomic, assign) BOOL active;
+@property (nonatomic, assign) NSInteger scopeButton;
 @property (nonatomic, assign) BOOL hideWhenScrolling;
 @property (nonatomic, assign) NSInteger mostRecentEventCount;
 @property (nonatomic, assign) NSInteger mostRecentActiveEventCount;

--- a/NavigationReactNative/src/ios/NVSearchBarView.m
+++ b/NavigationReactNative/src/ios/NVSearchBarView.m
@@ -67,14 +67,6 @@
     self.searchController.searchBar.scopeButtonTitles = scopeButtons;
 }
 
-- (void)setScopeButton:(NSInteger)scopeButton
-{
-    NSInteger eventLag = _nativeButtonEventCount - _mostRecentButtonEventCount;
-    if (eventLag == 0 && self.searchController.searchBar.selectedScopeButtonIndex != scopeButton) {
-        self.searchController.searchBar.selectedScopeButtonIndex = scopeButton;
-    }
-}
-
 - (void)didSetProps:(NSArray<NSString *> *)changedProps
 {
     if (@available(iOS 11.0, *)) {
@@ -88,6 +80,10 @@
     if (activeEventLag == 0 && self.searchController.active != _active) {
         [self.searchController setActive:_active];
         if (_active) [self.searchController.searchBar becomeFirstResponder];
+    }
+    NSInteger buttonEventLag = _nativeButtonEventCount - _mostRecentButtonEventCount;
+    if (buttonEventLag == 0 && self.searchController.searchBar.selectedScopeButtonIndex != _scopeButton) {
+        self.searchController.searchBar.selectedScopeButtonIndex = _scopeButton;
     }
 }
 

--- a/NavigationReactNative/src/ios/NVSearchBarView.m
+++ b/NavigationReactNative/src/ios/NVSearchBarView.m
@@ -55,14 +55,6 @@
     [self.searchController.searchBar setPlaceholder:placeholder];
 }
 
-- (void)setText:(NSString *)text
-{
-    NSInteger eventLag = _nativeEventCount - _mostRecentEventCount;
-    if (eventLag == 0 && ![self.searchController.searchBar.text isEqualToString:text]) {
-        [self.searchController.searchBar setText:text];
-    }
-}
-
 - (void)setBarTintColor:(UIColor *)barTintColor
 {
     if (@available(iOS 13.0, *)) {
@@ -88,8 +80,12 @@
     if (@available(iOS 11.0, *)) {
         [self.reactViewController.navigationItem setHidesSearchBarWhenScrolling:self.hideWhenScrolling];
     }
-    NSInteger eventLag = _nativeActiveEventCount - _mostRecentActiveEventCount;
-    if (eventLag == 0 && self.searchController.active != _active) {
+    NSInteger eventLag = _nativeEventCount - _mostRecentEventCount;
+    if (eventLag == 0 && ![self.searchController.searchBar.text isEqualToString:_text]) {
+        [self.searchController.searchBar setText:_text];
+    }
+    NSInteger activeEventLag = _nativeActiveEventCount - _mostRecentActiveEventCount;
+    if (activeEventLag == 0 && self.searchController.active != _active) {
         [self.searchController setActive:_active];
         if (_active) [self.searchController.searchBar becomeFirstResponder];
     }

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.m
@@ -25,17 +25,6 @@
     return self;
 }
 
-- (void)setSelectedTab:(NSInteger)selectedTab
-{
-    NSInteger eventLag = _nativeEventCount - _mostRecentEventCount;
-    if (eventLag == 0 && _selectedTab != selectedTab) {
-        _selectedTab = selectedTab;
-        if (_tabs.count > selectedTab) {
-            [self setCurrentTab:selectedTab];
-        }
-    }
-}
-
 - (void)insertReactSubview:(UIView *)subview atIndex:(NSInteger)atIndex
 {
     [super insertReactSubview:subview atIndex:atIndex];
@@ -61,6 +50,14 @@
         _selectedTab = reselectedTab != NSNotFound ? reselectedTab : MIN(_selectedTab, _tabs.count - 1);
     }
     [self setCurrentTab:_selectedTab];
+}
+
+- (void)didSetProps:(NSArray<NSString *> *)changedProps
+{
+    NSInteger eventLag = _nativeEventCount - _mostRecentEventCount;
+    if (eventLag == 0 && _tabs.count > _selectedTab) {
+        [self setCurrentTab:_selectedTab];
+    }
 }
 
 - (void)didMoveToWindow

--- a/NavigationReactNative/src/ios/NVTabBarView.h
+++ b/NavigationReactNative/src/ios/NVTabBarView.h
@@ -4,6 +4,7 @@
 @interface NVTabBarView : UIView <UITabBarControllerDelegate>
 
 @property (nonatomic, assign) NSInteger tabCount;
+@property (nonatomic, assign) NSInteger selectedTab;
 @property (nonatomic, copy) UIColor *barTintColor;
 @property (nonatomic, copy) UIColor *selectedTintColor;
 @property (nonatomic, copy) UIColor *unselectedTintColor;

--- a/NavigationReactNative/src/ios/NVTabBarView.m
+++ b/NavigationReactNative/src/ios/NVTabBarView.m
@@ -11,7 +11,7 @@
 @implementation NVTabBarView
 {
     UITabBarController *_tabBarController;
-    NSInteger _selectedTab;
+    NSInteger _selectedIndex;
     NSInteger _nativeEventCount;
     bool _firstSceneReselected;
 }
@@ -25,14 +25,6 @@
         _tabBarController.delegate = self;
     }
     return self;
-}
-
-- (void)setSelectedTab:(NSInteger)selectedTab
-{
-    NSInteger eventLag = _nativeEventCount - _mostRecentEventCount;
-    if (eventLag == 0) {
-        _selectedTab = selectedTab;
-    }
 }
 
 - (void)insertReactSubview:(UIView *)subview atIndex:(NSInteger)atIndex
@@ -60,14 +52,18 @@
 
 - (void)didSetProps:(NSArray<NSString *> *)changedProps
 {
+    NSInteger eventLag = _nativeEventCount - _mostRecentEventCount;
+    if (eventLag == 0) {
+        _selectedIndex = _selectedTab;
+    }
     if (_tabBarController.selectedIndex == NSNotFound) {
         _tabBarController.selectedIndex = 0;
     }
-    if (_tabBarController.selectedIndex != _selectedTab) {
+    if (_tabBarController.selectedIndex != _selectedIndex) {
         if ([changedProps containsObject:@"selectedTab"]) {
-            _tabBarController.selectedIndex = _selectedTab;
+            _tabBarController.selectedIndex = _selectedIndex;
         } else {
-            _selectedTab = _tabBarController.selectedIndex;
+            _selectedIndex = _tabBarController.selectedIndex;
         }
         [self selectTab];
     }
@@ -143,8 +139,8 @@
 - (void)tabBarController:(UITabBarController *)tabBarController didSelectViewController:(nonnull UIViewController *)viewController
 {
     NSInteger selectedIndex = [tabBarController.viewControllers indexOfObject:viewController];
-    if (_selectedTab != selectedIndex) {
-        _selectedTab = selectedIndex;
+    if (_selectedIndex != selectedIndex) {
+        _selectedIndex = selectedIndex;
         [self selectTab];
     }
     if (_firstSceneReselected && _scrollsToTop) {
@@ -175,16 +171,16 @@
 {
     NSInteger selectedIndex = [tabBarController.viewControllers indexOfObject:viewController];
     NSArray *viewControllers = ((UINavigationController *) viewController).viewControllers;
-    _firstSceneReselected = _selectedTab == selectedIndex && viewControllers.count == 1;
+    _firstSceneReselected = _selectedIndex == selectedIndex && viewControllers.count == 1;
     return YES;
 }
 
 -(void) selectTab
 {
     _nativeEventCount++;
-    NVTabBarItemView *tabBarItem = (NVTabBarItemView *)self.reactSubviews[_selectedTab];
+    NVTabBarItemView *tabBarItem = (NVTabBarItemView *)self.reactSubviews[_selectedIndex];
     self.onTabSelected(@{
-        @"tab": @(_selectedTab),
+        @"tab": @(_selectedIndex),
         @"eventCount": @(_nativeEventCount),
     });
     if (!!tabBarItem.onPress) {


### PR DESCRIPTION
Some props can be set from Native as well as JavaScript. For example, the `text` prop on the `SearchBar` changes when the user types (Native) and when the `text` state changes (JavaScript).

```jsx
<SearchBar text={text} onChangeText={setText}>
```
To prevent the updates fighting, keep track of an event lag on the native side. The JavaScript update only goes ahead if the event lag is 0 (if the JavaScript has seen the latest native change). This used to work with `setNativeProps` - Native tells JS about the latest change and JS tells Native it's seen the change by calling `setNativeProps`. 

But Fabric got rid of `setNativeProps` so switched the event lag tracking to `useState` on both old and new architectures instead. But this introduced 2 problems

1. Now there are 2 properties updated (event lag and text) and can't guarantee the event lag property change happens first on Native.
2. Was doing the event state update first in JS so it's possible that JS sends the stale value for text. If React Native sends the state updates separately, the first state update will be the event state with the old text value. Still shouldn't matter because the fresh value update happens next, but sending stale values is asking for trouble

So this PR fixes these by
1. Using `onAfterUpdateTransaction/didSetProps` instead of individual setters. Processing both together means it doesn't matter which property was set first
2. Updating the text state before the event lag state. Even if React Native sends the state updates separately, native will never get a stale text value. The event lag will be non-zero so Native will ignore the change but the value will never be stale

