### PR TITLE
Supported dynamic TabBar children, primary and bottomTabs props

### DIFF
--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -5,6 +5,7 @@ import BackButton from './BackButton';
 class TabBar extends React.Component<any, any> {
     private ref: React.RefObject<View>;
     private swiping = false;
+    private tabCount = 0;
     constructor(props) {
         super(props);
         this.state = {selectedTab: props.tab || props.defaultTab, mostRecentEventCount: 0};
@@ -23,6 +24,12 @@ class TabBar extends React.Component<any, any> {
         if (tab != null && tab !== selectedTab)
             return {selectedTab: tab};
         return null;
+    }
+    componentDidMount(): void {
+        this.tabCount = React.Children.toArray(this.props.children).filter(child => !!child).length;
+    }
+    componentDidUpdate(): void {
+        this.tabCount = React.Children.toArray(this.props.children).filter(child => !!child).length;
     }
     onTabSelected({nativeEvent}) {
         var {eventCount: mostRecentEventCount, tab} = nativeEvent;
@@ -106,7 +113,8 @@ class TabBar extends React.Component<any, any> {
                             .filter(child => !!child)
                             .map((child: any, index) => {
                                 var selected = index === this.state.selectedTab;
-                                var freezable = Math.abs(index - this.state.selectedTab) > (Platform.OS === 'android' && !primary ? 1 : 0);
+                                var freezable = Math.abs(index - this.state.selectedTab) > (Platform.OS === 'android' && !primary ? 1 : 0)
+                                    && tabBarItems.length === this.tabCount;
                                 return React.cloneElement(child, {...child.props, index, selected, freezable})
                             })}
                 </TabBar>}

--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -26,13 +26,11 @@ class TabBar extends React.Component<any, any> {
     }
     componentDidMount(): void {
         const tabCount = React.Children.toArray(this.props.children).filter(child => !!child).length;
-        if (this.state.tabCount !== tabCount)
-            this.setState({tabCount});
+        if (this.state.tabCount !== tabCount) this.setState({tabCount});
     }
     componentDidUpdate(): void {
         const tabCount = React.Children.toArray(this.props.children).filter(child => !!child).length;
-        if (this.state.tabCount !== tabCount)
-            this.setState({tabCount});
+        if (this.state.tabCount !== tabCount) this.setState({tabCount});
     }
     onTabSelected({nativeEvent}) {
         var {eventCount: mostRecentEventCount, tab} = nativeEvent;
@@ -117,7 +115,7 @@ class TabBar extends React.Component<any, any> {
                             .map((child: any, index) => {
                                 var selected = index === this.state.selectedTab;
                                 var freezable = Math.abs(index - this.state.selectedTab) > (Platform.OS === 'android' && !primary ? 1 : 0)
-                                    && tabBarItems.length === this.state.tabCount;
+                                    && (!this.state.tabCount || tabBarItems.length === this.state.tabCount);
                                 return React.cloneElement(child, {...child.props, index, selected, freezable})
                             })}
                 </TabBar>}

--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -25,10 +25,14 @@ class TabBar extends React.Component<any, any> {
         return null;
     }
     componentDidMount(): void {
-        this.setState({tabCount: React.Children.toArray(this.props.children).filter(child => !!child).length});
+        const tabCount = React.Children.toArray(this.props.children).filter(child => !!child).length;
+        if (this.state.tabCount !== tabCount)
+        this.setState({tabCount});
     }
     componentDidUpdate(): void {
-        this.setState({tabCount: React.Children.toArray(this.props.children).filter(child => !!child).length});
+        const tabCount = React.Children.toArray(this.props.children).filter(child => !!child).length;
+        if (this.state.tabCount !== tabCount)
+        this.setState({tabCount});
     }
     onTabSelected({nativeEvent}) {
         var {eventCount: mostRecentEventCount, tab} = nativeEvent;

--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -7,7 +7,7 @@ class TabBar extends React.Component<any, any> {
     private swiping = false;
     constructor(props) {
         super(props);
-        this.state = {selectedTab: props.tab || props.defaultTab, mostRecentEventCount: 0, tabCount: 0};
+        this.state = {selectedTab: props.tab || props.defaultTab, mostRecentEventCount: 0};
         this.ref = React.createRef<View>();
         this.onTabSelected = this.onTabSelected.bind(this);
         this.onTabSwipeStateChanged = this.onTabSwipeStateChanged.bind(this);
@@ -23,14 +23,6 @@ class TabBar extends React.Component<any, any> {
         if (tab != null && tab !== selectedTab)
             return {selectedTab: tab};
         return null;
-    }
-    componentDidMount(): void {
-        const tabCount = React.Children.toArray(this.props.children).filter(child => !!child).length;
-        if (this.state.tabCount !== tabCount) this.setState({tabCount});
-    }
-    componentDidUpdate(): void {
-        const tabCount = React.Children.toArray(this.props.children).filter(child => !!child).length;
-        if (this.state.tabCount !== tabCount) this.setState({tabCount});
     }
     onTabSelected({nativeEvent}) {
         var {eventCount: mostRecentEventCount, tab} = nativeEvent;
@@ -114,8 +106,7 @@ class TabBar extends React.Component<any, any> {
                             .filter(child => !!child)
                             .map((child: any, index) => {
                                 var selected = index === this.state.selectedTab;
-                                var freezable = Math.abs(index - this.state.selectedTab) > (Platform.OS === 'android' && !primary ? 1 : 0)
-                                    && (!this.state.tabCount || tabBarItems.length === this.state.tabCount);
+                                var freezable = Math.abs(index - this.state.selectedTab) > (Platform.OS === 'android' && !primary ? 1 : 0);
                                 return React.cloneElement(child, {...child.props, index, selected, freezable})
                             })}
                 </TabBar>}

--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -5,10 +5,9 @@ import BackButton from './BackButton';
 class TabBar extends React.Component<any, any> {
     private ref: React.RefObject<View>;
     private swiping = false;
-    private tabCount = 0;
     constructor(props) {
         super(props);
-        this.state = {selectedTab: props.tab || props.defaultTab, mostRecentEventCount: 0};
+        this.state = {selectedTab: props.tab || props.defaultTab, mostRecentEventCount: 0, tabCount: 0};
         this.ref = React.createRef<View>();
         this.onTabSelected = this.onTabSelected.bind(this);
         this.onTabSwipeStateChanged = this.onTabSwipeStateChanged.bind(this);
@@ -26,10 +25,10 @@ class TabBar extends React.Component<any, any> {
         return null;
     }
     componentDidMount(): void {
-        this.tabCount = React.Children.toArray(this.props.children).filter(child => !!child).length;
+        this.setState({tabCount: React.Children.toArray(this.props.children).filter(child => !!child).length});
     }
     componentDidUpdate(): void {
-        this.tabCount = React.Children.toArray(this.props.children).filter(child => !!child).length;
+        this.setState({tabCount: React.Children.toArray(this.props.children).filter(child => !!child).length});
     }
     onTabSelected({nativeEvent}) {
         var {eventCount: mostRecentEventCount, tab} = nativeEvent;
@@ -114,7 +113,7 @@ class TabBar extends React.Component<any, any> {
                             .map((child: any, index) => {
                                 var selected = index === this.state.selectedTab;
                                 var freezable = Math.abs(index - this.state.selectedTab) > (Platform.OS === 'android' && !primary ? 1 : 0)
-                                    && tabBarItems.length === this.tabCount;
+                                    && tabBarItems.length === this.state.tabCount;
                                 return React.cloneElement(child, {...child.props, index, selected, freezable})
                             })}
                 </TabBar>}

--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -62,7 +62,7 @@ class TabBar extends React.Component<any, any> {
         labelVisibilityMode = !(labelVisibilityMode === 'selected' && tabBarItems.length > 3) ? labelVisibilityMode : 'auto';
         var tabLayout = (Platform.OS === 'android' || !primary) && (
             <TabView
-                bottomTabs={bottomTabs}
+                key="tabView"
                 labelVisibilityMode={constants?.LabelVisibility[labelVisibilityMode]}
                 itemHorizontalTranslation={labelVisibilityMode !== 'selected'}
                 selectedTintColor={selectedTintColor}
@@ -85,6 +85,7 @@ class TabBar extends React.Component<any, any> {
             <>
                 {!bottomTabs && tabLayout}
                 {!!tabBarItems.length && <TabBar
+                    key="tabBar"
                     ref={this.ref}
                     tabCount={tabBarItems.length}
                     onTabSelected={this.onTabSelected}

--- a/NavigationReactNative/src/TabBar.tsx
+++ b/NavigationReactNative/src/TabBar.tsx
@@ -27,12 +27,12 @@ class TabBar extends React.Component<any, any> {
     componentDidMount(): void {
         const tabCount = React.Children.toArray(this.props.children).filter(child => !!child).length;
         if (this.state.tabCount !== tabCount)
-        this.setState({tabCount});
+            this.setState({tabCount});
     }
     componentDidUpdate(): void {
         const tabCount = React.Children.toArray(this.props.children).filter(child => !!child).length;
         if (this.state.tabCount !== tabCount)
-        this.setState({tabCount});
+            this.setState({tabCount});
     }
     onTabSelected({nativeEvent}) {
         var {eventCount: mostRecentEventCount, tab} = nativeEvent;

--- a/NavigationReactNative/src/TabBarItem.tsx
+++ b/NavigationReactNative/src/TabBarItem.tsx
@@ -16,7 +16,7 @@ const TabBarItem = ({selected, onPress, children, title, image, systemItem, badg
             if (global.nativeFabricUIManager && freezable) {
                 var timer = setTimeout(() => {
                     setFreeze(freezable);
-                }, 1000);
+                }, 100);
             } else {
                 setFreeze(freezable);
             }

--- a/NavigationReactNative/src/TabBarItem.tsx
+++ b/NavigationReactNative/src/TabBarItem.tsx
@@ -11,7 +11,9 @@ const TabBarItem = ({selected, onPress, children, title, image, systemItem, badg
     const [freeze, setFreeze] = useState(false);
     const backHandler = useRef(createBackHandler());
     const onLoad = useRef({ onLoad: () => setLoaded(true)});
-    if(freeze !== freezable) setFreeze(freezable);
+    useEffect(() => {
+        if(freeze !== freezable) setFreeze(freezable);
+    }, [freeze, freezable]);
     useEffect(() => {
         setFreeze(false);
     }, [image, systemItem, badge, title]);

--- a/NavigationReactNative/src/TabBarItem.tsx
+++ b/NavigationReactNative/src/TabBarItem.tsx
@@ -12,7 +12,16 @@ const TabBarItem = ({selected, onPress, children, title, image, systemItem, badg
     const backHandler = useRef(createBackHandler());
     const onLoad = useRef({ onLoad: () => setLoaded(true)});
     useEffect(() => {
-        if(freeze !== freezable) setFreeze(freezable);
+        if(freeze !== freezable) {
+            if (global.nativeFabricUIManager && freezable) {
+                var timer = setTimeout(() => {
+                    setFreeze(freezable);
+                }, 1000);
+            } else {
+                setFreeze(freezable);
+            }
+        }
+        return () => clearTimeout(timer);
     }, [freeze, freezable]);
     useEffect(() => {
         setFreeze(false);

--- a/NavigationReactNative/src/TabBarItem.tsx
+++ b/NavigationReactNative/src/TabBarItem.tsx
@@ -11,9 +11,7 @@ const TabBarItem = ({selected, onPress, children, title, image, systemItem, badg
     const [freeze, setFreeze] = useState(false);
     const backHandler = useRef(createBackHandler());
     const onLoad = useRef({ onLoad: () => setLoaded(true)});
-    useEffect(() => {
-        if(freeze !== freezable) setFreeze(freezable);
-    }, [freeze, freezable]);
+    if(freeze !== freezable) setFreeze(freezable);
     useEffect(() => {
         setFreeze(false);
     }, [image, systemItem, badge, title]);

--- a/NavigationReactNative/src/TabLayoutNativeComponent.js
+++ b/NavigationReactNative/src/TabLayoutNativeComponent.js
@@ -9,7 +9,6 @@ type NativeProps = $ReadOnly<{|
   selectedTintColor: ColorValue,
   unselectedTintColor: ColorValue,
   rippleColor: ColorValue,
-  bottomTabs: boolean,
   selectedIndicatorAtTop: boolean,
   scrollable: boolean,
 |}>;

--- a/NavigationReactNative/src/TabNavigationNativeComponent.js
+++ b/NavigationReactNative/src/TabNavigationNativeComponent.js
@@ -8,7 +8,6 @@ type NativeProps = $ReadOnly<{|
   ...ViewProps,
   selectedTintColor: ColorValue,
   unselectedTintColor: ColorValue,
-  bottomTabs: boolean,
   itemHorizontalTranslation: boolean,
   labelVisibilityMode: Int32,
   activeIndicatorColor: ColorValue,

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarManager.java
@@ -33,6 +33,7 @@ public class TabBarManager extends ViewGroupManager<TabBarView> {
     @ReactProp(name = "mostRecentEventCount")
     public void setMostRecentEventCount(TabBarView view, int mostRecentEventCount) {
         view.mostRecentEventCount = mostRecentEventCount;
+        view.nativeEventCount = Math.max(view.nativeEventCount, view.mostRecentEventCount);
     }
 
     @ReactProp(name = "tabCount")
@@ -58,14 +59,12 @@ public class TabBarManager extends ViewGroupManager<TabBarView> {
     public void addView(TabBarView parent, View child, int index) {
         ((TabBarItemView) child).changeListener = parent;
         parent.tabFragments.add(index, new TabFragment((TabBarItemView) child));
-        parent.tabsChanged = true;
     }
 
     @Override
     public void removeViewAt(TabBarView parent, int index) {
         parent.tabFragments.get(index).tabBarItem.changeListener = null;
         parent.tabFragments.remove(index);
-        parent.tabsChanged = true;
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarManager.java
@@ -71,7 +71,9 @@ public class TabBarManager extends ViewGroupManager<TabBarView> {
     @Override
     protected void onAfterUpdateTransaction(@NonNull TabBarView view) {
         super.onAfterUpdateTransaction(view);
+        view.jsUpdate = true;
         view.onAfterUpdateTransaction();
+        view.jsUpdate = false;
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarManager.java
@@ -59,6 +59,7 @@ public class TabBarManager extends ViewGroupManager<TabBarView> {
     public void addView(TabBarView parent, View child, int index) {
         ((TabBarItemView) child).changeListener = parent;
         parent.tabFragments.add(index, new TabFragment((TabBarItemView) child));
+        parent.requestOnAfterUpdateTransaction();
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerManager.java
@@ -35,6 +35,7 @@ public class TabBarPagerManager extends ViewGroupManager<TabBarPagerView> {
     @ReactProp(name = "mostRecentEventCount")
     public void setMostRecentEventCount(TabBarPagerView view, int mostRecentEventCount) {
         view.mostRecentEventCount = mostRecentEventCount;
+        view.nativeEventCount = Math.max(view.nativeEventCount, view.mostRecentEventCount);
     }
 
     @ReactProp(name = "tabCount")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerManager.java
@@ -80,7 +80,9 @@ public class TabBarPagerManager extends ViewGroupManager<TabBarPagerView> {
     @Override
     protected void onAfterUpdateTransaction(@Nonnull TabBarPagerView view) {
         super.onAfterUpdateTransaction(view);
+        view.jsUpdate = true;
         view.onAfterUpdateTransaction();
+        view.jsUpdate = false;
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLAdapter.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLAdapter.java
@@ -39,8 +39,10 @@ public class TabBarPagerRTLAdapter extends FragmentStateAdapter {
                 setCurrentItem(view, selectedTab);
         }
         populateTabs(getTabLayout(view));
-        selectedTab = Math.min(selectedTab, getTabsCount() - 1);
-        setCurrentItem(view, selectedTab);
+        if (getTabsCount() > 0) {
+            selectedTab = Math.min(selectedTab, getTabsCount() - 1);
+            setCurrentItem(view, selectedTab);
+        }
     }
 
     void setCurrentItem(ViewPager2 view, int selectedTab) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLAdapter.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLAdapter.java
@@ -6,6 +6,7 @@ import android.widget.ScrollView;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.RecyclerView;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
 import androidx.viewpager2.widget.ViewPager2;
 
@@ -95,6 +96,6 @@ public class TabBarPagerRTLAdapter extends FragmentStateAdapter {
 
     @Override
     public long getItemId(int position) {
-        return tabBarItems.get(position).content.get(0).hashCode();
+        return tabBarItems.get(position).content.size() > 0 ? tabBarItems.get(position).content.get(0).hashCode() : RecyclerView.NO_ID;
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLAdapter.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLAdapter.java
@@ -24,6 +24,7 @@ public class TabBarPagerRTLAdapter extends FragmentStateAdapter {
     int mostRecentEventCount;
     boolean dataSetChanged = false;
     private boolean onAfterUpdateTransactionRequested = false;
+    boolean jsUpdate = false;
 
     public TabBarPagerRTLAdapter(@NonNull Fragment fragment) {
         super(fragment);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLAdapter.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLAdapter.java
@@ -64,7 +64,7 @@ public class TabBarPagerRTLAdapter extends FragmentStateAdapter {
     }
 
     TabBarItemView getTabAt(int index) {
-        return tabBarItems.get(index);
+        return tabBarItems.size() > index ? tabBarItems.get(index) : null;
     }
 
     void addTab(TabBarItemView tab, int index) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLManager.java
@@ -64,7 +64,8 @@ public class TabBarPagerRTLManager extends ViewGroupManager<ViewPager2> {
                 event.putInt("tab", position);
                 event.putInt("eventCount", tabBarPagerAdapter.nativeEventCount);
                 reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(tabBarPager.getId(),"onTabSelected", event);
-                tabBarPagerAdapter.getTabAt(position).pressed();
+                if (tabBarPagerAdapter.getTabAt(position) != null)
+                    tabBarPagerAdapter.getTabAt(position).pressed();
             }
 
             @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLManager.java
@@ -178,6 +178,8 @@ public class TabBarPagerRTLManager extends ViewGroupManager<ViewPager2> {
                 setCurrentItem(view, getAdapter(view).selectedTab);
         }
         getAdapter(view).populateTabs(getTabLayout(view));
+        getAdapter(view).selectedTab = Math.min(getAdapter(view).selectedTab, getAdapter(view).getTabsCount() - 1);
+        setCurrentItem(view, getAdapter(view).selectedTab);
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLManager.java
@@ -56,13 +56,15 @@ public class TabBarPagerRTLManager extends ViewGroupManager<ViewPager2> {
             public void onPageSelected(int position) {
                 if (position == -1) return;
                 super.onPageSelected(position);
-                if (!tabBarPagerAdapter.dataSetChanged)
+                if (!tabBarPagerAdapter.dataSetChanged && !tabBarPagerAdapter.jsUpdate)
                     tabBarPagerAdapter.nativeEventCount++;
                 tabBarPagerAdapter.selectedTab = position;
-                WritableMap event = Arguments.createMap();
-                event.putInt("tab", position);
-                event.putInt("eventCount", tabBarPagerAdapter.nativeEventCount);
-                reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(tabBarPager.getId(),"onTabSelected", event);
+                if (!tabBarPagerAdapter.jsUpdate) {
+                    WritableMap event = Arguments.createMap();
+                    event.putInt("tab", position);
+                    event.putInt("eventCount", tabBarPagerAdapter.nativeEventCount);
+                    reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(tabBarPager.getId(), "onTabSelected", event);
+                }
                 if (tabBarPagerAdapter.getTabAt(position) != null)
                     tabBarPagerAdapter.getTabAt(position).pressed();
             }
@@ -161,7 +163,9 @@ public class TabBarPagerRTLManager extends ViewGroupManager<ViewPager2> {
     @Override
     protected void onAfterUpdateTransaction(@Nonnull ViewPager2 view) {
         super.onAfterUpdateTransaction(view);
+        getAdapter(view).jsUpdate = true;
         getAdapter(view).onAfterUpdateTransaction(view);
+        getAdapter(view).jsUpdate = false;
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLManager.java
@@ -55,6 +55,7 @@ public class TabBarPagerRTLManager extends ViewGroupManager<ViewPager2> {
         tabBarPager.registerOnPageChangeCallback(new ViewPager2.OnPageChangeCallback() {
             @Override
             public void onPageSelected(int position) {
+                if (position == -1) return;
                 super.onPageSelected(position);
                 if (!tabBarPagerAdapter.dataSetChanged)
                     tabBarPagerAdapter.nativeEventCount++;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLManager.java
@@ -126,6 +126,7 @@ public class TabBarPagerRTLManager extends ViewGroupManager<ViewPager2> {
     @ReactProp(name = "mostRecentEventCount")
     public void setMostRecentEventCount(ViewPager2 view, int mostRecentEventCount) {
         getAdapter(view).mostRecentEventCount = mostRecentEventCount;
+        getAdapter(view).nativeEventCount = Math.max(getAdapter(view).nativeEventCount, getAdapter(view).mostRecentEventCount);
     }
 
     @ReactProp(name = "tabCount")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLViewManager.java
@@ -146,6 +146,7 @@ public class TabBarPagerRTLViewManager extends ViewGroupManager<ViewPager2> impl
     @ReactProp(name = "mostRecentEventCount")
     public void setMostRecentEventCount(ViewPager2 view, int mostRecentEventCount) {
         getAdapter(view).mostRecentEventCount = mostRecentEventCount;
+        getAdapter(view).nativeEventCount = Math.max(getAdapter(view).nativeEventCount, getAdapter(view).mostRecentEventCount);
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLViewManager.java
@@ -7,7 +7,6 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.core.view.ViewCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
@@ -94,7 +93,7 @@ public class TabBarPagerRTLViewManager extends ViewGroupManager<ViewPager2> impl
         tabBarPager.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
             @Override
             public void onViewAttachedToWindow(View v) {
-                TabLayoutRTLView tabLayout = getTabLayout(v);
+                TabLayoutRTLView tabLayout = tabBarPagerAdapter.getTabLayout(v);
                 if (tabLayout != null) {
                     tabLayout.setVisibility(View.VISIBLE);
                     new TabLayoutMediator(tabLayout, tabBarPager,
@@ -119,7 +118,7 @@ public class TabBarPagerRTLViewManager extends ViewGroupManager<ViewPager2> impl
                 super.onItemRangeInserted(positionStart, itemCount);
                 if (tabBarPager.getCurrentItem() != tabBarPagerAdapter.selectedTab
                         && tabBarPagerAdapter.getTabsCount() > tabBarPagerAdapter.selectedTab) {
-                    setCurrentItem(tabBarPager, tabBarPagerAdapter.selectedTab);
+                    tabBarPagerAdapter.setCurrentItem(tabBarPager, tabBarPagerAdapter.selectedTab);
                 }
             }
         });
@@ -133,16 +132,6 @@ public class TabBarPagerRTLViewManager extends ViewGroupManager<ViewPager2> impl
     @ReactProp(name = "selectedTab")
     public void setSelectedTab(ViewPager2 view, int selectedTab) {
         getAdapter(view).pendingSelectedTab = selectedTab;
-    }
-
-    private void setCurrentItem(final ViewPager2 view, int selectedTab) {
-        view.post(() -> {
-            view.measure(
-                View.MeasureSpec.makeMeasureSpec(view.getWidth(), View.MeasureSpec.EXACTLY),
-                View.MeasureSpec.makeMeasureSpec(view.getHeight(), View.MeasureSpec.EXACTLY));
-            view.layout(view.getLeft(), view.getTop(), view.getRight(), view.getBottom());
-        });
-        view.setCurrentItem(selectedTab, false);
     }
 
     @ReactProp(name = "mostRecentEventCount")
@@ -174,6 +163,7 @@ public class TabBarPagerRTLViewManager extends ViewGroupManager<ViewPager2> impl
     @Override
     public void addView(ViewPager2 parent, View child, int index) {
         getAdapter(parent).addTab((TabBarItemView) child, index);
+        getAdapter(parent).requestOnAfterUpdateTransaction(parent);
     }
 
     @Override
@@ -192,15 +182,7 @@ public class TabBarPagerRTLViewManager extends ViewGroupManager<ViewPager2> impl
     @Override
     protected void onAfterUpdateTransaction(@Nonnull ViewPager2 view) {
         super.onAfterUpdateTransaction(view);
-        int eventLag = getAdapter(view).nativeEventCount - getAdapter(view).mostRecentEventCount;
-        if (eventLag == 0 && view.getCurrentItem() != getAdapter(view).pendingSelectedTab) {
-            getAdapter(view).selectedTab = getAdapter(view).pendingSelectedTab;
-            if (getAdapter(view).getTabsCount() > getAdapter(view).selectedTab)
-                setCurrentItem(view, getAdapter(view).selectedTab);
-        }
-        getAdapter(view).populateTabs(getTabLayout(view));
-        getAdapter(view).selectedTab = Math.min(getAdapter(view).selectedTab, getAdapter(view).getTabsCount() - 1);
-        setCurrentItem(view, getAdapter(view).selectedTab);
+        getAdapter(view).onAfterUpdateTransaction(view);
     }
 
     @Override
@@ -214,21 +196,6 @@ public class TabBarPagerRTLViewManager extends ViewGroupManager<ViewPager2> impl
             fragmentTransaction.commitAllowingStateLoss();
         }
         super.onDropViewInstance(view);
-    }
-
-    private TabLayoutRTLView getTabLayout(View view) {
-        ViewGroup parent = (ViewGroup) view.getParent();
-        if (parent instanceof CoordinatorLayout) {
-            parent = (ViewGroup) parent.getChildAt(0);
-            if (parent.getChildAt(0) instanceof CollapsingBarView)
-                parent = (ViewGroup) parent.getChildAt(0);
-        }
-        for(int i = 0; parent != null && i < parent.getChildCount(); i++) {
-            View child = parent.getChildAt(i);
-            if (child instanceof TabView)
-                return (TabLayoutRTLView) child;
-        }
-        return null;
     }
 
     public static class TabBarPagerFragment extends Fragment {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLViewManager.java
@@ -199,6 +199,8 @@ public class TabBarPagerRTLViewManager extends ViewGroupManager<ViewPager2> impl
                 setCurrentItem(view, getAdapter(view).selectedTab);
         }
         getAdapter(view).populateTabs(getTabLayout(view));
+        getAdapter(view).selectedTab = Math.min(getAdapter(view).selectedTab, getAdapter(view).getTabsCount() - 1);
+        setCurrentItem(view, getAdapter(view).selectedTab);
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLViewManager.java
@@ -73,13 +73,15 @@ public class TabBarPagerRTLViewManager extends ViewGroupManager<ViewPager2> impl
         tabBarPager.registerOnPageChangeCallback(new ViewPager2.OnPageChangeCallback() {
             @Override
             public void onPageSelected(int position) {
+                if (position == -1) return;
                 super.onPageSelected(position);
                 if (!tabBarPagerAdapter.dataSetChanged)
                     tabBarPagerAdapter.nativeEventCount++;
                 tabBarPagerAdapter.selectedTab = position;
                 EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, tabBarPager.getId());
                 eventDispatcher.dispatchEvent(new TabBarPagerRTLViewManager.TabSelectedEvent(tabBarPager.getId(), position, tabBarPagerAdapter.nativeEventCount));
-                tabBarPagerAdapter.getTabAt(position).pressed();
+                if (tabBarPagerAdapter.getTabAt(position) != null)
+                    tabBarPagerAdapter.getTabAt(position).pressed();
             }
 
             @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLViewManager.java
@@ -74,11 +74,13 @@ public class TabBarPagerRTLViewManager extends ViewGroupManager<ViewPager2> impl
             public void onPageSelected(int position) {
                 if (position == -1) return;
                 super.onPageSelected(position);
-                if (!tabBarPagerAdapter.dataSetChanged)
+                if (!tabBarPagerAdapter.dataSetChanged && !tabBarPagerAdapter.jsUpdate)
                     tabBarPagerAdapter.nativeEventCount++;
                 tabBarPagerAdapter.selectedTab = position;
-                EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, tabBarPager.getId());
-                eventDispatcher.dispatchEvent(new TabBarPagerRTLViewManager.TabSelectedEvent(tabBarPager.getId(), position, tabBarPagerAdapter.nativeEventCount));
+                if (!tabBarPagerAdapter.jsUpdate) {
+                    EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, tabBarPager.getId());
+                    eventDispatcher.dispatchEvent(new TabBarPagerRTLViewManager.TabSelectedEvent(tabBarPager.getId(), position, tabBarPagerAdapter.nativeEventCount));
+                }
                 if (tabBarPagerAdapter.getTabAt(position) != null)
                     tabBarPagerAdapter.getTabAt(position).pressed();
             }
@@ -182,7 +184,9 @@ public class TabBarPagerRTLViewManager extends ViewGroupManager<ViewPager2> impl
     @Override
     protected void onAfterUpdateTransaction(@Nonnull ViewPager2 view) {
         super.onAfterUpdateTransaction(view);
+        getAdapter(view).jsUpdate = true;
         getAdapter(view).onAfterUpdateTransaction(view);
+        getAdapter(view).jsUpdate = false;
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
@@ -40,6 +40,7 @@ public class TabBarPagerView extends ViewPager implements TabBarItemView.ChangeL
     int nativeEventCount;
     int mostRecentEventCount;
     private boolean dataSetChanged = false;
+    boolean jsUpdate = false;
 
     public TabBarPagerView(Context context) {
         super(context);
@@ -258,12 +259,14 @@ public class TabBarPagerView extends ViewPager implements TabBarItemView.ChangeL
 
         @Override
         public void onPageSelected(int position) {
-            if (!dataSetChanged)
+            if (!dataSetChanged && !jsUpdate)
                 nativeEventCount++;
             selectedTab = position;
-            ReactContext reactContext = (ReactContext) getContext();
-            EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
-            eventDispatcher.dispatchEvent(new TabBarPagerView.TabSelectedEvent(getId(), position, nativeEventCount));
+            if (!jsUpdate) {
+                ReactContext reactContext = (ReactContext) getContext();
+                EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
+                eventDispatcher.dispatchEvent(new TabBarPagerView.TabSelectedEvent(getId(), position, nativeEventCount));
+            }
             if (getAdapter() != null)
                 getAdapter().tabFragments.get(position).tabBarItem.pressed();
         }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
@@ -71,13 +71,6 @@ public class TabBarPagerView extends ViewPager implements TabBarItemView.ChangeL
         if (getTabLayout() != null)
             getTabLayout().setupWithViewPager(this);
         populateTabs();
-        if (!measured) {
-            measure(
-                MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
-                MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
-            layout(getLeft(), getTop(), getRight(), getBottom());
-            measured = true;
-        }
     }
 
     void onAfterUpdateTransaction() {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
@@ -233,6 +233,7 @@ public class TabBarPagerView extends ViewPager implements TabBarItemView.ChangeL
 
         @Override
         public int getItemPosition(@NonNull Object object) {
+            if (dataSetChanged) return POSITION_NONE;
             for(int i = 0; i < tabFragments.size(); i++) {
                 TabFragment tabFragment = tabFragments.get(i);
                 if (tabFragment == object && !tabFragment.viewChanged())

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
@@ -77,7 +77,6 @@ public class TabBarPagerView extends ViewPager implements TabBarItemView.ChangeL
                 MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
             layout(getLeft(), getTop(), getRight(), getBottom());
             measured = true;
-            getAdapter().notifyDataSetChanged();
         }
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
@@ -99,7 +99,7 @@ public class TabBarPagerView extends ViewPager implements TabBarItemView.ChangeL
         }
     }
 
-    private TabLayoutView getTabLayout() {
+    TabLayoutView getTabLayout() {
         ViewGroup parent = (ViewGroup) getParent();
         if (parent instanceof CoordinatorLayout) {
             parent = (ViewGroup) parent.getChildAt(0);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
@@ -40,7 +40,6 @@ public class TabBarPagerView extends ViewPager implements TabBarItemView.ChangeL
     int nativeEventCount;
     int mostRecentEventCount;
     private boolean dataSetChanged = false;
-    private boolean jsUpdate = false;
 
     public TabBarPagerView(Context context) {
         super(context);
@@ -75,7 +74,6 @@ public class TabBarPagerView extends ViewPager implements TabBarItemView.ChangeL
     }
 
     void onAfterUpdateTransaction() {
-        jsUpdate = true;
         int eventLag = nativeEventCount - mostRecentEventCount;
         if (eventLag == 0 && getCurrentItem() != pendingSelectedTab) {
             selectedTab = pendingSelectedTab;
@@ -83,7 +81,6 @@ public class TabBarPagerView extends ViewPager implements TabBarItemView.ChangeL
                 setCurrentItem(selectedTab, false);
         }
         populateTabs();
-        jsUpdate = false;
     }
 
     void populateTabs() {
@@ -260,14 +257,12 @@ public class TabBarPagerView extends ViewPager implements TabBarItemView.ChangeL
 
         @Override
         public void onPageSelected(int position) {
-            if (!dataSetChanged && !jsUpdate)
+            if (!dataSetChanged)
                 nativeEventCount++;
             selectedTab = position;
-            if (!jsUpdate) {
-                ReactContext reactContext = (ReactContext) getContext();
-                EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
-                eventDispatcher.dispatchEvent(new TabBarPagerView.TabSelectedEvent(getId(), position, nativeEventCount));
-            }
+            ReactContext reactContext = (ReactContext) getContext();
+            EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
+            eventDispatcher.dispatchEvent(new TabBarPagerView.TabSelectedEvent(getId(), position, nativeEventCount));
             if (getAdapter() != null)
                 getAdapter().tabFragments.get(position).tabBarItem.pressed();
         }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerViewManager.java
@@ -96,7 +96,9 @@ public class TabBarPagerViewManager extends ViewGroupManager<TabBarPagerView> im
     @Override
     protected void onAfterUpdateTransaction(@Nonnull TabBarPagerView view) {
         super.onAfterUpdateTransaction(view);
+        view.jsUpdate = true;
         view.onAfterUpdateTransaction();
+        view.jsUpdate = false;
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerViewManager.java
@@ -50,6 +50,7 @@ public class TabBarPagerViewManager extends ViewGroupManager<TabBarPagerView> im
     @ReactProp(name = "mostRecentEventCount")
     public void setMostRecentEventCount(TabBarPagerView view, int mostRecentEventCount) {
         view.mostRecentEventCount = mostRecentEventCount;
+        view.nativeEventCount = Math.max(view.nativeEventCount, view.mostRecentEventCount);
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -31,7 +31,6 @@ public class TabBarView extends ViewGroup implements TabBarItemView.ChangeListen
     private FragmentManager fragmentManager;
     private TabFragment selectedTabFragment;
     private Fragment fragment;
-    boolean tabsChanged = false;
     int pendingSelectedTab = 0;
     int selectedTab = 0;
     boolean scrollsToTop;
@@ -62,12 +61,9 @@ public class TabBarView extends ViewGroup implements TabBarItemView.ChangeListen
         TabNavigationView tabNavigation = getTabNavigation();
         if (tabNavigation == null)
             return;
-        if (tabsChanged) {
-            tabNavigation.setTitles();
-            for (int i = 0; i < tabFragments.size(); i++) {
-                tabFragments.get(i).tabBarItem.setTabView(tabNavigation, i);
-            }
-            tabsChanged = false;
+        tabNavigation.setTitles();
+        for (int i = 0; i < tabFragments.size(); i++) {
+            tabFragments.get(i).tabBarItem.setTabView(tabNavigation, i);
         }
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -37,7 +37,6 @@ public class TabBarView extends ViewGroup implements TabBarItemView.ChangeListen
     int nativeEventCount;
     int mostRecentEventCount;
     private int selectedIndex = 0;
-    private boolean jsUpdate = false;
 
     public TabBarView(Context context) {
         super(context);
@@ -80,32 +79,28 @@ public class TabBarView extends ViewGroup implements TabBarItemView.ChangeListen
     }
 
     void onAfterUpdateTransaction() {
-        jsUpdate = true;
         int eventLag = nativeEventCount - mostRecentEventCount;
         if (eventLag == 0 && pendingSelectedTab != selectedTab) {
             selectedTab = pendingSelectedTab;
             if (tabFragments.size() > selectedTab)
                 setCurrentTab(selectedTab);
         }
-        if (tabFragments.size() != 0) {
-            populateTabs();
-            if (selectedTabFragment != null) {
-                int reselectedTab = tabFragments.indexOf(selectedTabFragment);
-                selectedTab = reselectedTab != -1 ? reselectedTab : Math.min(selectedTab, tabFragments.size() - 1);
-            }
-            setCurrentTab(selectedTab);
+        if (tabFragments.size() == 0)
+            return;
+        populateTabs();
+        if (selectedTabFragment != null) {
+            int reselectedTab = tabFragments.indexOf(selectedTabFragment);
+            selectedTab = reselectedTab != -1 ? reselectedTab : Math.min(selectedTab, tabFragments.size() - 1);
         }
-        jsUpdate = false;
+        setCurrentTab(selectedTab);
     }
 
     void setCurrentTab(int index) {
         if (index != selectedIndex) {
-            if (!jsUpdate) {
-                nativeEventCount++;
-                ReactContext reactContext = (ReactContext) getContext();
-                EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
-                eventDispatcher.dispatchEvent(new TabBarView.TabSelectedEvent(getId(), index, nativeEventCount));
-            }
+            nativeEventCount++;
+            ReactContext reactContext = (ReactContext) getContext();
+            EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
+            eventDispatcher.dispatchEvent(new TabBarView.TabSelectedEvent(getId(), index, nativeEventCount));
             tabFragments.get(index).tabBarItem.pressed();
         }
         selectedTab = selectedIndex = index;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -37,6 +37,7 @@ public class TabBarView extends ViewGroup implements TabBarItemView.ChangeListen
     int nativeEventCount;
     int mostRecentEventCount;
     private int selectedIndex = 0;
+    private boolean onAfterUpdateTransactionRequested = false;
 
     public TabBarView(Context context) {
         super(context);
@@ -79,6 +80,7 @@ public class TabBarView extends ViewGroup implements TabBarItemView.ChangeListen
     }
 
     void onAfterUpdateTransaction() {
+        onAfterUpdateTransactionRequested = false;
         int eventLag = nativeEventCount - mostRecentEventCount;
         if (eventLag == 0 && pendingSelectedTab != selectedTab) {
             selectedTab = pendingSelectedTab;
@@ -94,6 +96,16 @@ public class TabBarView extends ViewGroup implements TabBarItemView.ChangeListen
         }
         setCurrentTab(selectedTab);
     }
+
+    void requestOnAfterUpdateTransaction() {
+        if (!onAfterUpdateTransactionRequested) {
+            onAfterUpdateTransactionRequested = true;
+            post(afterUpdateTransactionRequested);
+        }
+    }
+    private final Runnable afterUpdateTransactionRequested = () -> {
+        if (onAfterUpdateTransactionRequested) onAfterUpdateTransaction();
+    };
 
     void setCurrentTab(int index) {
         if (index != selectedIndex) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -38,6 +38,7 @@ public class TabBarView extends ViewGroup implements TabBarItemView.ChangeListen
     int mostRecentEventCount;
     private int selectedIndex = 0;
     private boolean onAfterUpdateTransactionRequested = false;
+    boolean jsUpdate = false;
 
     public TabBarView(Context context) {
         super(context);
@@ -109,10 +110,12 @@ public class TabBarView extends ViewGroup implements TabBarItemView.ChangeListen
 
     void setCurrentTab(int index) {
         if (index != selectedIndex) {
-            nativeEventCount++;
-            ReactContext reactContext = (ReactContext) getContext();
-            EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
-            eventDispatcher.dispatchEvent(new TabBarView.TabSelectedEvent(getId(), index, nativeEventCount));
+            if (!jsUpdate) {
+                nativeEventCount++;
+                ReactContext reactContext = (ReactContext) getContext();
+                EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
+                eventDispatcher.dispatchEvent(new TabBarView.TabSelectedEvent(getId(), index, nativeEventCount));
+            }
             tabFragments.get(index).tabBarItem.pressed();
         }
         selectedTab = selectedIndex = index;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -53,7 +53,8 @@ public class TabBarView extends ViewGroup implements TabBarItemView.ChangeListen
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
-        setCurrentTab(selectedTab);
+        if (tabFragments.size() > selectedTab)
+            setCurrentTab(selectedTab);
         populateTabs();
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarViewManager.java
@@ -123,7 +123,9 @@ public class TabBarViewManager extends ViewGroupManager<TabBarView> implements N
     @Override
     protected void onAfterUpdateTransaction(@NonNull TabBarView view) {
         super.onAfterUpdateTransaction(view);
+        view.jsUpdate = true;
         view.onAfterUpdateTransaction();
+        view.jsUpdate = false;
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarViewManager.java
@@ -65,6 +65,7 @@ public class TabBarViewManager extends ViewGroupManager<TabBarView> implements N
     @ReactProp(name = "mostRecentEventCount")
     public void setMostRecentEventCount(TabBarView view, int mostRecentEventCount) {
         view.mostRecentEventCount = mostRecentEventCount;
+        view.nativeEventCount = Math.max(view.nativeEventCount, view.mostRecentEventCount);
     }
 
     @ReactProp(name = "tabCount")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarViewManager.java
@@ -110,14 +110,12 @@ public class TabBarViewManager extends ViewGroupManager<TabBarView> implements N
     public void addView(TabBarView parent, View child, int index) {
         ((TabBarItemView) child).changeListener = parent;
         parent.tabFragments.add(index, new TabFragment((TabBarItemView) child));
-        parent.tabsChanged = true;
     }
 
     @Override
     public void removeViewAt(TabBarView parent, int index) {
         parent.tabFragments.get(index).tabBarItem.changeListener = null;
         parent.tabFragments.remove(index);
-        parent.tabsChanged = true;
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarViewManager.java
@@ -111,6 +111,7 @@ public class TabBarViewManager extends ViewGroupManager<TabBarView> implements N
     public void addView(TabBarView parent, View child, int index) {
         ((TabBarItemView) child).changeListener = parent;
         parent.tabFragments.add(index, new TabFragment((TabBarItemView) child));
+        parent.requestOnAfterUpdateTransaction();
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutManager.java
@@ -17,11 +17,6 @@ public class TabLayoutManager extends ViewGroupManager<TabLayoutView> {
         return "NVTabLayout";
     }
 
-    @ReactProp(name = "bottomTabs")
-    public void setBottomTabs(TabLayoutView view, boolean bottomTabs) {
-        view.bottomTabs = bottomTabs;
-    }
-
     @ReactProp(name = "selectedTintColor", customType = "Color", defaultInt = Integer.MAX_VALUE)
     public void setSelectedTintColor(TabLayoutView view, int selectedTintColor) {
         view.selectedTintColor = selectedTintColor != Integer.MAX_VALUE ? selectedTintColor : view.defaultTextColor;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutView.java
@@ -8,6 +8,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.Nullable;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.core.view.ViewCompat;
 import androidx.viewpager.widget.ViewPager;
 
@@ -17,7 +18,6 @@ import com.google.android.material.badge.BadgeDrawable;
 import com.google.android.material.tabs.TabLayout;
 
 public class TabLayoutView extends TabLayout implements TabView {
-    boolean bottomTabs;
     int defaultTextColor;
     int selectedTintColor;
     int unselectedTintColor;
@@ -53,12 +53,27 @@ public class TabLayoutView extends TabLayout implements TabView {
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
-        this.setVisibility(this.getTabCount() > 0 ? View.VISIBLE : View.INVISIBLE);
+        if (this.getNavigationBarTabLayout() != null)
+            this.setVisibility(View.INVISIBLE);
         TabBarPagerView tabBar = getTabBar();
-        if (bottomTabs && tabBar != null) {
+        if (tabBar != null) {
             setupWithViewPager(tabBar);
             tabBar.populateTabs();
         }
+    }
+    private TabLayoutView getNavigationBarTabLayout() {
+        ViewGroup parent = (ViewGroup) getParent();
+        if (parent instanceof CoordinatorLayout) {
+            parent = (ViewGroup) parent.getChildAt(0);
+            if (parent.getChildAt(0) instanceof CollapsingBarView)
+                parent = (ViewGroup) parent.getChildAt(0);
+        }
+        for(int i = 0; parent != null && i < parent.getChildCount(); i++) {
+            View child = parent.getChildAt(i);
+            if (child instanceof com.navigation.reactnative.TabView && child != this)
+                return (TabLayoutView) child;
+        }
+        return null;
     }
 
     private TabBarPagerView getTabBar() {
@@ -73,7 +88,6 @@ public class TabLayoutView extends TabLayout implements TabView {
     @Override
     public void setupWithViewPager(@Nullable final ViewPager viewPager) {
         super.setupWithViewPager(viewPager);
-        setVisibility(View.VISIBLE);
         if (tabSelectedListener != null)
             removeOnTabSelectedListener(tabSelectedListener);
         tabSelectedListener = new OnTabSelectedListener() {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutView.java
@@ -53,27 +53,15 @@ public class TabLayoutView extends TabLayout implements TabView {
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
-        if (this.getNavigationBarTabLayout() != null)
-            this.setVisibility(View.INVISIBLE);
         TabBarPagerView tabBar = getTabBar();
         if (tabBar != null) {
-            setupWithViewPager(tabBar);
-            tabBar.populateTabs();
+            if (tabBar.getTabLayout() == this) {
+                setupWithViewPager(tabBar);
+                tabBar.populateTabs();
+            } else {
+                this.setVisibility(View.INVISIBLE);
+            }
         }
-    }
-    private TabLayoutView getNavigationBarTabLayout() {
-        ViewGroup parent = (ViewGroup) getParent();
-        if (parent instanceof CoordinatorLayout) {
-            parent = (ViewGroup) parent.getChildAt(0);
-            if (parent.getChildAt(0) instanceof CollapsingBarView)
-                parent = (ViewGroup) parent.getChildAt(0);
-        }
-        for(int i = 0; parent != null && i < parent.getChildCount(); i++) {
-            View child = parent.getChildAt(i);
-            if (child instanceof com.navigation.reactnative.TabView && child != this)
-                return (TabLayoutView) child;
-        }
-        return null;
     }
 
     private TabBarPagerView getTabBar() {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabLayoutViewManager.java
@@ -33,11 +33,6 @@ public class TabLayoutViewManager extends ViewGroupManager<TabLayoutView> implem
         return "NVTabLayout";
     }
 
-    @ReactProp(name = "bottomTabs")
-    public void setBottomTabs(TabLayoutView view, boolean bottomTabs) {
-        view.bottomTabs = bottomTabs;
-    }
-
     @ReactProp(name = "selectedTintColor", customType = "Color")
     public void setSelectedTintColor(TabLayoutView view, @Nullable Integer selectedTintColor) {
         view.selectedTintColor = selectedTintColor != null ? selectedTintColor : view.defaultTextColor;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationManager.java
@@ -24,11 +24,6 @@ public class TabNavigationManager extends ViewGroupManager<TabNavigationView> {
         return "NVTabNavigation";
     }
 
-    @ReactProp(name = "bottomTabs")
-    public void setBottomTabs(TabNavigationView view, boolean bottomTabs) {
-        view.bottomTabs = bottomTabs;
-    }
-
     @ReactProp(name = "labelVisibilityMode", defaultInt = LABEL_VISIBILITY_AUTO)
     public void setLabelVisibilityMode (TabNavigationView view, int labelVisibilityMode) {
         view.setLabelVisibilityMode(labelVisibilityMode);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
@@ -15,7 +15,6 @@ import com.google.android.material.bottomnavigation.BottomNavigationItemView;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 
 public class TabNavigationView extends BottomNavigationView implements TabView {
-    boolean bottomTabs;
     final int defaultTextColor;
     int selectedTintColor;
     int unselectedTintColor;
@@ -43,10 +42,16 @@ public class TabNavigationView extends BottomNavigationView implements TabView {
     }
 
     void setTitles() {
-        getMenu().clear();
         TabBarView tabBar = getTabBar();
         for (int i = 0; tabBar != null && i < tabBar.tabFragments.size(); i++) {
-            getMenu().add(Menu.NONE, i, i, getTabBar().tabFragments.get(i).tabBarItem.styledTitle);
+            CharSequence title = getTabBar().tabFragments.get(i).tabBarItem.styledTitle;
+            if (getMenu().findItem(i) != null)
+                getMenu().findItem(i).setTitle(title);
+            else
+                getMenu().add(Menu.NONE, i, i, title);
+        }
+        for(int i = getMenu().size() - 1; i >= tabBar.tabFragments.size(); i--) {
+            getMenu().removeItem(i);
         }
     }
 
@@ -54,7 +59,7 @@ public class TabNavigationView extends BottomNavigationView implements TabView {
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
         TabBarView tabBar = getTabBar();
-        if (bottomTabs && tabBar != null) {
+        if (tabBar != null) {
             autoSelected = true;
             setSelectedItemId(tabBar.selectedTab);
             autoSelected = false;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationViewManager.java
@@ -40,11 +40,6 @@ public class TabNavigationViewManager extends ViewGroupManager<TabNavigationView
         return "NVTabNavigation";
     }
 
-    @ReactProp(name = "bottomTabs")
-    public void setBottomTabs(TabNavigationView view, boolean bottomTabs) {
-        view.bottomTabs = bottomTabs;
-    }
-
     @ReactProp(name = "labelVisibilityMode", defaultInt = LABEL_VISIBILITY_AUTO)
     public void setLabelVisibilityMode(TabNavigationView view, int labelVisibilityMode) {
         view.setLabelVisibilityMode(labelVisibilityMode);

--- a/NavigationReactNative/src/ios/NVSceneComponentView.mm
+++ b/NavigationReactNative/src/ios/NVSceneComponentView.mm
@@ -40,7 +40,6 @@ using namespace facebook::react;
     }
 }
 
-
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
     [self ensureViewController];

--- a/NavigationReactNative/src/ios/NVSceneComponentView.mm
+++ b/NavigationReactNative/src/ios/NVSceneComponentView.mm
@@ -17,6 +17,7 @@ using namespace facebook::react;
 @implementation NVSceneComponentView
 {
     BOOL _notifiedPeekable;
+    UIViewController *_oldViewController;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -28,9 +29,21 @@ using namespace facebook::react;
     return self;
 }
 
+- (void)ensureViewController
+{
+    if (!!_oldViewController) {
+        [_oldViewController willMoveToParentViewController:nil];
+        [_oldViewController.view removeFromSuperview];
+        [_oldViewController removeFromParentViewController];
+        _oldViewController.view = nil;
+        _oldViewController = nil;
+    }
+}
+
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
+    [self ensureViewController];
     const auto &newViewProps = *std::static_pointer_cast<NVSceneProps const>(props);
     _sceneKey = [[NSString alloc] initWithUTF8String: newViewProps.sceneKey.c_str()];
     _crumb = [NSNumber numberWithInt:newViewProps.crumb];
@@ -63,10 +76,7 @@ using namespace facebook::react;
 - (void)prepareForRecycle
 {
     [super prepareForRecycle];
-    [self.reactViewController willMoveToParentViewController:nil];
-    [self.reactViewController.view removeFromSuperview];
-    [self.reactViewController removeFromParentViewController];
-    self.reactViewController.view = nil;
+    _oldViewController = self.reactViewController;
     _notifiedPeekable = NO;
 }
 

--- a/NavigationReactNative/src/ios/NVSceneComponentView.mm
+++ b/NavigationReactNative/src/ios/NVSceneComponentView.mm
@@ -17,7 +17,6 @@ using namespace facebook::react;
 @implementation NVSceneComponentView
 {
     BOOL _notifiedPeekable;
-    UIViewController *_oldViewController;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -30,20 +29,8 @@ using namespace facebook::react;
 }
 
 
-- (void)ensureViewController
-{
-    if (!!_oldViewController) {
-        [_oldViewController willMoveToParentViewController:nil];
-        [_oldViewController.view removeFromSuperview];
-        [_oldViewController removeFromParentViewController];
-        _oldViewController.view = nil;
-        _oldViewController = nil;
-    }
-}
-
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-    [self ensureViewController];
     const auto &newViewProps = *std::static_pointer_cast<NVSceneProps const>(props);
     _sceneKey = [[NSString alloc] initWithUTF8String: newViewProps.sceneKey.c_str()];
     _crumb = [NSNumber numberWithInt:newViewProps.crumb];
@@ -76,7 +63,10 @@ using namespace facebook::react;
 - (void)prepareForRecycle
 {
     [super prepareForRecycle];
-    _oldViewController = self.reactViewController;
+    [self.reactViewController willMoveToParentViewController:nil];
+    [self.reactViewController.view removeFromSuperview];
+    [self.reactViewController removeFromParentViewController];
+    self.reactViewController.view = nil;
     _notifiedPeekable = NO;
 }
 

--- a/NavigationReactNative/src/ios/NVTabBarComponentView.mm
+++ b/NavigationReactNative/src/ios/NVTabBarComponentView.mm
@@ -226,6 +226,8 @@ using namespace facebook::react;
     NSMutableArray *controllers = [NSMutableArray arrayWithArray:[_tabBarController viewControllers]];
     [controllers insertObject:[(NVTabBarItemComponentView *) childComponentView navigationController] atIndex:index];
     [_tabBarController setViewControllers:controllers];
+    if (_selectedTab == controllers.count - 1)
+        _tabBarController.selectedIndex = _selectedTab;
     ((NVTabBarItemComponentView *) childComponentView).stackDidChangeBlock = ^(NVTabBarItemComponentView *tabBarItemView){
         NSMutableArray *controllers = [NSMutableArray arrayWithArray:[self->_tabBarController viewControllers]];
         [controllers insertObject:[tabBarItemView navigationController] atIndex: [self.reactSubviews indexOfObject:tabBarItemView]];

--- a/NavigationReactNative/src/ios/NVTabBarComponentView.mm
+++ b/NavigationReactNative/src/ios/NVTabBarComponentView.mm
@@ -108,6 +108,7 @@ using namespace facebook::react;
         [_tabBarController.tabBar setUnselectedItemTintColor: unselectedTintColor];
     }
     _mostRecentEventCount = newViewProps.mostRecentEventCount;
+    _nativeEventCount = MAX(_nativeEventCount, _mostRecentEventCount);
     NSInteger eventLag = _nativeEventCount - _mostRecentEventCount;
     BOOL tabChanged = eventLag == 0 && _selectedTab != newViewProps.selectedTab;
     if (tabChanged)

--- a/NavigationReactNative/src/ios/NVTabBarComponentView.mm
+++ b/NavigationReactNative/src/ios/NVTabBarComponentView.mm
@@ -27,6 +27,7 @@ using namespace facebook::react;
     NSInteger _selectedTab;
     NSInteger _nativeEventCount;
     bool _firstSceneReselected;
+    bool _jsUpdate;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -117,11 +118,15 @@ using namespace facebook::react;
         if (tabChanged) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 self->_tabBarController.selectedIndex = self->_selectedTab;
+                self->_jsUpdate = true;
                 [self selectTab];
+                self->_jsUpdate = false;
             });
         } else {
             _selectedTab = _tabBarController.selectedIndex;
+            _jsUpdate = true;
             [self selectTab];
+            _jsUpdate = false;
         }
     }
     _scrollsToTop = newViewProps.scrollsToTop;
@@ -194,14 +199,17 @@ using namespace facebook::react;
 
 -(void) selectTab
 {
-    _nativeEventCount++;
+    if (!_jsUpdate)
+        _nativeEventCount++;
     NVTabBarItemComponentView *tabBarItem = (NVTabBarItemComponentView *)self.reactSubviews[_selectedTab];
     if (_eventEmitter != nullptr) {
-        std::static_pointer_cast<NVTabBarEventEmitter const>(_eventEmitter)
-            ->onTabSelected(NVTabBarEventEmitter::OnTabSelected{
-                .tab = static_cast<int>(_selectedTab),
-                .eventCount = static_cast<int>(_nativeEventCount)
-            });
+        if (!_jsUpdate) {
+            std::static_pointer_cast<NVTabBarEventEmitter const>(_eventEmitter)
+                ->onTabSelected(NVTabBarEventEmitter::OnTabSelected{
+                    .tab = static_cast<int>(_selectedTab),
+                    .eventCount = static_cast<int>(_nativeEventCount)
+                });
+        }
         [tabBarItem onPress];
     }
 }

--- a/NavigationReactNative/src/ios/NVTabBarPagerComponentView.mm
+++ b/NavigationReactNative/src/ios/NVTabBarPagerComponentView.mm
@@ -136,7 +136,6 @@ using namespace facebook::react;
     UIViewController *viewController = [[UIViewController alloc] init];
     viewController.view = childComponentView;
     [_tabs insertObject:viewController atIndex:index];
-
 }
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index

--- a/NavigationReactNative/src/ios/NVTabBarPagerComponentView.mm
+++ b/NavigationReactNative/src/ios/NVTabBarPagerComponentView.mm
@@ -136,6 +136,8 @@ using namespace facebook::react;
     UIViewController *viewController = [[UIViewController alloc] init];
     viewController.view = childComponentView;
     [_tabs insertObject:viewController atIndex:index];
+    if (_selectedTab == _tabs.count - 1)
+        [self updateTab];
 }
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index

--- a/NavigationReactNative/src/ios/NVTabBarPagerComponentView.mm
+++ b/NavigationReactNative/src/ios/NVTabBarPagerComponentView.mm
@@ -52,6 +52,7 @@ using namespace facebook::react;
     [self ensurePageViewController];
     const auto &newViewProps = *std::static_pointer_cast<NVTabBarPagerProps const>(props);
     _mostRecentEventCount = newViewProps.mostRecentEventCount;
+    _nativeEventCount = MAX(_nativeEventCount, _mostRecentEventCount);
     NSInteger eventLag = _nativeEventCount - _mostRecentEventCount;
     NSInteger selectedTab = newViewProps.selectedTab;
     if (eventLag == 0 && _selectedTab != selectedTab) {

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.m
@@ -54,6 +54,7 @@
 
 - (void)didSetProps:(NSArray<NSString *> *)changedProps
 {
+    _nativeEventCount = MAX(_nativeEventCount, _mostRecentEventCount);
     NSInteger eventLag = _nativeEventCount - _mostRecentEventCount;
     if (eventLag == 0 && _tabs.count > _selectedTab) {
         [self setCurrentTab:_selectedTab];

--- a/NavigationReactNative/src/ios/NVTabBarPagerView.m
+++ b/NavigationReactNative/src/ios/NVTabBarPagerView.m
@@ -12,6 +12,7 @@
     NSMutableArray<UIViewController *> *_tabs;
     NSInteger _nativeEventCount;
     NSInteger _selectedIndex;
+    bool _jsUpdate;
 }
 
 - (id)init
@@ -57,7 +58,9 @@
     _nativeEventCount = MAX(_nativeEventCount, _mostRecentEventCount);
     NSInteger eventLag = _nativeEventCount - _mostRecentEventCount;
     if (eventLag == 0 && _tabs.count > _selectedTab) {
+        _jsUpdate = true;
         [self setCurrentTab:_selectedTab];
+        _jsUpdate = false;
     }
 }
 
@@ -80,11 +83,13 @@
 - (void)setCurrentTab:(NSInteger)index
 {
     if (index != _selectedIndex) {
-        _nativeEventCount++;
-        self.onTabSelected(@{
-            @"tab": @(index),
-            @"eventCount": @(_nativeEventCount),
-        });
+        if (!_jsUpdate) {
+            _nativeEventCount++;
+            self.onTabSelected(@{
+                @"tab": @(index),
+                @"eventCount": @(_nativeEventCount),
+            });
+        }
         NVTabBarItemView *tabBarItem = ((NVTabBarItemView *) _tabs[index].view);
         if (!!tabBarItem.onPress) {
             tabBarItem.onPress(nil);

--- a/NavigationReactNative/src/ios/NVTabBarView.m
+++ b/NavigationReactNative/src/ios/NVTabBarView.m
@@ -14,6 +14,7 @@
     NSInteger _selectedIndex;
     NSInteger _nativeEventCount;
     bool _firstSceneReselected;
+    bool _jsUpdate;
 }
 
 - (id)init
@@ -68,7 +69,9 @@
         } else {
             _selectedIndex = _tabBarController.selectedIndex;
         }
+        _jsUpdate = true;
         [self selectTab];
+        _jsUpdate = false;
     }
     if (@available(iOS 13.0, *)) {
         UITabBarAppearance *appearance = [UITabBarAppearance new];
@@ -181,12 +184,14 @@
 
 -(void) selectTab
 {
-    _nativeEventCount++;
+    if (!_jsUpdate) {
+        _nativeEventCount++;
+        self.onTabSelected(@{
+            @"tab": @(_selectedIndex),
+            @"eventCount": @(_nativeEventCount),
+        });
+    }
     NVTabBarItemView *tabBarItem = (NVTabBarItemView *)self.reactSubviews[_selectedIndex];
-    self.onTabSelected(@{
-        @"tab": @(_selectedIndex),
-        @"eventCount": @(_nativeEventCount),
-    });
     if (!!tabBarItem.onPress) {
         tabBarItem.onPress(nil);
     }

--- a/NavigationReactNative/src/ios/NVTabBarView.m
+++ b/NavigationReactNative/src/ios/NVTabBarView.m
@@ -52,6 +52,7 @@
 
 - (void)didSetProps:(NSArray<NSString *> *)changedProps
 {
+    _nativeEventCount = MAX(_nativeEventCount, _mostRecentEventCount);
     NSInteger eventLag = _nativeEventCount - _mostRecentEventCount;
     if (eventLag == 0) {
         _selectedIndex = _selectedTab;

--- a/NavigationReactNative/src/ios/NVTabBarView.m
+++ b/NavigationReactNative/src/ios/NVTabBarView.m
@@ -33,6 +33,8 @@
     NSMutableArray *controllers = [NSMutableArray arrayWithArray:[_tabBarController viewControllers]];
     [controllers insertObject:[(NVTabBarItemView *) subview navigationController] atIndex:atIndex];
     [_tabBarController setViewControllers:controllers];
+    if (_selectedTab == controllers.count - 1)
+        _tabBarController.selectedIndex = _selectedTab;
     ((NVTabBarItemView *) subview).stackDidChangeBlock = ^(NVTabBarItemView *tabBarItemView){
         NSMutableArray *controllers = [NSMutableArray arrayWithArray:[self->_tabBarController viewControllers]];
         [controllers replaceObjectAtIndex:[self.reactSubviews indexOfObject:tabBarItemView] withObject:[tabBarItemView navigationController]];


### PR DESCRIPTION
Although dynamically changing `primary` and `bottomTabs` is an unlikely app scenario, it probably happens a lot when building a scene. Don’t want to have to do a full reload when coding up a scene. Unless props can all be dynamically changed, can’t support hot reload.

Sure that dynamically adding, removing or replacing children worked once. Could’ve lost it when adding RTL on Android, freezing tabs or supporting Fabric.

There’s definitely Fabric problems with Suspense when changing children. React Native gets into an infinite loop where it keeps running the same mount state update. Worked around this by delaying the freeze on Fabric.

Added a `jsUpdate` check to avoid sending the `tabSelected` event back to React if it came from React in the first place. This seemed to prevent a Fabric/Suspense infinite loop. But it’s also just a good thing to do because React Native does something similar for its controlled props. Avoids infinite loop potential when changing the tab twice in quick succession from js.
