### PR TITLE
Applied TabBar tint props on iPad

### DIFF
--- a/NavigationReactNative/src/ios/NVTabBarComponentView.mm
+++ b/NavigationReactNative/src/ios/NVTabBarComponentView.mm
@@ -97,6 +97,7 @@ using namespace facebook::react;
         [itemAppearance.selected setIconColor:selectedTintColor];
         appearance.stackedLayoutAppearance = itemAppearance;
         appearance.compactInlineLayoutAppearance = itemAppearance;
+        appearance.inlineLayoutAppearance = itemAppearance;
         _tabBarController.tabBar.standardAppearance = appearance;
         [_tabBarController.tabBar setNeedsLayout];
         if (@available(iOS 15.0, *))

--- a/NavigationReactNative/src/ios/NVTabBarView.m
+++ b/NavigationReactNative/src/ios/NVTabBarView.m
@@ -98,6 +98,7 @@
         [itemAppearance.selected setIconColor:_selectedTintColor];
         appearance.stackedLayoutAppearance = itemAppearance;
         appearance.compactInlineLayoutAppearance = itemAppearance;
+        appearance.inlineLayoutAppearance = itemAppearance;
         _tabBarController.tabBar.standardAppearance = appearance;
         [_tabBarController.tabBar setNeedsLayout];
         if (@available(iOS 15.0, *))


### PR DESCRIPTION
On larger devices, iOS applies the `inlineLayoutAppearance` applies to the `UITabBarController`. There's enough room for iOS to 'inline' the text and image on the tab.
Thanks @RichardLindhout for letting me know about the error