### PR TITLE
Supported custom TabBar back behaviour (Android)

### DIFF
--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -44,7 +44,7 @@ class TabBar extends React.Component<any, any> {
         return false;
     }
     render() {
-        var {children, labelVisibilityMode, barTintColor, selectedTintColor, unselectedTintColor, activeIndicatorColor, rippleColor, bottomTabs, scrollable, primary, scrollsToTop} = this.props;
+        var {children, labelVisibilityMode, barTintColor, selectedTintColor, unselectedTintColor, activeIndicatorColor, rippleColor, bottomTabs, scrollable, primary, scrollsToTop, onPressBack} = this.props;
         const Material3 = global.__turboModuleProxy != null ? require("./NativeMaterial3Module").default : NativeModules.Material3;
         const { on: material3 } = Platform.OS === 'android' ? Material3.getConstants() : { on: false };
         bottomTabs = bottomTabs != null ? bottomTabs : primary;
@@ -100,7 +100,7 @@ class TabBar extends React.Component<any, any> {
                     fontStyle={fontStyle} fontSize={fontSize}
                     mostRecentEventCount={this.state.mostRecentEventCount}
                     style={styles.tabBar}>
-                        <BackButton onPress={() => this.changeTab(0)} />
+                        <BackButton onPress={() => onPressBack ? onPressBack() : this.changeTab(0)} />
                         {tabBarItems
                             .filter(child => !!child)
                             .map((child: any, index) => {

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -688,6 +688,10 @@ export interface TabBarProps {
      * Handles tab change events
      */
     onChangeTab?: (tab: number) => void;
+    /**
+     * Handles Android back button press events
+     */
+    onPressBack?: () => boolean;
 }
 
 /**

--- a/types/navigation-react-native.d.ts
+++ b/types/navigation-react-native.d.ts
@@ -688,6 +688,10 @@ export interface TabBarProps {
      * Handles tab change events
      */
     onChangeTab?: (tab: number) => void;
+    /**
+     * Handles Android back button press events
+     */
+    onPressBack?: () => boolean;
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/grahammendick/navigation/issues/691#issuecomment-1493384062

@afkcodes wants the Android back button to step back through the visited tabs. Thought this was already possible by user adding a custom Android back handler. But the `TabBar` back handler took precedence because React Native added before the user's one (child components' effects run before parent's).

Added a `onPressBack` prop to the `TabBar` so the user can provide alternative back behaviour. 

For @afkcodes behaviour
```jsx
const [tab, setTab] = useState(0)
const tabsVisited = useRef([0]);
useEffect(() => {
  if (tab) {
    const i = tabsVisited.current.indexOf(tab);
    if (i > -1) tabsVisited.current.splice(i, 1);
    tabsVisited.current.push(tab);
  }
}, [tab]);
const handleBack = () => {
  const visited = tabsVisited.current;
  if (visited.length > 1) {
    visited.pop();
    setTab(visited[visited.length - 1]);
    return true;
  };
  return false;
}
return (
    <TabBar tab={tab} onChangeTab={setTab} onPressBack={handleBack}>
```

Or to close the app
```jsx
<TabBar onPressBack={() => false}>
```

