### PR TITLE
Supported declarative animation api (Android)

### DIFF
--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -124,6 +124,15 @@ const NavigationStack = ({underlayColor: underlayColorStack = '#000', title, cru
                 ))
             };
         }
+        const convertPropsToStrings = (trans) => {
+            if (!trans) return;
+            ['fromX', 'fromY', 'toX', 'toY', 'pivotX', 'pivotY'].forEach(prop => {
+                trans[prop] = trans[prop] != undefined ? '' + trans[prop] : trans[prop]
+            });
+            trans.items?.forEach(item => convertPropsToStrings(item));
+        };
+        convertPropsToStrings(enterTrans);
+        convertPropsToStrings(exitTrans);
         enterAnim = !enterTrans ? enterAnim : null;
         exitAnim = !exitTrans ? exitAnim : null;
         const enterAnimOff = enterAnim === '';

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -106,36 +106,22 @@ const NavigationStack = ({underlayColor: underlayColorStack = '#000', title, cru
         sharedElements = containerTransform && sharedElements ? [sharedElements] : sharedElements;
         let enterTrans = typeof enterAnim === 'string' ? null : enterAnim;
         let exitTrans = typeof exitAnim === 'string' ? null : exitAnim;
-        if (enterTrans) {
-            const {start, startX, fromX, startY, fromY, pivotX, pivotY, items, ...rest} = enterTrans;
-            enterTrans = {
-                from: start,
-                fromX: (startX ?? fromX) !== undefined ? '' + (startX ?? fromX) : undefined,
-                fromY: (startY ?? fromY) !== undefined ? '' + (startY ?? fromY) : undefined,
-                pivotX: pivotX !== undefined ? '' + pivotX : undefined, pivotY: pivotY !== undefined ? '' + pivotY : undefined, ...rest,
-                items: items?.map(({start, startX, fromX, startY, fromY, pivotX, pivotY, ...rest}) => ({
-                        from: start,
-                        fromX: (startX ?? fromX) !== undefined ? '' + (startX ?? fromX) : undefined,
-                        fromY: (startY ?? fromY) !== undefined ? '' + (startY ?? fromY) : undefined,
-                        pivotX: pivotX !== undefined ? '' + pivotX : undefined, pivotY: pivotY !== undefined ? '' + pivotY : undefined, ...rest
-                    }))
-            };
-        }
-        if (exitTrans) {
-            const {start, startX, startY, toX, toY, pivotX, pivotY, items, ...rest} = exitTrans;
-            exitTrans = {
-                to: start,
-                toX: (startX ?? toX) !== undefined ? '' + (startX ?? toX) : undefined,
-                toY: (startY ?? toY) !== undefined ? '' + (startY ?? toY) : undefined,
-                pivotX: pivotX !== undefined ? '' + pivotX : undefined, pivotY: pivotY !== undefined ? '' + pivotY : undefined, ...rest,
-                items: items?.map(({start, startX, startY, toX, toY, pivotX, pivotY, ...rest}) => ({
-                        to: start,
-                        toX: (startX ?? toX) !== undefined ? '' + (startX ?? toX) : undefined,
-                        toY: (startY ?? toY) !== undefined ? '' + (startY ?? toY) : undefined,
-                        pivotX: pivotX !== undefined ? '' + pivotX : undefined, pivotY: pivotY !== undefined ? '' + pivotY : undefined, ...rest
-                    }))
-            };
-        }
+        const convertEnterTrans = ({start, startX, fromX, startY, fromY, pivotX, pivotY, items, ...rest}) => ({
+            from: start,
+            fromX: (startX ?? fromX) !== undefined ? '' + (startX ?? fromX) : undefined,
+            fromY: (startY ?? fromY) !== undefined ? '' + (startY ?? fromY) : undefined,
+            pivotX: pivotX !== undefined ? '' + pivotX : undefined, pivotY: pivotY !== undefined ? '' + pivotY : undefined, ...rest,
+            items: items?.map(convertEnterTrans),
+        })
+        const convertExitTrans = ({start, startX, startY, toX, toY, pivotX, pivotY, items, ...rest}) => ({
+            to: start,
+            toX: (startX ?? toX) !== undefined ? '' + (startX ?? toX) : undefined,
+            toY: (startY ?? toY) !== undefined ? '' + (startY ?? toY) : undefined,
+            pivotX: pivotX !== undefined ? '' + pivotX : undefined, pivotY: pivotY !== undefined ? '' + pivotY : undefined, ...rest,
+            items: items?.map(convertExitTrans),
+        });
+        enterTrans = enterTrans ? convertEnterTrans(enterTrans) : null;
+        exitTrans = exitTrans ? convertExitTrans(exitTrans) : null;
         enterAnim = !enterTrans ? enterAnim : null;
         exitAnim = !exitTrans ? exitAnim : null;
         const enterAnimOff = enterAnim === '';

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -106,6 +106,8 @@ const NavigationStack = ({underlayColor: underlayColorStack = '#000', title, cru
         sharedElements = containerTransform && sharedElements ? [sharedElements] : sharedElements;
         let enterTrans = typeof enterAnim === 'string' ? null : enterAnim;
         let exitTrans = typeof exitAnim === 'string' ? null : exitAnim;
+        enterTrans = !Array.isArray(enterTrans) ? enterTrans : {items: enterTrans};
+        exitTrans = !Array.isArray(exitTrans) ? exitTrans : {items: exitTrans};
         const convertEnterTrans = ({start, startX, fromX, startY, fromY, pivotX, pivotY, items, ...rest}) => ({
             from: start,
             fromX: (startX ?? fromX) !== undefined ? '' + (startX ?? fromX) : undefined,

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -70,8 +70,8 @@ const NavigationStack = ({underlayColor: underlayColorStack = '#000', title, cru
     }
     const sceneProps = ({key}: State) => firstLink ? allScenes[key].props : null;
     const returnOrCall = (item, ...args) => typeof item !== 'function' ? item : item(...args);
-    const unmountStyle = (from, state, ...rest) => sceneProps(state)?.unmountStyle ? sceneProps(state)?.unmountStyle(from, ...rest) : unmountStyleStack(from, state, ...rest);
-    const crumbStyle = (from, state, ...rest) => sceneProps(state)?.crumbStyle ? sceneProps(state)?.crumbStyle(from, ...rest) : crumbStyleStack(from, state, ...rest);
+    const unmountStyle = (from, state, ...rest) => sceneProps(state)?.unmountStyle ? returnOrCall(sceneProps(state)?.unmountStyle, from, ...rest) : returnOrCall(unmountStyleStack, from, state, ...rest);
+    const crumbStyle = (from, state, ...rest) => sceneProps(state)?.crumbStyle ? returnOrCall(sceneProps(state)?.crumbStyle, from, ...rest) : returnOrCall(crumbStyleStack, from, state, ...rest);
     const hidesTabBar = (state, ...rest) => sceneProps(state)?.hidesTabBar ? returnOrCall(sceneProps(state)?.hidesTabBar, ...rest) : hidesTabBarStack(state, ...rest);
     const getSharedElement = (state, ...rest) => sceneProps(state)?.sharedElement ? returnOrCall(sceneProps(state)?.sharedElement, ...rest) : getSharedElementStack(state, ...rest);
     const getSharedElements = (state, ...rest) => sceneProps(state)?.sharedElements ? returnOrCall(sceneProps(state)?.sharedElements, ...rest) : getSharedElementsStack(state, ...rest);

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -107,32 +107,35 @@ const NavigationStack = ({underlayColor: underlayColorStack = '#000', title, cru
         let enterTrans = typeof enterAnim === 'string' ? null : enterAnim;
         let exitTrans = typeof exitAnim === 'string' ? null : exitAnim;
         if (enterTrans) {
-            const {start, startX, startY, items, ...rest} = enterTrans;
+            const {start, startX, fromX, startY, fromY, pivotX, pivotY, items, ...rest} = enterTrans;
             enterTrans = {
-                from: start, fromX: startX, fromY: startY, ...rest,
-                items: items?.map(({start, startX, startY, ...rest}) => (
-                    {from: start, fromX: startX, fromY: startY, ...rest}
-                ))
+                from: start,
+                fromX: (startX ?? fromX) !== undefined ? '' + (startX ?? fromX) : undefined,
+                fromY: (startY ?? fromY) !== undefined ? '' + (startY ?? fromY) : undefined,
+                pivotX: pivotX !== undefined ? '' + pivotX : undefined, pivotY: pivotY !== undefined ? '' + pivotY : undefined, ...rest,
+                items: items?.map(({start, startX, fromX, startY, fromY, pivotX, pivotY, ...rest}) => ({
+                        from: start,
+                        fromX: (startX ?? fromX) !== undefined ? '' + (startX ?? fromX) : undefined,
+                        fromY: (startY ?? fromY) !== undefined ? '' + (startY ?? fromY) : undefined,
+                        pivotX: pivotX !== undefined ? '' + pivotX : undefined, pivotY: pivotY !== undefined ? '' + pivotY : undefined, ...rest
+                    }))
             };
         }
         if (exitTrans) {
-            const {start, startX, startY, items, ...rest} = exitTrans;
+            const {start, startX, startY, toX, toY, pivotX, pivotY, items, ...rest} = exitTrans;
             exitTrans = {
-                to: start, toX: startX, toY: startY, ...rest,
-                items: items?.map(({start, startX, startY, ...rest}) => (
-                    {to: start, toX: startX, toY: startY, ...rest}
-                ))
+                to: start,
+                toX: (startX ?? toX) !== undefined ? '' + (startX ?? toX) : undefined,
+                toY: (startY ?? toY) !== undefined ? '' + (startY ?? toY) : undefined,
+                pivotX: pivotX !== undefined ? '' + pivotX : undefined, pivotY: pivotY !== undefined ? '' + pivotY : undefined, ...rest,
+                items: items?.map(({start, startX, startY, toX, toY, pivotX, pivotY, ...rest}) => ({
+                        to: start,
+                        toX: (startX ?? toX) !== undefined ? '' + (startX ?? toX) : undefined,
+                        toY: (startY ?? toY) !== undefined ? '' + (startY ?? toY) : undefined,
+                        pivotX: pivotX !== undefined ? '' + pivotX : undefined, pivotY: pivotY !== undefined ? '' + pivotY : undefined, ...rest
+                    }))
             };
         }
-        const convertPropsToStrings = (trans) => {
-            if (!trans) return;
-            ['fromX', 'fromY', 'toX', 'toY', 'pivotX', 'pivotY'].forEach(prop => {
-                trans[prop] = trans[prop] != undefined ? '' + trans[prop] : trans[prop]
-            });
-            trans.items?.forEach(item => convertPropsToStrings(item));
-        };
-        convertPropsToStrings(enterTrans);
-        convertPropsToStrings(exitTrans);
         enterAnim = !enterTrans ? enterAnim : null;
         exitAnim = !exitTrans ? exitAnim : null;
         const enterAnimOff = enterAnim === '';

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -113,7 +113,7 @@ const NavigationStack = ({underlayColor: underlayColorStack = '#000', title, cru
             pivotX: pivotX !== undefined ? '' + pivotX : undefined, pivotY: pivotY !== undefined ? '' + pivotY : undefined, ...rest,
             items: items?.map(convertEnterTrans),
         })
-        const convertExitTrans = ({start, startX, startY, toX, toY, pivotX, pivotY, items, ...rest}) => ({
+        const convertExitTrans = ({start, startX, toX, startY, toY, pivotX, pivotY, items, ...rest}) => ({
             to: start,
             toX: (startX ?? toX) !== undefined ? '' + (startX ?? toX) : undefined,
             toY: (startY ?? toY) !== undefined ? '' + (startY ?? toY) : undefined,

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -104,8 +104,26 @@ const NavigationStack = ({underlayColor: underlayColorStack = '#000', title, cru
         }
         const containerTransform = typeof sharedElements === 'string';
         sharedElements = containerTransform && sharedElements ? [sharedElements] : sharedElements;
-        const enterTrans = typeof enterAnim === 'string' ? null : enterAnim;
-        const exitTrans = typeof exitAnim === 'string' ? null : exitAnim;
+        let enterTrans = typeof enterAnim === 'string' ? null : enterAnim;
+        let exitTrans = typeof exitAnim === 'string' ? null : exitAnim;
+        if (enterTrans) {
+            const {start, startX, startY, items, ...rest} = enterTrans;
+            enterTrans = {
+                from: start, fromX: startX, fromY: startY, ...rest,
+                items: items?.map(({start, startX, startY, ...rest}) => (
+                    {from: start, fromX: startX, fromY: startY, ...rest}
+                ))
+            };
+        }
+        if (exitTrans) {
+            const {start, startX, startY, items, ...rest} = exitTrans;
+            exitTrans = {
+                to: start, toX: startX, toY: startY, ...rest,
+                items: items?.map(({start, startX, startY, ...rest}) => (
+                    {to: start, toX: startX, toY: startY, ...rest}
+                ))
+            };
+        }
         enterAnim = !enterTrans ? enterAnim : null;
         exitAnim = !exitTrans ? exitAnim : null;
         const enterAnimOff = enterAnim === '';

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -132,32 +132,35 @@ class Scene extends React.Component<SceneProps, SceneState> {
         let enterTrans = typeof enterAnim === 'string' ? null : enterAnim;
         let exitTrans = typeof exitAnim === 'string' ? null : exitAnim;
         if (enterTrans) {
-            const {start, startX, startY, items, ...rest} = enterTrans;
+            const {start, startX, fromX, startY, fromY, pivotX, pivotY, items, ...rest} = enterTrans;
             enterTrans = {
-                from: start, fromX: startX, fromY: startY, ...rest,
-                items: items?.map(({start, startX, startY, ...rest}) => (
-                    {from: start, fromX: startX, fromY: startY, ...rest}
-                ))
+                from: start,
+                fromX: (startX ?? fromX) !== undefined ? '' + (startX ?? fromX) : undefined,
+                fromY: (startY ?? fromY) !== undefined ? '' + (startY ?? fromY) : undefined,
+                pivotX: pivotX !== undefined ? '' + pivotX : undefined, pivotY: pivotY !== undefined ? '' + pivotY : undefined, ...rest,
+                items: items?.map(({start, startX, fromX, startY, fromY, pivotX, pivotY, ...rest}) => ({
+                        from: start,
+                        fromX: (startX ?? fromX) !== undefined ? '' + (startX ?? fromX) : undefined,
+                        fromY: (startY ?? fromY) !== undefined ? '' + (startY ?? fromY) : undefined,
+                        pivotX: pivotX !== undefined ? '' + pivotX : undefined, pivotY: pivotY !== undefined ? '' + pivotY : undefined, ...rest
+                    }))
             };
         }
         if (exitTrans) {
-            const {start, startX, startY, items, ...rest} = exitTrans;
+            const {start, startX, startY, toX, toY, pivotX, pivotY, items, ...rest} = exitTrans;
             exitTrans = {
-                to: start, toX: startX, toY: startY, ...rest,
-                items: items?.map(({start, startX, startY, ...rest}) => (
-                    {to: start, toX: startX, toY: startY, ...rest}
-                ))
+                to: start,
+                toX: (startX ?? toX) !== undefined ? '' + (startX ?? toX) : undefined,
+                toY: (startY ?? toY) !== undefined ? '' + (startY ?? toY) : undefined,
+                pivotX: pivotX !== undefined ? '' + pivotX : undefined, pivotY: pivotY !== undefined ? '' + pivotY : undefined, ...rest,
+                items: items?.map(({start, startX, startY, toX, toY, pivotX, pivotY, ...rest}) => ({
+                        to: start,
+                        toX: (startX ?? toX) !== undefined ? '' + (startX ?? toX) : undefined,
+                        toY: (startY ?? toY) !== undefined ? '' + (startY ?? toY) : undefined,
+                        pivotX: pivotX !== undefined ? '' + pivotX : undefined, pivotY: pivotY !== undefined ? '' + pivotY : undefined, ...rest
+                    }))
             };
         }
-        const convertPropsToStrings = (trans) => {
-            if (!trans) return;
-            ['fromX', 'fromY', 'toX', 'toY', 'pivotX', 'pivotY'].forEach(prop => {
-                trans[prop] = trans[prop] != undefined ? '' + trans[prop] : trans[prop]
-            });
-            trans.items?.forEach(item => convertPropsToStrings(item));
-        };
-        convertPropsToStrings(enterTrans);
-        convertPropsToStrings(exitTrans);
         enterAnim = !enterTrans ? enterAnim : null;
         exitAnim = !exitTrans ? exitAnim : null;
         return {enterAnim, exitAnim, enterTrans, exitTrans, hidesTabBar, backgroundColor, landscape};

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -131,6 +131,8 @@ class Scene extends React.Component<SceneProps, SceneState> {
         var landscape = landscape(state, data, currentCrumbs);
         let enterTrans = typeof enterAnim === 'string' ? null : enterAnim;
         let exitTrans = typeof exitAnim === 'string' ? null : exitAnim;
+        enterTrans = !Array.isArray(enterTrans) ? enterTrans : {items: enterTrans};
+        exitTrans = !Array.isArray(exitTrans) ? exitTrans : {items: exitTrans};
         const convertEnterTrans = ({start, startX, fromX, startY, fromY, pivotX, pivotY, items, ...rest}) => ({
             from: start,
             fromX: (startX ?? fromX) !== undefined ? '' + (startX ?? fromX) : undefined,

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -123,9 +123,9 @@ class Scene extends React.Component<SceneProps, SceneState> {
         if (crumb > 0) {
             var {state: prevState, data: prevData} = crumbs[crumb - 1];
             var prevCrumbs = crumbs.slice(0, crumb - 1);
-            var enterAnim = crumbStyle(true, prevState, prevData, prevCrumbs, state, data);
+            var enterAnim = typeof crumbStyle === 'function' ? crumbStyle(true, prevState, prevData, prevCrumbs, state, data) : crumbStyle;
         }
-        var exitAnim = unmountStyle(false, state, data, currentCrumbs);
+        var exitAnim = typeof unmountStyle === 'function' ? unmountStyle(false, state, data, currentCrumbs) : unmountStyle;
         var hidesTabBar = hidesTabBar(state, data, currentCrumbs);
         var backgroundColor = backgroundColor(state, data, currentCrumbs) || '#fff';
         var landscape = landscape(state, data, currentCrumbs);

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -129,8 +129,26 @@ class Scene extends React.Component<SceneProps, SceneState> {
         var hidesTabBar = hidesTabBar(state, data, currentCrumbs);
         var backgroundColor = backgroundColor(state, data, currentCrumbs) || '#fff';
         var landscape = landscape(state, data, currentCrumbs);
-        const enterTrans = typeof enterAnim === 'string' ? null : enterAnim;
-        const exitTrans = typeof exitAnim === 'string' ? null : exitAnim;
+        let enterTrans = typeof enterAnim === 'string' ? null : enterAnim;
+        let exitTrans = typeof exitAnim === 'string' ? null : exitAnim;
+        if (enterTrans) {
+            const {start, startX, startY, items, ...rest} = enterTrans;
+            enterTrans = {
+                from: start, fromX: startX, fromY: startY, ...rest,
+                items: items?.map(({start, startX, startY, ...rest}) => (
+                    {from: start, fromX: startX, fromY: startY, ...rest}
+                ))
+            };
+        }
+        if (exitTrans) {
+            const {start, startX, startY, items, ...rest} = exitTrans;
+            exitTrans = {
+                to: start, toX: startX, toY: startY, ...rest,
+                items: items?.map(({start, startX, startY, ...rest}) => (
+                    {to: start, toX: startX, toY: startY, ...rest}
+                ))
+            };
+        }
         enterAnim = !enterTrans ? enterAnim : null;
         exitAnim = !exitTrans ? exitAnim : null;
         return {enterAnim, exitAnim, enterTrans, exitTrans, hidesTabBar, backgroundColor, landscape};

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -138,7 +138,7 @@ class Scene extends React.Component<SceneProps, SceneState> {
             pivotX: pivotX !== undefined ? '' + pivotX : undefined, pivotY: pivotY !== undefined ? '' + pivotY : undefined, ...rest,
             items: items?.map(convertEnterTrans),
         })
-        const convertExitTrans = ({start, startX, startY, toX, toY, pivotX, pivotY, items, ...rest}) => ({
+        const convertExitTrans = ({start, startX, toX, startY, toY, pivotX, pivotY, items, ...rest}) => ({
             to: start,
             toX: (startX ?? toX) !== undefined ? '' + (startX ?? toX) : undefined,
             toY: (startY ?? toY) !== undefined ? '' + (startY ?? toY) : undefined,

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -131,36 +131,22 @@ class Scene extends React.Component<SceneProps, SceneState> {
         var landscape = landscape(state, data, currentCrumbs);
         let enterTrans = typeof enterAnim === 'string' ? null : enterAnim;
         let exitTrans = typeof exitAnim === 'string' ? null : exitAnim;
-        if (enterTrans) {
-            const {start, startX, fromX, startY, fromY, pivotX, pivotY, items, ...rest} = enterTrans;
-            enterTrans = {
-                from: start,
-                fromX: (startX ?? fromX) !== undefined ? '' + (startX ?? fromX) : undefined,
-                fromY: (startY ?? fromY) !== undefined ? '' + (startY ?? fromY) : undefined,
-                pivotX: pivotX !== undefined ? '' + pivotX : undefined, pivotY: pivotY !== undefined ? '' + pivotY : undefined, ...rest,
-                items: items?.map(({start, startX, fromX, startY, fromY, pivotX, pivotY, ...rest}) => ({
-                        from: start,
-                        fromX: (startX ?? fromX) !== undefined ? '' + (startX ?? fromX) : undefined,
-                        fromY: (startY ?? fromY) !== undefined ? '' + (startY ?? fromY) : undefined,
-                        pivotX: pivotX !== undefined ? '' + pivotX : undefined, pivotY: pivotY !== undefined ? '' + pivotY : undefined, ...rest
-                    }))
-            };
-        }
-        if (exitTrans) {
-            const {start, startX, startY, toX, toY, pivotX, pivotY, items, ...rest} = exitTrans;
-            exitTrans = {
-                to: start,
-                toX: (startX ?? toX) !== undefined ? '' + (startX ?? toX) : undefined,
-                toY: (startY ?? toY) !== undefined ? '' + (startY ?? toY) : undefined,
-                pivotX: pivotX !== undefined ? '' + pivotX : undefined, pivotY: pivotY !== undefined ? '' + pivotY : undefined, ...rest,
-                items: items?.map(({start, startX, startY, toX, toY, pivotX, pivotY, ...rest}) => ({
-                        to: start,
-                        toX: (startX ?? toX) !== undefined ? '' + (startX ?? toX) : undefined,
-                        toY: (startY ?? toY) !== undefined ? '' + (startY ?? toY) : undefined,
-                        pivotX: pivotX !== undefined ? '' + pivotX : undefined, pivotY: pivotY !== undefined ? '' + pivotY : undefined, ...rest
-                    }))
-            };
-        }
+        const convertEnterTrans = ({start, startX, fromX, startY, fromY, pivotX, pivotY, items, ...rest}) => ({
+            from: start,
+            fromX: (startX ?? fromX) !== undefined ? '' + (startX ?? fromX) : undefined,
+            fromY: (startY ?? fromY) !== undefined ? '' + (startY ?? fromY) : undefined,
+            pivotX: pivotX !== undefined ? '' + pivotX : undefined, pivotY: pivotY !== undefined ? '' + pivotY : undefined, ...rest,
+            items: items?.map(convertEnterTrans),
+        })
+        const convertExitTrans = ({start, startX, startY, toX, toY, pivotX, pivotY, items, ...rest}) => ({
+            to: start,
+            toX: (startX ?? toX) !== undefined ? '' + (startX ?? toX) : undefined,
+            toY: (startY ?? toY) !== undefined ? '' + (startY ?? toY) : undefined,
+            pivotX: pivotX !== undefined ? '' + pivotX : undefined, pivotY: pivotY !== undefined ? '' + pivotY : undefined, ...rest,
+            items: items?.map(convertExitTrans),
+        });
+        enterTrans = enterTrans ? convertEnterTrans(enterTrans) : null;
+        exitTrans = exitTrans ? convertExitTrans(exitTrans) : null;
         enterAnim = !enterTrans ? enterAnim : null;
         exitAnim = !exitTrans ? exitAnim : null;
         return {enterAnim, exitAnim, enterTrans, exitTrans, hidesTabBar, backgroundColor, landscape};

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -149,6 +149,15 @@ class Scene extends React.Component<SceneProps, SceneState> {
                 ))
             };
         }
+        const convertPropsToStrings = (trans) => {
+            if (!trans) return;
+            ['fromX', 'fromY', 'toX', 'toY', 'pivotX', 'pivotY'].forEach(prop => {
+                trans[prop] = trans[prop] != undefined ? '' + trans[prop] : trans[prop]
+            });
+            trans.items?.forEach(item => convertPropsToStrings(item));
+        };
+        convertPropsToStrings(enterTrans);
+        convertPropsToStrings(exitTrans);
         enterAnim = !enterTrans ? enterAnim : null;
         exitAnim = !exitTrans ? exitAnim : null;
         return {enterAnim, exitAnim, enterTrans, exitTrans, hidesTabBar, backgroundColor, landscape};

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/AnimationPropParser.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/AnimationPropParser.java
@@ -1,6 +1,7 @@
 package com.navigation.reactnative;
 
 import android.util.Pair;
+import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
 import android.view.animation.ScaleAnimation;
 import android.view.animation.TranslateAnimation;
@@ -70,6 +71,11 @@ public class AnimationPropParser {
                 animation = new ScaleAnimation(fromX.second, toX.second, fromY.second, toY.second, pivotX.first, pivotX.second, pivotY.first, pivotY.second);
                 animation.setDuration(anim.hasKey("duration") ? anim.getInt("duration") : 300);
                 break;
+            case "alpha":
+                fromX = getTranslateValues(enter ? anim.getString("from") : null, 1, Animation.ABSOLUTE);
+                toX = getTranslateValues(!enter ? anim.getString("to") : null, 1, Animation.ABSOLUTE);
+                animation = new AlphaAnimation(fromX.second, toX.second);
+                animation.setDuration(anim.hasKey("duration") ? anim.getInt("duration") : 300);
         }
         return animation;
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/AnimationPropParser.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/AnimationPropParser.java
@@ -54,33 +54,33 @@ public class AnimationPropParser {
         if (animType == null) return null;
         switch (animType) {
             case "translate":
-                fromX = getTranslateValues(enter ? anim.getString("fromX") : null, 0, Animation.ABSOLUTE);
-                toX = getTranslateValues(!enter ? anim.getString("toX") : null, 0, Animation.ABSOLUTE);
-                fromY = getTranslateValues(enter ? anim.getString("fromY") : null, 0, Animation.ABSOLUTE);
-                toY = getTranslateValues(!enter ? anim.getString("toY") : null, 0, Animation.ABSOLUTE);
+                fromX = getValues(enter ? anim.getString("fromX") : null, 0, Animation.ABSOLUTE);
+                toX = getValues(!enter ? anim.getString("toX") : null, 0, Animation.ABSOLUTE);
+                fromY = getValues(enter ? anim.getString("fromY") : null, 0, Animation.ABSOLUTE);
+                toY = getValues(!enter ? anim.getString("toY") : null, 0, Animation.ABSOLUTE);
                 animation = new TranslateAnimation(fromX.first, fromX.second, toX.first, toX.second, fromY.first, fromY.second, toY.first, toY.second);
                 animation.setDuration(anim.hasKey("duration") ? anim.getInt("duration") : 300);
                 break;
             case "scale":
-                fromX = getTranslateValues(enter ? anim.getString("fromX") : null, 1, Animation.ABSOLUTE);
-                toX = getTranslateValues(!enter ? anim.getString("toX") : null, 1, Animation.ABSOLUTE);
-                fromY = getTranslateValues(enter ? anim.getString("fromY") : null, 1, Animation.ABSOLUTE);
-                toY = getTranslateValues(!enter ? anim.getString("toY") : null, 1, Animation.ABSOLUTE);
-                Pair<Integer, Float> pivotX = getTranslateValues(anim.getString("pivotX"),0.5f, Animation.RELATIVE_TO_SELF);
-                Pair<Integer, Float> pivotY = getTranslateValues(anim.getString("pivotY"),0.5f, Animation.RELATIVE_TO_SELF);
+                fromX = getValues(enter ? anim.getString("fromX") : null, 1, Animation.ABSOLUTE);
+                toX = getValues(!enter ? anim.getString("toX") : null, 1, Animation.ABSOLUTE);
+                fromY = getValues(enter ? anim.getString("fromY") : null, 1, Animation.ABSOLUTE);
+                toY = getValues(!enter ? anim.getString("toY") : null, 1, Animation.ABSOLUTE);
+                Pair<Integer, Float> pivotX = getValues(anim.getString("pivotX"),0.5f, Animation.RELATIVE_TO_SELF);
+                Pair<Integer, Float> pivotY = getValues(anim.getString("pivotY"),0.5f, Animation.RELATIVE_TO_SELF);
                 animation = new ScaleAnimation(fromX.second, toX.second, fromY.second, toY.second, pivotX.first, pivotX.second, pivotY.first, pivotY.second);
                 animation.setDuration(anim.hasKey("duration") ? anim.getInt("duration") : 300);
                 break;
             case "alpha":
-                fromX = getTranslateValues(enter ? anim.getString("from") : null, 1, Animation.ABSOLUTE);
-                toX = getTranslateValues(!enter ? anim.getString("to") : null, 1, Animation.ABSOLUTE);
+                fromX = getValues(enter ? anim.getString("from") : null, 1, Animation.ABSOLUTE);
+                toX = getValues(!enter ? anim.getString("to") : null, 1, Animation.ABSOLUTE);
                 animation = new AlphaAnimation(fromX.second, toX.second);
                 animation.setDuration(anim.hasKey("duration") ? anim.getInt("duration") : 300);
         }
         return animation;
     }
 
-    private static Pair<Integer, Float> getTranslateValues(String from, float defaultFromValue, int defaultFromType) {
+    private static Pair<Integer, Float> getValues(String from, float defaultFromValue, int defaultFromType) {
         float fromValue = defaultFromValue;
         int fromType = defaultFromType;
         if (from != null) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/AnimationPropParser.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/AnimationPropParser.java
@@ -3,12 +3,14 @@ package com.navigation.reactnative;
 import android.util.Pair;
 import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
+import android.view.animation.AnimationSet;
 import android.view.animation.RotateAnimation;
 import android.view.animation.ScaleAnimation;
 import android.view.animation.TranslateAnimation;
 
 import androidx.transition.Transition;
 
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.google.android.material.transition.Hold;
 import com.google.android.material.transition.MaterialElevationScale;
@@ -52,7 +54,18 @@ public class AnimationPropParser {
         Animation animation = null;
         Pair<Integer, Float> fromX, toX, fromY, toY, pivotX, pivotY;
         String animType = anim != null ? anim.getString("type") : null;
-        if (animType == null) return null;
+        if (anim == null) return null;
+        if (animType == null) {
+            ReadableArray items = anim.hasKey("items") ? anim.getArray("items") : null;
+            AnimationSet animationSet = new AnimationSet(true);
+            animationSet.setDuration(anim.hasKey("duration") ? anim.getInt("duration") : 300);
+            if (items != null) {
+                for(int i = 0; i < items.size(); i++) {
+                    animationSet.addAnimation(getAnimation(items.getMap(i), enter));
+                }
+            }
+            return animationSet;
+        };
         switch (animType) {
             case "translate":
                 fromX = getValues(enter ? anim.getString("fromX") : null, 0);
@@ -77,6 +90,7 @@ public class AnimationPropParser {
                 toX = getValues(!enter ? anim.getString("to") : null);
                 animation = new AlphaAnimation(fromX.second, toX.second);
                 animation.setDuration(anim.hasKey("duration") ? anim.getInt("duration") : 300);
+                break;
             case "rotate":
                 fromX = getValues(anim.getString("from"), 0);
                 toX = getValues(anim.getString("to"), 0);
@@ -84,6 +98,7 @@ public class AnimationPropParser {
                 pivotY = getValues(anim.getString("pivotY"),0.5f, Animation.RELATIVE_TO_SELF);
                 animation = new RotateAnimation(fromX.second, toX.second, pivotX.first, pivotX.second, pivotY.first, pivotY.second);
                 animation.setDuration(anim.hasKey("duration") ? anim.getInt("duration") : 300);
+                break;
         }
         return animation;
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/AnimationPropParser.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/AnimationPropParser.java
@@ -54,30 +54,38 @@ public class AnimationPropParser {
         if (animType == null) return null;
         switch (animType) {
             case "translate":
-                fromX = getValues(enter ? anim.getString("fromX") : null, 0, Animation.ABSOLUTE);
-                toX = getValues(!enter ? anim.getString("toX") : null, 0, Animation.ABSOLUTE);
-                fromY = getValues(enter ? anim.getString("fromY") : null, 0, Animation.ABSOLUTE);
-                toY = getValues(!enter ? anim.getString("toY") : null, 0, Animation.ABSOLUTE);
+                fromX = getValues(enter ? anim.getString("fromX") : null, 0);
+                toX = getValues(!enter ? anim.getString("toX") : null, 0);
+                fromY = getValues(enter ? anim.getString("fromY") : null, 0);
+                toY = getValues(!enter ? anim.getString("toY") : null, 0);
                 animation = new TranslateAnimation(fromX.first, fromX.second, toX.first, toX.second, fromY.first, fromY.second, toY.first, toY.second);
                 animation.setDuration(anim.hasKey("duration") ? anim.getInt("duration") : 300);
                 break;
             case "scale":
-                fromX = getValues(enter ? anim.getString("fromX") : null, 1, Animation.ABSOLUTE);
-                toX = getValues(!enter ? anim.getString("toX") : null, 1, Animation.ABSOLUTE);
-                fromY = getValues(enter ? anim.getString("fromY") : null, 1, Animation.ABSOLUTE);
-                toY = getValues(!enter ? anim.getString("toY") : null, 1, Animation.ABSOLUTE);
+                fromX = getValues(enter ? anim.getString("fromX") : null);
+                toX = getValues(!enter ? anim.getString("toX") : null);
+                fromY = getValues(enter ? anim.getString("fromY") : null);
+                toY = getValues(!enter ? anim.getString("toY") : null);
                 Pair<Integer, Float> pivotX = getValues(anim.getString("pivotX"),0.5f, Animation.RELATIVE_TO_SELF);
                 Pair<Integer, Float> pivotY = getValues(anim.getString("pivotY"),0.5f, Animation.RELATIVE_TO_SELF);
                 animation = new ScaleAnimation(fromX.second, toX.second, fromY.second, toY.second, pivotX.first, pivotX.second, pivotY.first, pivotY.second);
                 animation.setDuration(anim.hasKey("duration") ? anim.getInt("duration") : 300);
                 break;
             case "alpha":
-                fromX = getValues(enter ? anim.getString("from") : null, 1, Animation.ABSOLUTE);
-                toX = getValues(!enter ? anim.getString("to") : null, 1, Animation.ABSOLUTE);
+                fromX = getValues(enter ? anim.getString("from") : null);
+                toX = getValues(!enter ? anim.getString("to") : null);
                 animation = new AlphaAnimation(fromX.second, toX.second);
                 animation.setDuration(anim.hasKey("duration") ? anim.getInt("duration") : 300);
         }
         return animation;
+    }
+
+    private static Pair<Integer, Float> getValues(String from) {
+        return getValues(from, 1);
+    }
+
+    private static Pair<Integer, Float> getValues(String from, float defaultFromValue) {
+        return getValues(from, defaultFromValue, Animation.ABSOLUTE);
     }
 
     private static Pair<Integer, Float> getValues(String from, float defaultFromValue, int defaultFromType) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/AnimationPropParser.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/AnimationPropParser.java
@@ -86,17 +86,17 @@ public class AnimationPropParser {
                 animation.setDuration(anim.hasKey("duration") ? anim.getInt("duration") : 300);
                 break;
             case "alpha":
-                fromX = getValues(enter ? anim.getString("from") : null);
-                toX = getValues(!enter ? anim.getString("to") : null);
-                animation = new AlphaAnimation(fromX.second, toX.second);
+                float fromAlpha = enter && anim.hasKey("from") ? (float) anim.getDouble("from") : 1;
+                float toAlpha = !enter && anim.hasKey("to") ? (float) anim.getDouble("to") : 1;
+                animation = new AlphaAnimation(fromAlpha, toAlpha);
                 animation.setDuration(anim.hasKey("duration") ? anim.getInt("duration") : 300);
                 break;
             case "rotate":
-                fromX = getValues(anim.getString("from"), 0);
-                toX = getValues(anim.getString("to"), 0);
+                float fromDegrees = anim.hasKey("from") ? (float) anim.getDouble("from") : 0;
+                float toDegrees = anim.hasKey("to") ? (float) anim.getDouble("to") : 0;
                 pivotX = getValues(anim.getString("pivotX"),0.5f, Animation.RELATIVE_TO_SELF);
                 pivotY = getValues(anim.getString("pivotY"),0.5f, Animation.RELATIVE_TO_SELF);
-                animation = new RotateAnimation(fromX.second, toX.second, pivotX.first, pivotX.second, pivotY.first, pivotY.second);
+                animation = new RotateAnimation(fromDegrees, toDegrees, pivotX.first, pivotX.second, pivotY.first, pivotY.second);
                 animation.setDuration(anim.hasKey("duration") ? anim.getInt("duration") : 300);
                 break;
         }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/AnimationPropParser.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/AnimationPropParser.java
@@ -58,7 +58,7 @@ public class AnimationPropParser {
         if (animType == null) {
             ReadableArray items = anim.hasKey("items") ? anim.getArray("items") : null;
             AnimationSet animationSet = new AnimationSet(true);
-            animationSet.setDuration(anim.hasKey("duration") ? anim.getInt("duration") : 300);
+            if (anim.hasKey("duration")) animationSet.setDuration(anim.getInt("duration"));
             if (items != null) {
                 for(int i = 0; i < items.size(); i++) {
                     animationSet.addAnimation(getAnimation(items.getMap(i), enter));

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/AnimationPropParser.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/AnimationPropParser.java
@@ -3,6 +3,7 @@ package com.navigation.reactnative;
 import android.util.Pair;
 import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
+import android.view.animation.RotateAnimation;
 import android.view.animation.ScaleAnimation;
 import android.view.animation.TranslateAnimation;
 
@@ -49,7 +50,7 @@ public class AnimationPropParser {
 
     protected static Animation getAnimation(ReadableMap anim, boolean enter) {
         Animation animation = null;
-        Pair<Integer, Float> fromX, toX, fromY, toY;
+        Pair<Integer, Float> fromX, toX, fromY, toY, pivotX, pivotY;
         String animType = anim != null ? anim.getString("type") : null;
         if (animType == null) return null;
         switch (animType) {
@@ -66,8 +67,8 @@ public class AnimationPropParser {
                 toX = getValues(!enter ? anim.getString("toX") : null);
                 fromY = getValues(enter ? anim.getString("fromY") : null);
                 toY = getValues(!enter ? anim.getString("toY") : null);
-                Pair<Integer, Float> pivotX = getValues(anim.getString("pivotX"),0.5f, Animation.RELATIVE_TO_SELF);
-                Pair<Integer, Float> pivotY = getValues(anim.getString("pivotY"),0.5f, Animation.RELATIVE_TO_SELF);
+                pivotX = getValues(anim.getString("pivotX"),0.5f, Animation.RELATIVE_TO_SELF);
+                pivotY = getValues(anim.getString("pivotY"),0.5f, Animation.RELATIVE_TO_SELF);
                 animation = new ScaleAnimation(fromX.second, toX.second, fromY.second, toY.second, pivotX.first, pivotX.second, pivotY.first, pivotY.second);
                 animation.setDuration(anim.hasKey("duration") ? anim.getInt("duration") : 300);
                 break;
@@ -75,6 +76,13 @@ public class AnimationPropParser {
                 fromX = getValues(enter ? anim.getString("from") : null);
                 toX = getValues(!enter ? anim.getString("to") : null);
                 animation = new AlphaAnimation(fromX.second, toX.second);
+                animation.setDuration(anim.hasKey("duration") ? anim.getInt("duration") : 300);
+            case "rotate":
+                fromX = getValues(anim.getString("from"), 0);
+                toX = getValues(anim.getString("to"), 0);
+                pivotX = getValues(anim.getString("pivotX"),0.5f, Animation.RELATIVE_TO_SELF);
+                pivotY = getValues(anim.getString("pivotY"),0.5f, Animation.RELATIVE_TO_SELF);
+                animation = new RotateAnimation(fromX.second, toX.second, pivotX.first, pivotX.second, pivotY.first, pivotY.second);
                 animation.setDuration(anim.hasKey("duration") ? anim.getInt("duration") : 300);
         }
         return animation;
@@ -96,6 +104,7 @@ public class AnimationPropParser {
                 fromType = Animation.RELATIVE_TO_SELF;
                 fromValue = Float.parseFloat(from.substring(0, from.length() - 1)) / 100;
             } else {
+                fromType = Animation.ABSOLUTE;
                 fromValue = Float.parseFloat(from);
             }
         }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/AnimationPropParser.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/AnimationPropParser.java
@@ -1,0 +1,78 @@
+package com.navigation.reactnative;
+
+import android.util.Pair;
+import android.view.animation.Animation;
+import android.view.animation.TranslateAnimation;
+
+import androidx.transition.Transition;
+
+import com.facebook.react.bridge.ReadableMap;
+import com.google.android.material.transition.Hold;
+import com.google.android.material.transition.MaterialElevationScale;
+import com.google.android.material.transition.MaterialFade;
+import com.google.android.material.transition.MaterialFadeThrough;
+import com.google.android.material.transition.MaterialSharedAxis;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AnimationPropParser {
+    protected static Transition getTransition(ReadableMap trans) {
+        Transition transition = null;
+        String transType = trans != null ? trans.getString("type") : null;
+        if (transType == null) return transition;
+        switch (transType) {
+            case "sharedAxis":
+                Map<String, Integer> axisMap = new HashMap<>();
+                axisMap.put("x", MaterialSharedAxis.X);
+                axisMap.put("y", MaterialSharedAxis.Y);
+                Integer axis = axisMap.get(trans.getString("axis"));
+                transition = new MaterialSharedAxis(axis != null ? axis : MaterialSharedAxis.Z, true);
+                break;
+            case "elevationScale":
+                transition = new MaterialElevationScale(true);
+                break;
+            case "fade":
+                transition = new MaterialFade();
+                break;
+            case "fadeThrough":
+                transition = new MaterialFadeThrough();
+                break;
+            case "hold":
+                transition = new Hold();
+                break;
+        }
+        return transition;
+    }
+
+    protected static Animation getAnimation(ReadableMap anim) {
+        Animation animation = null;
+        String animType = anim != null ? anim.getString("type") : null;
+        if (animType == null) return animation;
+        switch (animType) {
+            case "translate":
+                Pair<Integer, Float> fromX = getTranslateValues(anim.getString("fromX"));
+                Pair<Integer, Float> toX = getTranslateValues(anim.getString("toX"));
+                Pair<Integer, Float> fromY = getTranslateValues(anim.getString("fromY"));
+                Pair<Integer, Float> toY = getTranslateValues(anim.getString("toY"));
+                animation = new TranslateAnimation(fromX.first, fromX.second, toX.first, toX.second, fromY.first, fromY.second, toY.first, toY.second);
+                animation.setDuration(anim.hasKey("duration") ? anim.getInt("duration") : 300);
+                break;
+        }
+        return animation;
+    }
+
+    private static Pair<Integer, Float> getTranslateValues(String from) {
+        float fromValue = 0f;
+        int fromType = Animation.ABSOLUTE;
+        if (from != null) {
+            if (from.endsWith("%")) {
+                fromType = Animation.RELATIVE_TO_SELF;
+                fromValue = Float.parseFloat(from.substring(0, from.length() - 1)) / 100;
+            } else {
+                fromValue = Float.parseFloat(from);
+            }
+        }
+        return new Pair<>(fromType, fromValue);
+    }
+}

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -54,31 +54,7 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
 
     @ReactProp(name = "exitTrans")
     public void setExitTrans(NavigationStackView view, ReadableMap exitTrans) {
-        if (exitTrans != null) {
-            switch (exitTrans.getString("type")) {
-                case "sharedAxis" :
-                    Map<String, Integer> axisMap = new HashMap();
-                    axisMap.put("x", MaterialSharedAxis.X);
-                    axisMap.put("y", MaterialSharedAxis.Y);
-                    Integer axis = axisMap.get(exitTrans.getString("axis"));
-                    view.exitTrans = new MaterialSharedAxis(axis != null ? axis : MaterialSharedAxis.Z, true);
-                    break;
-                case "elevationScale" :
-                    view.exitTrans = new MaterialElevationScale(false);
-                    break;
-                case "fade" :
-                    view.exitTrans = new MaterialFade();
-                    break;
-                case "fadeThrough" :
-                    view.exitTrans = new MaterialFadeThrough();
-                    break;
-                case "hold" :
-                    view.exitTrans = new Hold();
-                    break;
-            }
-        } else {
-            view.exitTrans = null;
-        }
+        view.exitTrans = AnimationPropParser.getTransition(exitTrans);
     }
 
     @ReactProp(name = "sharedElements")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -72,7 +72,29 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
                     view.enterTrans = new Hold();
                     break;
                 case "translate" :
-                    view.enterAnimation = new TranslateAnimation(Animation.RELATIVE_TO_SELF, 1, Animation.RELATIVE_TO_SELF, 0, Animation.RELATIVE_TO_SELF, 0, Animation.RELATIVE_TO_SELF, 0);
+                    String fromX = enterTrans.getString("fromX");
+                    float fromXValue = 0f;
+                    int fromXType = Animation.ABSOLUTE;
+                    if (fromX != null) {
+                        if (fromX.endsWith("%")) {
+                            fromXType = Animation.RELATIVE_TO_SELF;
+                            fromXValue = Float.parseFloat(fromX.substring(0, fromX.length() - 1)) / 100;
+                        } else {
+                            fromXValue = Float.parseFloat(fromX);
+                        }
+                    }
+                    String fromY = enterTrans.getString("fromY");
+                    float fromYValue = 0f;
+                    int fromYType = Animation.ABSOLUTE;
+                    if (fromY != null) {
+                        if (fromY.endsWith("%")) {
+                            fromYType = Animation.RELATIVE_TO_SELF;
+                            fromYValue = Float.parseFloat(fromY.substring(0, fromY.length() - 1)) / 100;
+                        } else {
+                            fromYValue = Float.parseFloat(fromY);
+                        }
+                    }
+                    view.enterAnimation = new TranslateAnimation(fromXType, fromXValue, Animation.RELATIVE_TO_SELF, 0, fromYType, fromYValue, Animation.RELATIVE_TO_SELF, 0);
                     view.enterAnimation.setDuration(300);
                     break;
             }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -95,7 +95,7 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
                         }
                     }
                     view.enterAnimation = new TranslateAnimation(fromXType, fromXValue, Animation.RELATIVE_TO_SELF, 0, fromYType, fromYValue, Animation.RELATIVE_TO_SELF, 0);
-                    view.enterAnimation.setDuration(300);
+                    view.enterAnimation.setDuration(enterTrans.hasKey("duration") ? enterTrans.getInt("duration") : 300);
                     break;
             }
         }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -48,57 +48,8 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
 
     @ReactProp(name = "enterTrans")
     public void setEnterTrans(NavigationStackView view, ReadableMap enterTrans) {
-        view.enterAnimation = null;
-        view.enterTrans = null;
-        if (enterTrans != null) {
-            switch (enterTrans.getString("type")) {
-                case "sharedAxis" :
-                    Map<String, Integer> axisMap = new HashMap<>();
-                    axisMap.put("x", MaterialSharedAxis.X);
-                    axisMap.put("y", MaterialSharedAxis.Y);
-                    Integer axis = axisMap.get(enterTrans.getString("axis"));
-                    view.enterTrans = new MaterialSharedAxis(axis != null ? axis : MaterialSharedAxis.Z, true);
-                    break;
-                case "elevationScale" :
-                    view.enterTrans = new MaterialElevationScale(true);
-                    break;
-                case "fade" :
-                    view.enterTrans = new MaterialFade();
-                    break;
-                case "fadeThrough" :
-                    view.enterTrans = new MaterialFadeThrough();
-                    break;
-                case "hold" :
-                    view.enterTrans = new Hold();
-                    break;
-                case "translate" :
-                    String fromX = enterTrans.getString("fromX");
-                    float fromXValue = 0f;
-                    int fromXType = Animation.ABSOLUTE;
-                    if (fromX != null) {
-                        if (fromX.endsWith("%")) {
-                            fromXType = Animation.RELATIVE_TO_SELF;
-                            fromXValue = Float.parseFloat(fromX.substring(0, fromX.length() - 1)) / 100;
-                        } else {
-                            fromXValue = Float.parseFloat(fromX);
-                        }
-                    }
-                    String fromY = enterTrans.getString("fromY");
-                    float fromYValue = 0f;
-                    int fromYType = Animation.ABSOLUTE;
-                    if (fromY != null) {
-                        if (fromY.endsWith("%")) {
-                            fromYType = Animation.RELATIVE_TO_SELF;
-                            fromYValue = Float.parseFloat(fromY.substring(0, fromY.length() - 1)) / 100;
-                        } else {
-                            fromYValue = Float.parseFloat(fromY);
-                        }
-                    }
-                    view.enterAnimation = new TranslateAnimation(fromXType, fromXValue, Animation.RELATIVE_TO_SELF, 0, fromYType, fromYValue, Animation.RELATIVE_TO_SELF, 0);
-                    view.enterAnimation.setDuration(enterTrans.hasKey("duration") ? enterTrans.getInt("duration") : 300);
-                    break;
-            }
-        }
+        view.enterTrans = AnimationPropParser.getTransition(enterTrans);
+        view.enterAnimation = AnimationPropParser.getAnimation(enterTrans);
     }
 
     @ReactProp(name = "exitTrans")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -55,6 +55,7 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
     @ReactProp(name = "exitTrans")
     public void setExitTrans(NavigationStackView view, ReadableMap exitTrans) {
         view.exitTrans = AnimationPropParser.getTransition(exitTrans);
+        view.exitAnimation = AnimationPropParser.getAnimation(exitTrans, false);
     }
 
     @ReactProp(name = "sharedElements")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -1,8 +1,6 @@
 package com.navigation.reactnative;
 
 import android.view.View;
-import android.view.animation.Animation;
-import android.view.animation.TranslateAnimation;
 
 import androidx.annotation.NonNull;
 
@@ -12,13 +10,7 @@ import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
-import com.google.android.material.transition.Hold;
-import com.google.android.material.transition.MaterialElevationScale;
-import com.google.android.material.transition.MaterialFade;
-import com.google.android.material.transition.MaterialFadeThrough;
-import com.google.android.material.transition.MaterialSharedAxis;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Nonnull;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -1,6 +1,8 @@
 package com.navigation.reactnative;
 
 import android.view.View;
+import android.view.animation.Animation;
+import android.view.animation.TranslateAnimation;
 
 import androidx.annotation.NonNull;
 
@@ -46,10 +48,12 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
 
     @ReactProp(name = "enterTrans")
     public void setEnterTrans(NavigationStackView view, ReadableMap enterTrans) {
+        view.enterAnimation = null;
+        view.enterTrans = null;
         if (enterTrans != null) {
             switch (enterTrans.getString("type")) {
                 case "sharedAxis" :
-                    Map<String, Integer> axisMap = new HashMap();
+                    Map<String, Integer> axisMap = new HashMap<>();
                     axisMap.put("x", MaterialSharedAxis.X);
                     axisMap.put("y", MaterialSharedAxis.Y);
                     Integer axis = axisMap.get(enterTrans.getString("axis"));
@@ -67,9 +71,11 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
                 case "hold" :
                     view.enterTrans = new Hold();
                     break;
+                case "translate" :
+                    view.enterAnimation = new TranslateAnimation(Animation.RELATIVE_TO_SELF, 1, Animation.RELATIVE_TO_SELF, 0, Animation.RELATIVE_TO_SELF, 0, Animation.RELATIVE_TO_SELF, 0);
+                    view.enterAnimation.setDuration(300);
+                    break;
             }
-        } else {
-            view.enterTrans = null;
         }
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -49,7 +49,7 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
     @ReactProp(name = "enterTrans")
     public void setEnterTrans(NavigationStackView view, ReadableMap enterTrans) {
         view.enterTrans = AnimationPropParser.getTransition(enterTrans);
-        view.enterAnimation = AnimationPropParser.getAnimation(enterTrans);
+        view.enterAnimation = AnimationPropParser.getAnimation(enterTrans, true);
     }
 
     @ReactProp(name = "exitTrans")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -151,11 +151,12 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                 }
                 boolean nonAnimatedEnter = oldCrumb == -1 || ((sharedElements != null || exitTrans != null) && enterTrans == null);
                 boolean nonAnimatedPopEnter = (sharedElements != null || scene.exitTrans != null) && scene.enterTrans == null;
-                fragmentTransaction.setCustomAnimations(!nonAnimatedEnter ? (enterAnimation != null ? 0 : enter) : 0, exit, !nonAnimatedPopEnter ? popEnter : 0, popExit);
+                fragmentTransaction.setCustomAnimations(!nonAnimatedEnter ? (enterAnimation != null ? 0 : enter) : 0, exit, !nonAnimatedPopEnter ? popEnter : 0, scene.exitAnimation != null ? -1 : popExit);
                 SceneFragment fragment = new SceneFragment(scene, getSharedElementSet(sharedElementNames), containerTransform);
                 fragment.setEnterTransition(enterTrans);
                 fragment.enterAnimation = !nonAnimatedEnter ? enterAnimation : null;
                 fragment.setReturnTransition(scene.exitTrans);
+                fragment.returnAnimation = scene.exitAnimation;
                 fragmentTransaction.replace(getId(), fragment, key);
                 fragmentTransaction.addToBackStack(String.valueOf(nextCrumb));
                 fragmentTransaction.commit();

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -125,6 +125,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
             int exit = getAnimationResourceId(currentActivity, exitAnim, android.R.attr.activityOpenExitAnimation);
             if (exit == 0 && exitAnim != null)
                 exit = getAnimationResourceId(currentActivity, null, android.R.attr.activityOpenExitAnimation);
+            SceneFragment prevFragment = null;
             for(int i = 0; i < crumb - currentCrumb; i++) {
                 int nextCrumb = currentCrumb + i + 1;
                 String key = keys.getString(nextCrumb);
@@ -137,7 +138,8 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                 Pair[] sharedElements = null;
                 if (nextCrumb > 0) {
                     String prevKey = keys.getString(nextCrumb - 1);
-                    SceneFragment prevFragment = (SceneFragment) fragmentManager.findFragmentByTag(prevKey);
+                    if (prevFragment == null)
+                        prevFragment = (SceneFragment) fragmentManager.findFragmentByTag(prevKey);
                     if (prevFragment != null) {
                         prevFragment.setExitTransition(exitTrans);
                         prevFragment.exitAnimation = exitAnimation;
@@ -163,6 +165,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                 fragmentTransaction.replace(getId(), fragment, key);
                 fragmentTransaction.addToBackStack(String.valueOf(nextCrumb));
                 fragmentTransaction.commit();
+                prevFragment = fragment;
             }
         }
         if (crumb == currentCrumb && !oldKey.equals(keys.getString(crumb))) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -53,6 +53,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
     protected String enterAnim;
     protected String exitAnim;
     protected Animation enterAnimation;
+    protected Animation exitAnimation;
     protected Transition enterTrans;
     protected Transition exitTrans;
     protected ReadableArray sharedElementNames;
@@ -139,7 +140,9 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                     SceneFragment prevFragment = (SceneFragment) fragmentManager.findFragmentByTag(prevKey);
                     if (prevFragment != null) {
                         prevFragment.setExitTransition(exitTrans);
+                        prevFragment.exitAnimation = exitAnimation;
                         prevFragment.setReenterTransition(scene.enterTrans);
+                        prevFragment.reenterAnimation = scene.enterAnimation;
                         sharedElements = getSharedElements(currentCrumb, crumb, prevFragment);
                     }
                 }
@@ -151,7 +154,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                 }
                 boolean nonAnimatedEnter = oldCrumb == -1 || ((sharedElements != null || exitTrans != null) && enterTrans == null);
                 boolean nonAnimatedPopEnter = (sharedElements != null || scene.exitTrans != null) && scene.enterTrans == null;
-                fragmentTransaction.setCustomAnimations(!nonAnimatedEnter ? (enterAnimation != null ? 0 : enter) : 0, exit, !nonAnimatedPopEnter ? popEnter : 0, scene.exitAnimation != null ? -1 : popExit);
+                fragmentTransaction.setCustomAnimations(!nonAnimatedEnter ? (enterAnimation != null ? 0 : enter) : 0, exitAnimation != null ? 0 : exit, !nonAnimatedPopEnter ? (scene.enterAnimation != null ? -1 : popEnter) : 0, scene.exitAnimation != null ? -1 : popExit);
                 SceneFragment fragment = new SceneFragment(scene, getSharedElementSet(sharedElementNames), containerTransform);
                 fragment.setEnterTransition(enterTrans);
                 fragment.enterAnimation = !nonAnimatedEnter ? enterAnimation : null;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -10,6 +10,7 @@ import android.util.SparseIntArray;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.animation.Animation;
 import android.widget.ScrollView;
 
 import androidx.annotation.NonNull;
@@ -51,6 +52,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
     private Activity mainActivity;
     protected String enterAnim;
     protected String exitAnim;
+    protected Animation enterAnimation;
     protected Transition enterTrans;
     protected Transition exitTrans;
     protected ReadableArray sharedElementNames;
@@ -149,9 +151,10 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                 }
                 boolean nonAnimatedEnter = oldCrumb == -1 || ((sharedElements != null || exitTrans != null) && enterTrans == null);
                 boolean nonAnimatedPopEnter = (sharedElements != null || scene.exitTrans != null) && scene.enterTrans == null;
-                fragmentTransaction.setCustomAnimations(!nonAnimatedEnter ? enter : 0, exit, !nonAnimatedPopEnter ? popEnter : 0, popExit);
+                fragmentTransaction.setCustomAnimations(!nonAnimatedEnter ? (enterAnimation != null ? 0 : enter) : 0, exit, !nonAnimatedPopEnter ? popEnter : 0, popExit);
                 SceneFragment fragment = new SceneFragment(scene, getSharedElementSet(sharedElementNames), containerTransform);
                 fragment.setEnterTransition(enterTrans);
+                fragment.enterAnimation = !nonAnimatedEnter ? enterAnimation : null;
                 fragment.setReturnTransition(scene.exitTrans);
                 fragmentTransaction.replace(getId(), fragment, key);
                 fragmentTransaction.addToBackStack(String.valueOf(nextCrumb));

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -174,10 +174,24 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
             int popEnter = getAnimationResourceId(currentActivity, scene.enterAnim, android.R.attr.activityCloseEnterAnimation);
             int popExit = getAnimationResourceId(currentActivity, scene.exitAnim, android.R.attr.activityCloseExitAnimation);
             FragmentManager fragmentManager = fragment.getChildFragmentManager();
+            SceneFragment prevFragment = (SceneFragment) fragmentManager.findFragmentByTag(oldKey);
+            if (prevFragment != null) {
+                prevFragment.setExitTransition(exitTrans);
+                prevFragment.exitAnimation = exitAnimation;
+                prevFragment.setReenterTransition(scene.enterTrans);
+                prevFragment.reenterAnimation = scene.enterAnimation;
+            }
             FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
             fragmentTransaction.setReorderingAllowed(true);
-            fragmentTransaction.setCustomAnimations(enter, exit, popEnter, popExit);
-            fragmentTransaction.replace(getId(), new SceneFragment(scene, null, containerTransform), key);
+            boolean nonAnimatedEnter = exitTrans != null && enterTrans == null;
+            boolean nonAnimatedPopEnter = scene.exitTrans != null && scene.enterTrans == null;
+            fragmentTransaction.setCustomAnimations(!nonAnimatedEnter ? (enterAnimation != null ? 0 : enter) : 0, exitAnimation != null ? 0 : exit, !nonAnimatedPopEnter ? (scene.enterAnimation != null ? -1 : popEnter) : 0, scene.exitAnimation != null ? -1 : popExit);
+            SceneFragment fragment = new SceneFragment(scene, null, containerTransform);
+            fragment.setEnterTransition(enterTrans);
+            fragment.enterAnimation = !nonAnimatedEnter ? enterAnimation : null;
+            fragment.setReturnTransition(scene.exitTrans);
+            fragment.returnAnimation = scene.exitAnimation;
+            fragmentTransaction.replace(getId(), fragment, key);
             fragmentTransaction.addToBackStack(String.valueOf(crumb));
             fragmentTransaction.commit();
         }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackViewManager.java
@@ -15,13 +15,7 @@ import com.facebook.react.uimanager.ViewManagerDelegate;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.viewmanagers.NVNavigationStackManagerDelegate;
 import com.facebook.react.viewmanagers.NVNavigationStackManagerInterface;
-import com.google.android.material.transition.Hold;
-import com.google.android.material.transition.MaterialElevationScale;
-import com.google.android.material.transition.MaterialFade;
-import com.google.android.material.transition.MaterialFadeThrough;
-import com.google.android.material.transition.MaterialSharedAxis;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
@@ -64,60 +58,14 @@ public class NavigationStackViewManager extends ViewGroupManager<NavigationStack
 
     @ReactProp(name = "enterTrans")
     public void setEnterTrans(NavigationStackView view, ReadableMap enterTrans) {
-        if (enterTrans != null) {
-            switch (enterTrans.getString("type")) {
-                case "sharedAxis" :
-                    Map<String, Integer> axisMap = new HashMap();
-                    axisMap.put("x", MaterialSharedAxis.X);
-                    axisMap.put("y", MaterialSharedAxis.Y);
-                    Integer axis = axisMap.get(enterTrans.getString("axis"));
-                    view.enterTrans = new MaterialSharedAxis(axis != null ? axis : MaterialSharedAxis.Z, true);
-                    break;
-                case "elevationScale" :
-                    view.enterTrans = new MaterialElevationScale(true);
-                    break;
-                case "fade" :
-                    view.enterTrans = new MaterialFade();
-                    break;
-                case "fadeThrough" :
-                    view.enterTrans = new MaterialFadeThrough();
-                    break;
-                case "hold" :
-                    view.enterTrans = new Hold();
-                    break;
-            }
-        } else {
-            view.enterTrans = null;
-        }
+        view.enterTrans = AnimationPropParser.getTransition(enterTrans);
+        view.enterAnimation = AnimationPropParser.getAnimation(enterTrans, true);
     }
 
     @ReactProp(name = "exitTrans")
     public void setExitTrans(NavigationStackView view, ReadableMap exitTrans) {
-        if (exitTrans != null) {
-            switch (exitTrans.getString("type")) {
-                case "sharedAxis" :
-                    Map<String, Integer> axisMap = new HashMap();
-                    axisMap.put("x", MaterialSharedAxis.X);
-                    axisMap.put("y", MaterialSharedAxis.Y);
-                    Integer axis = axisMap.get(exitTrans.getString("axis"));
-                    view.exitTrans = new MaterialSharedAxis(axis != null ? axis : MaterialSharedAxis.Z, true);
-                    break;
-                case "elevationScale" :
-                    view.exitTrans = new MaterialElevationScale(false);
-                    break;
-                case "fade" :
-                    view.exitTrans = new MaterialFade();
-                    break;
-                case "fadeThrough" :
-                    view.exitTrans = new MaterialFadeThrough();
-                    break;
-                case "hold" :
-                    view.exitTrans = new Hold();
-                    break;
-            }
-        } else {
-            view.exitTrans = null;
-        }
+        view.exitTrans = AnimationPropParser.getTransition(exitTrans);
+        view.exitAnimation = AnimationPropParser.getAnimation(exitTrans, false);
     }
 
     @ReactProp(name = "sharedElements")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 public class SceneFragment extends Fragment {
     private SceneView scene;
     protected Animation enterAnimation;
+    protected Animation returnAnimation;
 
     public SceneFragment() {
         super();
@@ -70,6 +71,7 @@ public class SceneFragment extends Fragment {
         if ((nextAnim == 0 && enterAnimation == null) && enter && getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED)) {
             ((NavigationStackView) scene.getParent()).onRest(scene.crumb);
         }
+        if (nextAnim == -1 && returnAnimation != null) return returnAnimation;
         return super.onCreateAnimation(transit, enter, nextAnim);
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 
 public class SceneFragment extends Fragment {
     private SceneView scene;
+    protected Animation enterAnimation;
 
     public SceneFragment() {
         super();
@@ -47,8 +48,8 @@ public class SceneFragment extends Fragment {
     @Nullable
     @Override
     public Animation onCreateAnimation(int transit, boolean enter, int nextAnim) {
-        if (nextAnim != 0 && enter) {
-            Animation anim = AnimationUtils.loadAnimation(getContext(), nextAnim);
+        if ((nextAnim != 0 || enterAnimation != null) && enter) {
+            Animation anim = nextAnim == 0 ? enterAnimation : AnimationUtils.loadAnimation(getContext(), nextAnim);
             anim.setAnimationListener(new Animation.AnimationListener() {
                 @Override
                 public void onAnimationStart(Animation animation) {
@@ -66,7 +67,7 @@ public class SceneFragment extends Fragment {
             });
             return anim;
         }
-        if (nextAnim == 0 && enter && getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED)) {
+        if ((nextAnim == 0 && enterAnimation == null) && enter && getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED)) {
             ((NavigationStackView) scene.getParent()).onRest(scene.crumb);
         }
         return super.onCreateAnimation(transit, enter, nextAnim);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -21,6 +21,8 @@ public class SceneFragment extends Fragment {
     private SceneView scene;
     protected Animation enterAnimation;
     protected Animation returnAnimation;
+    protected Animation exitAnimation;
+    protected Animation reenterAnimation;
 
     public SceneFragment() {
         super();
@@ -50,7 +52,7 @@ public class SceneFragment extends Fragment {
     @Override
     public Animation onCreateAnimation(int transit, boolean enter, int nextAnim) {
         if ((nextAnim != 0 || enterAnimation != null) && enter) {
-            Animation anim = nextAnim == 0 ? enterAnimation : AnimationUtils.loadAnimation(getContext(), nextAnim);
+            Animation anim = nextAnim == 0 ? enterAnimation : (nextAnim == -1 ? reenterAnimation : AnimationUtils.loadAnimation(getContext(), nextAnim));
             anim.setAnimationListener(new Animation.AnimationListener() {
                 @Override
                 public void onAnimationStart(Animation animation) {
@@ -71,6 +73,7 @@ public class SceneFragment extends Fragment {
         if ((nextAnim == 0 && enterAnimation == null) && enter && getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED)) {
             ((NavigationStackView) scene.getParent()).onRest(scene.crumb);
         }
+        if (nextAnim == 0 && exitAnimation != null && !enter) return exitAnimation;
         if (nextAnim == -1 && returnAnimation != null) return returnAnimation;
         return super.onCreateAnimation(transit, enter, nextAnim);
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneManager.java
@@ -1,20 +1,11 @@
 package com.navigation.reactnative;
 
-import android.view.animation.Animation;
-import android.view.animation.TranslateAnimation;
-
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
-import com.google.android.material.transition.Hold;
-import com.google.android.material.transition.MaterialElevationScale;
-import com.google.android.material.transition.MaterialFade;
-import com.google.android.material.transition.MaterialFadeThrough;
-import com.google.android.material.transition.MaterialSharedAxis;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Nonnull;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneManager.java
@@ -79,7 +79,7 @@ public class SceneManager extends ViewGroupManager<SceneView> {
     @ReactProp(name = "exitTrans")
     public void setExitTrans(SceneView view, ReadableMap exitTrans) {
         view.exitTrans = AnimationPropParser.getTransition(exitTrans);
-        view.exitAnimation = AnimationPropParser.getAnimation(exitTrans);
+        view.exitAnimation = AnimationPropParser.getAnimation(exitTrans, false);
     }
 
     @ReactProp(name = "landscape")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneManager.java
@@ -78,35 +78,8 @@ public class SceneManager extends ViewGroupManager<SceneView> {
 
     @ReactProp(name = "exitTrans")
     public void setExitTrans(SceneView view, ReadableMap exitTrans) {
-        view.exitTrans = null;
-        view.exitAnimation = null;
-        if (exitTrans != null) {
-            switch (exitTrans.getString("type")) {
-                case "sharedAxis" :
-                    Map<String, Integer> axisMap = new HashMap<>();
-                    axisMap.put("x", MaterialSharedAxis.X);
-                    axisMap.put("y", MaterialSharedAxis.Y);
-                    Integer axis = axisMap.get(exitTrans.getString("axis"));
-                    view.exitTrans = new MaterialSharedAxis(axis != null ? axis : MaterialSharedAxis.Z, false);
-                    break;
-                case "elevationScale" :
-                    view.exitTrans = new MaterialElevationScale(false);
-                    break;
-                case "fade" :
-                    view.exitTrans = new MaterialFade();
-                    break;
-                case "fadeThrough" :
-                    view.exitTrans = new MaterialFadeThrough();
-                    break;
-                case "hold" :
-                    view.exitTrans = new Hold();
-                    break;
-                case "translate" :
-                    view.exitAnimation = new TranslateAnimation(Animation.RELATIVE_TO_SELF, 0, Animation.RELATIVE_TO_SELF, 1, Animation.RELATIVE_TO_SELF, 0, Animation.RELATIVE_TO_SELF, 0);
-                    view.exitAnimation.setDuration(300);
-                    break;
-            }
-        }
+        view.exitTrans = AnimationPropParser.getTransition(exitTrans);
+        view.exitAnimation = AnimationPropParser.getAnimation(exitTrans);
     }
 
     @ReactProp(name = "landscape")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneManager.java
@@ -49,31 +49,8 @@ public class SceneManager extends ViewGroupManager<SceneView> {
 
     @ReactProp(name = "enterTrans")
     public void setEnterTrans(SceneView view, ReadableMap enterTrans) {
-        if (enterTrans != null) {
-            switch (enterTrans.getString("type")) {
-                case "sharedAxis" :
-                    Map<String, Integer> axisMap = new HashMap();
-                    axisMap.put("x", MaterialSharedAxis.X);
-                    axisMap.put("y", MaterialSharedAxis.Y);
-                    Integer axis = axisMap.get(enterTrans.getString("axis"));
-                    view.enterTrans = new MaterialSharedAxis(axis != null ? axis : MaterialSharedAxis.Z, false);
-                    break;
-                case "elevationScale" :
-                    view.enterTrans = new MaterialElevationScale(true);
-                    break;
-                case "fade" :
-                    view.enterTrans = new MaterialFade();
-                    break;
-                case "fadeThrough" :
-                    view.enterTrans = new MaterialFadeThrough();
-                    break;
-                case "hold" :
-                    view.enterTrans = new Hold();
-                    break;
-            }
-        } else {
-            view.enterTrans = null;
-        }
+        view.exitTrans = AnimationPropParser.getTransition(enterTrans);
+        view.enterAnimation = AnimationPropParser.getAnimation(enterTrans, true);
     }
 
     @ReactProp(name = "exitTrans")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneManager.java
@@ -49,7 +49,7 @@ public class SceneManager extends ViewGroupManager<SceneView> {
 
     @ReactProp(name = "enterTrans")
     public void setEnterTrans(SceneView view, ReadableMap enterTrans) {
-        view.exitTrans = AnimationPropParser.getTransition(enterTrans);
+        view.enterTrans = AnimationPropParser.getTransition(enterTrans);
         view.enterAnimation = AnimationPropParser.getAnimation(enterTrans, true);
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneManager.java
@@ -1,5 +1,8 @@
 package com.navigation.reactnative;
 
+import android.view.animation.Animation;
+import android.view.animation.TranslateAnimation;
+
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -75,10 +78,12 @@ public class SceneManager extends ViewGroupManager<SceneView> {
 
     @ReactProp(name = "exitTrans")
     public void setExitTrans(SceneView view, ReadableMap exitTrans) {
+        view.exitTrans = null;
+        view.exitAnimation = null;
         if (exitTrans != null) {
             switch (exitTrans.getString("type")) {
                 case "sharedAxis" :
-                    Map<String, Integer> axisMap = new HashMap();
+                    Map<String, Integer> axisMap = new HashMap<>();
                     axisMap.put("x", MaterialSharedAxis.X);
                     axisMap.put("y", MaterialSharedAxis.Y);
                     Integer axis = axisMap.get(exitTrans.getString("axis"));
@@ -96,9 +101,11 @@ public class SceneManager extends ViewGroupManager<SceneView> {
                 case "hold" :
                     view.exitTrans = new Hold();
                     break;
+                case "translate" :
+                    view.exitAnimation = new TranslateAnimation(Animation.RELATIVE_TO_SELF, 0, Animation.RELATIVE_TO_SELF, 1, Animation.RELATIVE_TO_SELF, 0, Animation.RELATIVE_TO_SELF, 0);
+                    view.exitAnimation.setDuration(300);
+                    break;
             }
-        } else {
-            view.exitTrans = null;
         }
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneView.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.pm.ActivityInfo;
 import android.view.View;
+import android.view.animation.Animation;
 
 import androidx.transition.Transition;
 
@@ -22,6 +23,7 @@ public class SceneView extends ReactViewGroup {
     protected String sceneKey;
     protected String enterAnim;
     protected String exitAnim;
+    protected Animation exitAnimation;
     protected Transition enterTrans;
     protected Transition exitTrans;
     private boolean landscape;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneView.java
@@ -23,6 +23,7 @@ public class SceneView extends ReactViewGroup {
     protected String sceneKey;
     protected String enterAnim;
     protected String exitAnim;
+    protected Animation enterAnimation;
     protected Animation exitAnimation;
     protected Transition enterTrans;
     protected Transition exitTrans;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneViewManager.java
@@ -11,13 +11,7 @@ import com.facebook.react.uimanager.ViewManagerDelegate;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.viewmanagers.NVSceneManagerDelegate;
 import com.facebook.react.viewmanagers.NVSceneManagerInterface;
-import com.google.android.material.transition.Hold;
-import com.google.android.material.transition.MaterialElevationScale;
-import com.google.android.material.transition.MaterialFade;
-import com.google.android.material.transition.MaterialFadeThrough;
-import com.google.android.material.transition.MaterialSharedAxis;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
@@ -72,60 +66,14 @@ public class SceneViewManager extends ViewGroupManager<SceneView> implements NVS
 
     @ReactProp(name = "enterTrans")
     public void setEnterTrans(SceneView view, ReadableMap enterTrans) {
-        if (enterTrans != null) {
-            switch (enterTrans.getString("type")) {
-                case "sharedAxis" :
-                    Map<String, Integer> axisMap = new HashMap();
-                    axisMap.put("x", MaterialSharedAxis.X);
-                    axisMap.put("y", MaterialSharedAxis.Y);
-                    Integer axis = axisMap.get(enterTrans.getString("axis"));
-                    view.enterTrans = new MaterialSharedAxis(axis != null ? axis : MaterialSharedAxis.Z, false);
-                    break;
-                case "elevationScale" :
-                    view.enterTrans = new MaterialElevationScale(true);
-                    break;
-                case "fade" :
-                    view.enterTrans = new MaterialFade();
-                    break;
-                case "fadeThrough" :
-                    view.enterTrans = new MaterialFadeThrough();
-                    break;
-                case "hold" :
-                    view.enterTrans = new Hold();
-                    break;
-            }
-        } else {
-            view.enterTrans = null;
-        }
+        view.enterTrans = AnimationPropParser.getTransition(enterTrans);
+        view.enterAnimation = AnimationPropParser.getAnimation(enterTrans, true);
     }
 
     @ReactProp(name = "exitTrans")
     public void setExitTrans(SceneView view, ReadableMap exitTrans) {
-        if (exitTrans != null) {
-            switch (exitTrans.getString("type")) {
-                case "sharedAxis" :
-                    Map<String, Integer> axisMap = new HashMap();
-                    axisMap.put("x", MaterialSharedAxis.X);
-                    axisMap.put("y", MaterialSharedAxis.Y);
-                    Integer axis = axisMap.get(exitTrans.getString("axis"));
-                    view.exitTrans = new MaterialSharedAxis(axis != null ? axis : MaterialSharedAxis.Z, false);
-                    break;
-                case "elevationScale" :
-                    view.exitTrans = new MaterialElevationScale(false);
-                    break;
-                case "fade" :
-                    view.exitTrans = new MaterialFade();
-                    break;
-                case "fadeThrough" :
-                    view.exitTrans = new MaterialFadeThrough();
-                    break;
-                case "hold" :
-                    view.exitTrans = new Hold();
-                    break;
-            }
-        } else {
-            view.exitTrans = null;
-        }
+        view.exitTrans = AnimationPropParser.getTransition(exitTrans);
+        view.exitAnimation = AnimationPropParser.getAnimation(exitTrans, false);
     }
 
     @ReactProp(name = "landscape")

--- a/build/npm/navigation-react-native/navigation.react.native.d.ts
+++ b/build/npm/navigation-react-native/navigation.react.native.d.ts
@@ -6,6 +6,52 @@ declare global {
     interface Location {}
 }
 
+type TranslateAnimation = {
+    type: 'translate',
+    duration?: number,
+    fromX?: number | string,
+    toX?: number | string,
+    startX?: number | string,
+    fromY?: number | string,
+    toY?: number | string,
+    startY?: number | string,
+};
+
+type ScaleAnimation = {
+    type: 'scale',
+    duration?: number,
+    fromX?: number | string,
+    toX?: number | string,
+    startX?: number | string,
+    fromY?: number | string,
+    toY?: number | string,
+    startY?: number | string,
+    pivotX?: number | string,
+    pivotY?: number | string
+};
+
+type AlphaAnimation = {
+    type: 'alpha',
+    duration?: number,
+    from?: number,
+    to?: number,
+    start?: number,
+};
+
+type RotateAnimation = {
+    type: 'rotate',
+    duration?: number,
+    from?: number,
+    to?: number,
+    start?: number,
+    pivotX?: number | string,
+    pivotY?: number | string
+};
+
+type Animation = TranslateAnimation | ScaleAnimation | AlphaAnimation | RotateAnimation;
+
+type Transition = { type: 'sharedAxis', axis?: 'x' | 'y' | 'z' } | { type: 'elevationScale' | 'fade' | 'fadeThrough' | 'hold' } | Animation | Animation[] | { duration?: number, items: Animation[] };
+
 /**
  * Defines the Navigation Stack Props contract
  */
@@ -22,13 +68,11 @@ export interface NavigationStackProps {
      * The Scene's to and from crumb trail style
      * @platform android
      */
-    crumbStyle?: (from: boolean, state: State, data: any, crumbs: Crumb[], nextState?: State, nextData?: any) =>
-        string | { type: 'sharedAxis', axis?: 'x' | 'y' | 'z' } | { type: 'elevationScale' | 'fade' | 'fadeThrough' | 'hold' };
+    crumbStyle?: ((from: boolean, state: State, data: any, crumbs: Crumb[], nextState?: State, nextData?: any) => string | Transition) | Transition;
     /**
      * The Scene's to and from unmount style
      */
-    unmountStyle?: (from: boolean, state: State, data: any, crumbs: Crumb[]) =>
-        string | { type: 'sharedAxis', axis?: 'x' | 'y' | 'z' } | { type: 'elevationScale' | 'fade' | 'fadeThrough' | 'hold' };
+    unmountStyle?: ((from: boolean, state: State, data: any, crumbs: Crumb[]) => string | Transition) | Transition;
     /**
      * Indicates whether the Scene should display the tab bar
      * @platform ios
@@ -85,13 +129,11 @@ export class NavigationStack extends Component<NavigationStackProps> { }
      * A Scene's to and from crumb trail style
      * @platform android
      */
-    crumbStyle?: (from: boolean, data: any, crumbs: Crumb[], nextState?: State, nextData?: any) =>
-        string | { type: 'sharedAxis', axis?: 'x' | 'y' | 'z' } | { type: 'elevationScale' | 'fade' | 'fadeThrough' | 'hold' };
+    crumbStyle?: ((from: boolean, data: any, crumbs: Crumb[], nextState?: State, nextData?: any) => string | Transition) | Transition;
     /**
      * A Scene's to and from unmount style
      */
-    unmountStyle?: (from: boolean, data: any, crumbs: Crumb[]) =>
-        string | { type: 'sharedAxis', axis?: 'x' | 'y' | 'z' } | { type: 'elevationScale' | 'fade' | 'fadeThrough' | 'hold' };
+    unmountStyle?: ((from: boolean, data: any, crumbs: Crumb[]) => string | Transition) | Transition;
     /**
      * Indicates whether a Scene should display the tab bar
      * @platform ios

--- a/types/navigation-react-native.d.ts
+++ b/types/navigation-react-native.d.ts
@@ -6,6 +6,52 @@ declare global {
     interface Location {}
 }
 
+type TranslateAnimation = {
+    type: 'translate',
+    duration?: number,
+    fromX?: number | string,
+    toX?: number | string,
+    startX?: number | string,
+    fromY?: number | string,
+    toY?: number | string,
+    startY?: number | string,
+};
+
+type ScaleAnimation = {
+    type: 'scale',
+    duration?: number,
+    fromX?: number | string,
+    toX?: number | string,
+    startX?: number | string,
+    fromY?: number | string,
+    toY?: number | string,
+    startY?: number | string,
+    pivotX?: number | string,
+    pivotY?: number | string
+};
+
+type AlphaAnimation = {
+    type: 'alpha',
+    duration?: number,
+    from?: number,
+    to?: number,
+    start?: number,
+};
+
+type RotateAnimation = {
+    type: 'rotate',
+    duration?: number,
+    from?: number,
+    to?: number,
+    start?: number,
+    pivotX?: number | string,
+    pivotY?: number | string
+};
+
+type Animation = TranslateAnimation | ScaleAnimation | AlphaAnimation | RotateAnimation;
+
+type Transition = { type: 'sharedAxis', axis?: 'x' | 'y' | 'z' } | { type: 'elevationScale' | 'fade' | 'fadeThrough' | 'hold' } | Animation | Animation[] | { duration?: number, items: Animation[] };
+
 /**
  * Defines the Navigation Stack Props contract
  */
@@ -22,13 +68,11 @@ export interface NavigationStackProps {
      * The Scene's to and from crumb trail style
      * @platform android
      */
-    crumbStyle?: (from: boolean, state: State, data: any, crumbs: Crumb[], nextState?: State, nextData?: any) =>
-        string | { type: 'sharedAxis', axis?: 'x' | 'y' | 'z' } | { type: 'elevationScale' | 'fade' | 'fadeThrough' | 'hold' };
+    crumbStyle?: ((from: boolean, state: State, data: any, crumbs: Crumb[], nextState?: State, nextData?: any) => string | Transition) | Transition;
     /**
      * The Scene's to and from unmount style
      */
-    unmountStyle?: (from: boolean, state: State, data: any, crumbs: Crumb[]) =>
-        string | { type: 'sharedAxis', axis?: 'x' | 'y' | 'z' } | { type: 'elevationScale' | 'fade' | 'fadeThrough' | 'hold' };
+    unmountStyle?: ((from: boolean, state: State, data: any, crumbs: Crumb[]) => string | Transition) | Transition;
     /**
      * Indicates whether the Scene should display the tab bar
      * @platform ios
@@ -85,13 +129,11 @@ export class NavigationStack extends Component<NavigationStackProps> { }
      * A Scene's to and from crumb trail style
      * @platform android
      */
-    crumbStyle?: (from: boolean, data: any, crumbs: Crumb[], nextState?: State, nextData?: any) =>
-        string | { type: 'sharedAxis', axis?: 'x' | 'y' | 'z' } | { type: 'elevationScale' | 'fade' | 'fadeThrough' | 'hold' };
+    crumbStyle?: ((from: boolean, data: any, crumbs: Crumb[], nextState?: State, nextData?: any) => string | Transition) | Transition;
     /**
      * A Scene's to and from unmount style
      */
-    unmountStyle?: (from: boolean, data: any, crumbs: Crumb[]) =>
-        string | { type: 'sharedAxis', axis?: 'x' | 'y' | 'z' } | { type: 'elevationScale' | 'fade' | 'fadeThrough' | 'hold' };
+    unmountStyle?: ((from: boolean, data: any, crumbs: Crumb[]) => string | Transition) | Transition;
     /**
      * Indicates whether a Scene should display the tab bar
      * @platform ios


### PR DESCRIPTION
Don't need anim resx files to create transitions anymore. Can do it all through a declarative api. Specify the starting position of an umounted/crumb scene and the Navigation router will animate the transition. Uses the same underlying native animation api as before but new's up `Animation` objects instead of loading them from resx files.

For example, here's how to define the transition from the Twitter sample

```jsx
<NavigationStack
  crumbStyle={[
    {type: 'alpha', start: 0},
    {type: 'scale', startX: 0.8, startY: '0.8'},
    {type: 'translate', startX: '5%'},
  ]}
  unmountStyle={{type: 'translate', startX: '100%'}}
>
```
Don't need to know the `from` direction of the transition anymore. But it's still available for more complicate scenarios, for example, an asymmetric unmount transition (where the 'from' doesn't match the 'to').

```jsx
unmountStyle={from => from ? {type: 'translate', fromX: '100%'} : {type: 'translate', toY: '100%'}}
```
Couldn't configure the shape of the `crumb/unmountStyle` props in the native spec on Fabric. Pretty sure Fabric still doesn't support arrays of objects. But it didn't matter because Fabric passed the whole prop to native anyway. For example, the `ReadableMap` had an array of `items` even though `items` wasn't in the native spec.