### PR TITLE
Ensured NavigationMotion style changes happen on first render

### DIFF
--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -77,8 +77,7 @@ const NavigationMotion = ({unmountedStyle: unmountedStyleStack, mountedStyle: mo
     const getStyle = (mounted: boolean, {state, data, crumbs, nextState, nextData, mount, fromUnmounted}: SceneContext) => {
         const styleProp = !mounted ? unmountedStyle : (mount ? mountedStyle : crumbStyle);
         fromUnmounted = (mounted && mount) ? fromUnmounted : undefined;
-        const style = styleProp(state, data, crumbs, nextState, nextData, fromUnmounted);
-        return {...style, __marker: !mounted ? 1 : (mount ? 0 : -1)};
+        return {...styleProp(state, data, crumbs, nextState, nextData, fromUnmounted)};
     }
     const getMotion = (styles: MotionStyle[]) => {
         let moving = false, mountMoving = false, mountDuration: number, mountProgress: number;
@@ -121,7 +120,7 @@ const NavigationMotion = ({unmountedStyle: unmountedStyleStack, mountedStyle: mo
                 {styles => {
                     const {rest, mountRest, mountDuration, mountProgress} = getMotion(styles);
                     return (
-                        styles.map(({data: {key, state, data}, style: {__marker, duration, ...style}}) => {
+                        styles.map(({data: {key, state, data}, style: {duration, ...style}}) => {
                             const crumb = +key.replace(/\++$/, '');
                             const scene = <Scene crumb={crumb} rest={rest} renderScene={renderScene} />;
                             return (


### PR DESCRIPTION
@RichardLindhout DM'ed bug on Twitter -

_On NavigationReactNativeWeb (and NavigationReactMobile), turn off animations on `NavigationStack/Motion` (duration 0). On Safari, navigate from A → B then swipe back to A. Safari shows the preview of A, then when let go of swipe the Navigation router shows B briefly before showing A. So get a blink of B when swiping back on Safari._

8e3197d introduced a `marker` property to ensure all animations take the same time. If one animation finished while another was still running then could cause the rested scene to keep rendering during the animation. The problem is that, even with duration 0, the leaving scene took 2 renders to disappear (the `marker` means there's always a change to animate).

But in 8e3197d changed to wait for all scenes to come to rest instead of allowing each scene to rest independently. This allowed for a different duration per scene. If didn't rest together then a scene could rest before another and could end up with over rendering again. But with this change the `marker` wasn't needed anymore.

Dropping the redundant `marker` means that scenes can go to their target style on the very first render. In the bug scenario, scene B will disappear instantly and won't get a flash on swiping back on Safari.

Note, on NavigationReactNativeWeb, to remove all animations set empty styles as well as duration 0. Otherwise [the NavigationStack sets default ones](https://github.com/grahammendick/navigation/blob/d6ae8e8aea5e22a5f58f471e78246dfa6642e538/NavigationReactNativeWeb/src/NavigationStack.tsx#L8).

```jsx
<NavigationStack
  unmountedStyle={{}}
  mountedStyle={{}}
  crumbedStyle={{}}
  duration={0}
```