### PR TITLE
Documented shared element transitions disable predictive back

### DIFF
--- a/documentation/native/shared-element-transition.html
+++ b/documentation/native/shared-element-transition.html
@@ -54,6 +54,10 @@
             <p>
                 Android supports shared element transitions, where you can smoothly animate changes between related Views across two scenes. The Navigation router exposes this functionality to React using the <code>SharedElement</code> component. To identify a pair of shareable elements, you wrap each one in a <code>SharedElement</code> component and give them both the same <code>name</code>.
             </p>
+            <div class="Note">
+                <h2>Note</h2>
+                Shared element transitions disable the predictive back gesture
+            </div>
             <p>
                 In our email example app, we smooth out the transition when a user opens an email by visually connecting the subject line on the 'inbox' scene with the open email on the 'mail' scene. We wrap the views on each scene inside a <code>SharedElement</code> component and give them both the same name.
             </p>


### PR DESCRIPTION
As explained in #781 had problems getting Transitions to play nicely with predictive back. The workaround allows Transitions to run but disables the predictive back for them