### PR TITLE
Supported predictive back gesture (Android)

### DIFF
--- a/NavigationReactNative/sample/fabric/App.js
+++ b/NavigationReactNative/sample/fabric/App.js
@@ -9,7 +9,7 @@ import Timeline from './Timeline';
 import {NavigationStack, Scene} from 'navigation-react-native';
 
 const stateNavigator = new StateNavigator([
-  {key: 'tabs'},
+  {key: 'tabs', trackCrumbTrail: true},
   {key: 'home'},
   {key: 'notifications'},
   {key: 'tweet', trackCrumbTrail: true},

--- a/NavigationReactNative/sample/fabric/App.js
+++ b/NavigationReactNative/sample/fabric/App.js
@@ -9,7 +9,7 @@ import Timeline from './Timeline';
 import {NavigationStack, Scene} from 'navigation-react-native';
 
 const stateNavigator = new StateNavigator([
-  {key: 'tabs', trackCrumbTrail: true},
+  {key: 'tabs'},
   {key: 'home'},
   {key: 'notifications'},
   {key: 'tweet', trackCrumbTrail: true},

--- a/NavigationReactNative/src/NavigationStack.tsx
+++ b/NavigationReactNative/src/NavigationStack.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, ReactElement, useRef, useState, useContext, useEffect, createContext, useId, useMemo } from 'react';
+import React, { ReactNode, ReactElement, useRef, useState, useContext, useEffect, createContext, useMemo } from 'react';
 import { Platform, requireNativeComponent, StyleSheet } from 'react-native';
 import { StateNavigator, Crumb, State } from 'navigation';
 import { NavigationContext } from 'navigation-react';
@@ -13,9 +13,9 @@ const NavigationStack = ({underlayColor: underlayColorStack = '#000', title, cus
     landscape: landscapeStack = () => null, stackInvalidatedLink, renderScene, children}: NavigationStackProps) => {
     const resumeNavigationRef = useRef(null);
     const ref = useRef(null);
-    const stackId = useId();
+    const stackId = React.useId?.();
     const ancestorStackIds = useContext(StackContext);
-    const stackIds = useMemo(() => [...ancestorStackIds, stackId], [ancestorStackIds, stackId]);
+    const stackIds = useMemo(() => stackId ? [...ancestorStackIds, stackId] : [], [ancestorStackIds, stackId]);
     const {stateNavigator} = useContext(NavigationContext);
     const [stackState, setStackState] = useState<NavigationStackState>({stateNavigator: null, keys: [], rest: true, counter: 0, mostRecentEventCount: 0});
     const scenes = {};

--- a/NavigationReactNative/src/NavigationStackNativeComponent.js
+++ b/NavigationReactNative/src/NavigationStackNativeComponent.js
@@ -7,6 +7,8 @@ import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNati
 type NativeProps = $ReadOnly<{|
   ...ViewProps,
   keys: $ReadOnlyArray<string>,
+  stackId: string,
+  ancestorStackIds: $ReadOnlyArray<string>,
   enterAnim: string,
   exitAnim: string,
   enterTrans: $ReadOnly<{|

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -51,7 +51,7 @@ class Scene extends React.Component<SceneProps, SceneState> {
     fluentPeekable() {
         var {navigationEvent, crumb} = this.props;
         var {crumbs} = navigationEvent.stateNavigator.stateContext;
-        return Platform.OS === 'ios' && !this.state.navigationEvent && crumb === crumbs.length -1;
+        return !this.state.navigationEvent && crumb === crumbs.length -1;
     }
     backgroundPeekNavigate() {
         if (this.fluentPeekable() && !this.timer) {

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { requireNativeComponent, Platform, StyleSheet } from 'react-native';
+import { requireNativeComponent, StyleSheet } from 'react-native';
 import { StateNavigator, StateContext, State, Crumb } from 'navigation';
 import { NavigationContext, NavigationEvent } from 'navigation-react';
 import BackButton from './BackButton';

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -71,7 +71,7 @@ class Scene extends React.Component<SceneProps, SceneState> {
     }
     onBeforeNavigate(_state, _data, url: string, history: boolean) {
         var {crumb} = this.props;
-        if (url.split('crumb=').length - 1 === crumb && history && Platform.OS === 'ios')
+        if (url.split('crumb=').length - 1 === crumb && history)
             this.peekNavigate();
         return true;
     }

--- a/NavigationReactNative/src/android/build.gradle
+++ b/NavigationReactNative/src/android/build.gradle
@@ -28,7 +28,7 @@ android {
     buildToolsVersion safeExtGet("buildToolsVersion", "28.0.3")
 
     defaultConfig {
-        minSdkVersion safeExtGet("minSdkVersion", 16)
+        minSdkVersion safeExtGet("minSdkVersion", 19)
         targetSdkVersion safeExtGet("targetSdkVersion", 28)
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
         versionCode 1
@@ -62,7 +62,7 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.google.android.material:material:1.8.0'
+    implementation 'com.google.android.material:material:1.12.0'
     implementation 'androidx.viewpager2:viewpager2:1.0.0'
     implementation 'androidx.fragment:fragment:1.7.0'
 }

--- a/NavigationReactNative/src/android/build.gradle
+++ b/NavigationReactNative/src/android/build.gradle
@@ -24,7 +24,7 @@ def safeExtGet(prop, fallback) {
 
 android {
     namespace "com.navigation.reactnative"
-    compileSdkVersion safeExtGet("compileSdkVersion", 28)
+    compileSdkVersion safeExtGet("compileSdkVersion", 34)
     buildToolsVersion safeExtGet("buildToolsVersion", "28.0.3")
 
     defaultConfig {
@@ -64,5 +64,6 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation 'com.google.android.material:material:1.8.0'
     implementation 'androidx.viewpager2:viewpager2:1.0.0'
+    implementation 'androidx.fragment:fragment:1.7.0'
 }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/AnimationPropParser.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/AnimationPropParser.java
@@ -2,7 +2,10 @@ package com.navigation.reactnative;
 
 import android.util.Pair;
 
+import androidx.annotation.NonNull;
 import androidx.transition.Transition;
+import androidx.transition.TransitionSet;
+import androidx.transition.TransitionValues;
 
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
@@ -36,6 +39,12 @@ public class AnimationPropParser {
             case "fade" -> transition = new MaterialFade();
             case "fadeThrough" -> transition = new MaterialFadeThrough();
             case "hold" -> transition = new Hold();
+        }
+        if (transition != null) {
+            TransitionSet transitionSet = new TransitionSet();
+            transitionSet.addTransition(transition);
+            transitionSet.addTransition(new VoidTransition());
+            return transitionSet;
         }
         return transition;
     }
@@ -72,6 +81,17 @@ public class AnimationPropParser {
             return new Pair<>(Float.parseFloat(val.substring(0, val.length() - 1)), true);
         } else {
             return new Pair<>(Float.parseFloat(val), false);
+        }
+    }
+
+    static class VoidTransition extends Transition
+    {
+        @Override
+        public void captureStartValues(@NonNull TransitionValues transitionValues) {
+        }
+
+        @Override
+        public void captureEndValues(@NonNull TransitionValues transitionValues) {
         }
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/AnimationPropParser.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/AnimationPropParser.java
@@ -1,7 +1,6 @@
 package com.navigation.reactnative;
 
 import android.util.Pair;
-import android.view.animation.Animation;
 
 import androidx.transition.Transition;
 
@@ -39,63 +38,6 @@ public class AnimationPropParser {
             case "hold" -> transition = new Hold();
         }
         return transition;
-    }
-
-    protected static Animation getAnimation(ReadableMap anim, boolean enter) {
-        return null;
-        /* Animation animation = null;
-        Pair<Integer, Float> fromX, toX, fromY, toY, pivotX, pivotY;
-        String animType = anim != null ? anim.getString("type") : null;
-        if (anim == null) return null;
-        if (animType == null) {
-            ReadableArray items = anim.hasKey("items") ? anim.getArray("items") : null;
-            AnimationSet animationSet = new AnimationSet(true);
-            String duration = anim.getString("duration");
-            if (duration != null) animationSet.setDuration(Integer.parseInt(duration));
-            if (anim.hasKey("duration")) animationSet.setDuration(anim.getInt("duration"));
-            if (items != null) {
-                for(int i = 0; i < items.size(); i++) {
-                    animation = getAnimation(items.getMap(i), enter);
-                    if (animation != null) animationSet.addAnimation(animation);
-                }
-            }
-            return animationSet.getAnimations().size() > 0 ? animationSet : null;
-        };
-        switch (animType) {
-            case "translate":
-                fromX = getValues(enter ? anim.getString("fromX") : null, 0);
-                toX = getValues(!enter ? anim.getString("toX") : null, 0);
-                fromY = getValues(enter ? anim.getString("fromY") : null, 0);
-                toY = getValues(!enter ? anim.getString("toY") : null, 0);
-                animation = new TranslateAnimation(fromX.first, fromX.second, toX.first, toX.second, fromY.first, fromY.second, toY.first, toY.second);
-                break;
-            case "scale":
-                fromX = getValues(enter ? anim.getString("fromX") : null);
-                toX = getValues(!enter ? anim.getString("toX") : null);
-                fromY = getValues(enter ? anim.getString("fromY") : null);
-                toY = getValues(!enter ? anim.getString("toY") : null);
-                pivotX = getValues(anim.getString("pivotX"),0.5f, Animation.RELATIVE_TO_SELF);
-                pivotY = getValues(anim.getString("pivotY"),0.5f, Animation.RELATIVE_TO_SELF);
-                animation = new ScaleAnimation(fromX.second, toX.second, fromY.second, toY.second, pivotX.first, pivotX.second, pivotY.first, pivotY.second);
-                break;
-            case "alpha":
-                float fromAlpha = getValues(enter ? anim.getString("from") : null).second;
-                float toAlpha = getValues(!enter ? anim.getString("to") : null).second;
-                animation = new AlphaAnimation(fromAlpha, toAlpha);
-                break;
-            case "rotate":
-                float fromDegrees = getValues(anim.getString("from"), 0).second;
-                float toDegrees = getValues(anim.getString("to"), 0).second;
-                pivotX = getValues(anim.getString("pivotX"),0.5f, Animation.RELATIVE_TO_SELF);
-                pivotY = getValues(anim.getString("pivotY"),0.5f, Animation.RELATIVE_TO_SELF);
-                animation = new RotateAnimation(fromDegrees, toDegrees, pivotX.first, pivotX.second, pivotY.first, pivotY.second);
-                break;
-        }
-        if (animation != null) {
-            String duration = anim.getString("duration");
-            animation.setDuration(duration != null ? Integer.parseInt(duration) : 300);
-        }
-        return animation; */
     }
 
     protected static Animator getAnimator(ReadableMap anim, boolean enter) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -41,13 +41,13 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
     @ReactProp(name = "enterTrans")
     public void setEnterTrans(NavigationStackView view, ReadableMap enterTrans) {
         view.enterTrans = AnimationPropParser.getTransition(enterTrans);
-        view.enterAnimation = AnimationPropParser.getAnimation(enterTrans, true);
+        view.enterAnimator = AnimationPropParser.getAnimator(enterTrans, true);
     }
 
     @ReactProp(name = "exitTrans")
     public void setExitTrans(NavigationStackView view, ReadableMap exitTrans) {
         view.exitTrans = AnimationPropParser.getTransition(exitTrans);
-        view.exitAnimation = AnimationPropParser.getAnimation(exitTrans, false);
+        view.exitAnimator = AnimationPropParser.getAnimator(exitTrans, false);
     }
 
     @ReactProp(name = "sharedElements")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -60,6 +60,11 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
         view.containerTransform = containerTransform;
     }
 
+    @ReactProp(name = "mostRecentEventCount")
+    public void setMostRecentEventCount(NavigationStackView view, int mostRecentEventCount) {
+        view.mostRecentEventCount = mostRecentEventCount;
+    }
+
     @Nonnull
     @Override
     protected NavigationStackView createViewInstance(@Nonnull ThemedReactContext reactContext) {
@@ -109,6 +114,7 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
             .put("topNavigateToTop", MapBuilder.of("registrationName", "onNavigateToTop"))
+            .put("topWillNavigateBack", MapBuilder.of("registrationName", "onWillNavigateBack"))
             .put("topRest", MapBuilder.of("registrationName", "onRest"))
             .build();
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackManager.java
@@ -28,6 +28,16 @@ public class NavigationStackManager extends ViewGroupManager<NavigationStackView
         view.keys = keys;
     }
 
+    @ReactProp(name = "stackId")
+    public void setStackId(NavigationStackView view, String stackId) {
+        view.stackId = stackId;
+    }
+
+    @ReactProp(name = "ancestorStackIds")
+    public void setAncestorStackIds(NavigationStackView view, ReadableArray ancestorStackIds) {
+        view.ancestorStackIds = ancestorStackIds;
+    }
+
     @ReactProp(name = "enterAnim")
     public void setEnterAnim(NavigationStackView view, String enterAnim) {
         view.enterAnim = enterAnim;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -3,17 +3,14 @@ package com.navigation.reactnative;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
-import android.content.res.TypedArray;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.Pair;
-import android.util.SparseIntArray;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ScrollView;
 
-import androidx.annotation.AnimatorRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.SharedElementCallback;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -86,7 +86,6 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
             fragment = new StackFragment(this);
             FragmentManager fragmentManager = ((FragmentActivity) currentActivity).getSupportFragmentManager();
             FragmentTransaction transaction = fragmentManager.beginTransaction();
-            transaction.setPrimaryNavigationFragment(fragment);
             transaction.add(fragment, "Stack" + getId());
             transaction.commitNowAllowingStateLoss();
             fragment.getChildFragmentManager().addOnBackStackChangedListener(new FragmentManager.OnBackStackChangedListener() {
@@ -299,6 +298,11 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
         super.onAttachedToWindow();
         onAfterUpdateTransaction();
         ((ThemedReactContext) getContext()).addLifecycleEventListener(this);
+        if (fragment.getParentFragmentManager().getPrimaryNavigationFragment() != fragment) {
+            FragmentTransaction transaction = fragment.getParentFragmentManager().beginTransaction();
+            transaction.setPrimaryNavigationFragment(fragment);
+            transaction.commitNowAllowingStateLoss();
+        }
     }
 
     @Override

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -322,10 +322,14 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
         ((ThemedReactContext) getContext()).addLifecycleEventListener(this);
         FragmentManager fragmentManager = fragment.getParentFragmentManager();
         if (fragmentManager.getPrimaryNavigationFragment() != fragment) {
-            fragmentManager
+            FragmentTransaction transaction = fragmentManager
                 .beginTransaction()
-                .setPrimaryNavigationFragment(fragment)
-                .commit();
+                .setPrimaryNavigationFragment(fragment);
+            try {
+                transaction.commitNowAllowingStateLoss();
+            } catch(IllegalStateException ignored) {
+                transaction.commit();
+            }
         }
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -335,10 +335,13 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
         ((ThemedReactContext) getContext()).removeLifecycleEventListener(this);
         FragmentManager fragmentManager = fragment.getParentFragmentManager();
         if (fragmentManager.getPrimaryNavigationFragment() == fragment) {
-            fragmentManager
+            FragmentTransaction transaction = fragmentManager
                 .beginTransaction()
-                .setPrimaryNavigationFragment(null)
-                .commitNowAllowingStateLoss();
+                .setPrimaryNavigationFragment(null);
+            try {
+                transaction.commitNowAllowingStateLoss();
+            } catch(IllegalStateException ignored) {
+            }
         }
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -193,6 +193,12 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
             FragmentManager fragmentManager = fragment.getChildFragmentManager();
             SceneFragment prevFragment = (SceneFragment) fragmentManager.findFragmentByTag(oldKey);
             if (prevFragment != null) {
+                if (enterTrans != null || exitTrans != null || scene.enterTrans != null || scene.exitTrans != null) {
+                    exitTrans = exitTrans != null ? exitTrans : new AnimationPropParser.VoidTransition();
+                    scene.enterTrans = scene.enterTrans != null ? scene.enterTrans : new AnimationPropParser.VoidTransition();
+                    enterTrans = enterTrans != null ? enterTrans : new AnimationPropParser.VoidTransition();
+                    scene.exitTrans = scene.exitTrans != null ? scene.exitTrans : new AnimationPropParser.VoidTransition();
+                }
                 prevFragment.setExitTransition(exitTrans);
                 prevFragment.exitAnimator = exitAnimator;
                 prevFragment.setReenterTransition(scene.enterTrans);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -149,11 +149,17 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                     if (prevFragment == null)
                         prevFragment = (SceneFragment) fragmentManager.findFragmentByTag(prevKey);
                     if (prevFragment != null) {
+                        sharedElements = getSharedElements(currentCrumb, crumb, prevFragment);
+                        if (sharedElements != null || enterTrans != null || exitTrans != null || scene.enterTrans != null || scene.exitTrans != null) {
+                            exitTrans = exitTrans != null ? exitTrans : new AnimationPropParser.VoidTransition();
+                            scene.enterTrans = scene.enterTrans != null ? scene.enterTrans : new AnimationPropParser.VoidTransition();
+                            enterTrans = enterTrans != null ? enterTrans : new AnimationPropParser.VoidTransition();
+                            scene.exitTrans = scene.exitTrans != null ? scene.exitTrans : new AnimationPropParser.VoidTransition();
+                        }
                         prevFragment.setExitTransition(exitTrans);
                         prevFragment.exitAnimator = exitAnimator;
                         prevFragment.setReenterTransition(scene.enterTrans);
                         prevFragment.reenterAnimator = scene.enterAnimator;
-                        sharedElements = getSharedElements(currentCrumb, crumb, prevFragment);
                     }
                 }
                 if (sharedElements != null) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -209,7 +209,10 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
             fragment.setReturnTransition(scene.exitTrans);
             fragment.returnAnimator = scene.exitAnimator;
             fragmentTransaction.replace(getId(), fragment, key);
-            if (crumb > 0) fragmentTransaction.addToBackStack(String.valueOf(crumb));
+            if (crumb > 0) {
+                fragmentManager.popBackStack();
+                fragmentTransaction.addToBackStack(String.valueOf(crumb));
+            }
             fragmentTransaction.commit();
         }
         oldCrumb = keys.size() - 1;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackViewManager.java
@@ -59,13 +59,13 @@ public class NavigationStackViewManager extends ViewGroupManager<NavigationStack
     @ReactProp(name = "enterTrans")
     public void setEnterTrans(NavigationStackView view, ReadableMap enterTrans) {
         view.enterTrans = AnimationPropParser.getTransition(enterTrans);
-        view.enterAnimation = AnimationPropParser.getAnimation(enterTrans, true);
+        view.enterAnimator = AnimationPropParser.getAnimator(enterTrans, true);
     }
 
     @ReactProp(name = "exitTrans")
     public void setExitTrans(NavigationStackView view, ReadableMap exitTrans) {
         view.exitTrans = AnimationPropParser.getTransition(exitTrans);
-        view.exitAnimation = AnimationPropParser.getAnimation(exitTrans, false);
+        view.exitAnimator = AnimationPropParser.getAnimator(exitTrans, false);
     }
 
     @ReactProp(name = "sharedElements")
@@ -84,6 +84,7 @@ public class NavigationStackViewManager extends ViewGroupManager<NavigationStack
 
     @ReactProp(name = "mostRecentEventCount")
     public void setMostRecentEventCount(NavigationStackView view, int mostRecentEventCount) {
+        view.mostRecentEventCount = mostRecentEventCount;
     }
 
     @ReactProp(name = "enterAnimOff")
@@ -139,6 +140,7 @@ public class NavigationStackViewManager extends ViewGroupManager<NavigationStack
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
             .put("topNavigateToTop", MapBuilder.of("registrationName", "onNavigateToTop"))
+            .put("topWillNavigateBack", MapBuilder.of("registrationName", "onWillNavigateBack"))
             .put("topRest", MapBuilder.of("registrationName", "onRest"))
             .build();
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackViewManager.java
@@ -46,6 +46,18 @@ public class NavigationStackViewManager extends ViewGroupManager<NavigationStack
         view.keys = keys;
     }
 
+    @Override
+    @ReactProp(name = "stackId")
+    public void setStackId(NavigationStackView view, @Nullable String stackId) {
+        view.stackId = stackId;
+    }
+
+    @Override
+    @ReactProp(name = "ancestorStackIds")
+    public void setAncestorStackIds(NavigationStackView view, @Nullable ReadableArray ancestorStackIds) {
+        view.ancestorStackIds = ancestorStackIds;
+    }
+
     @ReactProp(name = "enterAnim")
     public void setEnterAnim(NavigationStackView view, String enterAnim) {
         view.enterAnim = enterAnim;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -60,7 +60,7 @@ public class SceneFragment extends Fragment {
             Animation anim;
             try {
                 anim = AnimationUtils.loadAnimation(getContext(), nextAnim);
-            } catch(Resources.NotFoundException e) {
+            } catch(RuntimeException e) {
                 return null;
             }
             anim.setAnimationListener(new Animation.AnimationListener() {
@@ -90,7 +90,7 @@ public class SceneFragment extends Fragment {
             Animator anim;
             try {
                 anim = nextAnim == 0 ? transform(enterAnimator, true) : (nextAnim == -1 ? transform(reenterAnimator, true) : AnimatorInflater.loadAnimator(getContext(), nextAnim));
-            } catch(Resources.NotFoundException e) {
+            } catch(RuntimeException e) {
                 return null;
             }
             assert anim != null;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -161,6 +161,13 @@ public class SceneFragment extends Fragment {
                 alphaAnimator.setDuration(item.duration != null ? item.duration : 300);
                 animatorSet.playTogether(alphaAnimator);
             }
+            if ("rotate".equals(item.type)) {
+                ObjectAnimator rotateAnimator = new ObjectAnimator();
+                rotateAnimator.setPropertyName("rotation");
+                rotateAnimator.setFloatValues(from ? item.x.first : 0, from ? 0 : item.x.first);
+                rotateAnimator.setDuration(item.duration != null ? item.duration : 300);
+                animatorSet.playTogether(rotateAnimator);
+            }
         }
         return animatorSet;
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -143,6 +143,20 @@ public class SceneFragment extends Fragment {
                 animator.setDuration(item.duration != null ? item.duration : 300);
                 builder = builder.with(animator);
             }
+            if ("scale".equals(item.type)) {
+                ObjectAnimator animator = new ObjectAnimator();
+                animator.setPropertyName("scaleX");
+                float xVal = item.x.second ? item.x.first / 100 : item.x.first;
+                animator.setFloatValues(from ? xVal : 1, from ? 1 : xVal);
+                animator.setDuration(item.duration != null ? item.duration : 300);
+                builder = builder == null ? animatorSet.play(animator) : builder.with(animator);
+                animator = new ObjectAnimator();
+                animator.setPropertyName("scaleY");
+                float yVal = item.y.second ? item.y.first / 100 : item.y.first;
+                animator.setFloatValues(from ? yVal : 1, from ? 1 : yVal);
+                animator.setDuration(item.duration != null ? item.duration : 300);
+                builder = builder.with(animator);
+            }
         }
         return animatorSet;
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -126,36 +126,33 @@ public class SceneFragment extends Fragment {
         AnimatorSet animatorSet = new AnimatorSet();
         if (anim.duration != null)
             animatorSet.setDuration(anim.duration);
-        AnimatorSet.Builder builder = null;
         for (int i = 0; i < anim.items.length; i++) {
             AnimationPropParser.AnimatorItem item = anim.items[i];
             if ("translate".equals(item.type)) {
-                ObjectAnimator animator = new ObjectAnimator();
-                animator.setPropertyName("translationX");
+                ObjectAnimator xAnimator = new ObjectAnimator();
+                xAnimator.setPropertyName("translationX");
                 float xVal = item.x.second ? scene.getWidth() * item.x.first / 100 : item.x.first;
-                animator.setFloatValues(from ? xVal : 0, from ? 0 : xVal);
-                animator.setDuration(item.duration != null ? item.duration : 300);
-                builder = builder == null ? animatorSet.play(animator) : builder.with(animator);
-                animator = new ObjectAnimator();
-                animator.setPropertyName("translationY");
+                xAnimator.setFloatValues(from ? xVal : 0, from ? 0 : xVal);
+                xAnimator.setDuration(item.duration != null ? item.duration : 300);
+                ObjectAnimator yAnimator = new ObjectAnimator();
+                yAnimator.setPropertyName("translationY");
                 float yVal = item.y.second ? scene.getWidth() * item.y.first / 100 : item.y.first;
-                animator.setFloatValues(from ? yVal : 0, from ? 0 : yVal);
-                animator.setDuration(item.duration != null ? item.duration : 300);
-                builder = builder.with(animator);
+                yAnimator.setFloatValues(from ? yVal : 0, from ? 0 : yVal);
+                yAnimator.setDuration(item.duration != null ? item.duration : 300);
+                animatorSet.playTogether(xAnimator, yAnimator);
             }
             if ("scale".equals(item.type)) {
-                ObjectAnimator animator = new ObjectAnimator();
-                animator.setPropertyName("scaleX");
+                ObjectAnimator xAnimator = new ObjectAnimator();
+                xAnimator.setPropertyName("scaleX");
                 float xVal = item.x.second ? item.x.first / 100 : item.x.first;
-                animator.setFloatValues(from ? xVal : 1, from ? 1 : xVal);
-                animator.setDuration(item.duration != null ? item.duration : 300);
-                builder = builder == null ? animatorSet.play(animator) : builder.with(animator);
-                animator = new ObjectAnimator();
-                animator.setPropertyName("scaleY");
+                xAnimator.setFloatValues(from ? xVal : 1, from ? 1 : xVal);
+                xAnimator.setDuration(item.duration != null ? item.duration : 300);
+                ObjectAnimator yAnimator = new ObjectAnimator();
+                yAnimator.setPropertyName("scaleY");
                 float yVal = item.y.second ? item.y.first / 100 : item.y.first;
-                animator.setFloatValues(from ? yVal : 1, from ? 1 : yVal);
-                animator.setDuration(item.duration != null ? item.duration : 300);
-                builder = builder.with(animator);
+                yAnimator.setFloatValues(from ? yVal : 1, from ? 1 : yVal);
+                yAnimator.setDuration(item.duration != null ? item.duration : 300);
+                animatorSet.playTogether(xAnimator, yAnimator);
             }
         }
         return animatorSet;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -154,6 +154,13 @@ public class SceneFragment extends Fragment {
                 yAnimator.setDuration(item.duration != null ? item.duration : 300);
                 animatorSet.playTogether(xAnimator, yAnimator);
             }
+            if ("alpha".equals(item.type)) {
+                ObjectAnimator alphaAnimator = new ObjectAnimator();
+                alphaAnimator.setPropertyName("alpha");
+                alphaAnimator.setFloatValues(from ? item.x.first : 1, from ? 1 : item.x.first);
+                alphaAnimator.setDuration(item.duration != null ? item.duration : 300);
+                animatorSet.playTogether(alphaAnimator);
+            }
         }
         return animatorSet;
     }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -4,7 +4,6 @@ import android.animation.Animator;
 import android.animation.AnimatorInflater;
 import android.animation.AnimatorSet;
 import android.animation.ObjectAnimator;
-import android.content.res.Resources;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneManager.java
@@ -41,13 +41,13 @@ public class SceneManager extends ViewGroupManager<SceneView> {
     @ReactProp(name = "enterTrans")
     public void setEnterTrans(SceneView view, ReadableMap enterTrans) {
         view.enterTrans = AnimationPropParser.getTransition(enterTrans);
-        view.enterAnimation = AnimationPropParser.getAnimation(enterTrans, true);
+        view.enterAnimator = AnimationPropParser.getAnimator(enterTrans, true);
     }
 
     @ReactProp(name = "exitTrans")
     public void setExitTrans(SceneView view, ReadableMap exitTrans) {
         view.exitTrans = AnimationPropParser.getTransition(exitTrans);
-        view.exitAnimation = AnimationPropParser.getAnimation(exitTrans, false);
+        view.exitAnimator = AnimationPropParser.getAnimator(exitTrans, false);
     }
 
     @ReactProp(name = "landscape")

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneView.java
@@ -23,8 +23,8 @@ public class SceneView extends ReactViewGroup {
     protected String sceneKey;
     protected String enterAnim;
     protected String exitAnim;
-    protected Animation enterAnimation;
-    protected Animation exitAnimation;
+    protected AnimationPropParser.Animator enterAnimator;
+    protected AnimationPropParser.Animator exitAnimator;
     protected Transition enterTrans;
     protected Transition exitTrans;
     private boolean landscape;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneViewManager.java
@@ -67,13 +67,13 @@ public class SceneViewManager extends ViewGroupManager<SceneView> implements NVS
     @ReactProp(name = "enterTrans")
     public void setEnterTrans(SceneView view, ReadableMap enterTrans) {
         view.enterTrans = AnimationPropParser.getTransition(enterTrans);
-        view.enterAnimation = AnimationPropParser.getAnimation(enterTrans, true);
+        view.enterAnimator = AnimationPropParser.getAnimator(enterTrans, true);
     }
 
     @ReactProp(name = "exitTrans")
     public void setExitTrans(SceneView view, ReadableMap exitTrans) {
         view.exitTrans = AnimationPropParser.getTransition(exitTrans);
-        view.exitAnimation = AnimationPropParser.getAnimation(exitTrans, false);
+        view.exitAnimator = AnimationPropParser.getAnimator(exitTrans, false);
     }
 
     @ReactProp(name = "landscape")


### PR DESCRIPTION
Updated [Fragments to v1.7 and switched from Animations to Animators as per the Android guide](https://developer.android.com/guide/navigation/custom-back/support-animations#use_existing_apis). This brings predictive back gesture support to the `FragmentManager` back stack. Because the previous scene is now peekable on Android as well as iOS, removed the platform checks from the peekable logic. For example, rendering a fluently skipped scene in the background is necessary on Android, too.

The `FragmentManager` only supports predictive back on primary Fragments. A Fragment is only primary if it and all its ancestor Fragments are primary. The simplest way to do this was to create all stack Fragments as children of the Activity’s `FragmentManager`. Then don’t have to worry about the ancestors because they have none. But a `FragmentManager` can only have one primary Fragment at a time and switching the primary Fragment around, depending on which one was at the top, is difficult. Can’t just use `onAttached/Detached` to/from the window to move it around.

For example, consider a stack within a stack (not inside a modal - just one of the scenes in a stack renders a new stack). What happens after gesturing back to the beginning of the child stack? The child stack is still in the window but the gesture back should go to the parent instead.

So created the stack Fragments inside each other’s `childFragmentManagers`. In the Twitter sample, the top level stack is in the Activity’s `FragmentManager` and the child nested tab stacks are created in the top level stack’s `childFragmentManager`. That way both the parent stack and (one of) the nested stacks can both be primary Fragments at the same time. Now only have to shift the primary around between the sibling stacks, not between parent and child, and can use `onAttached/Detached` for that.

There’s some weirdness around the predictive back that couldn’t get to the bottom of.
- Couldn’t get Transitions to work. Not just shared elements but material transitions, too. Even with the predictive back turned off transitions still wouldn’t work. Some of it is the switch to Animators. The fragment library doesn’t like Animators and Transitions configured together. But even after skipping `setCutomAnimations`, when there’s a Transition, there were still problems. Kept getting a blank screen when the gesture back was cancelled ([cancelling Transactions was added for predictive back](https://issuetracker.google.com/issues/319531491#comment12)). Also `OnTransitionEnd` fired when Transition was cancelled so it’s hard to tell cancel apart from success. Even if all this worked the `ChangeTransform` returned false from `isSeekingSupported` so predictive back wouldn’t work for shared elements?! Worked around it by forcing in all four transitions (enter, return, exit, reenter) if there was at least one and making sure they had `isSeekingSupported` set to false.
- Predictive back listeners don’t always fire in reverse order as promised. The modal back listener in the medley sample always received the gesture back even if there was a back stack in the modal. So the modal closed instead of going back through the stack first. Think it must be that different `OnBackPressedDispatchers` have different precedence?! Writing a custom gesture back for a modal that uses the Activity’s dispatcher should fix it.