### PR TITLE
Prevented error when SearchBar is unmounted (iOS Fabric)

### DIFF
--- a/NavigationReactNative/src/ios/NVSearchBarComponentView.mm
+++ b/NavigationReactNative/src/ios/NVSearchBarComponentView.mm
@@ -21,7 +21,6 @@ using namespace facebook::react;
 
 @implementation NVSearchBarComponentView
 {
-    UIView *_reactSubview;
     UIFont *_font;
     NSInteger _nativeEventCount;
     NSInteger _nativeActiveEventCount;
@@ -189,13 +188,6 @@ using namespace facebook::react;
     }
 }
 
-- (void)observeValueForKeyPath:(NSString*)keyPath ofObject:(id)object change:(NSDictionary*)change context:(void*)context
-{
-    if (self.searchController.searchBar.text.length == 0 && !_reactSubview.isHidden) {
-        _reactSubview.hidden = YES;
-    }
-}
-
 - (void)notifyForBoundsChange:(CGRect)newBounds
 {
     if (_state != nullptr) {
@@ -204,23 +196,15 @@ using namespace facebook::react;
     }
 }
 
-- (void)dealloc
-{
-    [_reactSubview removeObserver:self forKeyPath:@"hidden"];
-}
-
 #pragma mark - RCTComponentViewProtocol
 
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
     self.searchController.searchResultsController.view = childComponentView;
-    _reactSubview = childComponentView;
-    [_reactSubview addObserver:self forKeyPath:@"hidden" options:0 context:nil];
 }
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
-    [_reactSubview removeObserver:self forKeyPath:@"hidden"];
     self.searchController.searchResultsController.view = nil;
 }
 

--- a/NavigationReactNative/src/ios/NVSearchBarView.m
+++ b/NavigationReactNative/src/ios/NVSearchBarView.m
@@ -208,7 +208,8 @@
 
 - (void)dealloc
 {
-    [_reactSubview removeObserver:self forKeyPath:@"hidden"];
+    if (_reactSubview)
+        [_reactSubview removeObserver:self forKeyPath:@"hidden"];
 }
 
 


### PR DESCRIPTION
Fixes #797

When the `SearchBar` is unmounted on Fabric the Navigation router throws an error because it tries to remove the keyPath observer twice. (This only happens on Fabric because React Native unmounts the child and then iOS calls dealloc - on the old arch React Native doesn't call `removeReactSubview`).

Retested the original scenario for [why the keyPath observer was introduced](https://github.com/grahammendick/navigation/commit/475f588f2998bdb6ce49ef514749f73f43b24368) and the problem doesn't happen on Fabric. The search results aren't shown when first tapping the search bar. So removed the keyPath observer logic on Fabric.

(Even though the double remove didn't happen on the old architecture, added a defensive check in dealloc to make sure the observer is only removed if it's still added.) 
