### PR TITLE
Supported modal Bottom Sheet Component (Android)

### DIFF
--- a/NavigationReactNative/src/BottomSheet.tsx
+++ b/NavigationReactNative/src/BottomSheet.tsx
@@ -73,7 +73,7 @@ class BottomSheet extends React.Component<any, any> {
 } 
 
 var NVBottomSheet = global.nativeFabricUIManager ? require('./BottomSheetNativeComponent').default : requireNativeComponent('NVBottomSheet');
-var NVBottomSheetDialog = global.nativeFabricUIManager ? require('./BottomSheetNativeComponent').default : requireNativeComponent('NVBottomSheetDialog');
+var NVBottomSheetDialog = global.nativeFabricUIManager ? require('./BottomSheetDialogNativeComponent').default : requireNativeComponent('NVBottomSheetDialog');
 
 const styles = StyleSheet.create({
     bottomSheet: {

--- a/NavigationReactNative/src/BottomSheet.tsx
+++ b/NavigationReactNative/src/BottomSheet.tsx
@@ -63,7 +63,7 @@ class BottomSheet extends React.Component<any, any> {
                     expandedHeight != null ? { height: expandedHeight } : null,
                     expandedOffset != null ? { top: expandedOffset } : null,
                     expandedHeight == null && expandedOffset == null ? { top: 0 } : null,
-                    Platform.OS === 'ios' || modal ? { height: modal ? expandedHeight : undefined, top: undefined } : null, 
+                    Platform.OS === 'ios' || modal ? { height: undefined, top: undefined } : null, 
                 ]}
             >
                 {children}

--- a/NavigationReactNative/src/BottomSheet.tsx
+++ b/NavigationReactNative/src/BottomSheet.tsx
@@ -50,7 +50,7 @@ class BottomSheet extends React.Component<any, any> {
                 peekHeight={peekHeight}
                 expandedHeight={expandedHeight}
                 expandedOffset={expandedOffset}
-                fitToContents={expandedOffset == null}
+                fitToContents={expandedOffset == null && !halfExpandedRatio}
                 halfExpandedRatio={halfExpandedRatio}
                 hideable={hideable}
                 skipCollapsed={skipCollapsed}

--- a/NavigationReactNative/src/BottomSheet.tsx
+++ b/NavigationReactNative/src/BottomSheet.tsx
@@ -6,7 +6,7 @@ class BottomSheet extends React.Component<any, any> {
     private dragging = false;
     constructor(props) {
         super(props);
-        this.state = {selectedDetent: props.detent || props.defaultDetent, mostRecentEventCount: 0};
+        this.state = {selectedDetent: props.detent || props.defaultDetent, mostRecentEventCount: 0, dismissed: (props.detent || props.defaultDetent) === 'hidden'};
         this.ref = React.createRef<View>();
         this.onDetentChanged = this.onDetentChanged.bind(this);
     }
@@ -14,9 +14,9 @@ class BottomSheet extends React.Component<any, any> {
         draggable: true,
         defaultDetent: 'collapsed'
     }
-    static getDerivedStateFromProps({detent}, {selectedDetent}) {
+    static getDerivedStateFromProps({detent}, {selectedDetent, dismissed}) {
         if (detent != null && detent !== selectedDetent)
-            return {selectedDetent: detent};
+            return {selectedDetent: detent, dismissed: detent === 'hidden' && dismissed};
         return null;
     }
     onDetentChanged({nativeEvent}) {
@@ -43,6 +43,7 @@ class BottomSheet extends React.Component<any, any> {
         const { expandedHeight, expandedOffset, peekHeight, halfExpandedRatio, hideable, skipCollapsed, draggable, modal, children } = this.props
         const detents = (UIManager as any).getViewManagerConfig('NVBottomSheet').Constants?.Detent;
         const BottomSheetView = Platform.OS === 'ios' || !modal ? NVBottomSheet : NVBottomSheetDialog;
+        if (this.state.dismissed) return null;
         return (
             <BottomSheetView
                 ref={this.ref}
@@ -59,6 +60,7 @@ class BottomSheet extends React.Component<any, any> {
                 mostRecentEventCount={this.state.mostRecentEventCount}
                 onMoveShouldSetResponderCapture={() => this.dragging}
                 onDetentChanged={this.onDetentChanged}
+                onDismissed={() => this.setState({dismissed: true})}
                 style={[
                     styles.bottomSheet,
                     expandedHeight != null ? { height: expandedHeight } : null,

--- a/NavigationReactNative/src/BottomSheet.tsx
+++ b/NavigationReactNative/src/BottomSheet.tsx
@@ -64,7 +64,6 @@ class BottomSheet extends React.Component<any, any> {
                     expandedOffset != null ? { top: expandedOffset } : null,
                     expandedHeight == null && expandedOffset == null ? { top: 0 } : null,
                     Platform.OS === 'ios' || modal ? { height: undefined, top: undefined } : null, 
-                    { display: this.state.selectedDetent !== 'hidden' ? 'flex' : 'none' }, 
                 ]}
             >
                 {children}

--- a/NavigationReactNative/src/BottomSheet.tsx
+++ b/NavigationReactNative/src/BottomSheet.tsx
@@ -62,7 +62,9 @@ class BottomSheet extends React.Component<any, any> {
                 style={[
                     styles.bottomSheet,
                     expandedHeight != null ? { height: expandedHeight } : null,
-                    Platform.OS === 'ios' ? { height: undefined, top: undefined } : null, 
+                    expandedOffset != null ? { top: expandedOffset } : null,
+                    expandedHeight == null && expandedOffset == null ? { top: 0 } : null,
+                    Platform.OS === 'ios' || modal ? { height: undefined, top: undefined } : null, 
                     { display: this.state.selectedDetent !== 'hidden' ? 'flex' : 'none' }, 
                 ]}
             >

--- a/NavigationReactNative/src/BottomSheet.tsx
+++ b/NavigationReactNative/src/BottomSheet.tsx
@@ -2,12 +2,10 @@ import React from 'react';
 import { requireNativeComponent, Platform, UIManager, View, StyleSheet } from 'react-native';
 
 class BottomSheet extends React.Component<any, any> {
-    private ref: React.RefObject<View>;
     private dragging = false;
     constructor(props) {
         super(props);
         this.state = {selectedDetent: props.detent || props.defaultDetent, mostRecentEventCount: 0, dismissed: (props.detent || props.defaultDetent) === 'hidden'};
-        this.ref = React.createRef<View>();
         this.onDetentChanged = this.onDetentChanged.bind(this);
     }
     static defaultProps = {
@@ -46,7 +44,6 @@ class BottomSheet extends React.Component<any, any> {
         if (this.state.dismissed) return null;
         return (
             <BottomSheetView
-                ref={this.ref}
                 detent={Platform.OS === 'android' ? '' + detents[this.state.selectedDetent] : this.state.selectedDetent}
                 peekHeight={peekHeight}
                 expandedHeight={expandedHeight}

--- a/NavigationReactNative/src/BottomSheet.tsx
+++ b/NavigationReactNative/src/BottomSheet.tsx
@@ -62,7 +62,6 @@ class BottomSheet extends React.Component<any, any> {
                 style={[
                     styles.bottomSheet,
                     expandedHeight != null ? { height: expandedHeight } : null,
-                    expandedOffset != null ? { top: expandedOffset } : null,
                     Platform.OS === 'ios' ? { height: undefined, top: undefined } : null, 
                     { display: this.state.selectedDetent !== 'hidden' ? 'flex' : 'none' }, 
                 ]}

--- a/NavigationReactNative/src/BottomSheet.tsx
+++ b/NavigationReactNative/src/BottomSheet.tsx
@@ -40,10 +40,11 @@ class BottomSheet extends React.Component<any, any> {
     }
     render() {
         if (Platform.OS === 'ios' && +Platform.Version < 15) return null;
-        var { expandedHeight, expandedOffset, peekHeight, halfExpandedRatio, hideable, skipCollapsed, draggable, children } = this.props
+        const { expandedHeight, expandedOffset, peekHeight, halfExpandedRatio, hideable, skipCollapsed, draggable, modal, children } = this.props
         const detents = (UIManager as any).getViewManagerConfig('NVBottomSheet').Constants?.Detent;
+        const BottomSheetView = Platform.OS === 'ios' || !modal ? NVBottomSheet : NVBottomSheetDialog;
         return (
-            <NVBottomSheet
+            <BottomSheetView
                 ref={this.ref}
                 detent={Platform.OS === 'android' ? '' + detents[this.state.selectedDetent] : this.state.selectedDetent}
                 peekHeight={peekHeight}
@@ -68,12 +69,13 @@ class BottomSheet extends React.Component<any, any> {
                 ]}
             >
                 {children}
-            </NVBottomSheet>
+            </BottomSheetView>
         )
     }
 } 
 
 var NVBottomSheet = global.nativeFabricUIManager ? require('./BottomSheetNativeComponent').default : requireNativeComponent('NVBottomSheet');
+var NVBottomSheetDialog = global.nativeFabricUIManager ? require('./BottomSheetNativeComponent').default : requireNativeComponent('NVBottomSheetDialog');
 
 const styles = StyleSheet.create({
     bottomSheet: {

--- a/NavigationReactNative/src/BottomSheet.tsx
+++ b/NavigationReactNative/src/BottomSheet.tsx
@@ -63,7 +63,6 @@ class BottomSheet extends React.Component<any, any> {
                     styles.bottomSheet,
                     expandedHeight != null ? { height: expandedHeight } : null,
                     expandedOffset != null ? { top: expandedOffset } : null,
-                    expandedHeight == null && expandedOffset == null ? { top: 0 } : null,
                     Platform.OS === 'ios' ? { height: undefined, top: undefined } : null, 
                     { display: this.state.selectedDetent !== 'hidden' ? 'flex' : 'none' }, 
                 ]}

--- a/NavigationReactNative/src/BottomSheet.tsx
+++ b/NavigationReactNative/src/BottomSheet.tsx
@@ -48,7 +48,7 @@ class BottomSheet extends React.Component<any, any> {
                 peekHeight={peekHeight}
                 expandedHeight={expandedHeight}
                 expandedOffset={expandedOffset}
-                fitToContents={expandedOffset == null && !halfExpandedRatio}
+                fitToContents={expandedOffset == null && (!halfExpandedRatio || !!expandedHeight)}
                 halfExpandedRatio={halfExpandedRatio}
                 hideable={hideable}
                 skipCollapsed={skipCollapsed}
@@ -63,7 +63,7 @@ class BottomSheet extends React.Component<any, any> {
                     expandedHeight != null ? { height: expandedHeight } : null,
                     expandedOffset != null ? { top: expandedOffset } : null,
                     expandedHeight == null && expandedOffset == null ? { top: 0 } : null,
-                    Platform.OS === 'ios' || modal ? { height: undefined, top: undefined } : null, 
+                    Platform.OS === 'ios' || modal ? { height: modal ? expandedHeight : undefined, top: undefined } : null, 
                 ]}
             >
                 {children}

--- a/NavigationReactNative/src/BottomSheetDialogNativeComponent.js
+++ b/NavigationReactNative/src/BottomSheetDialogNativeComponent.js
@@ -25,6 +25,6 @@ type NativeProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<NativeProps>(
-   'NVBottomSheet',
+   'NVBottomSheetDialog',
    {interfaceOnly: true}
 ): HostComponent<NativeProps>);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
@@ -1,6 +1,7 @@
 package com.navigation.reactnative;
 
 import android.view.View;
+import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -11,7 +12,6 @@ import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
-import com.facebook.react.uimanager.events.EventDispatcher;
 
 import java.util.Map;
 
@@ -56,6 +56,14 @@ public class BottomSheetDialogManager extends ViewGroupManager<BottomSheetDialog
     @ReactProp(name = "fitToContents")
     public void setFitToContents(BottomSheetDialogView view, boolean fitToContents) {
         view.bottomSheetBehavior.setFitToContents(fitToContents);
+    }
+
+    @ReactProp(name = "height")
+    public void setHeight(BottomSheetDialogView view, double height) {
+        view.sheetView.setExpandedHeight(height != 0 ? (int) PixelUtil.toPixelFromDIP(height) : ViewGroup.LayoutParams.WRAP_CONTENT);
+        view.sheetView.requestLayout();
+        if (view.sheetView.getParent() != null)
+            view.sheetView.getParent().requestLayout();
     }
 
     @ReactProp(name = "halfExpandedRatio", defaultFloat = Float.MAX_VALUE)
@@ -117,7 +125,6 @@ public class BottomSheetDialogManager extends ViewGroupManager<BottomSheetDialog
     @Override
     protected void addEventEmitters(@NonNull ThemedReactContext reactContext, @NonNull BottomSheetDialogView view) {
         super.addEventEmitters(reactContext, view);
-        EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.getId());
-        view.sheetView.eventDispatcher = dispatcher;
+        view.sheetView.eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.getId());
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
@@ -1,5 +1,7 @@
 package com.navigation.reactnative;
 
+import static com.google.android.material.bottomsheet.BottomSheetBehavior.PEEK_HEIGHT_AUTO;
+
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -40,7 +42,7 @@ public class BottomSheetDialogManager extends ViewGroupManager<BottomSheetDialog
 
     @ReactProp(name = "peekHeight")
     public void setPeekHeight(BottomSheetDialogView view, int peekHeight) {
-        view.bottomSheetBehavior.setPeekHeight((int) PixelUtil.toPixelFromDIP(peekHeight), true);
+        view.bottomSheetBehavior.setPeekHeight(peekHeight != 0 ? (int) PixelUtil.toPixelFromDIP(peekHeight) : PEEK_HEIGHT_AUTO, true);
     }
 
     @ReactProp(name = "expandedOffset")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
@@ -27,6 +27,9 @@ public class BottomSheetDialogManager extends ViewGroupManager<BottomSheetDialog
         int offset = (int) PixelUtil.toPixelFromDIP(expandedOffset);
         view.getBehavior().setExpandedOffset(offset);
         view.sheetView.setExpandedOffset(offset);
+        view.sheetView.requestLayout();
+        if (view.sheetView.getParent() != null)
+            view.sheetView.getParent().requestLayout();
     }
 
     @ReactProp(name = "fitToContents")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
@@ -22,6 +22,21 @@ public class BottomSheetDialogManager extends ViewGroupManager<BottomSheetDialog
 
     @Override
     public void addView(BottomSheetDialogView parent, View child, int index) {
-        parent.sheet = child;
+        parent.sheetView.addView(child, index);
+    }
+
+    @Override
+    public void removeViewAt(BottomSheetDialogView parent, int index) {
+        parent.sheetView.removeViewAt(index);
+    }
+
+    @Override
+    public int getChildCount(BottomSheetDialogView parent) {
+        return parent.sheetView.getChildCount();
+    }
+
+    @Override
+    public View getChildAt(BottomSheetDialogView parent, int index) {
+        return parent.getChildAt(index);
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
@@ -27,7 +27,6 @@ public class BottomSheetDialogManager extends ViewGroupManager<BottomSheetDialog
         int offset = (int) PixelUtil.toPixelFromDIP(expandedOffset);
         view.getBehavior().setExpandedOffset(offset);
         view.sheetView.setExpandedOffset(offset);
-        view.requestLayout();
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
@@ -8,8 +8,10 @@ import androidx.annotation.Nullable;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.uimanager.events.EventDispatcher;
 
 import java.util.Map;
 
@@ -108,6 +110,14 @@ public class BottomSheetDialogManager extends ViewGroupManager<BottomSheetDialog
 
     @Override
     public View getChildAt(BottomSheetDialogView parent, int index) {
-        return parent.getChildAt(index);
+        return parent.sheetView.getChildAt(index);
+    }
+
+    @Override
+    protected void addEventEmitters(@NonNull ThemedReactContext reactContext, @NonNull BottomSheetDialogView view) {
+        super.addEventEmitters(reactContext, view);
+        EventDispatcher dispatcher =
+                UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.getId());
+        view.sheetView.eventDispatcher = dispatcher;
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
@@ -42,6 +42,27 @@ public class BottomSheetDialogManager extends ViewGroupManager<BottomSheetDialog
         view.getBehavior().setFitToContents(fitToContents);
     }
 
+    @ReactProp(name = "halfExpandedRatio", defaultFloat = Float.MAX_VALUE)
+    public void setHalfExpandedRatio(BottomSheetDialogView view, float halfExpandedRatio) {
+        view.getBehavior().setHalfExpandedRatio(halfExpandedRatio != Float.MAX_VALUE ? halfExpandedRatio : view.defaultHalfExpandedRatio);
+        view.requestLayout();
+    }
+
+    @ReactProp(name = "hideable")
+    public void setHideable(BottomSheetDialogView view, boolean hideable) {
+        view.getBehavior().setHideable(hideable);
+    }
+
+    @ReactProp(name = "skipCollapsed")
+    public void setSkipCollapsed(BottomSheetDialogView view, boolean skipCollapsed) {
+        view.getBehavior().setSkipCollapsed(skipCollapsed);
+    }
+
+    @ReactProp(name = "draggable")
+    public void setDraggable(BottomSheetDialogView view, boolean draggable) {
+        view.getBehavior().setDraggable(draggable);
+    }
+
     @Override
     public void addView(BottomSheetDialogView parent, View child, int index) {
         parent.sheetView.addView(child, index);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
@@ -22,6 +22,11 @@ public class BottomSheetDialogManager extends ViewGroupManager<BottomSheetDialog
         return new BottomSheetDialogView(themedReactContext);
     }
 
+    @ReactProp(name = "peekHeight")
+    public void setPeekHeight(BottomSheetDialogView view, int peekHeight) {
+        view.getBehavior().setPeekHeight((int) PixelUtil.toPixelFromDIP(peekHeight), true);
+    }
+
     @ReactProp(name = "expandedOffset")
     public void setExpandedOffset(BottomSheetDialogView view, int expandedOffset) {
         int offset = (int) PixelUtil.toPixelFromDIP(expandedOffset);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
@@ -26,6 +26,7 @@ public class BottomSheetDialogManager extends ViewGroupManager<BottomSheetDialog
     public void setExpandedOffset(BottomSheetDialogView view, int expandedOffset) {
         int offset = (int) PixelUtil.toPixelFromDIP(expandedOffset);
         view.getBehavior().setExpandedOffset(offset);
+        view.getBehavior().setFitToContents(offset == 0);
         view.sheetView.setExpandedOffset(offset);
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
@@ -90,6 +90,7 @@ public class BottomSheetDialogManager extends ViewGroupManager<BottomSheetDialog
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
             .put("topOnDetentChanged", MapBuilder.of("registrationName", "onDetentChanged"))
+            .put("topOnDismissed", MapBuilder.of("registrationName", "onDismissed"))
             .build();
     }
 
@@ -116,8 +117,7 @@ public class BottomSheetDialogManager extends ViewGroupManager<BottomSheetDialog
     @Override
     protected void addEventEmitters(@NonNull ThemedReactContext reactContext, @NonNull BottomSheetDialogView view) {
         super.addEventEmitters(reactContext, view);
-        EventDispatcher dispatcher =
-                UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.getId());
+        EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.getId());
         view.sheetView.eventDispatcher = dispatcher;
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
@@ -1,0 +1,27 @@
+package com.navigation.reactnative;
+
+import android.view.View;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewGroupManager;
+
+public class BottomSheetDialogManager extends ViewGroupManager<BottomSheetDialogView> {
+    @NonNull
+    @Override
+    public String getName() {
+        return "NVBottomSheetDialog";
+    }
+
+    @NonNull
+    @Override
+    protected BottomSheetDialogView createViewInstance(@NonNull ThemedReactContext themedReactContext) {
+        return new BottomSheetDialogView(themedReactContext);
+    }
+
+    @Override
+    public void addView(BottomSheetDialogView parent, View child, int index) {
+        parent.sheet = child;
+    }
+}

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
@@ -26,8 +26,12 @@ public class BottomSheetDialogManager extends ViewGroupManager<BottomSheetDialog
     public void setExpandedOffset(BottomSheetDialogView view, int expandedOffset) {
         int offset = (int) PixelUtil.toPixelFromDIP(expandedOffset);
         view.getBehavior().setExpandedOffset(offset);
-        view.getBehavior().setFitToContents(offset == 0);
         view.sheetView.setExpandedOffset(offset);
+    }
+
+    @ReactProp(name = "fitToContents")
+    public void setFitToContents(BottomSheetDialogView view, boolean fitToContents) {
+        view.getBehavior().setFitToContents(fitToContents);
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
@@ -4,8 +4,10 @@ import android.view.View;
 
 import androidx.annotation.NonNull;
 
+import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.annotations.ReactProp;
 
 public class BottomSheetDialogManager extends ViewGroupManager<BottomSheetDialogView> {
     @NonNull
@@ -18,6 +20,14 @@ public class BottomSheetDialogManager extends ViewGroupManager<BottomSheetDialog
     @Override
     protected BottomSheetDialogView createViewInstance(@NonNull ThemedReactContext themedReactContext) {
         return new BottomSheetDialogView(themedReactContext);
+    }
+
+    @ReactProp(name = "expandedOffset")
+    public void setExpandedOffset(BottomSheetDialogView view, int expandedOffset) {
+        int offset = (int) PixelUtil.toPixelFromDIP(expandedOffset);
+        view.getBehavior().setExpandedOffset(offset);
+        view.sheetView.setExpandedOffset(offset);
+        view.requestLayout();
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
@@ -3,11 +3,15 @@ package com.navigation.reactnative;
 import android.view.View;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
+import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
+
+import java.util.Map;
 
 public class BottomSheetDialogManager extends ViewGroupManager<BottomSheetDialogView> {
     @NonNull
@@ -20,6 +24,16 @@ public class BottomSheetDialogManager extends ViewGroupManager<BottomSheetDialog
     @Override
     protected BottomSheetDialogView createViewInstance(@NonNull ThemedReactContext themedReactContext) {
         return new BottomSheetDialogView(themedReactContext);
+    }
+
+    @ReactProp(name = "detent")
+    public void setDetent(BottomSheetDialogView view, String detent) {
+        view.pendingDetent = Integer.parseInt(detent);
+    }
+
+    @ReactProp(name = "mostRecentEventCount")
+    public void setMostRecentEventCount(BottomSheetDialogView view, int mostRecentEventCount) {
+        view.mostRecentEventCount = mostRecentEventCount;
     }
 
     @ReactProp(name = "peekHeight")
@@ -61,6 +75,20 @@ public class BottomSheetDialogManager extends ViewGroupManager<BottomSheetDialog
     @ReactProp(name = "draggable")
     public void setDraggable(BottomSheetDialogView view, boolean draggable) {
         view.getBehavior().setDraggable(draggable);
+    }
+
+    @Override
+    protected void onAfterUpdateTransaction(@NonNull BottomSheetDialogView view) {
+        super.onAfterUpdateTransaction(view);
+        view.onAfterUpdateTransaction();
+    }
+
+    @Nullable
+    @Override
+    public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
+        return MapBuilder.<String, Object>builder()
+            .put("topOnDetentChanged", MapBuilder.of("registrationName", "onDetentChanged"))
+            .build();
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
@@ -58,9 +58,9 @@ public class BottomSheetDialogManager extends ViewGroupManager<BottomSheetDialog
         view.bottomSheetBehavior.setFitToContents(fitToContents);
     }
 
-    @ReactProp(name = "height")
-    public void setHeight(BottomSheetDialogView view, double height) {
-        view.sheetView.setExpandedHeight(height != 0 ? (int) PixelUtil.toPixelFromDIP(height) : ViewGroup.LayoutParams.WRAP_CONTENT);
+    @ReactProp(name = "sheetHeight")
+    public void setSheetHeight(BottomSheetDialogView view, double sheetHeight) {
+        view.sheetView.setExpandedHeight(sheetHeight != 0 ? (int) PixelUtil.toPixelFromDIP(sheetHeight) : ViewGroup.LayoutParams.WRAP_CONTENT);
         view.sheetView.requestLayout();
         if (view.sheetView.getParent() != null)
             view.sheetView.getParent().requestLayout();

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
@@ -38,13 +38,13 @@ public class BottomSheetDialogManager extends ViewGroupManager<BottomSheetDialog
 
     @ReactProp(name = "peekHeight")
     public void setPeekHeight(BottomSheetDialogView view, int peekHeight) {
-        view.getBehavior().setPeekHeight((int) PixelUtil.toPixelFromDIP(peekHeight), true);
+        view.bottomSheetBehavior.setPeekHeight((int) PixelUtil.toPixelFromDIP(peekHeight), true);
     }
 
     @ReactProp(name = "expandedOffset")
     public void setExpandedOffset(BottomSheetDialogView view, int expandedOffset) {
         int offset = (int) PixelUtil.toPixelFromDIP(expandedOffset);
-        view.getBehavior().setExpandedOffset(offset);
+        view.bottomSheetBehavior.setExpandedOffset(offset);
         view.sheetView.setExpandedOffset(offset);
         view.sheetView.requestLayout();
         if (view.sheetView.getParent() != null)
@@ -53,28 +53,28 @@ public class BottomSheetDialogManager extends ViewGroupManager<BottomSheetDialog
 
     @ReactProp(name = "fitToContents")
     public void setFitToContents(BottomSheetDialogView view, boolean fitToContents) {
-        view.getBehavior().setFitToContents(fitToContents);
+        view.bottomSheetBehavior.setFitToContents(fitToContents);
     }
 
     @ReactProp(name = "halfExpandedRatio", defaultFloat = Float.MAX_VALUE)
     public void setHalfExpandedRatio(BottomSheetDialogView view, float halfExpandedRatio) {
-        view.getBehavior().setHalfExpandedRatio(halfExpandedRatio != Float.MAX_VALUE ? halfExpandedRatio : view.defaultHalfExpandedRatio);
+        view.bottomSheetBehavior.setHalfExpandedRatio(halfExpandedRatio != Float.MAX_VALUE ? halfExpandedRatio : view.defaultHalfExpandedRatio);
         view.requestLayout();
     }
 
     @ReactProp(name = "hideable")
     public void setHideable(BottomSheetDialogView view, boolean hideable) {
-        view.getBehavior().setHideable(hideable);
+        view.bottomSheetBehavior.setHideable(hideable);
     }
 
     @ReactProp(name = "skipCollapsed")
     public void setSkipCollapsed(BottomSheetDialogView view, boolean skipCollapsed) {
-        view.getBehavior().setSkipCollapsed(skipCollapsed);
+        view.bottomSheetBehavior.setSkipCollapsed(skipCollapsed);
     }
 
     @ReactProp(name = "draggable")
     public void setDraggable(BottomSheetDialogView view, boolean draggable) {
-        view.getBehavior().setDraggable(draggable);
+        view.bottomSheetBehavior.setDraggable(draggable);
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
@@ -132,7 +132,7 @@ public class BottomSheetDialogView extends ReactViewGroup {
                 dialogView.detent = BottomSheetBehavior.STATE_HIDDEN;
                 dialogView.dismissed = true;
                 ReactContext reactContext = (ReactContext) dialogView.getContext();
-                EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
+                EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, dialogView.getId());
                 eventDispatcher.dispatchEvent(new BottomSheetDialogView.DetentChangedEvent(dialogView.getId(), dialogView.detent, dialogView.nativeEventCount));
                 eventDispatcher.dispatchEvent(new BottomSheetDialogView.DismissedEvent(dialogView.getId()));
             }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
@@ -23,12 +23,12 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 
 public class BottomSheetDialogView extends ReactViewGroup {
     private final BottomSheetFragment bottomSheetFragment;
-    private final BottomSheetBehavior bottomSheetBehavior;
+    private final BottomSheetBehavior<FrameLayout> bottomSheetBehavior;
     final SheetView sheetView;
     public BottomSheetDialogView(Context context) {
         super(context);
         bottomSheetFragment = new BottomSheetFragment();
-        bottomSheetBehavior = new BottomSheetBehavior();
+        bottomSheetBehavior = new BottomSheetBehavior<>();
         bottomSheetBehavior.setFitToContents(false);
         sheetView = new SheetView(context);
     }
@@ -52,12 +52,12 @@ public class BottomSheetDialogView extends ReactViewGroup {
 
     public static class BottomSheetFragment extends BottomSheetDialogFragment {
         private SheetView sheetView;
-        private BottomSheetBehavior bottomSheetBehavior;
+        private BottomSheetBehavior<FrameLayout> bottomSheetBehavior;
 
         @Nullable
         @Override
         public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-            BottomSheetBehavior behavior = ((BottomSheetDialog) getDialog()).getBehavior();
+            BottomSheetBehavior<FrameLayout> behavior = ((BottomSheetDialog) getDialog()).getBehavior();
             behavior.setFitToContents(false);
             behavior.setExpandedOffset(bottomSheetBehavior.getExpandedOffset());
             return sheetView != null ? sheetView : new View(getContext());

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
@@ -66,7 +66,7 @@ public class BottomSheetDialogView extends ReactViewGroup {
             BottomSheetBehavior<FrameLayout> behavior = ((BottomSheetDialog) Objects.requireNonNull(getDialog())).getBehavior();
             behavior.setPeekHeight(bottomSheetBehavior.getPeekHeight());
             behavior.setExpandedOffset(bottomSheetBehavior.getExpandedOffset());
-            behavior.setFitToContents(bottomSheetBehavior.getExpandedOffset() == 0);
+            behavior.setFitToContents(bottomSheetBehavior.isFitToContents());
             behavior.setHalfExpandedRatio(bottomSheetBehavior.getHalfExpandedRatio());
             behavior.setHideable(bottomSheetBehavior.isHideable());
             behavior.setSkipCollapsed(bottomSheetBehavior.getSkipCollapsed());

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
@@ -164,16 +164,12 @@ public class BottomSheetDialogView extends ReactViewGroup {
         private int viewHeight;
         private int expandedOffset = 0;
         private final JSTouchDispatcher jsTouchDispatcher = new JSTouchDispatcher(this);
-        @Nullable private JSPointerDispatcher jsPointerDispatcher;
         EventDispatcher eventDispatcher;
         private StateWrapper stateWrapper = null;
 
         public SheetView(Context context) {
             super(context);
             setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT));
-            if (ReactFeatureFlags.dispatchPointerEvents) {
-                jsPointerDispatcher = new JSPointerDispatcher(this);
-            }
         }
 
         public void setExpandedOffset(int expandedOffset) {
@@ -254,44 +250,19 @@ public class BottomSheetDialogView extends ReactViewGroup {
         @Override
         public boolean onInterceptTouchEvent(MotionEvent event) {
             jsTouchDispatcher.handleTouchEvent(event, eventDispatcher);
-            if (jsPointerDispatcher != null) {
-                jsPointerDispatcher.handleMotionEvent(event, eventDispatcher, true);
-            }
             return super.onInterceptTouchEvent(event);
         }
 
         @Override
         public boolean onTouchEvent(MotionEvent event) {
             jsTouchDispatcher.handleTouchEvent(event, eventDispatcher);
-            if (jsPointerDispatcher != null) {
-                jsPointerDispatcher.handleMotionEvent(event, eventDispatcher, false);
-            }
             super.onTouchEvent(event);
             return true;
         }
 
         @Override
-        public boolean onInterceptHoverEvent(MotionEvent event) {
-            if (jsPointerDispatcher != null) {
-                jsPointerDispatcher.handleMotionEvent(event, eventDispatcher, true);
-            }
-            return super.onHoverEvent(event);
-        }
-
-        @Override
-        public boolean onHoverEvent(MotionEvent event) {
-            if (jsPointerDispatcher != null) {
-                jsPointerDispatcher.handleMotionEvent(event, eventDispatcher, false);
-            }
-            return super.onHoverEvent(event);
-        }
-
-        @Override
         public void onChildStartedNativeGesture(View childView, MotionEvent ev) {
             jsTouchDispatcher.onChildStartedNativeGesture(ev, eventDispatcher);
-            if (jsPointerDispatcher != null) {
-                jsPointerDispatcher.onChildStartedNativeGesture(childView, ev, eventDispatcher);
-            }
         }
 
         @Override
@@ -302,9 +273,6 @@ public class BottomSheetDialogView extends ReactViewGroup {
         @Override
         public void onChildEndedNativeGesture(View childView, MotionEvent ev) {
             jsTouchDispatcher.onChildEndedNativeGesture(ev, eventDispatcher);
-            if (jsPointerDispatcher != null) {
-                jsPointerDispatcher.onChildEndedNativeGesture();
-            }
         }
 
         @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
@@ -58,7 +58,7 @@ public class BottomSheetDialogView extends ReactViewGroup {
         @Override
         public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
             BottomSheetBehavior<FrameLayout> behavior = ((BottomSheetDialog) getDialog()).getBehavior();
-            behavior.setFitToContents(false);
+            behavior.setFitToContents(bottomSheetBehavior.getExpandedOffset() == 0);
             behavior.setExpandedOffset(bottomSheetBehavior.getExpandedOffset());
             return sheetView != null ? sheetView : new View(getContext());
         }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
@@ -78,7 +78,7 @@ public class BottomSheetDialogView extends ReactViewGroup {
     @Override
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
-        bottomSheetFragment.dismiss();
+        if (!dismissed) bottomSheetFragment.dismissAllowingStateLoss();
     }
 
     public static class BottomSheetFragment extends BottomSheetDialogFragment {
@@ -119,15 +119,23 @@ public class BottomSheetDialogView extends ReactViewGroup {
         }
 
         @Override
+        public void onResume() {
+            super.onResume();
+            if (dialogView == null) this.dismissAllowingStateLoss();
+        }
+
+        @Override
         public void onDismiss(@NonNull DialogInterface dialog) {
             super.onDismiss(dialog);
-            dialogView.nativeEventCount++;
-            dialogView.detent = BottomSheetBehavior.STATE_HIDDEN;
-            dialogView.dismissed = true;
-            ReactContext reactContext = (ReactContext) dialogView.getContext();
-            EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
-            eventDispatcher.dispatchEvent(new BottomSheetDialogView.DetentChangedEvent(dialogView.getId(), dialogView.detent, dialogView.nativeEventCount));
-            eventDispatcher.dispatchEvent(new BottomSheetDialogView.DismissedEvent(dialogView.getId()));
+            if (dialogView != null) {
+                dialogView.nativeEventCount++;
+                dialogView.detent = BottomSheetBehavior.STATE_HIDDEN;
+                dialogView.dismissed = true;
+                ReactContext reactContext = (ReactContext) dialogView.getContext();
+                EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
+                eventDispatcher.dispatchEvent(new BottomSheetDialogView.DetentChangedEvent(dialogView.getId(), dialogView.detent, dialogView.nativeEventCount));
+                eventDispatcher.dispatchEvent(new BottomSheetDialogView.DismissedEvent(dialogView.getId()));
+            }
         }
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
@@ -1,5 +1,6 @@
 package com.navigation.reactnative;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
@@ -27,12 +28,14 @@ public class BottomSheetDialogView extends ReactViewGroup {
     private final BottomSheetFragment bottomSheetFragment;
     private final BottomSheetBehavior<FrameLayout> bottomSheetBehavior;
     final SheetView sheetView;
+    float defaultHalfExpandedRatio;
     public BottomSheetDialogView(Context context) {
         super(context);
         bottomSheetFragment = new BottomSheetFragment();
         bottomSheetBehavior = new BottomSheetBehavior<>();
         bottomSheetBehavior.setFitToContents(false);
         sheetView = new SheetView(context);
+        defaultHalfExpandedRatio = bottomSheetBehavior.getHalfExpandedRatio();
     }
 
     protected BottomSheetBehavior<FrameLayout> getBehavior() {
@@ -56,6 +59,7 @@ public class BottomSheetDialogView extends ReactViewGroup {
         private SheetView sheetView;
         private BottomSheetBehavior<FrameLayout> bottomSheetBehavior;
 
+        @SuppressLint("Range")
         @Nullable
         @Override
         public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
@@ -63,6 +67,10 @@ public class BottomSheetDialogView extends ReactViewGroup {
             behavior.setPeekHeight(bottomSheetBehavior.getPeekHeight());
             behavior.setExpandedOffset(bottomSheetBehavior.getExpandedOffset());
             behavior.setFitToContents(bottomSheetBehavior.getExpandedOffset() == 0);
+            behavior.setHalfExpandedRatio(bottomSheetBehavior.getHalfExpandedRatio());
+            behavior.setHideable(bottomSheetBehavior.isHideable());
+            behavior.setSkipCollapsed(bottomSheetBehavior.getSkipCollapsed());
+            behavior.setDraggable(bottomSheetBehavior.isDraggable());
             return sheetView != null ? sheetView : new View(getContext());
         }
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
@@ -135,6 +135,7 @@ public class BottomSheetDialogView extends ReactViewGroup {
 
         public SheetView(Context context) {
             super(context);
+            setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT));
             if (ReactFeatureFlags.dispatchPointerEvents) {
                 jsPointerDispatcher = new JSPointerDispatcher(this);
             }
@@ -142,6 +143,11 @@ public class BottomSheetDialogView extends ReactViewGroup {
 
         public void setExpandedOffset(int expandedOffset) {
             this.expandedOffset = expandedOffset;
+            updateFirstChildView();
+        }
+
+        public void setExpandedHeight(int expandedHeight) {
+            getLayoutParams().height = expandedHeight;
             updateFirstChildView();
         }
 
@@ -167,7 +173,7 @@ public class BottomSheetDialogView extends ReactViewGroup {
                             if (uiManager == null) {
                                 return;
                             }
-                            uiManager.updateNodeSize(viewTag, viewWidth, viewHeight - expandedOffset);
+                            uiManager.updateNodeSize(viewTag, viewWidth, getLayoutParams().height > 0 ? getLayoutParams().height : viewHeight - expandedOffset);
                         }
                     });
             }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
@@ -117,6 +117,7 @@ public class BottomSheetDialogView extends ReactViewGroup {
             ReactContext reactContext = (ReactContext) dialogView.getContext();
             EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
             eventDispatcher.dispatchEvent(new BottomSheetDialogView.DetentChangedEvent(dialogView.getId(), dialogView.detent, dialogView.nativeEventCount));
+            eventDispatcher.dispatchEvent(new BottomSheetDialogView.DismissedEvent(dialogView.getId()));
         }
     }
 
@@ -247,7 +248,7 @@ public class BottomSheetDialogView extends ReactViewGroup {
         }
     }
 
-    static class DetentChangedEvent extends Event<BottomSheetView.DetentChangedEvent> {
+    static class DetentChangedEvent extends Event<BottomSheetDialogView.DetentChangedEvent> {
         private final int detent;
         private final int eventCount;
 
@@ -268,6 +269,22 @@ public class BottomSheetDialogView extends ReactViewGroup {
             event.putInt("detent", this.detent);
             event.putInt("eventCount", this.eventCount);
             rctEventEmitter.receiveEvent(getViewTag(), getEventName(), event);
+        }
+    }
+
+    static class DismissedEvent extends Event<BottomSheetDialogView.DismissedEvent> {
+        public DismissedEvent(int viewId) {
+            super(viewId);
+        }
+
+        @Override
+        public String getEventName() {
+            return "topOnDismissed";
+        }
+
+        @Override
+        public void dispatch(RCTEventEmitter rctEventEmitter) {
+            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), Arguments.createMap());
         }
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
@@ -1,0 +1,52 @@
+package com.navigation.reactnative;
+
+import android.app.Activity;
+import android.content.Context;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.views.view.ReactViewGroup;
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import com.google.android.material.bottomsheet.BottomSheetDialog;
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
+
+public class BottomSheetDialogView extends ReactViewGroup {
+    private BottomSheetFragment bottomSheetFragment;
+    View sheet;
+    public BottomSheetDialogView(Context context) {
+        super(context);
+        bottomSheetFragment = new BottomSheetFragment();
+    }
+
+    protected BottomSheetBehavior<FrameLayout> getBehavior() {
+        return ((BottomSheetDialog) bottomSheetFragment.getDialog()).getBehavior();
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        Activity currentActivity = ((ThemedReactContext) getContext()).getCurrentActivity();
+        FragmentManager fragmentManager = ((FragmentActivity) currentActivity).getSupportFragmentManager();
+        bottomSheetFragment.sheet = sheet;
+        bottomSheetFragment.show(fragmentManager, "BottomSheetDialog");
+    }
+
+    public static class BottomSheetFragment extends BottomSheetDialogFragment {
+        private View sheet;
+
+        @Nullable
+        @Override
+        public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+            return sheet != null ? sheet : new View(getContext());
+        }
+    }
+}

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
@@ -126,7 +126,6 @@ public class BottomSheetDialogView extends ReactViewGroup {
 
     static class SheetView extends ReactViewGroup implements RootView
     {
-        private boolean hasAdjustedSize = false;
         private int viewWidth;
         private int viewHeight;
         private int expandedOffset = 0;
@@ -156,7 +155,6 @@ public class BottomSheetDialogView extends ReactViewGroup {
 
         private void updateFirstChildView() {
             if (getChildCount() > 0) {
-                hasAdjustedSize = false;
                 final int viewTag = getChildAt(0).getId();
                 ThemedReactContext reactContext = (ThemedReactContext) getContext();
                 reactContext.runOnNativeModulesQueueThread(
@@ -172,17 +170,13 @@ public class BottomSheetDialogView extends ReactViewGroup {
                             uiManager.updateNodeSize(viewTag, viewWidth, viewHeight - expandedOffset);
                         }
                     });
-            } else {
-                hasAdjustedSize = true;
             }
         }
 
         @Override
         public void addView(View child, int index, LayoutParams params) {
             super.addView(child, index, params);
-            if (hasAdjustedSize) {
-                updateFirstChildView();
-            }
+            updateFirstChildView();
         }
 
         @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
@@ -204,7 +204,7 @@ public class BottomSheetDialogView extends ReactViewGroup {
         public boolean onInterceptTouchEvent(MotionEvent event) {
             jsTouchDispatcher.handleTouchEvent(event, eventDispatcher);
             if (jsPointerDispatcher != null) {
-                jsPointerDispatcher.handleMotionEvent(event, eventDispatcher);
+                jsPointerDispatcher.handleMotionEvent(event, eventDispatcher, true);
             }
             return super.onInterceptTouchEvent(event);
         }
@@ -213,7 +213,7 @@ public class BottomSheetDialogView extends ReactViewGroup {
         public boolean onTouchEvent(MotionEvent event) {
             jsTouchDispatcher.handleTouchEvent(event, eventDispatcher);
             if (jsPointerDispatcher != null) {
-                jsPointerDispatcher.handleMotionEvent(event, eventDispatcher);
+                jsPointerDispatcher.handleMotionEvent(event, eventDispatcher, false);
             }
             super.onTouchEvent(event);
             return true;
@@ -222,7 +222,7 @@ public class BottomSheetDialogView extends ReactViewGroup {
         @Override
         public boolean onInterceptHoverEvent(MotionEvent event) {
             if (jsPointerDispatcher != null) {
-                jsPointerDispatcher.handleMotionEvent(event, eventDispatcher);
+                jsPointerDispatcher.handleMotionEvent(event, eventDispatcher, true);
             }
             return super.onHoverEvent(event);
         }
@@ -230,7 +230,7 @@ public class BottomSheetDialogView extends ReactViewGroup {
         @Override
         public boolean onHoverEvent(MotionEvent event) {
             if (jsPointerDispatcher != null) {
-                jsPointerDispatcher.handleMotionEvent(event, eventDispatcher);
+                jsPointerDispatcher.handleMotionEvent(event, eventDispatcher, false);
             }
             return super.onHoverEvent(event);
         }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
@@ -50,6 +50,7 @@ public class BottomSheetDialogView extends ReactViewGroup {
         super(context);
         bottomSheetFragment = new BottomSheetFragment();
         bottomSheetBehavior = new BottomSheetBehavior<>();
+        bottomSheetBehavior.setPeekHeight(BottomSheetBehavior.PEEK_HEIGHT_AUTO);
         bottomSheetFragment.dialogView = this;
         bottomSheetBehavior.setFitToContents(false);
         sheetView = new SheetView(context);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
@@ -23,8 +23,6 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
-import com.facebook.react.config.ReactFeatureFlags;
-import com.facebook.react.uimanager.JSPointerDispatcher;
 import com.facebook.react.uimanager.JSTouchDispatcher;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.RootView;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
@@ -60,8 +60,9 @@ public class BottomSheetDialogView extends ReactViewGroup {
         @Override
         public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
             BottomSheetBehavior<FrameLayout> behavior = ((BottomSheetDialog) Objects.requireNonNull(getDialog())).getBehavior();
-            behavior.setFitToContents(bottomSheetBehavior.getExpandedOffset() == 0);
+            behavior.setPeekHeight(bottomSheetBehavior.getPeekHeight());
             behavior.setExpandedOffset(bottomSheetBehavior.getExpandedOffset());
+            behavior.setFitToContents(bottomSheetBehavior.getExpandedOffset() == 0);
             return sheetView != null ? sheetView : new View(getContext());
         }
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
@@ -32,7 +32,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 
 public class BottomSheetDialogView extends ReactViewGroup {
     private final BottomSheetFragment bottomSheetFragment;
-    private final BottomSheetBehavior<FrameLayout> bottomSheetBehavior;
+    BottomSheetBehavior<FrameLayout> bottomSheetBehavior;
     final SheetView sheetView;
     float defaultHalfExpandedRatio;
     int pendingDetent;
@@ -49,13 +49,6 @@ public class BottomSheetDialogView extends ReactViewGroup {
         defaultHalfExpandedRatio = bottomSheetBehavior.getHalfExpandedRatio();
     }
 
-    protected BottomSheetBehavior<FrameLayout> getBehavior() {
-        if (bottomSheetFragment.getDialog() != null)
-            return ((BottomSheetDialog) bottomSheetFragment.getDialog()).getBehavior();
-        else
-            return bottomSheetBehavior;
-    }
-
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
@@ -70,8 +63,8 @@ public class BottomSheetDialogView extends ReactViewGroup {
         if (eventLag == 0) {
             detent = pendingDetent;
         }
-        if (getBehavior().getState() != detent)
-            getBehavior().setState(detent);
+        if (bottomSheetBehavior.getState() != detent)
+            bottomSheetBehavior.setState(detent);
     }
 
     public static class BottomSheetFragment extends BottomSheetDialogFragment {
@@ -106,6 +99,7 @@ public class BottomSheetDialogView extends ReactViewGroup {
                     }
                 };
                 behavior.addBottomSheetCallback(bottomSheetCallback);
+                dialogView.bottomSheetBehavior = behavior;
             }
             return dialogView.sheetView != null ? dialogView.sheetView : new View(getContext());
         }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
@@ -21,6 +21,8 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.bottomsheet.BottomSheetDialog;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 
+import java.util.Objects;
+
 public class BottomSheetDialogView extends ReactViewGroup {
     private final BottomSheetFragment bottomSheetFragment;
     private final BottomSheetBehavior<FrameLayout> bottomSheetBehavior;
@@ -44,7 +46,7 @@ public class BottomSheetDialogView extends ReactViewGroup {
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
         Activity currentActivity = ((ThemedReactContext) getContext()).getCurrentActivity();
-        FragmentManager fragmentManager = ((FragmentActivity) currentActivity).getSupportFragmentManager();
+        FragmentManager fragmentManager = ((FragmentActivity) Objects.requireNonNull(currentActivity)).getSupportFragmentManager();
         bottomSheetFragment.sheetView = sheetView;
         bottomSheetFragment.bottomSheetBehavior = bottomSheetBehavior;
         bottomSheetFragment.show(fragmentManager, "BottomSheetDialog");
@@ -57,7 +59,7 @@ public class BottomSheetDialogView extends ReactViewGroup {
         @Nullable
         @Override
         public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-            BottomSheetBehavior<FrameLayout> behavior = ((BottomSheetDialog) getDialog()).getBehavior();
+            BottomSheetBehavior<FrameLayout> behavior = ((BottomSheetDialog) Objects.requireNonNull(getDialog())).getBehavior();
             behavior.setFitToContents(bottomSheetBehavior.getExpandedOffset() == 0);
             behavior.setExpandedOffset(bottomSheetBehavior.getExpandedOffset());
             return sheetView != null ? sheetView : new View(getContext());

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
@@ -83,7 +83,7 @@ public class BottomSheetDialogView extends ReactViewGroup {
         @Nullable
         @Override
         public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-            if (bottomSheetCallback == null) {
+            if (bottomSheetCallback == null && dialogView != null) {
                 BottomSheetBehavior<FrameLayout> behavior = ((BottomSheetDialog) getDialog()).getBehavior();
                 behavior.setPeekHeight(dialogView.bottomSheetBehavior.getPeekHeight());
                 behavior.setExpandedOffset(dialogView.bottomSheetBehavior.getExpandedOffset());
@@ -109,7 +109,7 @@ public class BottomSheetDialogView extends ReactViewGroup {
                 behavior.addBottomSheetCallback(bottomSheetCallback);
                 dialogView.bottomSheetBehavior = behavior;
             }
-            return dialogView.sheetView != null ? dialogView.sheetView : new View(getContext());
+            return dialogView != null ? dialogView.sheetView : new View(getContext());
         }
 
         @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
@@ -75,6 +75,12 @@ public class BottomSheetDialogView extends ReactViewGroup {
         }
     }
 
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        bottomSheetFragment.dismiss();
+    }
+
     public static class BottomSheetFragment extends BottomSheetDialogFragment {
         private BottomSheetDialogView dialogView;
         BottomSheetBehavior.BottomSheetCallback bottomSheetCallback;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogViewManager.java
@@ -11,6 +11,7 @@ import androidx.annotation.Nullable;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.ViewManagerDelegate;
 import com.facebook.react.viewmanagers.NVBottomSheetDialogManagerDelegate;
@@ -140,5 +141,11 @@ public class BottomSheetDialogViewManager extends ViewGroupManager<BottomSheetDi
     @Override
     public View getChildAt(BottomSheetDialogView parent, int index) {
         return parent.sheetView.getChildAt(index);
+    }
+
+    @Override
+    protected void addEventEmitters(@NonNull ThemedReactContext reactContext, @NonNull BottomSheetDialogView view) {
+        super.addEventEmitters(reactContext, view);
+        view.sheetView.eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.getId());
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogViewManager.java
@@ -1,0 +1,91 @@
+package com.navigation.reactnative;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.ViewManagerDelegate;
+import com.facebook.react.viewmanagers.NVBottomSheetDialogManagerDelegate;
+import com.facebook.react.viewmanagers.NVBottomSheetDialogManagerInterface;
+
+public class BottomSheetDialogViewManager extends ViewGroupManager<BottomSheetDialogView> implements NVBottomSheetDialogManagerInterface<BottomSheetDialogView> {
+    private final ViewManagerDelegate<BottomSheetDialogView> delegate;
+
+    public BottomSheetDialogViewManager() {
+        delegate = new NVBottomSheetDialogManagerDelegate<>(this);
+    }
+
+    @Nullable
+    @Override
+    public ViewManagerDelegate<BottomSheetDialogView> getDelegate() {
+        return delegate;
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "NVBottomSheetDialog";
+    }
+
+    @NonNull
+    @Override
+    protected BottomSheetDialogView createViewInstance(@NonNull ThemedReactContext themedReactContext) {
+        return new BottomSheetDialogView(themedReactContext);
+    }
+
+    @Override
+    public void setDetent(BottomSheetDialogView view, @Nullable String value) {
+
+    }
+
+    @Override
+    public void setMostRecentEventCount(BottomSheetDialogView view, int value) {
+
+    }
+
+    @Override
+    public void setPeekHeight(BottomSheetDialogView view, int value) {
+
+    }
+
+    @Override
+    public void setExpandedHeight(BottomSheetDialogView view, int value) {
+
+    }
+
+    @Override
+    public void setExpandedOffset(BottomSheetDialogView view, int value) {
+
+    }
+
+    @Override
+    public void setFitToContents(BottomSheetDialogView view, boolean value) {
+
+    }
+
+    @Override
+    public void setHalfExpandedRatio(BottomSheetDialogView view, float value) {
+
+    }
+
+    @Override
+    public void setHideable(BottomSheetDialogView view, boolean value) {
+
+    }
+
+    @Override
+    public void setSkipCollapsed(BottomSheetDialogView view, boolean value) {
+
+    }
+
+    @Override
+    public void setDraggable(BottomSheetDialogView view, boolean value) {
+
+    }
+
+    @Override
+    public void setSheetHeight(BottomSheetDialogView view, double value) {
+
+    }
+}

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogViewManager.java
@@ -16,6 +16,7 @@ import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.ViewManagerDelegate;
+import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.viewmanagers.NVBottomSheetDialogManagerDelegate;
 import com.facebook.react.viewmanagers.NVBottomSheetDialogManagerInterface;
 
@@ -46,17 +47,17 @@ public class BottomSheetDialogViewManager extends ViewGroupManager<BottomSheetDi
         return new BottomSheetDialogView(themedReactContext);
     }
 
-    @Override
+    @ReactProp(name = "detent")
     public void setDetent(BottomSheetDialogView view, @Nullable String detent) {
         view.pendingDetent = Integer.parseInt(detent);
     }
 
-    @Override
+    @ReactProp(name = "mostRecentEventCount")
     public void setMostRecentEventCount(BottomSheetDialogView view, int mostRecentEventCount) {
         view.mostRecentEventCount = mostRecentEventCount;
     }
 
-    @Override
+    @ReactProp(name = "peekHeight")
     public void setPeekHeight(BottomSheetDialogView view, int peekHeight) {
         view.bottomSheetBehavior.setPeekHeight(peekHeight != 0 ? (int) PixelUtil.toPixelFromDIP(peekHeight) : PEEK_HEIGHT_AUTO, true);
     }
@@ -66,7 +67,7 @@ public class BottomSheetDialogViewManager extends ViewGroupManager<BottomSheetDi
 
     }
 
-    @Override
+    @ReactProp(name = "expandedOffset")
     public void setExpandedOffset(BottomSheetDialogView view, int expandedOffset) {
         int offset = (int) PixelUtil.toPixelFromDIP(expandedOffset);
         view.bottomSheetBehavior.setExpandedOffset(offset);
@@ -76,33 +77,33 @@ public class BottomSheetDialogViewManager extends ViewGroupManager<BottomSheetDi
             view.sheetView.getParent().requestLayout();
     }
 
-    @Override
+    @ReactProp(name = "fitToContents")
     public void setFitToContents(BottomSheetDialogView view, boolean fitToContents) {
         view.bottomSheetBehavior.setFitToContents(fitToContents);
     }
 
-    @Override
+    @ReactProp(name = "halfExpandedRatio")
     public void setHalfExpandedRatio(BottomSheetDialogView view, float halfExpandedRatio) {
         view.bottomSheetBehavior.setHalfExpandedRatio(halfExpandedRatio != -1 ? halfExpandedRatio : view.defaultHalfExpandedRatio);
         view.requestLayout();
     }
 
-    @Override
+    @ReactProp(name = "hideable")
     public void setHideable(BottomSheetDialogView view, boolean hideable) {
         view.bottomSheetBehavior.setHideable(hideable);
     }
 
-    @Override
+    @ReactProp(name = "skipCollapsed")
     public void setSkipCollapsed(BottomSheetDialogView view, boolean skipCollapsed) {
         view.bottomSheetBehavior.setSkipCollapsed(skipCollapsed);
     }
 
-    @Override
+    @ReactProp(name = "draggable")
     public void setDraggable(BottomSheetDialogView view, boolean draggable) {
         view.bottomSheetBehavior.setDraggable(draggable);
     }
 
-    @Override
+    @ReactProp(name = "sheetHeight")
     public void setSheetHeight(BottomSheetDialogView view, double sheetHeight) {
         view.sheetView.setExpandedHeight(sheetHeight != 0 ? (int) PixelUtil.toPixelFromDIP(sheetHeight) : ViewGroup.LayoutParams.WRAP_CONTENT);
         view.sheetView.requestLayout();

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogViewManager.java
@@ -10,6 +10,8 @@ import androidx.annotation.Nullable;
 
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.PixelUtil;
+import com.facebook.react.uimanager.ReactStylesDiffMap;
+import com.facebook.react.uimanager.StateWrapper;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.ViewGroupManager;
@@ -147,5 +149,12 @@ public class BottomSheetDialogViewManager extends ViewGroupManager<BottomSheetDi
     protected void addEventEmitters(@NonNull ThemedReactContext reactContext, @NonNull BottomSheetDialogView view) {
         super.addEventEmitters(reactContext, view);
         view.sheetView.eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.getId());
+    }
+
+    @Nullable
+    @Override
+    public Object updateState(@NonNull BottomSheetDialogView view, ReactStylesDiffMap props, StateWrapper stateWrapper) {
+        view.setStateWrapper(stateWrapper);
+        return null;
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogViewManager.java
@@ -1,13 +1,22 @@
 package com.navigation.reactnative;
 
+import static com.google.android.material.bottomsheet.BottomSheetBehavior.PEEK_HEIGHT_AUTO;
+
+import android.view.View;
+import android.view.ViewGroup;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.facebook.react.common.MapBuilder;
+import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.ViewManagerDelegate;
 import com.facebook.react.viewmanagers.NVBottomSheetDialogManagerDelegate;
 import com.facebook.react.viewmanagers.NVBottomSheetDialogManagerInterface;
+
+import java.util.Map;
 
 public class BottomSheetDialogViewManager extends ViewGroupManager<BottomSheetDialogView> implements NVBottomSheetDialogManagerInterface<BottomSheetDialogView> {
     private final ViewManagerDelegate<BottomSheetDialogView> delegate;
@@ -35,18 +44,18 @@ public class BottomSheetDialogViewManager extends ViewGroupManager<BottomSheetDi
     }
 
     @Override
-    public void setDetent(BottomSheetDialogView view, @Nullable String value) {
-
+    public void setDetent(BottomSheetDialogView view, @Nullable String detent) {
+        view.pendingDetent = Integer.parseInt(detent);
     }
 
     @Override
-    public void setMostRecentEventCount(BottomSheetDialogView view, int value) {
-
+    public void setMostRecentEventCount(BottomSheetDialogView view, int mostRecentEventCount) {
+        view.mostRecentEventCount = mostRecentEventCount;
     }
 
     @Override
-    public void setPeekHeight(BottomSheetDialogView view, int value) {
-
+    public void setPeekHeight(BottomSheetDialogView view, int peekHeight) {
+        view.bottomSheetBehavior.setPeekHeight(peekHeight != 0 ? (int) PixelUtil.toPixelFromDIP(peekHeight) : PEEK_HEIGHT_AUTO, true);
     }
 
     @Override
@@ -55,37 +64,81 @@ public class BottomSheetDialogViewManager extends ViewGroupManager<BottomSheetDi
     }
 
     @Override
-    public void setExpandedOffset(BottomSheetDialogView view, int value) {
-
+    public void setExpandedOffset(BottomSheetDialogView view, int expandedOffset) {
+        int offset = (int) PixelUtil.toPixelFromDIP(expandedOffset);
+        view.bottomSheetBehavior.setExpandedOffset(offset);
+        view.sheetView.setExpandedOffset(offset);
+        view.sheetView.requestLayout();
+        if (view.sheetView.getParent() != null)
+            view.sheetView.getParent().requestLayout();
     }
 
     @Override
-    public void setFitToContents(BottomSheetDialogView view, boolean value) {
-
+    public void setFitToContents(BottomSheetDialogView view, boolean fitToContents) {
+        view.bottomSheetBehavior.setFitToContents(fitToContents);
     }
 
     @Override
-    public void setHalfExpandedRatio(BottomSheetDialogView view, float value) {
-
+    public void setHalfExpandedRatio(BottomSheetDialogView view, float halfExpandedRatio) {
+        view.bottomSheetBehavior.setHalfExpandedRatio(halfExpandedRatio != -1 ? halfExpandedRatio : view.defaultHalfExpandedRatio);
+        view.requestLayout();
     }
 
     @Override
-    public void setHideable(BottomSheetDialogView view, boolean value) {
-
+    public void setHideable(BottomSheetDialogView view, boolean hideable) {
+        view.bottomSheetBehavior.setHideable(hideable);
     }
 
     @Override
-    public void setSkipCollapsed(BottomSheetDialogView view, boolean value) {
-
+    public void setSkipCollapsed(BottomSheetDialogView view, boolean skipCollapsed) {
+        view.bottomSheetBehavior.setSkipCollapsed(skipCollapsed);
     }
 
     @Override
-    public void setDraggable(BottomSheetDialogView view, boolean value) {
-
+    public void setDraggable(BottomSheetDialogView view, boolean draggable) {
+        view.bottomSheetBehavior.setDraggable(draggable);
     }
 
     @Override
-    public void setSheetHeight(BottomSheetDialogView view, double value) {
+    public void setSheetHeight(BottomSheetDialogView view, double sheetHeight) {
+        view.sheetView.setExpandedHeight(sheetHeight != 0 ? (int) PixelUtil.toPixelFromDIP(sheetHeight) : ViewGroup.LayoutParams.WRAP_CONTENT);
+        view.sheetView.requestLayout();
+        if (view.sheetView.getParent() != null)
+            view.sheetView.getParent().requestLayout();
+    }
 
+    @Override
+    protected void onAfterUpdateTransaction(@NonNull BottomSheetDialogView view) {
+        super.onAfterUpdateTransaction(view);
+        view.onAfterUpdateTransaction();
+    }
+
+    @Nullable
+    @Override
+    public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
+        return MapBuilder.<String, Object>builder()
+            .put("topOnDetentChanged", MapBuilder.of("registrationName", "onDetentChanged"))
+            .put("topOnDismissed", MapBuilder.of("registrationName", "onDismissed"))
+            .build();
+    }
+
+    @Override
+    public void addView(BottomSheetDialogView parent, View child, int index) {
+        parent.sheetView.addView(child, index);
+    }
+
+    @Override
+    public void removeViewAt(BottomSheetDialogView parent, int index) {
+        parent.sheetView.removeViewAt(index);
+    }
+
+    @Override
+    public int getChildCount(BottomSheetDialogView parent) {
+        return parent.sheetView.getChildCount();
+    }
+
+    @Override
+    public View getChildAt(BottomSheetDialogView parent, int index) {
+        return parent.sheetView.getChildAt(index);
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetManager.java
@@ -39,7 +39,7 @@ public class BottomSheetManager extends ViewGroupManager<BottomSheetView> {
 
     @ReactProp(name = "peekHeight")
     public void setPeekHeight(BottomSheetView view, int peekHeight) {
-        view.bottomSheetBehavior.setPeekHeight((int) PixelUtil.toPixelFromDIP(peekHeight), true);
+        view.bottomSheetBehavior.setPeekHeight(peekHeight != 0 ? (int) PixelUtil.toPixelFromDIP(peekHeight) : BottomSheetBehavior.PEEK_HEIGHT_AUTO, true);
     }
 
     @ReactProp(name = "expandedOffset")
@@ -99,7 +99,7 @@ public class BottomSheetManager extends ViewGroupManager<BottomSheetView> {
     @Nullable
     @Override
     public Map<String, Object> getExportedViewConstants() {
-        return MapBuilder.<String, Object>of(
+        return MapBuilder.of(
             "Detent",
             MapBuilder.of(
                 "hidden", BottomSheetBehavior.STATE_HIDDEN,

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetViewManager.java
@@ -82,9 +82,9 @@ public class BottomSheetViewManager extends ViewGroupManager<BottomSheetView> im
             view.getParent().requestLayout();
     }
 
-    @ReactProp(name = "halfExpandedRatio", defaultFloat = Float.MAX_VALUE)
+    @ReactProp(name = "halfExpandedRatio")
     public void setHalfExpandedRatio(BottomSheetView view, float halfExpandedRatio) {
-        view.bottomSheetBehavior.setHalfExpandedRatio(halfExpandedRatio != Float.MAX_VALUE ? halfExpandedRatio : view.defaultHalfExpandedRatio);
+        view.bottomSheetBehavior.setHalfExpandedRatio(halfExpandedRatio != -1 ? halfExpandedRatio : view.defaultHalfExpandedRatio);
         view.requestLayout();
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetViewManager.java
@@ -1,5 +1,7 @@
 package com.navigation.reactnative;
 
+import static com.google.android.material.bottomsheet.BottomSheetBehavior.PEEK_HEIGHT_AUTO;
+
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
@@ -54,7 +56,7 @@ public class BottomSheetViewManager extends ViewGroupManager<BottomSheetView> im
 
     @ReactProp(name = "peekHeight")
     public void setPeekHeight(BottomSheetView view, int peekHeight) {
-        view.bottomSheetBehavior.setPeekHeight((int) PixelUtil.toPixelFromDIP(peekHeight), true);
+        view.bottomSheetBehavior.setPeekHeight(peekHeight != 0 ? (int) PixelUtil.toPixelFromDIP(peekHeight) : PEEK_HEIGHT_AUTO, true);
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationPackage.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationPackage.java
@@ -36,6 +36,7 @@ public class NavigationPackage implements ReactPackage {
             new ActionBarManager(),
             new StatusBarManager(),
             new BottomSheetManager(),
+            new BottomSheetDialogManager(),
             new FloatingActionButtonManager(),
             new ExtendedFloatingActionButtonManager(),
             new BottomAppBarManager()

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/newarch/NavigationPackage.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/newarch/NavigationPackage.java
@@ -25,6 +25,7 @@ public class NavigationPackage extends TurboReactPackage implements ReactPackage
             new BarButtonViewManager(),
             new BottomAppBarViewManager(),
             new BottomSheetViewManager(),
+            new BottomSheetDialogViewManager(),
             new CollapsingBarViewManager(),
             new CoordinatorLayoutViewManager(),
             new ExtendedFloatingActionButtonViewManager(),

--- a/NavigationReactNative/src/cpp/navigationreactnative.h
+++ b/NavigationReactNative/src/cpp/navigationreactnative.h
@@ -16,6 +16,7 @@
 #include <react/renderer/components/navigationreactnative/NVActionBarComponentDescriptor.h>
 #include <react/renderer/components/navigationreactnative/NVBarButtonComponentDescriptor.h>
 #include <react/renderer/components/navigationreactnative/NVBottomSheetComponentDescriptor.h>
+#include <react/renderer/components/navigationreactnative/NVBottomSheetDialogComponentDescriptor.h>
 #include <react/renderer/components/navigationreactnative/NVNavigationBarComponentDescriptor.h>
 #include <react/renderer/components/navigationreactnative/NVSearchBarComponentDescriptor.h>
 #include <react/renderer/components/navigationreactnative/NVTabBarItemComponentDescriptor.h>

--- a/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVBottomSheetDialogComponentDescriptor.h
+++ b/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVBottomSheetDialogComponentDescriptor.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <react/debug/react_native_assert.h>
+#include "NVBottomSheetDialogShadowNode.h"
+#include <react/renderer/core/ConcreteComponentDescriptor.h>
+
+namespace facebook {
+namespace react {
+
+class NVBottomSheetDialogComponentDescriptor final
+    : public ConcreteComponentDescriptor<NVBottomSheetDialogShadowNode> {
+ public:
+  using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
+
+  void adopt(ShadowNode::Unshared const &shadowNode) const override {
+    react_native_assert(
+        std::dynamic_pointer_cast<NVBottomSheetDialogShadowNode>(shadowNode));
+    auto screenShadowNode =
+        std::static_pointer_cast<NVBottomSheetDialogShadowNode>(shadowNode);
+
+    react_native_assert(
+        std::dynamic_pointer_cast<YogaLayoutableShadowNode>(screenShadowNode));
+    auto layoutableShadowNode =
+        std::static_pointer_cast<YogaLayoutableShadowNode>(screenShadowNode);
+
+    auto state =
+        std::static_pointer_cast<const NVBottomSheetDialogShadowNode::ConcreteState>(
+            shadowNode->getState());
+    auto stateData = state->getData();
+
+    if (stateData.frameSize.width != 0 && stateData.frameSize.height != 0) {
+      layoutableShadowNode->setSize(
+          Size{stateData.frameSize.width, stateData.frameSize.height});
+    }
+
+    ConcreteComponentDescriptor::adopt(shadowNode);
+  }
+};
+
+} // namespace react
+} // namespace facebook

--- a/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVBottomSheetDialogShadowNode.cpp
+++ b/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVBottomSheetDialogShadowNode.cpp
@@ -1,0 +1,9 @@
+#include "NVBottomSheetDialogShadowNode.h"
+
+namespace facebook {
+namespace react {
+
+extern const char NVBottomSheetDialogComponentName[] = "NVBottomSheetDialog";
+
+} // namespace react
+} // namespace facebook

--- a/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVBottomSheetDialogShadowNode.h
+++ b/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVBottomSheetDialogShadowNode.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "NVBottomSheetDialogState.h"
+#include <react/renderer/components/navigationreactnative/EventEmitters.h>
+#include <react/renderer/components/navigationreactnative/Props.h>
+#include <react/renderer/components/view/ConcreteViewShadowNode.h>
+
+namespace facebook {
+namespace react {
+
+JSI_EXPORT extern const char NVBottomSheetDialogComponentName[];
+
+class JSI_EXPORT NVBottomSheetDialogShadowNode final : public ConcreteViewShadowNode<
+                                          NVBottomSheetDialogComponentName,
+                                          NVBottomSheetDialogProps,
+                                          NVBottomSheetDialogEventEmitter,
+                                          NVBottomSheetDialogState> {
+ public:
+  using ConcreteViewShadowNode::ConcreteViewShadowNode;
+
+  static ShadowNodeTraits BaseTraits() {
+    auto traits = ConcreteViewShadowNode::BaseTraits();
+    traits.set(ShadowNodeTraits::Trait::RootNodeKind);
+    return traits;
+  }
+};
+
+} // namespace react
+} // namespace facebook

--- a/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVBottomSheetDialogState.cpp
+++ b/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVBottomSheetDialogState.cpp
@@ -1,0 +1,14 @@
+#include "NVBottomSheetDialogState.h"
+
+namespace facebook {
+namespace react {
+
+#ifdef ANDROID
+folly::dynamic NVBottomSheetDialogState::getDynamic() const {
+  return folly::dynamic::object("frameWidth", frameSize.width)(
+      "frameHeight", frameSize.height);
+}
+#endif
+
+} // namespace react
+} // namespace facebook

--- a/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVBottomSheetDialogState.h
+++ b/NavigationReactNative/src/cpp/react/renderer/components/navigationreactnative/NVBottomSheetDialogState.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <react/renderer/graphics/Float.h>
+#include <react/renderer/core/graphicsConversions.h>
+
+#ifdef ANDROID
+#include <folly/dynamic.h>
+#include <react/renderer/mapbuffer/MapBuffer.h>
+#include <react/renderer/mapbuffer/MapBufferBuilder.h>
+#endif
+
+namespace facebook {
+namespace react {
+
+class JSI_EXPORT NVBottomSheetDialogState final {
+ public:
+  using Shared = std::shared_ptr<const NVBottomSheetDialogState>;
+
+  NVBottomSheetDialogState(){};
+  NVBottomSheetDialogState(Size frameSize_) : frameSize(frameSize_){};
+
+#ifdef ANDROID
+  NVBottomSheetDialogState(
+      NVBottomSheetDialogState const &previousState,
+      folly::dynamic data)
+      : frameSize(Size{
+            (Float)data["frameWidth"].getDouble(),
+            (Float)data["frameHeight"].getDouble()}){};
+#endif
+
+  const Size frameSize{};
+
+#ifdef ANDROID
+  folly::dynamic getDynamic() const;
+  MapBuffer getMapBuffer() const {
+    return MapBufferBuilder::EMPTY();
+  };
+
+#endif
+
+#pragma mark - Getters
+};
+
+} // namespace react
+} // namespace facebook

--- a/NavigationReactNative/src/ios/NVBottomSheetComponentView.mm
+++ b/NavigationReactNative/src/ios/NVBottomSheetComponentView.mm
@@ -103,18 +103,20 @@ using namespace facebook::react;
             _bottomSheetController.presentationController.delegate = self;
             [[self reactViewController] presentViewController:_bottomSheetController animated:true completion:nil];
         }
-        [sheet animateChanges:^{
-            [sheet setDetents: [[self halfExpandedIdentifier] isEqual:UISheetPresentationControllerDetentIdentifierLarge] ? @[_collapsedDetent, _expandedDetent] : @[_collapsedDetent, _halfExpandedDetent, _expandedDetent]];
-            if (newViewProps.skipCollapsed && ![_detent isEqual:@"collapsed"]) {
-                [sheet setDetents: [[self halfExpandedIdentifier] isEqual:UISheetPresentationControllerDetentIdentifierLarge] ? @[ _expandedDetent] : @[_halfExpandedDetent, _expandedDetent]];
-            }
-            if (!newViewProps.draggable) {
-                [sheet setDetents: @[[newDetent isEqual:[self collapsedIdentifier]] ? _collapsedDetent : ([newDetent isEqual:[self expandedIdentifier]] ? _expandedDetent : _halfExpandedDetent)]];
-            }
-            if (eventLag == 0 && [sheet selectedDetentIdentifier] != newDetent) {
-                sheet.selectedDetentIdentifier = newDetent;
-            }
-        }];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [sheet animateChanges:^{
+                [sheet setDetents: [[self halfExpandedIdentifier] isEqual:UISheetPresentationControllerDetentIdentifierLarge] ? @[self->_collapsedDetent, self->_expandedDetent] : @[self->_collapsedDetent, self->_halfExpandedDetent, self->_expandedDetent]];
+                if (newViewProps.skipCollapsed && ![self->_detent isEqual:@"collapsed"]) {
+                    [sheet setDetents: [[self halfExpandedIdentifier] isEqual:UISheetPresentationControllerDetentIdentifierLarge] ? @[ self->_expandedDetent] : @[self->_halfExpandedDetent, self->_expandedDetent]];
+                }
+                if (!newViewProps.draggable) {
+                    [sheet setDetents: @[[newDetent isEqual:[self collapsedIdentifier]] ? self->_collapsedDetent : ([newDetent isEqual:[self expandedIdentifier]] ? self->_expandedDetent : self->_halfExpandedDetent)]];
+                }
+                if (eventLag == 0 && [sheet selectedDetentIdentifier] != newDetent) {
+                    sheet.selectedDetentIdentifier = newDetent;
+                }
+            }];
+        });
     } else {
         [_bottomSheetController dismissViewControllerAnimated:YES completion:nil];
         _presented = NO;

--- a/NavigationReactNative/src/ios/NVBottomSheetComponentView.mm
+++ b/NavigationReactNative/src/ios/NVBottomSheetComponentView.mm
@@ -165,8 +165,11 @@ using namespace facebook::react;
 - (void)notifyForBoundsChange:(CGRect)newBounds
 {
     if (_state != nullptr) {
-        auto newState = NVBottomSheetState{RCTSizeFromCGSize(newBounds.size)};
-        _state->updateState(std::move(newState));
+        CAAnimation *dropping = [_bottomSheetController.view.layer animationForKey:@"bounds.size"];
+        if (!dropping) {
+            auto newState = NVBottomSheetState{RCTSizeFromCGSize(newBounds.size)};
+            _state->updateState(std::move(newState));
+        }
     }
 }
 

--- a/NavigationReactNative/src/ios/NVBottomSheetComponentView.mm
+++ b/NavigationReactNative/src/ios/NVBottomSheetComponentView.mm
@@ -221,6 +221,8 @@ using namespace facebook::react;
                 .detent = std::string([@"hidden" UTF8String]),
                 .eventCount = static_cast<int>(_nativeEventCount),
             });
+        std::static_pointer_cast<NVBottomSheetEventEmitter const>(_eventEmitter)
+            ->onDismissed(NVBottomSheetEventEmitter::OnDismissed{});
     }
 }
 

--- a/NavigationReactNative/src/ios/NVBottomSheetComponentView.mm
+++ b/NavigationReactNative/src/ios/NVBottomSheetComponentView.mm
@@ -107,7 +107,7 @@ using namespace facebook::react;
             [sheet animateChanges:^{
                 [sheet setDetents: [[self halfExpandedIdentifier] isEqual:UISheetPresentationControllerDetentIdentifierLarge] ? @[self->_collapsedDetent, self->_expandedDetent] : @[self->_collapsedDetent, self->_halfExpandedDetent, self->_expandedDetent]];
                 if (newViewProps.skipCollapsed && ![self->_detent isEqual:@"collapsed"]) {
-                    [sheet setDetents: [[self halfExpandedIdentifier] isEqual:UISheetPresentationControllerDetentIdentifierLarge] ? @[ self->_expandedDetent] : @[self->_halfExpandedDetent, self->_expandedDetent]];
+                    [sheet setDetents: [[self halfExpandedIdentifier] isEqual:UISheetPresentationControllerDetentIdentifierLarge] ? @[self->_expandedDetent] : @[self->_halfExpandedDetent, self->_expandedDetent]];
                 }
                 if (!newViewProps.draggable) {
                     [sheet setDetents: @[[newDetent isEqual:[self collapsedIdentifier]] ? self->_collapsedDetent : ([newDetent isEqual:[self expandedIdentifier]] ? self->_expandedDetent : self->_halfExpandedDetent)]];

--- a/NavigationReactNative/src/ios/NVBottomSheetDialogComponentView.h
+++ b/NavigationReactNative/src/ios/NVBottomSheetDialogComponentView.h
@@ -1,0 +1,13 @@
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <UIKit/UIKit.h>
+#import <React/RCTViewComponentView.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NVBottomSheetDialogComponentView : RCTViewComponentView
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/NavigationReactNative/src/ios/NVBottomSheetDialogComponentView.mm
+++ b/NavigationReactNative/src/ios/NVBottomSheetDialogComponentView.mm
@@ -1,0 +1,40 @@
+#ifdef RCT_NEW_ARCH_ENABLED
+#import "NVBottomSheetDialogComponentView.h"
+
+#import <react/renderer/components/navigationreactnative/ComponentDescriptors.h>
+#import <react/renderer/components/navigationreactnative/EventEmitters.h>
+#import <react/renderer/components/navigationreactnative/Props.h>
+#import <react/renderer/components/navigationreactnative/RCTComponentViewHelpers.h>
+#import <NVBottomSheetDialogComponentDescriptor.h>
+
+#import "RCTFabricComponentsPlugins.h"
+
+using namespace facebook::react;
+
+@interface NVBottomSheetDialogComponentView () <RCTNVBottomSheetDialogViewProtocol>
+@end
+
+@implementation NVBottomSheetDialogComponentView
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+    if (self = [super initWithFrame:frame]) {
+    }
+    return self;
+}
+
+#pragma mark - RCTComponentViewProtocol
+
++ (ComponentDescriptorProvider)componentDescriptorProvider
+{
+  return concreteComponentDescriptorProvider<NVBottomSheetDialogComponentDescriptor>();
+}
+
+@end
+
+Class<RCTComponentViewProtocol> NVBottomSheetDialogCls(void)
+{
+  return NVBottomSheetDialogComponentView.class;
+}
+
+#endif

--- a/NavigationReactNative/src/ios/NVBottomSheetManager.m
+++ b/NavigationReactNative/src/ios/NVBottomSheetManager.m
@@ -35,5 +35,6 @@ RCT_EXPORT_VIEW_PROPERTY(draggable, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(skipCollapsed, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(mostRecentEventCount, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(onDetentChanged, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onDismissed, RCTDirectEventBlock)
 
 @end

--- a/NavigationReactNative/src/ios/NVBottomSheetView.h
+++ b/NavigationReactNative/src/ios/NVBottomSheetView.h
@@ -16,6 +16,7 @@ API_AVAILABLE(ios(15.0))
 @property (nonatomic, assign) BOOL skipCollapsed;
 @property (nonatomic, assign) NSInteger mostRecentEventCount;
 @property (nonatomic, copy) RCTDirectEventBlock onDetentChanged;
+@property (nonatomic, copy) RCTDirectEventBlock onDismissed;
 
 -(id)initWithBridge: (RCTBridge *)bridge;
 

--- a/NavigationReactNative/src/ios/NVBottomSheetView.m
+++ b/NavigationReactNative/src/ios/NVBottomSheetView.m
@@ -211,6 +211,9 @@
             @"eventCount": @(_nativeEventCount),
         });
     }
+    if (!!self.onDismissed) {
+        self.onDismissed(@{});
+    }
 }
 
 @end

--- a/NavigationReactNative/src/ios/NavigationReactNative.xcodeproj/project.pbxproj
+++ b/NavigationReactNative/src/ios/NavigationReactNative.xcodeproj/project.pbxproj
@@ -94,6 +94,8 @@
 		70BB32A1212B2CA900DE0D13 /* NVBarButtonView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NVBarButtonView.h; sourceTree = "<group>"; };
 		70BB32A2212B2D3700DE0D13 /* NVBarView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NVBarView.h; sourceTree = "<group>"; };
 		70BB32A3212B2D4100DE0D13 /* NVBarView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NVBarView.m; sourceTree = "<group>"; };
+		70CCAAC42B18F9B200747AFF /* NVBottomSheetDialogComponentView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NVBottomSheetDialogComponentView.h; sourceTree = "<group>"; };
+		70CCAAC52B18F9C500747AFF /* NVBottomSheetDialogComponentView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NVBottomSheetDialogComponentView.mm; sourceTree = "<group>"; };
 		70DC9BDC2843AA930047EEF4 /* NVActionBarComponentView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NVActionBarComponentView.mm; sourceTree = "<group>"; };
 		70DC9BDD2843AAA00047EEF4 /* NVActionBarComponentView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NVActionBarComponentView.h; sourceTree = "<group>"; };
 		70DC9BDE2843AB800047EEF4 /* NVCollapsingBarComponentView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NVCollapsingBarComponentView.mm; sourceTree = "<group>"; };
@@ -148,6 +150,8 @@
 				702E38C12AFCFEAE0009E0A7 /* NVBottomSheetController.m */,
 				707C4BF82AF64BF6008FC72E /* NVBottomSheetManager.m */,
 				707C4BF72AF64BE6008FC72E /* NVBottomSheetView.m */,
+				70CCAAC42B18F9B200747AFF /* NVBottomSheetDialogComponentView.h */,
+				70CCAAC52B18F9C500747AFF /* NVBottomSheetDialogComponentView.mm */,
 				707C4BF62AF64BCD008FC72E /* NVBottomSheetView.h */,
 				709C5C22298EAD4900DF5B14 /* NVSearchResultsComponentView.h */,
 				709C5C23298EAE0A00DF5B14 /* NVSearchToolbarComponentView.mm */,

--- a/NavigationReactNative/src/react-native.config.js
+++ b/NavigationReactNative/src/react-native.config.js
@@ -16,6 +16,7 @@ module.exports = {
           'NVBarButtonComponentDescriptor',
           'NVBottomAppBarComponentDescriptor',
           'NVBottomSheetComponentDescriptor',
+          'NVBottomSheetDialogComponentDescriptor',
           'NVCollapsingBarComponentDescriptor',
           'NVCoordinatorLayoutComponentDescriptor',
           'NVExtendedFloatingActionButtonComponentDescriptor',

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -737,6 +737,10 @@ export class TabBar extends Component<TabBarProps> {}
  */
 export interface BottomSheetProps {
     /**
+     * Indicates whether the bottom sheet disables the scene behind
+     */
+    modal?: boolean;
+    /**
      * The height of the bottom sheet when it is collapsed
      */
     peekHeight?: number;

--- a/types/navigation-react-native.d.ts
+++ b/types/navigation-react-native.d.ts
@@ -737,6 +737,10 @@ export class TabBar extends Component<TabBarProps> {}
  */
 export interface BottomSheetProps {
     /**
+     * Indicates whether the bottom sheet disables the scene behind
+     */
+    modal?: boolean;
+    /**
      * The height of the bottom sheet when it is collapsed
      */
     peekHeight?: number;


### PR DESCRIPTION
Added `modal` prop to the `BottomSheet` Component. When true, it renders to a `BottomSheetDialogFragment`.

```jsx
<BottomSheet modal>
```
When the modal is hidden rendered null otherwise can't interact with the scene behind. For non-modal hidden still render the sheet otherwise animation doesn't run when unhidden. 
