### PR TITLE
Prevented SearchBar error when navigationImage missing from NavigationBar (Android)

### DIFF
--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchResultsView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchResultsView.java
@@ -48,6 +48,13 @@ public class SearchResultsView extends SearchView {
         defaultFontSize = PixelUtil.toDIPFromPixel(getEditText().getTextSize());
         addTransitionListener((searchView, previousState, newState) -> {
             if (newState == TransitionState.SHOWING) {
+                ViewGroup view = (ViewGroup) getParent();
+                for(int i = 0; i < view.getChildCount(); i++) {
+                    if (view.getChildAt(i) instanceof NavigationBarView) {
+                        SearchToolbarView searchToolbarView = (SearchToolbarView) ((NavigationBarView) view.getChildAt(i)).getChildAt(0);
+                        setAnimatedNavigationIcon(searchToolbarView.getNavigationIcon() == searchToolbarView.defaultNavigationIcon);
+                    }
+                }
                 nativeActiveEventCount++;
                 ReactContext reactContext = (ReactContext) ((ContextWrapper) getContext()).getBaseContext();
                 EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchResultsView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchResultsView.java
@@ -48,13 +48,6 @@ public class SearchResultsView extends SearchView {
         defaultFontSize = PixelUtil.toDIPFromPixel(getEditText().getTextSize());
         addTransitionListener((searchView, previousState, newState) -> {
             if (newState == TransitionState.SHOWING) {
-                ViewGroup view = (ViewGroup) getParent();
-                for(int i = 0; i < view.getChildCount(); i++) {
-                    if (view.getChildAt(i) instanceof NavigationBarView) {
-                        SearchToolbarView searchToolbarView = (SearchToolbarView) ((NavigationBarView) view.getChildAt(i)).getChildAt(0);
-                        setAnimatedNavigationIcon(searchToolbarView.getNavigationIcon() == searchToolbarView.defaultNavigationIcon);
-                    }
-                }
                 nativeActiveEventCount++;
                 ReactContext reactContext = (ReactContext) ((ContextWrapper) getContext()).getBaseContext();
                 EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
@@ -138,7 +131,9 @@ public class SearchResultsView extends SearchView {
         ViewGroup view = (ViewGroup) getParent();
         for(int i = 0; i < view.getChildCount(); i++) {
             if (view.getChildAt(i) instanceof NavigationBarView) {
-                setupWithSearchBar((SearchToolbarView) ((NavigationBarView) view.getChildAt(i)).getChildAt(0));
+                SearchToolbarView searchToolbarView = (SearchToolbarView) ((NavigationBarView) view.getChildAt(i)).getChildAt(0);
+                setupWithSearchBar(searchToolbarView);
+                setAnimatedNavigationIcon(searchToolbarView.getNavigationIcon() == searchToolbarView.defaultNavigationIcon);
             }
         }
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchToolbarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchToolbarView.java
@@ -48,6 +48,7 @@ public class SearchToolbarView extends SearchBar {
     private boolean placeholderFontChanged = false;
     private final Typeface defaultTypeface;
     private final float defaultFontSize;
+    final Drawable defaultNavigationIcon;
     private final IconResolver.IconResolverListener navIconResolverListener;
     private final IconResolver.IconResolverListener overflowIconResolverListener;
     final ArrayList<BarButtonView> children = new ArrayList<>();
@@ -61,8 +62,12 @@ public class SearchToolbarView extends SearchBar {
         defaultTypeface = getTextView().getTypeface();
         defaultFontSize = PixelUtil.toDIPFromPixel(getTextView().getTextSize());
         defaultOverflowIcon = getOverflowIcon();
+        defaultNavigationIcon = getNavigationIcon();
         navIconResolverListener = d -> {
-            setNavigationIcon(d);
+            if (d != null)
+                setNavigationIcon(d);
+            else
+                setNavigationIcon(defaultNavigationIcon);
             setTintColor(getNavigationIcon());
             setTestID();
         };


### PR DESCRIPTION
The Material3 `SearchBar` throws when the navigation icon is null. Used the default navigation icon if the user doesn't provide one. Disabled the navigation icon animation if not using the default otherwise Android shows the default icon when transitioning between the toolbar and results.