### PR TITLE
Matched platform spec to React Native docs (iOS Fabric)

### DIFF
--- a/build/npm/navigation-react-native/navigation-react-native.podspec
+++ b/build/npm/navigation-react-native/navigation-react-native.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |spec|
   spec.source_files = "ios/**/*.{h,m,mm}"
   spec.dependency "React-Core"
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
+    spec.platform   = :ios, "11.0"
     spec.source_files = "ios/**/*.{h,m,mm}", "cpp/react/**/*.{h,cpp}"
     spec.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
     spec.pod_target_xcconfig    = {


### PR DESCRIPTION
See [React Native fabric podspec docs](https://reactnative.dev/docs/next/the-new-architecture/pillars-turbomodules#ios-create-the-podspec-file)