### PR TITLE
Prevented hot reload error on back (iOS)

### DIFF
--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -114,7 +114,8 @@ class Scene extends React.Component<SceneProps, SceneState> {
         return stateContext;
     }
     getAnimation() {
-        var {crumb, navigationEvent: {stateNavigator}, unmountStyle, crumbStyle, hidesTabBar, backgroundColor} = this.props;
+        var {crumb, navigationEvent, unmountStyle, crumbStyle, hidesTabBar, backgroundColor} = this.props;
+        var {stateNavigator} = this.state.navigationEvent || navigationEvent;
         var {crumbs, nextCrumb} = stateNavigator.stateContext;
         var {state, data} = crumbs[crumb] || nextCrumb;
         var currentCrumbs = crumbs.slice(0, crumb);


### PR DESCRIPTION
The `Scene` component took the `stateNavigator` from props instead of state. When navigating back the `stateNavigator` from props has a shorter stack and so `getAnimation` returned null. Noticed when working on orientation that the orientation prop was incorrectly cleared when navigating back. Mostly this doesn't matter because the props returned from `getAnimation` are only used when going forward.

Navigating from A --> B, editing the code in B and pressing back would throw an error on iOS. React Native creates a brand new stateNavigator (still not sure why) on hot reload and the following code throws because there aren't any crumbs. Taking the `stateNavigator` from state fixes this. 
```js
var {state, data} = crumbs[crumb] || nextCrumb;
```
