### PR TITLE
Supported predictive back on Material Transitions

### DIFF
--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/AnimationPropParser.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/AnimationPropParser.java
@@ -40,12 +40,6 @@ public class AnimationPropParser {
             case "fadeThrough" -> transition = new MaterialFadeThrough();
             case "hold" -> transition = new Hold();
         }
-        if (transition != null) {
-            TransitionSet transitionSet = new TransitionSet();
-            transitionSet.addTransition(transition);
-            transitionSet.addTransition(new VoidTransition());
-            return transitionSet;
-        }
         return transition;
     }
 
@@ -81,17 +75,6 @@ public class AnimationPropParser {
             return new Pair<>(Float.parseFloat(val.substring(0, val.length() - 1)), true);
         } else {
             return new Pair<>(Float.parseFloat(val), false);
-        }
-    }
-
-    static class VoidTransition extends Transition
-    {
-        @Override
-        public void captureStartValues(@NonNull TransitionValues transitionValues) {
-        }
-
-        @Override
-        public void captureEndValues(@NonNull TransitionValues transitionValues) {
         }
     }
 

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -33,6 +33,7 @@ import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
+import com.google.android.material.transition.MaterialFade;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -158,10 +159,10 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                     if (prevFragment != null) {
                         sharedElements = getSharedElements(currentCrumb, crumb, prevFragment);
                         if (sharedElements != null || enterTrans != null || exitTrans != null || scene.enterTrans != null || scene.exitTrans != null) {
-                            exitTrans = exitTrans != null ? exitTrans : new AnimationPropParser.VoidTransition();
-                            scene.enterTrans = scene.enterTrans != null ? scene.enterTrans : new AnimationPropParser.VoidTransition();
-                            enterTrans = enterTrans != null ? enterTrans : new AnimationPropParser.VoidTransition();
-                            scene.exitTrans = scene.exitTrans != null ? scene.exitTrans : new AnimationPropParser.VoidTransition();
+                            exitTrans = exitTrans != null ? exitTrans : new MaterialFade();
+                            scene.enterTrans = scene.enterTrans != null ? scene.enterTrans : new MaterialFade();
+                            enterTrans = enterTrans != null ? enterTrans : new MaterialFade();
+                            scene.exitTrans = scene.exitTrans != null ? scene.exitTrans : new MaterialFade();
                         }
                         prevFragment.setExitTransition(exitTrans);
                         prevFragment.exitAnimator = exitAnimator;
@@ -201,10 +202,10 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
             SceneFragment prevFragment = (SceneFragment) fragmentManager.findFragmentByTag(oldKey);
             if (prevFragment != null) {
                 if (enterTrans != null || exitTrans != null || scene.enterTrans != null || scene.exitTrans != null) {
-                    exitTrans = exitTrans != null ? exitTrans : new AnimationPropParser.VoidTransition();
-                    scene.enterTrans = scene.enterTrans != null ? scene.enterTrans : new AnimationPropParser.VoidTransition();
-                    enterTrans = enterTrans != null ? enterTrans : new AnimationPropParser.VoidTransition();
-                    scene.exitTrans = scene.exitTrans != null ? scene.exitTrans : new AnimationPropParser.VoidTransition();
+                    exitTrans = exitTrans != null ? exitTrans : new MaterialFade();
+                    scene.enterTrans = scene.enterTrans != null ? scene.enterTrans : new MaterialFade();
+                    enterTrans = enterTrans != null ? enterTrans : new MaterialFade();
+                    scene.exitTrans = scene.exitTrans != null ? scene.exitTrans : new MaterialFade();
                 }
                 prevFragment.setExitTransition(exitTrans);
                 prevFragment.exitAnimator = exitAnimator;

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -105,10 +105,10 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                 public void onBackStackChangeStarted(@NonNull Fragment sceneFragment, boolean pop) {
                     if (pop && sceneFragment.isRemoving()) {
                         int crumb = ((SceneFragment) sceneFragment).getScene().crumb;
-                        if (crumb < keys.size() - 1) {
+                        if (crumb < keys.size()) {
                             ReactContext reactContext = (ReactContext) getContext();
                             EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
-                            eventDispatcher.dispatchEvent(new NavigationStackView.WillNavigateBackEvent(getId(), crumb));
+                            eventDispatcher.dispatchEvent(new NavigationStackView.WillNavigateBackEvent(getId(), keys.size() - 2));
                         }
                     }
                 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SceneFragment.java
@@ -180,7 +180,7 @@ public class SceneFragment extends Fragment {
             @Override
             public void onTransitionEnd(@NonNull Transition transition) {
                 super.onTransitionEnd(transition);
-                if (scene.getParent() instanceof NavigationStackView)
+                if (scene.getParent() instanceof NavigationStackView && isVisible())
                     ((NavigationStackView) scene.getParent()).onRest(scene.crumb);
             }
         });
@@ -194,7 +194,7 @@ public class SceneFragment extends Fragment {
             @Override
             public void onTransitionEnd(@NonNull Transition transition) {
                 super.onTransitionEnd(transition);
-                if (scene.getParent() instanceof NavigationStackView)
+                if (scene.getParent() instanceof NavigationStackView && isVisible())
                     ((NavigationStackView) scene.getParent()).onRest(scene.crumb);
             }
         });
@@ -208,7 +208,7 @@ public class SceneFragment extends Fragment {
             @Override
             public void onTransitionEnd(@NonNull Transition transition) {
                 super.onTransitionEnd(transition);
-                if (scene != null)
+                if (scene != null && !isVisible())
                   scene.popped();
             }
         });


### PR DESCRIPTION
Predictive back is buggy and this caused confusion when working on #781. Couldn’t work out what was breaking - was it shared elements? Was it when only one transition was specified? Different scenarios gave different breakages. So put in `VoidTransition` to just turn off predictive back when not using `Animators`. 

But after revisiting it was actually `VoidTransition` that broke the predictive back with Material Transitions. For example, cancel the gesture back and then a second gesture back would show a blank screen. Removing `VoidTransition` fixed this. As long as all four Transitions are specified (enter, exit, reenter, return) then gesture back works for Material Transitions.

The cmd + del on Android emulator doesn’t go back with predictive back enabled and Material Transitions. With predictive back disabled and/or with Animators it works. Not a blocker because only an emulator issue.

Also fixed `enableOnBackInvokedCallback` set to true on API < 34 where swipe back stopped the previous scene from being interacted with. This is yet another Android bug. For example, navigate from A → B → C and gesture back. Android calls `onBackStackChangeStarted` twice, once passing in fragment B and again passing in fragment C. On API 33 fragment C `isRemoving` (correct) but on API 34 fragment B `isRemoving` (incorrect). Used the keys length to work out the previous crumb instead of using the removing fragment.
