### PR TITLE
Restored traditional shared element support (Android)

### DIFF
--- a/NavigationReactNative/sample/zoom/ios/Podfile.lock
+++ b/NavigationReactNative/sample/zoom/ios/Podfile.lock
@@ -74,7 +74,7 @@ PODS:
   - fmt (6.2.1)
   - glog (0.3.5)
   - libevent (2.1.12)
-  - navigation-react-native (9.2.4):
+  - navigation-react-native (9.0.0):
     - React-Core
   - OpenSSL-Universal (1.1.1100)
   - RCT-Folly (2021.06.28.00-v2):
@@ -520,7 +520,7 @@ SPEC CHECKSUMS:
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 3d02b25ca00c2d456734d0bcff864cbc62f6ae1a
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  navigation-react-native: c451dff7b090950ca9d4795c292829e593a338f9
+  navigation-react-native: 8023a14af3ecbcb760f6355fbb09084823585117
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: b9d9fe1fc70114b751c076104e52f3b1b5e5a95a
   RCTRequired: fe80e9f71dd15939e5399dd94d0aa0e5e069d592

--- a/NavigationReactNative/sample/zoom/ios/Podfile.lock
+++ b/NavigationReactNative/sample/zoom/ios/Podfile.lock
@@ -74,7 +74,7 @@ PODS:
   - fmt (6.2.1)
   - glog (0.3.5)
   - libevent (2.1.12)
-  - navigation-react-native (9.0.0):
+  - navigation-react-native (9.2.4):
     - React-Core
   - OpenSSL-Universal (1.1.1100)
   - RCT-Folly (2021.06.28.00-v2):
