### PR TITLE
Replaced deprecated FabricViewStateManager with StateWrapper

### DIFF
--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ActionBarViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ActionBarViewManager.java
@@ -50,7 +50,7 @@ public class ActionBarViewManager extends ViewGroupManager<ActionBarView> implem
     @Override
     public Object updateState(
             ActionBarView view, ReactStylesDiffMap props, StateWrapper stateWrapper) {
-        view.getFabricViewStateManager().setStateWrapper(stateWrapper);
+        view.setStateWrapper(stateWrapper);
         return null;
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
@@ -86,7 +86,7 @@ public class BottomSheetDialogView extends ReactViewGroup {
 
     public void setStateWrapper(StateWrapper stateWrapper) {
         sheetView.setStateWrapper(stateWrapper);
-    };
+    }
 
     public void updateState(final int width, final int height) {
         sheetView.updateState(width, height);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TitleBarViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TitleBarViewManager.java
@@ -43,7 +43,7 @@ public class TitleBarViewManager extends ViewGroupManager<TitleBarView> implemen
     @Override
     public Object updateState(
             TitleBarView view, ReactStylesDiffMap props, StateWrapper stateWrapper) {
-        view.getFabricViewStateManager().setStateWrapper(stateWrapper);
+        view.setStateWrapper(stateWrapper);
         return null;
     }
 }


### PR DESCRIPTION
Found that React Native Modal doesn't use `FabricViewStateManager` anymore when doing `BottomSheetDialog`