### PR TITLE
Supported bridgeless mode (Fabric)

### DIFF
--- a/NavigationReactNative/sample/fabric/Timeline.js
+++ b/NavigationReactNative/sample/fabric/Timeline.js
@@ -18,7 +18,7 @@ export default () => {
     <CoordinatorLayout overlap={110}>
       <NavigationBar
         title={name}
-        onOffsetChanged={Animated.event([{nativeEvent:{offset}}], {useNativeDriver: false})}
+        onOffsetChanged={Animated.event([{nativeEvent:{offset}}], {useNativeDriver: true})}
         navigationImage={require('./arrow.png')}
         barTintColor={Platform.OS === 'android' ? standard => standard ? colors[0] : colors[1] : 'rgb(247,247,247)'}
         tintColor={Platform.OS === 'android' ? "#fff" : null}

--- a/NavigationReactNative/sample/fabric/android/app/src/main/java/com/fabric/MainApplication.kt
+++ b/NavigationReactNative/sample/fabric/android/app/src/main/java/com/fabric/MainApplication.kt
@@ -38,7 +38,7 @@ class MainApplication : Application(), ReactApplication {
     SoLoader.init(this, false)
     if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
       // If you opted-in for the New Architecture, we load the native entry point for this app.
-      load()
+      load(bridgelessEnabled = true)
     }
     ReactNativeFlipper.initializeFlipper(this, reactNativeHost.reactInstanceManager)
   }

--- a/NavigationReactNative/sample/fabric/android/app/src/main/java/com/fabric/MainApplication.kt
+++ b/NavigationReactNative/sample/fabric/android/app/src/main/java/com/fabric/MainApplication.kt
@@ -38,7 +38,7 @@ class MainApplication : Application(), ReactApplication {
     SoLoader.init(this, false)
     if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
       // If you opted-in for the New Architecture, we load the native entry point for this app.
-      load(bridgelessEnabled = true)
+      load()
     }
     ReactNativeFlipper.initializeFlipper(this, reactNativeHost.reactInstanceManager)
   }

--- a/NavigationReactNative/sample/fabric/ios/fabric/AppDelegate.mm
+++ b/NavigationReactNative/sample/fabric/ios/fabric/AppDelegate.mm
@@ -28,4 +28,9 @@
 #endif
 }
 
+- (BOOL)bridgelessEnabled
+{
+    return YES;
+}
+
 @end

--- a/NavigationReactNative/sample/fabric/ios/fabric/AppDelegate.mm
+++ b/NavigationReactNative/sample/fabric/ios/fabric/AppDelegate.mm
@@ -28,9 +28,4 @@
 #endif
 }
 
-- (BOOL)bridgelessEnabled
-{
-    return YES;
-}
-
 @end