@@ -520,7 +520,7 @@ SPEC CHECKSUMS:
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 3d02b25ca00c2d456734d0bcff864cbc62f6ae1a
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  navigation-react-native: 8023a14af3ecbcb760f6355fbb09084823585117
+  navigation-react-native: c451dff7b090950ca9d4795c292829e593a338f9
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: b9d9fe1fc70114b751c076104e52f3b1b5e5a95a
   RCTRequired: fe80e9f71dd15939e5399dd94d0aa0e5e069d592

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -87,23 +87,23 @@ const NavigationStack = ({underlayColor = '#000', title, crumbStyle: crumbStyleS
             const {state: nextState, data: nextData} = crumbs.concat(nextCrumb)[oldCrumbs.length + 1];
             enterAnim = unmountStyle(true, state, data, crumbs);
             exitAnim = crumbStyle(false, oldState, oldData, oldCrumbs, nextState, nextData);
-            const sharedElement = getSharedElement(state, data, crumbs);
-            sharedElements = sharedElement ? [sharedElement] : getSharedElements(state, data, crumbs);
+            sharedElements = getSharedElement(state, data, crumbs) || getSharedElements(state, data, crumbs);
         }
         if (crumbs.length < oldCrumbs.length) {
             nextCrumb = new Crumb(oldData, oldState, null, null, false);
             const {state: nextState, data: nextData} = oldCrumbs.concat(nextCrumb)[crumbs.length + 1];
             enterAnim = crumbStyle(true, state, data, crumbs, nextState, nextData);
             exitAnim = unmountStyle(false, oldState, oldData, oldCrumbs);
-            const sharedElement = getSharedElement(oldState, oldData, oldCrumbs);
-            sharedElements = sharedElement ? [sharedElement] : getSharedElements(oldState, oldData, oldCrumbs);
+            sharedElements = getSharedElement(oldState, oldData, oldCrumbs) || getSharedElements(oldState, oldData, oldCrumbs);
         }
         if (crumbs.length === oldCrumbs.length) {
             enterAnim = unmountStyle(true, state, data, crumbs);
             exitAnim = unmountStyle(false, oldState, oldData, oldCrumbs, state, data);
         }
-        var enterAnimOff = enterAnim === '';
-        return {enterAnim, exitAnim, enterAnimOff, sharedElements};
+        const containerTransform = typeof sharedElements === 'string';            
+        sharedElements = containerTransform && sharedElements ? [sharedElements] : sharedElements;
+        const enterAnimOff = enterAnim === '';
+        return {enterAnim, exitAnim, enterAnimOff, sharedElements, containerTransform};
     }
     const {stateNavigator: prevStateNavigator, keys, rest, mostRecentEventCount} = stackState;
     if (prevStateNavigator !== stateNavigator && stateNavigator.stateContext.state) {

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -100,7 +100,7 @@ const NavigationStack = ({underlayColor = '#000', title, crumbStyle: crumbStyleS
             enterAnim = unmountStyle(true, state, data, crumbs);
             exitAnim = unmountStyle(false, oldState, oldData, oldCrumbs, state, data);
         }
-        const containerTransform = typeof sharedElements === 'string';            
+        const containerTransform = typeof sharedElements === 'string';
         sharedElements = containerTransform && sharedElements ? [sharedElements] : sharedElements;
         const enterAnimOff = enterAnim === '';
         return {enterAnim, exitAnim, enterAnimOff, sharedElements, containerTransform};

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -82,7 +82,7 @@ const NavigationStack = ({underlayColor = '#000', title, crumbStyle: crumbStyleS
         if (!oldState)
             return null;
         const {crumbs: oldCrumbs} = stateNavigator.parseLink(oldUrl);
-        let enterAnim, exitAnim, sharedElements, oldSharedElements;
+        let enterAnim, exitAnim, sharedElements;
         if (oldCrumbs.length < crumbs.length) {
             const {state: nextState, data: nextData} = crumbs.concat(nextCrumb)[oldCrumbs.length + 1];
             enterAnim = unmountStyle(true, state, data, crumbs);
@@ -95,15 +95,15 @@ const NavigationStack = ({underlayColor = '#000', title, crumbStyle: crumbStyleS
             const {state: nextState, data: nextData} = oldCrumbs.concat(nextCrumb)[crumbs.length + 1];
             enterAnim = crumbStyle(true, state, data, crumbs, nextState, nextData);
             exitAnim = unmountStyle(false, oldState, oldData, oldCrumbs);
-            const oldSharedElement = getSharedElement(oldState, oldData, oldCrumbs);
-            oldSharedElements = oldSharedElement ? [oldSharedElement] : getSharedElements(oldState, oldData, oldCrumbs);
+            const sharedElement = getSharedElement(oldState, oldData, oldCrumbs);
+            sharedElements = sharedElement ? [sharedElement] : getSharedElements(oldState, oldData, oldCrumbs);
         }
         if (crumbs.length === oldCrumbs.length) {
             enterAnim = unmountStyle(true, state, data, crumbs);
             exitAnim = unmountStyle(false, oldState, oldData, oldCrumbs, state, data);
         }
         var enterAnimOff = enterAnim === '';
-        return {enterAnim, exitAnim, enterAnimOff, sharedElements, oldSharedElements};
+        return {enterAnim, exitAnim, enterAnimOff, sharedElements};
     }
     const {stateNavigator: prevStateNavigator, keys, rest, mostRecentEventCount} = stackState;
     if (prevStateNavigator !== stateNavigator && stateNavigator.stateContext.state) {

--- a/NavigationReactNative/src/NavigationStackNativeComponent.js
+++ b/NavigationReactNative/src/NavigationStackNativeComponent.js
@@ -10,8 +10,8 @@ type NativeProps = $ReadOnly<{|
   enterAnim: string,
   exitAnim: string,
   enterAnimOff: boolean,
-  sharedElement: string,
-  oldSharedElement: string,
+  sharedElements: $ReadOnlyArray<string>,
+  containerTransform: boolean,
   mostRecentEventCount: Int32,
   onNavigateToTop: DirectEventHandler<null>,
   onWillNavigateBack: DirectEventHandler<$ReadOnly<{|

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -42,6 +42,11 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
         view.sharedElementNames = sharedElements;
     }
 
+    @ReactProp(name = "containerTransform")
+    public void setContainerTransform(NavigationStackView view, boolean containerTransform) {
+        view.containerTransform = containerTransform;
+    }
+
     @Nonnull
     @Override
     protected NavigationStackView createViewInstance(@Nonnull ThemedReactContext reactContext) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -42,11 +42,6 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
         view.sharedElementNames = sharedElements;
     }
 
-    @ReactProp(name = "oldSharedElements")
-    public void setOldSharedElements(NavigationStackView view, ReadableArray oldSharedElements) {
-        view.oldSharedElementNames = oldSharedElements;
-    }
-
     @Nonnull
     @Override
     protected NavigationStackView createViewInstance(@Nonnull ThemedReactContext reactContext) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -37,14 +37,14 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
         view.exitAnim = exitAnim;
     }
 
-    @ReactProp(name = "sharedElement")
-    public void setSharedElement(NavigationStackView view, String sharedElement) {
-        view.sharedElementName = sharedElement;
+    @ReactProp(name = "sharedElements")
+    public void setSharedElements(NavigationStackView view, ReadableArray sharedElements) {
+        view.sharedElementNames = sharedElements;
     }
 
-    @ReactProp(name = "oldSharedElement")
-    public void setOldSharedElement(NavigationStackView view, String oldSharedElement) {
-        view.oldSharedElementName = oldSharedElement;
+    @ReactProp(name = "oldSharedElements")
+    public void setOldSharedElements(NavigationStackView view, ReadableArray oldSharedElements) {
+        view.oldSharedElementNames = oldSharedElements;
     }
 
     @Nonnull

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -134,7 +134,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                         fragmentTransaction.addSharedElement(containerTransform ? sharedEl : sharedEl.getChildAt(0), (containerTransform ? "" : "element__") + sharedElement.second);
                     }
                 }
-                fragmentTransaction.setCustomAnimations(oldCrumb != -1 ? enter : 0, exit, popEnter, popExit);
+                fragmentTransaction.setCustomAnimations(oldCrumb != -1 && sharedElements == null ? enter : 0, exit, sharedElements == null ? popEnter : 0, popExit);
                 SceneFragment fragment = new SceneFragment(scene, getSharedElementSet(sharedElementNames), containerTransform);
                 fragmentTransaction.replace(getId(), fragment, key);
                 fragmentTransaction.addToBackStack(String.valueOf(nextCrumb));

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -130,7 +130,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                 }
                 if (sharedElements != null) {
                     for(Pair sharedElement : sharedElements) {
-                        fragmentTransaction.addSharedElement(((SharedElementView) sharedElement.first).getChildAt(0), (String) sharedElement.second);
+                        fragmentTransaction.addSharedElement(((SharedElementView) sharedElement.first).getChildAt(0), "element__" + sharedElement.second);
                     }
                 }
                 fragmentTransaction.setCustomAnimations(oldCrumb != -1 ? enter : 0, exit, popEnter, popExit);
@@ -182,7 +182,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
     HashMap<String, SharedElementView> getSharedElementMap(SceneView scene) {
         HashMap<String, SharedElementView> sharedElementMap = new HashMap<>();
         for(SharedElementView sharedElement : scene.sharedElements) {
-            sharedElementMap.put(sharedElement.name, sharedElement);
+            sharedElementMap.put(sharedElement.getTransitionName(), sharedElement);
         }
         return sharedElementMap;
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -51,7 +51,6 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
     protected String enterAnim;
     protected String exitAnim;
     protected ReadableArray sharedElementNames;
-    protected ReadableArray oldSharedElementNames;
     protected Boolean startNavigation = null;
 
     public NavigationStackView(Context context) {
@@ -103,7 +102,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
             Pair[] sharedElements = fragment != null ? getOldSharedElements(currentCrumb, crumb, fragment) : null;
             SceneFragment prevFragment = (SceneFragment) fragmentManager.findFragmentByTag(keys.getString(crumb));
             if (sharedElements != null && prevFragment != null && prevFragment.getScene() != null)
-                prevFragment.getScene().sharedElementMotion = new SharedElementMotion(fragment, prevFragment, getSharedElementSet(oldSharedElementNames));
+                prevFragment.getScene().sharedElementMotion = new SharedElementMotion(fragment, prevFragment, getSharedElementSet(sharedElementNames));
             fragmentManager.popBackStack(String.valueOf(crumb), 0);
         }
         if (crumb > currentCrumb) {
@@ -201,13 +200,13 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
 
     private Pair[] getOldSharedElements(int currentCrumb, int crumb, SceneFragment sceneFragment) {
         final HashMap<String, SharedElementView> oldSharedElementsMap = getSharedElementMap(sceneFragment.getScene());
-        final Pair[] oldSharedElements = currentCrumb - crumb == 1 ? getSharedElements(oldSharedElementsMap, oldSharedElementNames) : null;
+        final Pair[] oldSharedElements = currentCrumb - crumb == 1 ? getSharedElements(oldSharedElementsMap, sharedElementNames) : null;
         if (oldSharedElements != null && oldSharedElements.length != 0) {
             sceneFragment.setEnterSharedElementCallback(new SharedElementCallback() {
                 @Override
                 public void onMapSharedElements(List<String> names, Map<String, View> elements) {
-                    for(int i = 0; i < oldSharedElementNames.size(); i++) {
-                        String name = oldSharedElementNames.getString(i);
+                    for(int i = 0; i < sharedElementNames.size(); i++) {
+                        String name = sharedElementNames.getString(i);
                         if (oldSharedElementsMap.containsKey(name)) {
                             View oldSharedElement = oldSharedElementsMap.get(name).getChildAt(0);
                             elements.put(names.get(i), oldSharedElement);
@@ -229,8 +228,8 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                 public void onMapSharedElements(List<String> names, Map<String, View> elements) {
                     for(int i = 0; i < names.size(); i++) {
                         String mappedName = names.get(i);
-                        if (oldSharedElementNames != null && oldSharedElementNames.size() > i)
-                            mappedName = oldSharedElementNames.getString(i);
+                        if (sharedElementNames != null && sharedElementNames.size() > i)
+                            mappedName = sharedElementNames.getString(i);
                         if (sharedElementsMap.containsKey(mappedName))
                             elements.put(names.get(i), sharedElementsMap.get(mappedName).getChildAt(0));
                     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -130,7 +130,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                 }
                 if (sharedElements != null) {
                     for(Pair sharedElement : sharedElements) {
-                        fragmentTransaction.addSharedElement((View) sharedElement.first, (String) sharedElement.second);
+                        fragmentTransaction.addSharedElement(((SharedElementView) sharedElement.first).getChildAt(0), (String) sharedElement.second);
                     }
                 }
                 fragmentTransaction.setCustomAnimations(oldCrumb != -1 ? enter : 0, exit, popEnter, popExit);
@@ -182,7 +182,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
     HashMap<String, SharedElementView> getSharedElementMap(SceneView scene) {
         HashMap<String, SharedElementView> sharedElementMap = new HashMap<>();
         for(SharedElementView sharedElement : scene.sharedElements) {
-            sharedElementMap.put(sharedElement.getTransitionName(), sharedElement);
+            sharedElementMap.put(sharedElement.name, sharedElement);
         }
         return sharedElementMap;
     }
@@ -209,7 +209,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                     for(int i = 0; i < oldSharedElementNames.size(); i++) {
                         String name = oldSharedElementNames.getString(i);
                         if (oldSharedElementsMap.containsKey(name)) {
-                            View oldSharedElement = oldSharedElementsMap.get(name);
+                            View oldSharedElement = oldSharedElementsMap.get(name).getChildAt(0);
                             elements.put(names.get(i), oldSharedElement);
                         }
                     }
@@ -232,7 +232,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                         if (oldSharedElementNames != null && oldSharedElementNames.size() > i)
                             mappedName = oldSharedElementNames.getString(i);
                         if (sharedElementsMap.containsKey(mappedName))
-                            elements.put(names.get(i), sharedElementsMap.get(mappedName));
+                            elements.put(names.get(i), sharedElementsMap.get(mappedName).getChildAt(0));
                     }
                 }
             });

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -19,6 +19,7 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
+import androidx.transition.Fade;
 import androidx.viewpager2.widget.ViewPager2;
 
 import com.facebook.react.bridge.Arguments;
@@ -127,6 +128,10 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                     SceneFragment prevFragment = (SceneFragment) fragmentManager.findFragmentByTag(prevKey);
                     if (prevFragment != null)
                         sharedElements = getSharedElements(currentCrumb, crumb, prevFragment);
+                    if (sharedElements != null && sharedElements.length > 0) {
+                        prevFragment.setExitTransition(new Fade());
+                        startViewTransition(prevFragment.getScene());
+                    }
                 }
                 if (sharedElements != null) {
                     for(Pair sharedElement : sharedElements) {
@@ -136,6 +141,10 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                 }
                 fragmentTransaction.setCustomAnimations(oldCrumb != -1 ? enter : 0, exit, popEnter, popExit);
                 SceneFragment fragment = new SceneFragment(scene, getSharedElementSet(sharedElementNames), containerTransform);
+                if (sharedElements != null && sharedElements.length > 0) {
+                    fragment.setEnterTransition(new Fade());
+                    startViewTransition(fragment.getScene());
+                }
                 fragmentTransaction.replace(getId(), fragment, key);
                 fragmentTransaction.addToBackStack(String.valueOf(nextCrumb));
                 fragmentTransaction.commit();

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -35,6 +35,7 @@ import com.facebook.react.uimanager.events.RCTEventEmitter;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -49,8 +50,8 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
     private Activity mainActivity;
     protected String enterAnim;
     protected String exitAnim;
-    protected String sharedElementName;
-    protected String oldSharedElementName;
+    protected ReadableArray sharedElementNames;
+    protected ReadableArray oldSharedElementNames;
     protected Boolean startNavigation = null;
 
     public NavigationStackView(Context context) {
@@ -99,10 +100,10 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
         if (crumb < currentCrumb) {
             FragmentManager fragmentManager = fragment.getChildFragmentManager();
             SceneFragment fragment = (SceneFragment) fragmentManager.findFragmentByTag(oldKey);
-            Pair<SharedElementView, String> sharedElement = fragment != null ? getOldSharedElement(currentCrumb, crumb, fragment) : null;
+            Pair[] sharedElements = fragment != null ? getOldSharedElements(currentCrumb, crumb, fragment) : null;
             SceneFragment prevFragment = (SceneFragment) fragmentManager.findFragmentByTag(keys.getString(crumb));
-            if (sharedElement != null && prevFragment != null && prevFragment.getScene() != null)
-                prevFragment.getScene().sharedElementMotion = new SharedElementMotion(fragment, prevFragment, oldSharedElementName);
+            if (sharedElements != null && prevFragment != null && prevFragment.getScene() != null)
+                prevFragment.getScene().sharedElementMotion = new SharedElementMotion(fragment, prevFragment, getSharedElementSet(oldSharedElementNames));
             fragmentManager.popBackStack(String.valueOf(crumb), 0);
         }
         if (crumb > currentCrumb) {
@@ -120,18 +121,20 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                 int popExit = getAnimationResourceId(currentActivity, scene.exitAnim, android.R.attr.activityCloseExitAnimation);
                 FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
                 fragmentTransaction.setReorderingAllowed(true);
-                Pair<SharedElementView, String> sharedElement = null;
+                Pair[] sharedElements = null;
                 if (nextCrumb > 0) {
                     String prevKey = keys.getString(nextCrumb - 1);
                     SceneFragment prevFragment = (SceneFragment) fragmentManager.findFragmentByTag(prevKey);
                     if (prevFragment != null)
-                        sharedElement = getSharedElement(currentCrumb, crumb, prevFragment);
+                        sharedElements = getSharedElements(currentCrumb, crumb, prevFragment);
                 }
-                if (sharedElement != null) {
-                    fragmentTransaction.addSharedElement(sharedElement.first, sharedElement.second);
+                if (sharedElements != null) {
+                    for(Pair sharedElement : sharedElements) {
+                        fragmentTransaction.addSharedElement((View) sharedElement.first, (String) sharedElement.second);
+                    }
                 }
                 fragmentTransaction.setCustomAnimations(oldCrumb != -1 ? enter : 0, exit, popEnter, popExit);
-                SceneFragment fragment = new SceneFragment(scene, sharedElementName);
+                SceneFragment fragment = new SceneFragment(scene, getSharedElementSet(sharedElementNames));
                 fragmentTransaction.replace(getId(), fragment, key);
                 fragmentTransaction.addToBackStack(String.valueOf(nextCrumb));
                 fragmentTransaction.commit();
@@ -166,6 +169,16 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
         return context.getResources().getIdentifier(animationName, "anim", packageName);
     }
 
+    HashSet<String> getSharedElementSet(ReadableArray sharedElementNames) {
+        if (sharedElementNames == null)
+            return null;
+        HashSet<String> sharedElementSet = new HashSet<>();
+        for(int i = 0; i < sharedElementNames.size(); i++) {
+            sharedElementSet.add(sharedElementNames.getString(i));
+        }
+        return sharedElementSet;
+    }
+
     HashMap<String, SharedElementView> getSharedElementMap(SceneView scene) {
         HashMap<String, SharedElementView> sharedElementMap = new HashMap<>();
         for(SharedElementView sharedElement : scene.sharedElements) {
@@ -174,45 +187,56 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
         return sharedElementMap;
     }
 
-    Pair<SharedElementView, String> getSharedElement(HashMap<String, SharedElementView> sharedElementMap, String sharedElementName) {
-        if (sharedElementMap == null || sharedElementName == null)
+    Pair[] getSharedElements(HashMap<String, SharedElementView> sharedElementMap, ReadableArray sharedElementNames) {
+        if (sharedElementMap == null || sharedElementNames == null)
             return null;
-        if (sharedElementMap.containsKey(sharedElementName))
-            return Pair.create(sharedElementMap.get(sharedElementName), sharedElementName);
-        return null;
+        ArrayList<Pair> sharedElementPairs = new ArrayList<>();
+        for(int i = 0; i < sharedElementNames.size(); i++) {
+            String name = sharedElementNames.getString(i);
+            if (sharedElementMap.containsKey(name))
+                sharedElementPairs.add(Pair.create(sharedElementMap.get(name), name));
+        }
+        return sharedElementPairs.toArray(new Pair[0]);
     }
 
-    private Pair<SharedElementView, String> getOldSharedElement(int currentCrumb, int crumb, SceneFragment sceneFragment) {
+    private Pair[] getOldSharedElements(int currentCrumb, int crumb, SceneFragment sceneFragment) {
         final HashMap<String, SharedElementView> oldSharedElementsMap = getSharedElementMap(sceneFragment.getScene());
-        final Pair<SharedElementView, String> oldSharedElement = currentCrumb - crumb == 1 ? getSharedElement(oldSharedElementsMap, oldSharedElementName) : null;
-        if (oldSharedElement != null) {
+        final Pair[] oldSharedElements = currentCrumb - crumb == 1 ? getSharedElements(oldSharedElementsMap, oldSharedElementNames) : null;
+        if (oldSharedElements != null && oldSharedElements.length != 0) {
             sceneFragment.setEnterSharedElementCallback(new SharedElementCallback() {
                 @Override
                 public void onMapSharedElements(List<String> names, Map<String, View> elements) {
-                    if (oldSharedElementsMap.containsKey(oldSharedElementName)) {
-                        View oldSharedElement = oldSharedElementsMap.get(oldSharedElementName);
-                        elements.put(names.get(0), oldSharedElement);
+                    for(int i = 0; i < oldSharedElementNames.size(); i++) {
+                        String name = oldSharedElementNames.getString(i);
+                        if (oldSharedElementsMap.containsKey(name)) {
+                            View oldSharedElement = oldSharedElementsMap.get(name);
+                            elements.put(names.get(i), oldSharedElement);
+                        }
                     }
                 }
             });
-            return oldSharedElement;
+            return oldSharedElements;
         }
         return null;
     }
 
-    private Pair<SharedElementView, String> getSharedElement(int currentCrumb, int crumb, SceneFragment sceneFragment) {
+    private Pair[] getSharedElements(int currentCrumb, int crumb, SceneFragment sceneFragment) {
         final HashMap<String, SharedElementView> sharedElementsMap = getSharedElementMap(sceneFragment.getScene());
-        final Pair<SharedElementView, String> sharedElement = crumb - currentCrumb == 1 ? getSharedElement(sharedElementsMap, sharedElementName) : null;
-        if (sharedElement != null) {
+        final Pair[] sharedElements = crumb - currentCrumb == 1 ? getSharedElements(sharedElementsMap, sharedElementNames) : null;
+        if (sharedElements != null && sharedElements.length != 0) {
             sceneFragment.setExitSharedElementCallback(new SharedElementCallback() {
                 @Override
                 public void onMapSharedElements(List<String> names, Map<String, View> elements) {
-                    String mappedName = oldSharedElementName != null ? oldSharedElementName : names.get(0);
-                    if (sharedElementsMap.containsKey(mappedName))
-                        elements.put(names.get(0), sharedElementsMap.get(mappedName));
+                    for(int i = 0; i < names.size(); i++) {
+                        String mappedName = names.get(i);
+                        if (oldSharedElementNames != null && oldSharedElementNames.size() > i)
+                            mappedName = oldSharedElementNames.getString(i);
+                        if (sharedElementsMap.containsKey(mappedName))
+                            elements.put(names.get(i), sharedElementsMap.get(mappedName));
+                    }
                 }
             });
-            return sharedElement;
+            return sharedElements;
         }
         return null;
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -20,8 +20,6 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.transition.Fade;
-import androidx.transition.Transition;
-import androidx.transition.TransitionListenerAdapter;
 import androidx.viewpager2.widget.ViewPager2;
 
 import com.facebook.react.bridge.Arguments;
@@ -131,17 +129,8 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                     if (prevFragment != null)
                         sharedElements = getSharedElements(currentCrumb, crumb, prevFragment);
                     if (sharedElements != null && sharedElements.length > 0) {
-                        Fade fade = new Fade();
-                        prevFragment.setExitTransition(fade);
+                        prevFragment.setExitTransition(new Fade());
                         startViewTransition(prevFragment.getScene());
-                        fade.addListener(new TransitionListenerAdapter() {
-                            @Override
-                            public void onTransitionEnd(@NonNull Transition transition) {
-                                super.onTransitionEnd(transition);
-                                onRest(prevFragment.getScene().crumb);
-                                endViewTransition(prevFragment.getScene());
-                            }
-                        });
                     }
                 }
                 if (sharedElements != null) {
@@ -153,18 +142,8 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                 fragmentTransaction.setCustomAnimations(oldCrumb != -1 ? enter : 0, exit, popEnter, popExit);
                 SceneFragment fragment = new SceneFragment(scene, getSharedElementSet(sharedElementNames), containerTransform);
                 if (sharedElements != null && sharedElements.length > 0) {
-                    Fade fade = new Fade();
-                    fragment.setEnterTransition(fade);
+                    fragment.setEnterTransition(new Fade());
                     startViewTransition(fragment.getScene());
-                    fade.addListener(new TransitionListenerAdapter() {
-                        @Override
-                        public void onTransitionEnd(@NonNull Transition transition) {
-                            super.onTransitionEnd(transition);
-                            endViewTransition(scene);
-                            onRest(scene.crumb);
-                            if (fragment.destroyed) scene.popped();
-                        }
-                    });
                 }
                 fragmentTransaction.replace(getId(), fragment, key);
                 fragmentTransaction.addToBackStack(String.valueOf(nextCrumb));

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -103,7 +103,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
             Pair[] sharedElements = fragment != null ? getOldSharedElements(currentCrumb, crumb, fragment) : null;
             SceneFragment prevFragment = (SceneFragment) fragmentManager.findFragmentByTag(keys.getString(crumb));
             if (sharedElements != null && prevFragment != null && prevFragment.getScene() != null)
-                prevFragment.getScene().sharedElementMotion = new SharedElementMotion(fragment, prevFragment, getSharedElementSet(sharedElementNames));
+                prevFragment.getScene().sharedElementMotion = new SharedElementMotion(fragment, prevFragment, getSharedElementSet(sharedElementNames), containerTransform);
             fragmentManager.popBackStack(String.valueOf(crumb), 0);
         }
         if (crumb > currentCrumb) {
@@ -131,11 +131,11 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                 if (sharedElements != null) {
                     for(Pair sharedElement : sharedElements) {
                         SharedElementView sharedEl = (SharedElementView) sharedElement.first;
-                        fragmentTransaction.addSharedElement(containerTransform ? sharedEl : sharedEl.getChildAt(0), "element__" + sharedElement.second);
+                        fragmentTransaction.addSharedElement(containerTransform ? sharedEl : sharedEl.getChildAt(0), (containerTransform ? "" : "element__") + sharedElement.second);
                     }
                 }
                 fragmentTransaction.setCustomAnimations(oldCrumb != -1 ? enter : 0, exit, popEnter, popExit);
-                SceneFragment fragment = new SceneFragment(scene, getSharedElementSet(sharedElementNames));
+                SceneFragment fragment = new SceneFragment(scene, getSharedElementSet(sharedElementNames), containerTransform);
                 fragmentTransaction.replace(getId(), fragment, key);
                 fragmentTransaction.addToBackStack(String.valueOf(nextCrumb));
                 fragmentTransaction.commit();
@@ -153,7 +153,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
             FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
             fragmentTransaction.setReorderingAllowed(true);
             fragmentTransaction.setCustomAnimations(enter, exit, popEnter, popExit);
-            fragmentTransaction.replace(getId(), new SceneFragment(scene, null), key);
+            fragmentTransaction.replace(getId(), new SceneFragment(scene, null, containerTransform), key);
             fragmentTransaction.addToBackStack(String.valueOf(crumb));
             fragmentTransaction.commit();
         }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -52,6 +52,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
     protected String exitAnim;
     protected ReadableArray sharedElementNames;
     protected Boolean startNavigation = null;
+    protected boolean containerTransform = false;
 
     public NavigationStackView(Context context) {
         super(context);
@@ -129,7 +130,8 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                 }
                 if (sharedElements != null) {
                     for(Pair sharedElement : sharedElements) {
-                        fragmentTransaction.addSharedElement(((SharedElementView) sharedElement.first).getChildAt(0), "element__" + sharedElement.second);
+                        SharedElementView sharedEl = (SharedElementView) sharedElement.first;
+                        fragmentTransaction.addSharedElement(containerTransform ? sharedEl : sharedEl.getChildAt(0), "element__" + sharedElement.second);
                     }
                 }
                 fragmentTransaction.setCustomAnimations(oldCrumb != -1 ? enter : 0, exit, popEnter, popExit);
@@ -208,8 +210,8 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                     for(int i = 0; i < sharedElementNames.size(); i++) {
                         String name = sharedElementNames.getString(i);
                         if (oldSharedElementsMap.containsKey(name)) {
-                            View oldSharedElement = oldSharedElementsMap.get(name).getChildAt(0);
-                            elements.put(names.get(i), oldSharedElement);
+                            SharedElementView oldSharedElement = oldSharedElementsMap.get(name);
+                            elements.put(names.get(i), containerTransform ? oldSharedElement : oldSharedElement.getChildAt(0));
                         }
                     }
                 }
@@ -230,8 +232,10 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                         String mappedName = names.get(i);
                         if (sharedElementNames != null && sharedElementNames.size() > i)
                             mappedName = sharedElementNames.getString(i);
-                        if (sharedElementsMap.containsKey(mappedName))
-                            elements.put(names.get(i), sharedElementsMap.get(mappedName).getChildAt(0));
+                        if (sharedElementsMap.containsKey(mappedName)) {
+                            SharedElementView sharedElement = sharedElementsMap.get(mappedName);
+                            elements.put(names.get(i), containerTransform ? sharedElement : sharedElement.getChildAt(0));
+                        }
                     }
                 }
             });

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -138,8 +138,9 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                             @Override
                             public void onTransitionEnd(@NonNull Transition transition) {
                                 super.onTransitionEnd(transition);
-                                onRest(prevFragment.getScene().crumb);
-                                endViewTransition(prevFragment.getScene());
+                                SceneView prevScene = prevFragment.getScene();
+                                if (prevScene.crumb == oldCrumb) onRest(prevScene.crumb);
+                                endViewTransition(prevScene);
                             }
                         });
                     }
@@ -161,7 +162,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                         public void onTransitionEnd(@NonNull Transition transition) {
                             super.onTransitionEnd(transition);
                             endViewTransition(scene);
-                            onRest(scene.crumb);
+                            if (scene.crumb == oldCrumb) onRest(scene.crumb);
                             if (fragment.destroyed) scene.popped();
                         }
                     });

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -138,9 +138,8 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                             @Override
                             public void onTransitionEnd(@NonNull Transition transition) {
                                 super.onTransitionEnd(transition);
-                                SceneView prevScene = prevFragment.getScene();
-                                if (prevScene.crumb == oldCrumb) onRest(prevScene.crumb);
-                                endViewTransition(prevScene);
+                                onRest(prevFragment.getScene().crumb);
+                                endViewTransition(prevFragment.getScene());
                             }
                         });
                     }
@@ -162,7 +161,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                         public void onTransitionEnd(@NonNull Transition transition) {
                             super.onTransitionEnd(transition);
                             endViewTransition(scene);
-                            if (scene.crumb == oldCrumb) onRest(scene.crumb);
+                            onRest(scene.crumb);
                             if (fragment.destroyed) scene.popped();
                         }
                     });

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -20,6 +20,8 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.transition.Fade;
+import androidx.transition.Transition;
+import androidx.transition.TransitionListenerAdapter;
 import androidx.viewpager2.widget.ViewPager2;
 
 import com.facebook.react.bridge.Arguments;
@@ -129,8 +131,17 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                     if (prevFragment != null)
                         sharedElements = getSharedElements(currentCrumb, crumb, prevFragment);
                     if (sharedElements != null && sharedElements.length > 0) {
-                        prevFragment.setExitTransition(new Fade());
+                        Fade fade = new Fade();
+                        prevFragment.setExitTransition(fade);
                         startViewTransition(prevFragment.getScene());
+                        fade.addListener(new TransitionListenerAdapter() {
+                            @Override
+                            public void onTransitionEnd(@NonNull Transition transition) {
+                                super.onTransitionEnd(transition);
+                                onRest(prevFragment.getScene().crumb);
+                                endViewTransition(prevFragment.getScene());
+                            }
+                        });
                     }
                 }
                 if (sharedElements != null) {
@@ -142,8 +153,18 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                 fragmentTransaction.setCustomAnimations(oldCrumb != -1 ? enter : 0, exit, popEnter, popExit);
                 SceneFragment fragment = new SceneFragment(scene, getSharedElementSet(sharedElementNames), containerTransform);
                 if (sharedElements != null && sharedElements.length > 0) {
-                    fragment.setEnterTransition(new Fade());
+                    Fade fade = new Fade();
+                    fragment.setEnterTransition(fade);
                     startViewTransition(fragment.getScene());
+                    fade.addListener(new TransitionListenerAdapter() {
+                        @Override
+                        public void onTransitionEnd(@NonNull Transition transition) {
+                            super.onTransitionEnd(transition);
+                            endViewTransition(scene);
+                            onRest(scene.crumb);
+                            if (fragment.destroyed) scene.popped();
+                        }
+                    });
                 }
                 fragmentTransaction.replace(getId(), fragment, key);
                 fragmentTransaction.addToBackStack(String.valueOf(nextCrumb));

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -19,7 +19,6 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
-import androidx.transition.Fade;
 import androidx.viewpager2.widget.ViewPager2;
 
 import com.facebook.react.bridge.Arguments;
@@ -128,10 +127,6 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                     SceneFragment prevFragment = (SceneFragment) fragmentManager.findFragmentByTag(prevKey);
                     if (prevFragment != null)
                         sharedElements = getSharedElements(currentCrumb, crumb, prevFragment);
-                    if (sharedElements != null && sharedElements.length > 0) {
-                        prevFragment.setExitTransition(new Fade());
-                        startViewTransition(prevFragment.getScene());
-                    }
                 }
                 if (sharedElements != null) {
                     for(Pair sharedElement : sharedElements) {
@@ -141,10 +136,6 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                 }
                 fragmentTransaction.setCustomAnimations(oldCrumb != -1 ? enter : 0, exit, popEnter, popExit);
                 SceneFragment fragment = new SceneFragment(scene, getSharedElementSet(sharedElementNames), containerTransform);
-                if (sharedElements != null && sharedElements.length > 0) {
-                    fragment.setEnterTransition(new Fade());
-                    startViewTransition(fragment.getScene());
-                }
                 fragmentTransaction.replace(getId(), fragment, key);
                 fragmentTransaction.addToBackStack(String.valueOf(nextCrumb));
                 fragmentTransaction.commit();

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackViewManager.java
@@ -55,14 +55,14 @@ public class NavigationStackViewManager extends ViewGroupManager<NavigationStack
         view.exitAnim = exitAnim;
     }
 
-    @ReactProp(name = "sharedElement")
-    public void setSharedElement(NavigationStackView view, String sharedElement) {
-        view.sharedElementName = sharedElement;
+    @ReactProp(name = "sharedElements")
+    public void setSharedElements(NavigationStackView view, ReadableArray sharedElements) {
+        view.sharedElementNames = sharedElements;
     }
 
-    @ReactProp(name = "oldSharedElement")
-    public void setOldSharedElement(NavigationStackView view, String oldSharedElement) {
-        view.oldSharedElementName = oldSharedElement;
+    @ReactProp(name = "containerTransform")
+    public void setContainerTransform(NavigationStackView view, boolean containerTransform) {
+        view.containerTransform = containerTransform;
     }
 
     @ReactProp(name = "mostRecentEventCount")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -37,7 +37,7 @@ public class SceneFragment extends Fragment {
             if (scene.getParent() != null)
                 ((ViewGroup) scene.getParent()).endViewTransition(scene);
             if (scene.sharedElementMotion != null)
-                postponeEnterTransition(300, TimeUnit.MILLISECONDS);
+                postponeEnterTransition(500, TimeUnit.MILLISECONDS);
             return scene;
         }
         return new View(getContext());

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -11,8 +11,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Lifecycle;
-import androidx.transition.Transition;
-import androidx.transition.TransitionListenerAdapter;
 
 import java.util.HashSet;
 import java.util.concurrent.TimeUnit;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -21,11 +21,11 @@ public class SceneFragment extends Fragment {
         super();
     }
 
-    SceneFragment(SceneView scene, HashSet<String> sharedElements) {
+    SceneFragment(SceneView scene, HashSet<String> sharedElements, boolean containerTransform) {
         super();
         this.scene = scene;
         if (sharedElements != null )
-            scene.sharedElementMotion = new SharedElementMotion(this, this, sharedElements);
+            scene.sharedElementMotion = new SharedElementMotion(this, this, sharedElements, containerTransform);
     }
 
     @Nullable

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -11,11 +11,14 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Lifecycle;
+import androidx.transition.Transition;
+import androidx.transition.TransitionListenerAdapter;
 
 import java.util.HashSet;
 
 public class SceneFragment extends Fragment {
     private SceneView scene;
+    private boolean destroyed = false;
 
     public SceneFragment() {
         super();
@@ -69,9 +72,35 @@ public class SceneFragment extends Fragment {
     }
 
     @Override
+    public void setEnterTransition(@Nullable Object transition) {
+        super.setEnterTransition(transition);
+        ((Transition) transition).addListener(new TransitionListenerAdapter() {
+            @Override
+            public void onTransitionEnd(@NonNull Transition transition) {
+                super.onTransitionEnd(transition);
+                ((ViewGroup) scene.getParent()).endViewTransition(scene);
+                if (destroyed) scene.popped();
+            }
+        });
+    }
+
+    @Override
+    public void setExitTransition(@Nullable Object transition) {
+        super.setExitTransition(transition);
+        ((Transition) transition).addListener(new TransitionListenerAdapter() {
+            @Override
+            public void onTransitionEnd(@NonNull Transition transition) {
+                super.onTransitionEnd(transition);
+                ((ViewGroup) scene.getParent()).endViewTransition(scene);
+            }
+        });
+    }
+
+    @Override
     public void onDestroy() {
         super.onDestroy();
-        if (scene != null)
+        destroyed = true;
+        if (scene != null && getEnterTransition() == null)
             scene.popped();
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -11,15 +11,12 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Lifecycle;
-import androidx.transition.Transition;
-import androidx.transition.TransitionListenerAdapter;
 
 import java.util.HashSet;
 import java.util.concurrent.TimeUnit;
 
 public class SceneFragment extends Fragment {
     private SceneView scene;
-    private boolean destroyed = false;
 
     public SceneFragment() {
         super();
@@ -73,35 +70,9 @@ public class SceneFragment extends Fragment {
     }
 
     @Override
-    public void setEnterTransition(@Nullable Object transition) {
-        super.setEnterTransition(transition);
-        ((Transition) transition).addListener(new TransitionListenerAdapter() {
-            @Override
-            public void onTransitionEnd(@NonNull Transition transition) {
-                super.onTransitionEnd(transition);
-                ((ViewGroup) scene.getParent()).endViewTransition(scene);
-                if (destroyed) scene.popped();
-            }
-        });
-    }
-
-    @Override
-    public void setExitTransition(@Nullable Object transition) {
-        super.setExitTransition(transition);
-        ((Transition) transition).addListener(new TransitionListenerAdapter() {
-            @Override
-            public void onTransitionEnd(@NonNull Transition transition) {
-                super.onTransitionEnd(transition);
-                ((ViewGroup) scene.getParent()).endViewTransition(scene);
-            }
-        });
-    }
-
-    @Override
     public void onDestroy() {
         super.onDestroy();
-        destroyed = true;
-        if (scene != null && getEnterTransition() == null)
+        if (scene != null)
             scene.popped();
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit;
 
 public class SceneFragment extends Fragment {
     private SceneView scene;
-    boolean destroyed = false;
+    private boolean destroyed = false;
 
     public SceneFragment() {
         super();
@@ -70,6 +70,31 @@ public class SceneFragment extends Fragment {
             ((NavigationStackView) scene.getParent()).onRest(scene.crumb);
         }
         return super.onCreateAnimation(transit, enter, nextAnim);
+    }
+
+    @Override
+    public void setEnterTransition(@Nullable Object transition) {
+        super.setEnterTransition(transition);
+        ((Transition) transition).addListener(new TransitionListenerAdapter() {
+            @Override
+            public void onTransitionEnd(@NonNull Transition transition) {
+                super.onTransitionEnd(transition);
+                ((ViewGroup) scene.getParent()).endViewTransition(scene);
+                if (destroyed) scene.popped();
+            }
+        });
+    }
+
+    @Override
+    public void setExitTransition(@Nullable Object transition) {
+        super.setExitTransition(transition);
+        ((Transition) transition).addListener(new TransitionListenerAdapter() {
+            @Override
+            public void onTransitionEnd(@NonNull Transition transition) {
+                super.onTransitionEnd(transition);
+                ((ViewGroup) scene.getParent()).endViewTransition(scene);
+            }
+        });
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit;
 
 public class SceneFragment extends Fragment {
     private SceneView scene;
-    private boolean destroyed = false;
+    boolean destroyed = false;
 
     public SceneFragment() {
         super();
@@ -70,31 +70,6 @@ public class SceneFragment extends Fragment {
             ((NavigationStackView) scene.getParent()).onRest(scene.crumb);
         }
         return super.onCreateAnimation(transit, enter, nextAnim);
-    }
-
-    @Override
-    public void setEnterTransition(@Nullable Object transition) {
-        super.setEnterTransition(transition);
-        ((Transition) transition).addListener(new TransitionListenerAdapter() {
-            @Override
-            public void onTransitionEnd(@NonNull Transition transition) {
-                super.onTransitionEnd(transition);
-                ((ViewGroup) scene.getParent()).endViewTransition(scene);
-                if (destroyed) scene.popped();
-            }
-        });
-    }
-
-    @Override
-    public void setExitTransition(@Nullable Object transition) {
-        super.setExitTransition(transition);
-        ((Transition) transition).addListener(new TransitionListenerAdapter() {
-            @Override
-            public void onTransitionEnd(@NonNull Transition transition) {
-                super.onTransitionEnd(transition);
-                ((ViewGroup) scene.getParent()).endViewTransition(scene);
-            }
-        });
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -11,6 +11,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Lifecycle;
+import androidx.transition.Transition;
+import androidx.transition.TransitionListenerAdapter;
 
 import java.util.HashSet;
 import java.util.concurrent.TimeUnit;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -37,7 +37,7 @@ public class SceneFragment extends Fragment {
             if (scene.getParent() != null)
                 ((ViewGroup) scene.getParent()).endViewTransition(scene);
             if (scene.sharedElementMotion != null)
-                postponeEnterTransition(500, TimeUnit.MILLISECONDS);
+                postponeEnterTransition(300, TimeUnit.MILLISECONDS);
             return scene;
         }
         return new View(getContext());

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -15,6 +15,7 @@ import androidx.transition.Transition;
 import androidx.transition.TransitionListenerAdapter;
 
 import java.util.HashSet;
+import java.util.concurrent.TimeUnit;
 
 public class SceneFragment extends Fragment {
     private SceneView scene;
@@ -38,7 +39,7 @@ public class SceneFragment extends Fragment {
             if (scene.getParent() != null)
                 ((ViewGroup) scene.getParent()).endViewTransition(scene);
             if (scene.sharedElementMotion != null)
-                postponeEnterTransition();
+                postponeEnterTransition(300, TimeUnit.MILLISECONDS);
             return scene;
         }
         return new View(getContext());

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -12,6 +12,8 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Lifecycle;
 
+import java.util.HashSet;
+
 public class SceneFragment extends Fragment {
     private SceneView scene;
 
@@ -19,11 +21,11 @@ public class SceneFragment extends Fragment {
         super();
     }
 
-    SceneFragment(SceneView scene, String sharedElement) {
+    SceneFragment(SceneView scene, HashSet<String> sharedElements) {
         super();
         this.scene = scene;
-        if (sharedElement != null )
-            scene.sharedElementMotion = new SharedElementMotion(this, this, sharedElement);
+        if (sharedElements != null )
+            scene.sharedElementMotion = new SharedElementMotion(this, this, sharedElements);
     }
 
     @Nullable

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementManager.java
@@ -23,7 +23,9 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
 
     @ReactProp(name = "name")
     public void setName(SharedElementView view, String name) {
-        view.setTransitionName(name);
+        view.name = name;
+        if (view.getChildCount() > 0)
+            view.getChildAt(0).setTransitionName(name);
     }
 
     @ReactProp(name = "duration", defaultInt = -1)
@@ -33,10 +35,10 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
 
     @ReactProp(name = "fadeMode")
     public void setFadeMode(SharedElementView view, String fadeMode) {
-        if (fadeMode == null) view.transition.setFadeMode(view.defaultFadeMode);
+        /*if (fadeMode == null) view.transition.setFadeMode(view.defaultFadeMode);
         if (("in").equals(fadeMode)) view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_IN);
         if (("out").equals(fadeMode)) view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_OUT);
         if (("cross").equals(fadeMode)) view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_CROSS);
-        if (("through").equals(fadeMode)) view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_THROUGH);
+        if (("through").equals(fadeMode)) view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_THROUGH);*/
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementManager.java
@@ -23,9 +23,9 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
 
     @ReactProp(name = "name")
     public void setName(SharedElementView view, String name) {
-        view.name = name;
+        view.setTransitionName(name);
         if (view.getChildCount() > 0)
-            view.getChildAt(0).setTransitionName(name);
+            view.getChildAt(0).setTransitionName("element__" + name);
     }
 
     @ReactProp(name = "duration", defaultInt = -1)

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementManager.java
@@ -30,15 +30,15 @@ public class SharedElementManager extends ViewGroupManager<SharedElementView> {
 
     @ReactProp(name = "duration", defaultInt = -1)
     public void setDuration(SharedElementView view, int duration) {
-        view.transition.setDuration(duration != -1 ? duration : view.defaultDuration);
+        view.duration = duration;
     }
 
     @ReactProp(name = "fadeMode")
     public void setFadeMode(SharedElementView view, String fadeMode) {
-        /*if (fadeMode == null) view.transition.setFadeMode(view.defaultFadeMode);
-        if (("in").equals(fadeMode)) view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_IN);
-        if (("out").equals(fadeMode)) view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_OUT);
-        if (("cross").equals(fadeMode)) view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_CROSS);
-        if (("through").equals(fadeMode)) view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_THROUGH);*/
+        if (fadeMode == null) view.fadeMode = MaterialContainerTransform.FADE_MODE_IN;
+        if (("in").equals(fadeMode)) view.fadeMode = MaterialContainerTransform.FADE_MODE_IN;
+        if (("out").equals(fadeMode)) view.fadeMode = MaterialContainerTransform.FADE_MODE_OUT;
+        if (("cross").equals(fadeMode)) view.fadeMode = MaterialContainerTransform.FADE_MODE_CROSS;
+        if (("through").equals(fadeMode)) view.fadeMode = MaterialContainerTransform.FADE_MODE_THROUGH;
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementMotion.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementMotion.java
@@ -27,7 +27,6 @@ class SharedElementMotion {
             loadedSharedElements.add(sharedElementView.getTransitionName());
             if(sharedElements.size() == loadedSharedElements.size()) {
                 Transition transition = sharedElementView.getTransition(containerTransform, enterScene == scene);
-                // transition.addTarget(sharedElementView.getTransitionName());
                 enterScene.setSharedElementEnterTransition(transition);
                 enterScene.setSharedElementReturnTransition(transition);
                 scene.startPostponedEnterTransition();

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementMotion.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementMotion.java
@@ -2,6 +2,8 @@ package com.navigation.reactnative;
 
 import android.graphics.Color;
 
+import androidx.transition.Transition;
+
 import com.google.android.material.transition.MaterialContainerTransform;
 
 import java.util.HashSet;
@@ -19,12 +21,12 @@ class SharedElementMotion {
     }
 
     void load(SharedElementView sharedElementView) {
-        if (sharedElements.contains(sharedElementView.getTransitionName()) && !loadedSharedElements.contains(sharedElementView.getTransitionName())) {
-            loadedSharedElements.add(sharedElementView.getTransitionName());
-            MaterialContainerTransform transition = sharedElementView.transition;
-            transition.setTransitionDirection(enterScene == scene ? MaterialContainerTransform.TRANSITION_DIRECTION_ENTER : MaterialContainerTransform.TRANSITION_DIRECTION_RETURN);
-            transition.addTarget(sharedElementView.getTransitionName());
-            transition.setScrimColor(Color.TRANSPARENT);
+        if (sharedElements.contains(sharedElementView.name) && !loadedSharedElements.contains(sharedElementView.name)) {
+            loadedSharedElements.add(sharedElementView.name);
+            Transition transition = sharedElementView.transition;
+            // transition.setTransitionDirection(enterScene == scene ? MaterialContainerTransform.TRANSITION_DIRECTION_ENTER : MaterialContainerTransform.TRANSITION_DIRECTION_RETURN);
+            transition.addTarget(sharedElementView.name);
+            // transition.setScrimColor(Color.TRANSPARENT);
             if(sharedElements.size() == loadedSharedElements.size()) {
                 enterScene.setSharedElementEnterTransition(transition);
                 enterScene.setSharedElementReturnTransition(transition);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementMotion.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementMotion.java
@@ -4,27 +4,33 @@ import android.graphics.Color;
 
 import com.google.android.material.transition.MaterialContainerTransform;
 
+import java.util.HashSet;
+
 class SharedElementMotion {
     private final SceneFragment enterScene;
     private final SceneFragment scene;
-    private final String sharedElement;
+    private HashSet<String> sharedElements;
+    private HashSet<String> loadedSharedElements = new HashSet<>();
 
-    SharedElementMotion(SceneFragment enterScene, SceneFragment scene, String sharedElement) {
-        this.sharedElement = sharedElement;
+    SharedElementMotion(SceneFragment enterScene, SceneFragment scene, HashSet<String> sharedElements) {
+        this.sharedElements = sharedElements;
         this.enterScene = enterScene;
         this.scene = scene;
     }
 
     void load(SharedElementView sharedElementView) {
-        if (sharedElement.equals(sharedElementView.getTransitionName())) {
+        if (sharedElements.contains(sharedElementView.getTransitionName()) && !loadedSharedElements.contains(sharedElementView.getTransitionName())) {
+            loadedSharedElements.add(sharedElementView.getTransitionName());
             MaterialContainerTransform transition = sharedElementView.transition;
             transition.setTransitionDirection(enterScene == scene ? MaterialContainerTransform.TRANSITION_DIRECTION_ENTER : MaterialContainerTransform.TRANSITION_DIRECTION_RETURN);
             transition.addTarget(sharedElementView.getTransitionName());
             transition.setScrimColor(Color.TRANSPARENT);
-            enterScene.setSharedElementEnterTransition(transition);
-            enterScene.setSharedElementReturnTransition(transition);
-            scene.startPostponedEnterTransition();
-            scene.getScene().sharedElementMotion = null;
+            if(sharedElements.size() == loadedSharedElements.size()) {
+                enterScene.setSharedElementEnterTransition(transition);
+                enterScene.setSharedElementReturnTransition(transition);
+                scene.startPostponedEnterTransition();
+                scene.getScene().sharedElementMotion = null;
+            }
         }
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementMotion.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementMotion.java
@@ -13,21 +13,21 @@ class SharedElementMotion {
     private final SceneFragment scene;
     private HashSet<String> sharedElements;
     private HashSet<String> loadedSharedElements = new HashSet<>();
+    private boolean containerTransform = false;
 
-    SharedElementMotion(SceneFragment enterScene, SceneFragment scene, HashSet<String> sharedElements) {
+    SharedElementMotion(SceneFragment enterScene, SceneFragment scene, HashSet<String> sharedElements, boolean containerTransform) {
         this.sharedElements = sharedElements;
         this.enterScene = enterScene;
         this.scene = scene;
+        this.containerTransform = containerTransform;
     }
 
     void load(SharedElementView sharedElementView) {
         if (sharedElements.contains(sharedElementView.getTransitionName()) && !loadedSharedElements.contains(sharedElementView.getTransitionName())) {
             loadedSharedElements.add(sharedElementView.getTransitionName());
             if(sharedElements.size() == loadedSharedElements.size()) {
-                Transition transition = sharedElementView.getTransition();
-                // transition.setTransitionDirection(enterScene == scene ? MaterialContainerTransform.TRANSITION_DIRECTION_ENTER : MaterialContainerTransform.TRANSITION_DIRECTION_RETURN);
+                Transition transition = sharedElementView.getTransition(containerTransform, enterScene == scene);
                 // transition.addTarget(sharedElementView.getTransitionName());
-                // transition.setScrimColor(Color.TRANSPARENT);
                 enterScene.setSharedElementEnterTransition(transition);
                 enterScene.setSharedElementReturnTransition(transition);
                 scene.startPostponedEnterTransition();

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementMotion.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementMotion.java
@@ -23,11 +23,11 @@ class SharedElementMotion {
     void load(SharedElementView sharedElementView) {
         if (sharedElements.contains(sharedElementView.getTransitionName()) && !loadedSharedElements.contains(sharedElementView.getTransitionName())) {
             loadedSharedElements.add(sharedElementView.getTransitionName());
-            Transition transition = sharedElementView.transition;
-            // transition.setTransitionDirection(enterScene == scene ? MaterialContainerTransform.TRANSITION_DIRECTION_ENTER : MaterialContainerTransform.TRANSITION_DIRECTION_RETURN);
-            // transition.addTarget(sharedElementView.getTransitionName());
-            // transition.setScrimColor(Color.TRANSPARENT);
             if(sharedElements.size() == loadedSharedElements.size()) {
+                Transition transition = sharedElementView.getTransition();
+                // transition.setTransitionDirection(enterScene == scene ? MaterialContainerTransform.TRANSITION_DIRECTION_ENTER : MaterialContainerTransform.TRANSITION_DIRECTION_RETURN);
+                // transition.addTarget(sharedElementView.getTransitionName());
+                // transition.setScrimColor(Color.TRANSPARENT);
                 enterScene.setSharedElementEnterTransition(transition);
                 enterScene.setSharedElementReturnTransition(transition);
                 scene.startPostponedEnterTransition();

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementMotion.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementMotion.java
@@ -21,11 +21,11 @@ class SharedElementMotion {
     }
 
     void load(SharedElementView sharedElementView) {
-        if (sharedElements.contains(sharedElementView.name) && !loadedSharedElements.contains(sharedElementView.name)) {
-            loadedSharedElements.add(sharedElementView.name);
+        if (sharedElements.contains(sharedElementView.getTransitionName()) && !loadedSharedElements.contains(sharedElementView.getTransitionName())) {
+            loadedSharedElements.add(sharedElementView.getTransitionName());
             Transition transition = sharedElementView.transition;
             // transition.setTransitionDirection(enterScene == scene ? MaterialContainerTransform.TRANSITION_DIRECTION_ENTER : MaterialContainerTransform.TRANSITION_DIRECTION_RETURN);
-            transition.addTarget(sharedElementView.name);
+            // transition.addTarget(sharedElementView.getTransitionName());
             // transition.setScrimColor(Color.TRANSPARENT);
             if(sharedElements.size() == loadedSharedElements.size()) {
                 enterScene.setSharedElementEnterTransition(transition);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -1,6 +1,7 @@
 package com.navigation.reactnative;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.os.Build;
 import android.view.View;
 import android.view.ViewGroup;
@@ -55,13 +56,22 @@ public class SharedElementView extends ViewGroup {
         });
     }
 
-    Transition getTransition() {
-        TransitionSet transition = new TransitionSet();
-        transition.addTransition(new ChangeBounds());
-        transition.addTransition(new ChangeTransform());
-        transition.addTransition(new ChangeClipBounds());
-        transition.addTransition(new ChangeImageTransform());
-        return transition;
+    Transition getTransition(boolean containerTransform, boolean enter) {
+        if (!containerTransform) {
+            TransitionSet transition = new TransitionSet();
+            transition.addTransition(new ChangeBounds());
+            transition.addTransition(new ChangeTransform());
+            transition.addTransition(new ChangeClipBounds());
+            transition.addTransition(new ChangeImageTransform());
+            return transition;
+        } else {
+            MaterialContainerTransform transition = new MaterialContainerTransform();
+            transition.setDuration(duration);
+            transition.setFadeMode(fadeMode);
+            transition.setTransitionDirection(enter ? MaterialContainerTransform.TRANSITION_DIRECTION_ENTER : MaterialContainerTransform.TRANSITION_DIRECTION_RETURN);
+            transition.setScrimColor(Color.TRANSPARENT);
+            return transition;
+        }
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -66,7 +66,7 @@ public class SharedElementView extends ViewGroup {
             return transition;
         } else {
             MaterialContainerTransform transition = new MaterialContainerTransform();
-            transition.setDuration(duration);
+            if (duration != -1) transition.setDuration(duration);
             transition.setFadeMode(fadeMode);
             transition.setTransitionDirection(enter ? MaterialContainerTransform.TRANSITION_DIRECTION_ENTER : MaterialContainerTransform.TRANSITION_DIRECTION_RETURN);
             transition.setScrimColor(Color.TRANSPARENT);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -29,8 +29,7 @@ public class SharedElementView extends ViewGroup {
     public void addView(View child, int index) {
         if (index == 0 && getChildAt(0) != null) getChildAt(0).setTransitionName(null);
         super.addView(child, index);
-        if (index == 0) child.setTransitionName("element__" + this.getTransitionName());
-        else child.setTransitionName(null);
+        child.setTransitionName(index == 0 ? "element__" + this.getTransitionName() : null);
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -1,22 +1,51 @@
 package com.navigation.reactnative;
 
 import android.content.Context;
+import android.os.Build;
+import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
 import android.view.ViewTreeObserver;
 
+import androidx.transition.ChangeBounds;
+import androidx.transition.ChangeClipBounds;
+import androidx.transition.ChangeImageTransform;
+import androidx.transition.ChangeTransform;
+import androidx.transition.Transition;
+import androidx.transition.TransitionSet;
+
 import com.google.android.material.transition.MaterialContainerTransform;
 
 public class SharedElementView extends ViewGroup {
-    final MaterialContainerTransform transition;
+    final Transition transition;
     final long defaultDuration;
     final int defaultFadeMode;
+    String name;
 
     public SharedElementView(Context context) {
         super(context);
-        transition = new MaterialContainerTransform(context, false);
+        TransitionSet transitionSet = new TransitionSet();
+        transitionSet.addTransition(new ChangeBounds());
+        transitionSet.addTransition(new ChangeTransform());
+        transitionSet.addTransition(new ChangeClipBounds());
+        transitionSet.addTransition(new ChangeImageTransform());
+        transition = transitionSet;
         defaultDuration = transition.getDuration();
-        defaultFadeMode = transition.getFadeMode();
+        defaultFadeMode = 0;
+    }
+
+    @Override
+    public void addView(View child, int index) {
+        super.addView(child, index);
+        if (index == 0) child.setTransitionName(this.name);
+    }
+
+    @Override
+    public void endViewTransition(View view) {
+        super.endViewTransition(view);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            view.setTransitionAlpha(1);
+        }
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -20,7 +20,6 @@ public class SharedElementView extends ViewGroup {
     final Transition transition;
     final long defaultDuration;
     final int defaultFadeMode;
-    String name;
 
     public SharedElementView(Context context) {
         super(context);
@@ -37,7 +36,7 @@ public class SharedElementView extends ViewGroup {
     @Override
     public void addView(View child, int index) {
         super.addView(child, index);
-        if (index == 0) child.setTransitionName(this.name);
+        if (index == 0) child.setTransitionName("element__" + this.getTransitionName());
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -17,20 +17,11 @@ import androidx.transition.TransitionSet;
 import com.google.android.material.transition.MaterialContainerTransform;
 
 public class SharedElementView extends ViewGroup {
-    final Transition transition;
-    final long defaultDuration;
-    final int defaultFadeMode;
+    long duration = -1;
+    int fadeMode = MaterialContainerTransform.FADE_MODE_IN;
 
     public SharedElementView(Context context) {
         super(context);
-        TransitionSet transitionSet = new TransitionSet();
-        transitionSet.addTransition(new ChangeBounds());
-        transitionSet.addTransition(new ChangeTransform());
-        transitionSet.addTransition(new ChangeClipBounds());
-        transitionSet.addTransition(new ChangeImageTransform());
-        transition = transitionSet;
-        defaultDuration = transition.getDuration();
-        defaultFadeMode = 0;
     }
 
     @Override
@@ -62,6 +53,15 @@ public class SharedElementView extends ViewGroup {
                 return true;
             }
         });
+    }
+
+    Transition getTransition() {
+        TransitionSet transition = new TransitionSet();
+        transition.addTransition(new ChangeBounds());
+        transition.addTransition(new ChangeTransform());
+        transition.addTransition(new ChangeClipBounds());
+        transition.addTransition(new ChangeImageTransform());
+        return transition;
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -30,6 +30,7 @@ public class SharedElementView extends ViewGroup {
         if (index == 0 && getChildAt(0) != null) getChildAt(0).setTransitionName(null);
         super.addView(child, index);
         if (index == 0) child.setTransitionName("element__" + this.getTransitionName());
+        else child.setTransitionName(null);
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementView.java
@@ -27,8 +27,15 @@ public class SharedElementView extends ViewGroup {
 
     @Override
     public void addView(View child, int index) {
+        if (index == 0 && getChildAt(0) != null) getChildAt(0).setTransitionName(null);
         super.addView(child, index);
         if (index == 0) child.setTransitionName("element__" + this.getTransitionName());
+    }
+
+    @Override
+    public void removeViewAt(int index) {
+        super.removeViewAt(index);
+        if (getChildAt(0) != null) getChildAt(0).setTransitionName("element__" + this.getTransitionName());
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SharedElementViewManager.java
@@ -40,19 +40,21 @@ public class SharedElementViewManager extends ViewGroupManager<SharedElementView
     @ReactProp(name = "name")
     public void setName(SharedElementView view, String name) {
         view.setTransitionName(name);
+        if (view.getChildCount() > 0)
+            view.getChildAt(0).setTransitionName("element__" + name);
     }
 
     @ReactProp(name = "duration")
     public void setDuration(SharedElementView view, int duration) {
-        view.transition.setDuration(duration != -1 ? duration : view.defaultDuration);
+        view.duration = duration;
     }
 
     @ReactProp(name = "fadeMode")
     public void setFadeMode(SharedElementView view, String fadeMode) {
-        if (fadeMode == null) view.transition.setFadeMode(view.defaultFadeMode);
-        if (("in").equals(fadeMode)) view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_IN);
-        if (("out").equals(fadeMode)) view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_OUT);
-        if (("cross").equals(fadeMode)) view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_CROSS);
-        if (("through").equals(fadeMode)) view.transition.setFadeMode(MaterialContainerTransform.FADE_MODE_THROUGH);
+        if (fadeMode == null) view.fadeMode = MaterialContainerTransform.FADE_MODE_IN;
+        if (("in").equals(fadeMode)) view.fadeMode = MaterialContainerTransform.FADE_MODE_IN;
+        if (("out").equals(fadeMode)) view.fadeMode = MaterialContainerTransform.FADE_MODE_OUT;
+        if (("cross").equals(fadeMode)) view.fadeMode = MaterialContainerTransform.FADE_MODE_CROSS;
+        if (("through").equals(fadeMode)) view.fadeMode = MaterialContainerTransform.FADE_MODE_THROUGH;
     }
 }

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -39,6 +39,10 @@ export interface NavigationStackProps {
      */
     sharedElement?: (state: State, data: any, crumbs: Crumb[]) => string;
     /**
+     * The Scene's shared elements
+     */
+    sharedElements?: (state: State, data: any, crumbs: Crumb[]) => string | string[];
+    /**
      * The color of the Scene's background
      */
     backgroundColor?: (state: State, data: any, crumbs: Crumb[]) => ColorValue;
@@ -530,7 +534,7 @@ export class StatusBar extends Component<StatusBarProps> {}
  */
 export interface SharedElementProps {
     /**
-     * The name shared across Scenes by the two views
+     * The name shared across Scenes by the two elements
      */
     name: string;
     /**
@@ -538,7 +542,7 @@ export interface SharedElementProps {
      */
     duration?: number;
     /**
-     * The fade mode used to swap the content of the two views
+     * The fade mode used to swap the content of the two elements
      */
     fadeMode?: 'in' | 'out' | 'cross' | 'through';
     /**

--- a/types/navigation-react-native.d.ts
+++ b/types/navigation-react-native.d.ts
@@ -39,6 +39,10 @@ export interface NavigationStackProps {
      */
     sharedElement?: (state: State, data: any, crumbs: Crumb[]) => string;
     /**
+     * The Scene's shared elements
+     */
+    sharedElements?: (state: State, data: any, crumbs: Crumb[]) => string | string[];
+    /**
      * The color of the Scene's background
      */
     backgroundColor?: (state: State, data: any, crumbs: Crumb[]) => ColorValue;
@@ -530,7 +534,7 @@ export class StatusBar extends Component<StatusBarProps> {}
  */
 export interface SharedElementProps {
     /**
-     * The name shared across Scenes by the two views
+     * The name shared across Scenes by the two elements
      */
     name: string;
     /**
@@ -538,7 +542,7 @@ export interface SharedElementProps {
      */
     duration?: number;
     /**
-     * The fade mode used to swap the content of the two views
+     * The fade mode used to swap the content of the two elements
      */
     fadeMode?: 'in' | 'out' | 'cross' | 'through';
     /**


### PR DESCRIPTION
Dropped support for traditional shared elements, in #528, in favour of Material container transforms. But container transforms don't support more than one shared element at a time so bringing back traditional support.

Added `sharedElements` prop to the `NavigationStack`. It receives either a string or a string array. If it's a string it will use a container transform. If it's an array it will use the traditional transform.

Android doesn't support animations during a shared element transition. It only supports fragment transitions. But can't use these yet because React Native doesn't support them. React Native has a bug where images disappear from the exiting scene during the transition. Need to PR [setLegacyVisibilityHandlingEnabled](https://github.com/facebook/fresco/issues/1445#issuecomment-315763953) in `ReactImageView`, then can revisit fragment transition support. So can, for example, fade in and out the scenes during a shared element transition.