### PR TITLE
Fixed "No matching constructor" on React Native Fabric

### DIFF
--- a/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVBarButtonShadowNode.h
+++ b/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVBarButtonShadowNode.h
@@ -30,7 +30,7 @@ public:
     auto imageSource = ImageSource{ImageSource::Type::Invalid};
     return {
       imageSource,
-      {imageSource, nullptr}};
+      {imageSource, nullptr, {}}};
   }
 
 #pragma mark - LayoutableShadowNode

--- a/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVNavigationBarShadowNode.h
+++ b/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVNavigationBarShadowNode.h
@@ -30,7 +30,7 @@ public:
     auto imageSource = ImageSource{ImageSource::Type::Invalid};
     return {
       imageSource,
-      {imageSource, nullptr}};
+      {imageSource, nullptr, {}}};
   }
 
 #pragma mark - LayoutableShadowNode

--- a/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVTabBarItemShadowNode.h
+++ b/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVTabBarItemShadowNode.h
@@ -30,7 +30,7 @@ public:
     auto imageSource = ImageSource{ImageSource::Type::Invalid};
     return {
       imageSource,
-      {imageSource, nullptr}};
+      {imageSource, nullptr, {}}};
   }
 
 #pragma mark - LayoutableShadowNode


### PR DESCRIPTION
Fixes #716

Think the error started in React Native 0.72.1. Tracked down [the solution on React Native SVG](https://github.com/software-mansion/react-native-svg/pull/2079)