--- a/NavigationReactNative/src/BarButtonNativeComponent.js
+++ b/NavigationReactNative/src/BarButtonNativeComponent.js
@@ -19,7 +19,7 @@ type NativeProps = $ReadOnly<{|
   showAsAction: Int32,
   buttonWidth: Double,
   actionBar: boolean,
-  onPress: DirectEventHandler<null>
+  onPress: BubblingEventHandler<null>
 |}>;
 
 export default (codegenNativeComponent<NativeProps>(

--- a/NavigationReactNative/src/SearchResultsNativeComponent.js
+++ b/NavigationReactNative/src/SearchResultsNativeComponent.js
@@ -24,6 +24,9 @@ type NativeProps = $ReadOnly<{|
     active: boolean,
     eventCount: Int32,
   |}>>,
+  onQuery: DirectEventHandler<$ReadOnly<{|
+    text: string,
+  |}>>,
 |}>;
 
 export default (codegenNativeComponent<NativeProps>(

--- a/NavigationReactNative/src/TabBarItemNativeComponent.js
+++ b/NavigationReactNative/src/TabBarItemNativeComponent.js
@@ -16,7 +16,7 @@ type NativeProps = $ReadOnly<{|
   badgeColor: ColorValue,
   image: ImageSource,
   systemItem: string,
-  onPress: DirectEventHandler<null>
+  onPress: BubblingEventHandler<null>
 |}>;
 
 export default (codegenNativeComponent<NativeProps>(

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ActionBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ActionBarManager.java
@@ -24,8 +24,8 @@ public class ActionBarManager extends ViewGroupManager<ActionBarView> {
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnExpanded", MapBuilder.of("registrationName", "onExpanded"))
-            .put("topOnCollapsed", MapBuilder.of("registrationName", "onCollapsed"))
+            .put("topExpanded", MapBuilder.of("registrationName", "onExpanded"))
+            .put("topCollapsed", MapBuilder.of("registrationName", "onCollapsed"))
             .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ActionBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ActionBarView.java
@@ -121,7 +121,7 @@ public class ActionBarView extends ViewGroup {
 
         @Override
         public String getEventName() {
-            return "topOnExpanded";
+            return "topExpanded";
         }
 
         @Override
@@ -137,7 +137,7 @@ public class ActionBarView extends ViewGroup {
 
         @Override
         public String getEventName() {
-            return "topOnCollapsed";
+            return "topCollapsed";
         }
 
         @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ActionBarViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ActionBarViewManager.java
@@ -42,8 +42,8 @@ public class ActionBarViewManager extends ViewGroupManager<ActionBarView> implem
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnExpanded", MapBuilder.of("registrationName", "onExpanded"))
-            .put("topOnCollapsed", MapBuilder.of("registrationName", "onCollapsed"))
+            .put("topExpanded", MapBuilder.of("registrationName", "onExpanded"))
+            .put("topCollapsed", MapBuilder.of("registrationName", "onCollapsed"))
             .build();
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonManager.java
@@ -99,7 +99,7 @@ public class BarButtonManager extends ViewGroupManager<BarButtonView> {
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnPress", MapBuilder.of("registrationName", "onPress"))
+            .put("topPress", MapBuilder.of("registrationName", "onPress"))
             .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonView.java
@@ -200,7 +200,7 @@ public class BarButtonView extends ViewGroup implements CollapsibleActionView {
 
         @Override
         public String getEventName() {
-            return "topOnPress";
+            return "topPress";
         }
 
         @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BarButtonViewManager.java
@@ -124,7 +124,7 @@ public class BarButtonViewManager extends ViewGroupManager<BarButtonView> implem
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnPress", MapBuilder.of("registrationName", "onPress"))
+            .put("topPress", MapBuilder.of("registrationName", "onPress"))
             .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomAppBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomAppBarManager.java
@@ -128,7 +128,7 @@ public class BottomAppBarManager extends ViewGroupManager<BottomAppBarView> {
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnNavigationPress", MapBuilder.of("registrationName", "onNavigationPress"))
+            .put("topNavigationPress", MapBuilder.of("registrationName", "onNavigationPress"))
             .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomAppBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomAppBarView.java
@@ -1,6 +1,7 @@
 package com.navigation.reactnative;
 
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
@@ -86,7 +87,7 @@ public class BottomAppBarView extends BottomAppBar implements ActionView {
         setNavigationOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View view) {
-                ReactContext reactContext = (ReactContext) getContext();
+                ReactContext reactContext = (ReactContext) (getContext() instanceof ReactContext ? getContext() : ((ContextWrapper) getContext()).getBaseContext());
                 EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
                 eventDispatcher.dispatchEvent(new BottomAppBarView.NavigationPressEvent(getId()));
             }
@@ -277,7 +278,7 @@ public class BottomAppBarView extends BottomAppBar implements ActionView {
 
         @Override
         public String getEventName() {
-            return "topOnNavigationPress";
+            return "topNavigationPress";
         }
 
         @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomAppBarViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomAppBarViewManager.java
@@ -138,7 +138,7 @@ public class BottomAppBarViewManager extends ViewGroupManager<BottomAppBarView> 
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnNavigationPress", MapBuilder.of("registrationName", "onNavigationPress"))
+            .put("topNavigationPress", MapBuilder.of("registrationName", "onNavigationPress"))
             .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogManager.java
@@ -99,8 +99,8 @@ public class BottomSheetDialogManager extends ViewGroupManager<BottomSheetDialog
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnDetentChanged", MapBuilder.of("registrationName", "onDetentChanged"))
-            .put("topOnDismissed", MapBuilder.of("registrationName", "onDismissed"))
+            .put("topDetentChanged", MapBuilder.of("registrationName", "onDetentChanged"))
+            .put("topDismissed", MapBuilder.of("registrationName", "onDismissed"))
             .build();
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
@@ -304,7 +304,7 @@ public class BottomSheetDialogView extends ReactViewGroup {
 
         @Override
         public String getEventName() {
-            return "topOnDetentChanged";
+            return "topDetentChanged";
         }
 
         @Override
@@ -323,7 +323,7 @@ public class BottomSheetDialogView extends ReactViewGroup {
 
         @Override
         public String getEventName() {
-            return "topOnDismissed";
+            return "topDismissed";
         }
 
         @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogViewManager.java
@@ -121,8 +121,8 @@ public class BottomSheetDialogViewManager extends ViewGroupManager<BottomSheetDi
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnDetentChanged", MapBuilder.of("registrationName", "onDetentChanged"))
-            .put("topOnDismissed", MapBuilder.of("registrationName", "onDismissed"))
+            .put("topDetentChanged", MapBuilder.of("registrationName", "onDetentChanged"))
+            .put("topDismissed", MapBuilder.of("registrationName", "onDismissed"))
             .build();
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetManager.java
@@ -92,7 +92,7 @@ public class BottomSheetManager extends ViewGroupManager<BottomSheetView> {
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnDetentChanged", MapBuilder.of("registrationName", "onDetentChanged"))
+            .put("topDetentChanged", MapBuilder.of("registrationName", "onDetentChanged"))
             .build();
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetView.java
@@ -78,7 +78,7 @@ public class BottomSheetView extends ReactViewGroup {
 
         @Override
         public String getEventName() {
-            return "topOnDetentChanged";
+            return "topDetentChanged";
         }
 
         @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetViewManager.java
@@ -113,7 +113,7 @@ public class BottomSheetViewManager extends ViewGroupManager<BottomSheetView> im
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnDetentChanged", MapBuilder.of("registrationName", "onDetentChanged"))
+            .put("topDetentChanged", MapBuilder.of("registrationName", "onDetentChanged"))
             .build();
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ExtendedFloatingActionButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ExtendedFloatingActionButtonManager.java
@@ -187,7 +187,7 @@ public class ExtendedFloatingActionButtonManager extends SimpleViewManager<Exten
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnPress", MapBuilder.of("registrationName", "onPress"))
+            .put("topPress", MapBuilder.of("registrationName", "onPress"))
             .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ExtendedFloatingActionButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ExtendedFloatingActionButtonView.java
@@ -147,7 +147,7 @@ public class ExtendedFloatingActionButtonView extends ExtendedFloatingActionButt
 
         @Override
         public String getEventName() {
-            return "topOnPress";
+            return "topPress";
         }
 
         @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ExtendedFloatingActionButtonViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ExtendedFloatingActionButtonViewManager.java
@@ -202,7 +202,7 @@ public class ExtendedFloatingActionButtonViewManager extends SimpleViewManager<E
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnPress", MapBuilder.of("registrationName", "onPress"))
+            .put("topPress", MapBuilder.of("registrationName", "onPress"))
             .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonManager.java
@@ -172,7 +172,7 @@ public class FloatingActionButtonManager extends SimpleViewManager<FloatingActio
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnPress", MapBuilder.of("registrationName", "onPress"))
+            .put("topPress", MapBuilder.of("registrationName", "onPress"))
             .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonView.java
@@ -74,7 +74,7 @@ public class FloatingActionButtonView extends FloatingActionButton {
 
         @Override
         public String getEventName() {
-            return "topOnPress";
+            return "topPress";
         }
 
         @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/FloatingActionButtonViewManager.java
@@ -188,7 +188,7 @@ public class FloatingActionButtonViewManager extends SimpleViewManager<FloatingA
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnPress", MapBuilder.of("registrationName", "onPress"))
+            .put("topPress", MapBuilder.of("registrationName", "onPress"))
             .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarManager.java
@@ -70,7 +70,7 @@ public class NavigationBarManager extends ViewGroupManager<NavigationBarView> {
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnOffsetChanged", MapBuilder.of("registrationName", "onOffsetChanged"))
+            .put("topOffsetChanged", MapBuilder.of("registrationName", "onOffsetChanged"))
             .build();
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarView.java
@@ -89,7 +89,7 @@ public class NavigationBarView extends AppBarLayout {
 
         @Override
         public String getEventName() {
-            return "topOnOffsetChanged";
+            return "topOffsetChanged";
         }
 
         @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarViewManager.java
@@ -187,7 +187,7 @@ public class NavigationBarViewManager extends ViewGroupManager<NavigationBarView
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnOffsetChanged", MapBuilder.of("registrationName", "onOffsetChanged"))
+            .put("topOffsetChanged", MapBuilder.of("registrationName", "onOffsetChanged"))
             .build();
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -161,7 +161,7 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
             .put("topOnNavigateToTop", MapBuilder.of("registrationName", "onNavigateToTop"))
-            .put("topOnRest", MapBuilder.of("registrationName", "onRest"))
+            .put("topRest", MapBuilder.of("registrationName", "onRest"))
             .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -160,7 +160,7 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnNavigateToTop", MapBuilder.of("registrationName", "onNavigateToTop"))
+            .put("topNavigateToTop", MapBuilder.of("registrationName", "onNavigateToTop"))
             .put("topRest", MapBuilder.of("registrationName", "onRest"))
             .build();
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -356,7 +356,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
 
         @Override
         public String getEventName() {
-            return "topOnNavigateToTop";
+            return "topNavigateToTop";
         }
 
         @Override
@@ -375,7 +375,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
 
         @Override
         public String getEventName() {
-            return "topOnRest";
+            return "topRest";
         }
 
         @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackViewManager.java
@@ -186,8 +186,8 @@ public class NavigationStackViewManager extends ViewGroupManager<NavigationStack
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnNavigateToTop", MapBuilder.of("registrationName", "onNavigateToTop"))
-            .put("topOnRest", MapBuilder.of("registrationName", "onRest"))
+            .put("topNavigateToTop", MapBuilder.of("registrationName", "onNavigateToTop"))
+            .put("topRest", MapBuilder.of("registrationName", "onRest"))
             .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneManager.java
@@ -116,7 +116,7 @@ public class SceneManager extends ViewGroupManager<SceneView> {
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnPopped", MapBuilder.of("registrationName", "onPopped"))
+            .put("topPopped", MapBuilder.of("registrationName", "onPopped"))
             .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneView.java
@@ -83,7 +83,7 @@ public class SceneView extends ReactViewGroup {
 
         @Override
         public String getEventName() {
-            return "topOnPopped";
+            return "topPopped";
         }
 
         @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneViewManager.java
@@ -142,7 +142,7 @@ public class SceneViewManager extends ViewGroupManager<SceneView> implements NVS
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnPopped", MapBuilder.of("registrationName", "onPopped"))
+            .put("topPopped", MapBuilder.of("registrationName", "onPopped"))
             .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarManager.java
@@ -111,9 +111,9 @@ public class SearchBarManager extends ViewGroupManager<SearchBarView> {
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnChangeText", MapBuilder.of("registrationName", "onChangeText"))
-            .put("topOnChangeActive", MapBuilder.of("registrationName", "onChangeActive"))
-            .put("topOnQuery", MapBuilder.of("registrationName", "onQuery"))
+            .put("topChangeText", MapBuilder.of("registrationName", "onChangeText"))
+            .put("topChangeActive", MapBuilder.of("registrationName", "onChangeActive"))
+            .put("topQuery", MapBuilder.of("registrationName", "onQuery"))
             .build();
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarView.java
@@ -214,7 +214,7 @@ public class SearchBarView extends ReactViewGroup {
 
         @Override
         public String getEventName() {
-            return "topOnChangeText";
+            return "topChangeText";
         }
 
         @Override
@@ -237,7 +237,7 @@ public class SearchBarView extends ReactViewGroup {
 
         @Override
         public String getEventName() {
-            return "topOnChangeActive";
+            return "topChangeActive";
         }
 
         @Override
@@ -259,7 +259,7 @@ public class SearchBarView extends ReactViewGroup {
 
         @Override
         public String getEventName() {
-            return "topOnQuery";
+            return "topQuery";
         }
 
         @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchBarViewManager.java
@@ -153,9 +153,9 @@ public class SearchBarViewManager extends ViewGroupManager<SearchBarView> implem
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnChangeText", MapBuilder.of("registrationName", "onChangeText"))
-            .put("topOnChangeActive", MapBuilder.of("registrationName", "onChangeActive"))
-            .put("topOnQuery", MapBuilder.of("registrationName", "onQuery"))
+            .put("topChangeText", MapBuilder.of("registrationName", "onChangeText"))
+            .put("topChangeActive", MapBuilder.of("registrationName", "onChangeActive"))
+            .put("topQuery", MapBuilder.of("registrationName", "onQuery"))
             .build();
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchResultsManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchResultsManager.java
@@ -91,9 +91,9 @@ public class SearchResultsManager extends ViewGroupManager<SearchResultsView> {
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnChangeText", MapBuilder.of("registrationName", "onChangeText"))
-            .put("topOnChangeActive", MapBuilder.of("registrationName", "onChangeActive"))
-            .put("topOnQuery", MapBuilder.of("registrationName", "onQuery"))
+            .put("topChangeText", MapBuilder.of("registrationName", "onChangeText"))
+            .put("topChangeActive", MapBuilder.of("registrationName", "onChangeActive"))
+            .put("topQuery", MapBuilder.of("registrationName", "onQuery"))
             .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchResultsView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchResultsView.java
@@ -190,7 +190,7 @@ public class SearchResultsView extends SearchView {
 
         @Override
         public String getEventName() {
-            return "topOnChangeText";
+            return "topChangeText";
         }
 
         @Override
@@ -213,7 +213,7 @@ public class SearchResultsView extends SearchView {
 
         @Override
         public String getEventName() {
-            return "topOnChangeActive";
+            return "topChangeActive";
         }
 
         @Override
@@ -235,7 +235,7 @@ public class SearchResultsView extends SearchView {
 
         @Override
         public String getEventName() {
-            return "topOnQuery";
+            return "topQuery";
         }
 
         @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchResultsViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchResultsViewManager.java
@@ -113,9 +113,9 @@ public class SearchResultsViewManager extends ViewGroupManager<SearchResultsView
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnChangeText", MapBuilder.of("registrationName", "onChangeText"))
-            .put("topOnChangeActive", MapBuilder.of("registrationName", "onChangeActive"))
-            .put("topOnQuery", MapBuilder.of("registrationName", "onQuery"))
+            .put("topChangeText", MapBuilder.of("registrationName", "onChangeText"))
+            .put("topChangeActive", MapBuilder.of("registrationName", "onChangeActive"))
+            .put("topQuery", MapBuilder.of("registrationName", "onQuery"))
             .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchToolbarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchToolbarManager.java
@@ -134,7 +134,7 @@ public class SearchToolbarManager extends ViewGroupManager<SearchToolbarView> {
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnNavigationPress", MapBuilder.of("registrationName", "onNavigationPress"))
+            .put("topNavigationPress", MapBuilder.of("registrationName", "onNavigationPress"))
             .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchToolbarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchToolbarView.java
@@ -239,7 +239,7 @@ public class SearchToolbarView extends SearchBar {
 
         @Override
         public String getEventName() {
-            return "topOnNavigationPress";
+            return "topNavigationPress";
         }
 
         @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchToolbarViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchToolbarViewManager.java
@@ -6,6 +6,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.common.MapBuilder;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
@@ -13,6 +14,8 @@ import com.facebook.react.uimanager.ViewManagerDelegate;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.viewmanagers.NVSearchToolbarManagerDelegate;
 import com.facebook.react.viewmanagers.NVSearchToolbarManagerInterface;
+
+import java.util.Map;
 
 @ReactModule(name = "NVSearchToolbar")
 public class SearchToolbarViewManager extends ViewGroupManager<SearchToolbarView> implements NVSearchToolbarManagerInterface<SearchToolbarView> {
@@ -151,5 +154,12 @@ public class SearchToolbarViewManager extends ViewGroupManager<SearchToolbarView
     @Override
     public boolean needsCustomLayoutForChildren() {
         return true;
+    }
+
+    @Override
+    public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
+        return MapBuilder.<String, Object>builder()
+            .put("topNavigationPress", MapBuilder.of("registrationName", "onNavigationPress"))
+            .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemManager.java
@@ -83,7 +83,7 @@ public class TabBarItemManager extends ViewGroupManager<TabBarItemView> {
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnPress", MapBuilder.of("registrationName", "onPress"))
+            .put("topPress", MapBuilder.of("registrationName", "onPress"))
             .build();
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemView.java
@@ -178,7 +178,7 @@ public class TabBarItemView extends ViewGroup {
 
         @Override
         public String getEventName() {
-            return "topOnPress";
+            return "topPress";
         }
 
         @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemViewManager.java
@@ -104,7 +104,7 @@ public class TabBarItemViewManager extends ViewGroupManager<TabBarItemView> impl
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnPress", MapBuilder.of("registrationName", "onPress"))
+            .put("topPress", MapBuilder.of("registrationName", "onPress"))
             .build();
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarManager.java
@@ -85,7 +85,7 @@ public class TabBarManager extends ViewGroupManager<TabBarView> {
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnTabSelected", MapBuilder.of("registrationName", "onTabSelected"))
+            .put("topTabSelected", MapBuilder.of("registrationName", "onTabSelected"))
             .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerManager.java
@@ -72,8 +72,8 @@ public class TabBarPagerManager extends ViewGroupManager<TabBarPagerView> {
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnTabSelected", MapBuilder.of("registrationName", "onTabSelected"))
-            .put("topOnTabSwipeStateChanged", MapBuilder.of("registrationName", "onTabSwipeStateChanged"))
+            .put("topTabSelected", MapBuilder.of("registrationName", "onTabSelected"))
+            .put("topTabSwipeStateChanged", MapBuilder.of("registrationName", "onTabSwipeStateChanged"))
             .build();
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLManager.java
@@ -63,7 +63,7 @@ public class TabBarPagerRTLManager extends ViewGroupManager<ViewPager2> {
                     WritableMap event = Arguments.createMap();
                     event.putInt("tab", position);
                     event.putInt("eventCount", tabBarPagerAdapter.nativeEventCount);
-                    reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(tabBarPager.getId(), "onTabSelected", event);
+                    reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(tabBarPager.getId(), "topTabSelected", event);
                 }
                 if (tabBarPagerAdapter.getTabAt(position) != null)
                     tabBarPagerAdapter.getTabAt(position).pressed();
@@ -74,7 +74,7 @@ public class TabBarPagerRTLManager extends ViewGroupManager<ViewPager2> {
                 super.onPageScrollStateChanged(state);
                 WritableMap event = Arguments.createMap();
                 event.putBoolean("swiping", state == ViewPager2.SCROLL_STATE_DRAGGING);
-                reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(tabBarPager.getId(),"onTabSwipeStateChanged", event);
+                reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(tabBarPager.getId(),"topTabSwipeStateChanged", event);
             }
         });
         tabBarPager.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
@@ -155,8 +155,8 @@ public class TabBarPagerRTLManager extends ViewGroupManager<ViewPager2> {
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("onTabSelected", MapBuilder.of("registrationName", "onTabSelected"))
-            .put("onTabSwipeStateChanged", MapBuilder.of("registrationName", "onTabSwipeStateChanged"))
+            .put("topTabSelected", MapBuilder.of("registrationName", "onTabSelected"))
+            .put("topTabSwipeStateChanged", MapBuilder.of("registrationName", "onTabSwipeStateChanged"))
             .build();
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerRTLViewManager.java
@@ -176,8 +176,8 @@ public class TabBarPagerRTLViewManager extends ViewGroupManager<ViewPager2> impl
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnTabSelected", MapBuilder.of("registrationName", "onTabSelected"))
-            .put("topOnTabSwipeStateChanged", MapBuilder.of("registrationName", "onTabSwipeStateChanged"))
+            .put("topTabSelected", MapBuilder.of("registrationName", "onTabSelected"))
+            .put("topTabSwipeStateChanged", MapBuilder.of("registrationName", "onTabSwipeStateChanged"))
             .build();
     }
 
@@ -233,7 +233,7 @@ public class TabBarPagerRTLViewManager extends ViewGroupManager<ViewPager2> impl
 
         @Override
         public String getEventName() {
-            return "topOnTabSelected";
+            return "topTabSelected";
         }
 
         @Override
@@ -255,7 +255,7 @@ public class TabBarPagerRTLViewManager extends ViewGroupManager<ViewPager2> impl
 
         @Override
         public String getEventName() {
-            return "topOnTabSwipeStateChanged";
+            return "topTabSwipeStateChanged";
         }
 
         @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerView.java
@@ -310,7 +310,7 @@ public class TabBarPagerView extends ViewPager implements TabBarItemView.ChangeL
 
         @Override
         public String getEventName() {
-            return "topOnTabSelected";
+            return "topTabSelected";
         }
 
         @Override
@@ -332,7 +332,7 @@ public class TabBarPagerView extends ViewPager implements TabBarItemView.ChangeL
 
         @Override
         public String getEventName() {
-            return "topOnTabSwipeStateChanged";
+            return "topTabSwipeStateChanged";
         }
 
         @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarPagerViewManager.java
@@ -88,8 +88,8 @@ public class TabBarPagerViewManager extends ViewGroupManager<TabBarPagerView> im
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnTabSelected", MapBuilder.of("registrationName", "onTabSelected"))
-            .put("topOnTabSwipeStateChanged", MapBuilder.of("registrationName", "onTabSwipeStateChanged"))
+            .put("topTabSelected", MapBuilder.of("registrationName", "onTabSelected"))
+            .put("topTabSwipeStateChanged", MapBuilder.of("registrationName", "onTabSwipeStateChanged"))
             .build();
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarView.java
@@ -207,7 +207,7 @@ public class TabBarView extends ViewGroup implements TabBarItemView.ChangeListen
 
         @Override
         public String getEventName() {
-            return "topOnTabSelected";
+            return "topTabSelected";
         }
 
         @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarViewManager.java
@@ -137,7 +137,7 @@ public class TabBarViewManager extends ViewGroupManager<TabBarView> implements N
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnTabSelected", MapBuilder.of("registrationName", "onTabSelected"))
+            .put("topTabSelected", MapBuilder.of("registrationName", "onTabSelected"))
             .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarManager.java
@@ -169,7 +169,7 @@ public class ToolbarManager extends ViewGroupManager<ToolbarView> {
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnNavigationPress", MapBuilder.of("registrationName", "onNavigationPress"))
+            .put("topNavigationPress", MapBuilder.of("registrationName", "onNavigationPress"))
             .build();
     }
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
@@ -330,7 +330,7 @@ public class ToolbarView extends MaterialToolbar implements ActionView {
 
         @Override
         public String getEventName() {
-            return "topOnNavigationPress";
+            return "topNavigationPress";
         }
 
         @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarViewManager.java
@@ -197,7 +197,7 @@ public class ToolbarViewManager extends ViewGroupManager<ToolbarView> implements
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
-            .put("topOnNavigationPress", MapBuilder.of("registrationName", "onNavigationPress"))
+            .put("topNavigationPress", MapBuilder.of("registrationName", "onNavigationPress"))
             .build();
     }
 }


### PR DESCRIPTION
Followed [React Native discussion to enable bridgeless mode](https://github.com/reactwg/react-native-new-architecture/discussions/154). Seems that bridgeless mode has extra event validation because
- On iOS, `onPress` had to be bubbling event (think because has same name as a bubbling event in React Native)
- On Android, had to rename `topOn{EventName}` to `top{EventName}`

Not enabling bridgeless mode in the fabric sample because get a `NullPointerException` on startup on Android. This happens with a default React Native project, so nothing to do with the Navigation router. Will enable bridgeless mode in fabric sample when React Native resolves this.
