### PR TITLE
Prevented reanimated 3 error (Android)

### DIFF
--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ActionBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ActionBarView.java
@@ -5,6 +5,7 @@ import android.view.ViewGroup;
 
 import androidx.annotation.UiThread;
 
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.GuardedRunnable;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
@@ -130,7 +131,7 @@ public class ActionBarView extends ViewGroup implements FabricViewStateManager.H
 
         @Override
         public void dispatch(RCTEventEmitter rctEventEmitter) {
-            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), null);
+            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), Arguments.createMap());
         }
     }
 
@@ -146,7 +147,7 @@ public class ActionBarView extends ViewGroup implements FabricViewStateManager.H
 
         @Override
         public void dispatch(RCTEventEmitter rctEventEmitter) {
-            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), null);
+            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), Arguments.createMap());
         }
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
@@ -15,6 +15,7 @@ import android.widget.ImageButton;
 import androidx.annotation.Nullable;
 import androidx.appcompat.view.CollapsibleActionView;
 
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.UIManagerHelper;
@@ -204,7 +205,7 @@ public class BarButtonView extends ViewGroup implements CollapsibleActionView {
 
         @Override
         public void dispatch(RCTEventEmitter rctEventEmitter) {
-            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), null);
+            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), Arguments.createMap());
         }
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomAppBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomAppBarView.java
@@ -21,6 +21,7 @@ import androidx.appcompat.widget.AppCompatImageView;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.core.view.ViewCompat;
 
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.modules.i18nmanager.I18nUtil;
@@ -281,7 +282,7 @@ public class BottomAppBarView extends BottomAppBar implements ActionView {
 
         @Override
         public void dispatch(RCTEventEmitter rctEventEmitter) {
-            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), null);
+            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), Arguments.createMap());
         }
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ExtendedFloatingActionButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ExtendedFloatingActionButtonView.java
@@ -14,6 +14,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.UIManagerHelper;
@@ -151,7 +152,7 @@ public class ExtendedFloatingActionButtonView extends ExtendedFloatingActionButt
 
         @Override
         public void dispatch(RCTEventEmitter rctEventEmitter) {
-            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), null);
+            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), Arguments.createMap());
         }
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonView.java
@@ -9,6 +9,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.UIManagerHelper;
@@ -78,7 +79,7 @@ public class FloatingActionButtonView extends FloatingActionButton {
 
         @Override
         public void dispatch(RCTEventEmitter rctEventEmitter) {
-            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), null);
+            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), Arguments.createMap());
         }
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -317,7 +317,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
 
         @Override
         public void dispatch(RCTEventEmitter rctEventEmitter) {
-            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), null);
+            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), Arguments.createMap());
         }
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneView.java
@@ -3,6 +3,7 @@ package com.navigation.reactnative;
 import android.content.Context;
 import android.view.View;
 
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.events.Event;
@@ -64,7 +65,7 @@ public class SceneView extends ReactViewGroup {
 
         @Override
         public void dispatch(RCTEventEmitter rctEventEmitter) {
-            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), null);
+            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), Arguments.createMap());
         }
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchToolbarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchToolbarView.java
@@ -17,6 +17,7 @@ import androidx.appcompat.widget.ActionMenuView;
 import androidx.appcompat.widget.AppCompatImageButton;
 import androidx.appcompat.widget.AppCompatImageView;
 
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.UIManagerHelper;
@@ -195,7 +196,7 @@ public class SearchToolbarView extends SearchBar {
 
         @Override
         public void dispatch(RCTEventEmitter rctEventEmitter) {
-            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), null);
+            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), Arguments.createMap());
         }
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemView.java
@@ -12,6 +12,7 @@ import android.view.ViewGroup;
 
 import androidx.annotation.Nullable;
 
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.UIManagerHelper;
@@ -182,7 +183,7 @@ public class TabBarItemView extends ViewGroup {
 
         @Override
         public void dispatch(RCTEventEmitter rctEventEmitter) {
-            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), null);
+            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), Arguments.createMap());
         }
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
@@ -23,6 +23,7 @@ import androidx.appcompat.widget.ActionMenuView;
 import androidx.appcompat.widget.AppCompatImageButton;
 import androidx.appcompat.widget.AppCompatImageView;
 
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.UIManagerHelper;
@@ -334,7 +335,7 @@ public class ToolbarView extends MaterialToolbar implements ActionView {
 
         @Override
         public void dispatch(RCTEventEmitter rctEventEmitter) {
-            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), null);
+            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), Arguments.createMap());
         }
     }
 }


### PR DESCRIPTION
Reanimated 3 throws errors if pass null for the `WritableMap` when receiving an event
Thanks @RichardLindhout for letting me know about the error