### PR TITLE
Supported native declarative animation api (Web)

### DIFF
--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -28,15 +28,15 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountSty
   return (
       <NavigationMotion
           unmountedStyle={unmountedStyle || ((state, data, crumbs) => {
-            let trans = returnOrCall(unmountStyle, true, state, data, crumbs);
+            const trans = returnOrCall(unmountStyle, true, state, data, crumbs);
             return getStyle(trans && typeof trans !== 'string' ? trans : trans ? {type: 'translate',  startX: '100%'} : {duration: 0});
           })}
           mountedStyle={mountedStyle || ((state, data, crumbs, _nextState, _nextData, from) => {
-            let trans = returnOrCall(from ? unmountStyle : crumbStyle, true, state, data, crumbs);
+            const trans = returnOrCall(from ? unmountStyle : crumbStyle, true, state, data, crumbs);
             return {...emptyStyle, duration: trans && typeof trans !== 'string' ? getStyle(trans).duration : undefined};
           })}
           crumbStyle={crumbedStyle || ((state, data, crumbs, nextState, nextData) => {
-            let trans = returnOrCall(crumbStyle, true, state, data, crumbs, nextState, nextData);
+            const trans = returnOrCall(crumbStyle, true, state, data, crumbs, nextState, nextData);
             return getStyle(trans && typeof trans !== 'string' ? trans : trans ? {type: 'translate',  startX: '0%'} : {duration: 0});
           })}
           sharedElementMotion={sharedElementTransition}

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -17,7 +17,7 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountSty
             if (!trans || typeof trans === 'string')
               trans = {type: 'translate',  startX: 100};
             trans = !Array.isArray(trans) ? trans : {items: trans};
-            const transStyle = {duration};
+            const transStyle = {duration, translateX: 0, translateX_pc: 0, scaleX: 1, scaleX_pc: 100, alpha: 1};
             const addStyle = (type: string, start: string | number) => {
               if (start === undefined) return;
               const percent = typeof start === 'string' && start.endsWith('%')
@@ -39,13 +39,14 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountSty
             convertTrans(trans);
             return transStyle;
           })}
-          mountedStyle={mountedStyle || {translateX_pc: 0, alpha: 1, scaleX: 1, scaleY: 1}}
+          // only return the exact ones needed
+          mountedStyle={mountedStyle || {duration, translateX: 0, translateX_pc: 0, scaleX: 1, scaleX_pc: 100, alpha: 1}}
           crumbStyle={crumbedStyle || ((state, data, crumbs, nextState, nextData) => {
             let trans = returnOrCall(crumbStyle, true, state, data, crumbs, nextState, nextData);
             if (!trans || typeof trans === 'string')
               trans = {type: 'translate',  startX: 0};
             trans = !Array.isArray(trans) ? trans : {items: trans};
-            const transStyle = {duration};
+            const transStyle = {duration, translateX: 0, translateX_pc: 0, scaleX: 1, scaleX_pc: 100, alpha: 1};
             const addStyle = (type: string, start: string | number) => {
               if (start === undefined) return;
               const percent = typeof start === 'string' && start.endsWith('%')
@@ -76,12 +77,13 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountSty
   );
 }
 
+// check for !== undefined instead to allow for 0 values
 const renderMotion = ({translateX, translateX_pc, scaleX, scaleX_pc}, scene, key) => (
   <View key={key}
     style={{
       transform: `
         translate(${translateX ? `${translateX}px` : translateX_pc ? `${translateX_pc}%` : '0'})
-        scale(${scaleX ? `${scaleX}` : scaleX_pc ? `${scaleX_pc / 100}` : '1'})
+        scale(${scaleX !== 1 ? `${scaleX}` : scaleX_pc ? `${scaleX_pc / 100}` : '1'})
       ` as any,
       position: 'absolute',
       backgroundColor: '#fff',

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -5,10 +5,6 @@ import { MobileHistoryManager } from 'navigation-react-mobile';
 
 const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountStyle = () => null, crumbStyle = () => null,
   sharedElementTransition, duration, renderScene, renderTransition, children}) => {
-  const customRender = typeof children === 'function' || renderTransition;
-  // if !customRender then turn unmountStyle into unmounted style (and mountedStyle)
-  // and crumbStyle into crumbStyle
-  // (what about if they're empty like in the zoom sample?)
   const emptyStyle = {duration, translateX: 0, translateX_pc: 0, scaleX: 1, scaleX_pc: 100, alpha: 1, rotate: 0};
   const returnOrCall = (item, ...args) => typeof item !== 'function' ? item : item(...args);
   const getStyle = (trans) => {

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -16,11 +16,8 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountSty
       transStyle[type + suffix] = +(suffix ? `${start}`.slice(0, -1) : start);
     }
     const convertTrans = ({type, start, from, startX, fromX, startY, fromY, items}) => {
-      if (type === 'translate' || type === 'scale') {
-        addStyle(`${type}X`, startX ?? fromX);
-        addStyle(`${type}Y`, startY ?? fromY);
-      }
-      // can do pivot? transform origin?
+      if (type === 'translate' || type === 'scale') addStyle(`${type}X`, startX ?? fromX);
+      if (type === 'translate' || type === 'scale') addStyle(`${type}Y`, startY ?? fromY);
       if (type === 'alpha' || type === 'rotate') addStyle(type, start ?? from);
       items?.forEach(convertTrans);
     };

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -3,19 +3,19 @@ import { View } from 'react-native';
 import { NavigationMotion, Scene, SharedElementMotion } from 'navigation-react-mobile';
 import { MobileHistoryManager } from 'navigation-react-mobile';
 
-const NavigationStack = ({ unmountedStyle, mountedStyle, crumbedStyle, unmountStyle = () => null, crumbStyle = () => null,
-    sharedElementTransition, duration, renderScene, renderTransition, children }) => {
-    const emptyStyle = { duration: undefined, translateX: 0, translateX_pc: 0, scaleX: 1, scaleX_pc: 100, alpha: 1, rotate: 0 };
+const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountStyle = () => null, crumbStyle = () => null,
+    sharedElementTransition, duration, renderScene, renderTransition, children}) => {
+    const emptyStyle = {duration: undefined, translateX: 0, translateX_pc: 0, scaleX: 1, scaleX_pc: 100, alpha: 1, rotate: 0};
     const returnOrCall = (item, ...args) => typeof item !== 'function' ? item : item(...args);
     const getStyle = (trans) => {
-        trans = !Array.isArray(trans) ? trans : { items: trans };
-        const transStyle = { ...emptyStyle };
+        trans = !Array.isArray(trans) ? trans : {items: trans};
+        const transStyle = {...emptyStyle};
         const addStyle = (type: string, start: string | number) => {
             if (start === undefined) return;
             const suffix = `${start}`.endsWith('%') ? '_pc' : '';
             transStyle[type + suffix] = +(suffix ? `${start}`.slice(0, -1) : start);
         }
-        const convertTrans = ({ type, start, from, startX, fromX, startY, fromY, items, duration }) => {
+        const convertTrans = ({type, start, from, startX, fromX, startY, fromY, items, duration}) => {
             if (type === 'translate' || type === 'scale') addStyle(`${type}X`, startX ?? fromX);
             if (type === 'translate' || type === 'scale') addStyle(`${type}Y`, startY ?? fromY);
             if (type === 'alpha' || type === 'rotate') addStyle(type, start ?? from);
@@ -29,15 +29,15 @@ const NavigationStack = ({ unmountedStyle, mountedStyle, crumbedStyle, unmountSt
         <NavigationMotion
             unmountedStyle={unmountedStyle || ((state, data, crumbs) => {
                 const trans = returnOrCall(unmountStyle, true, state, data, crumbs);
-                return getStyle(trans && typeof trans !== 'string' ? trans : trans ? { type: 'translate', startX: '100%' } : { duration: 0 });
+                return getStyle(trans && typeof trans !== 'string' ? trans : trans ? {type: 'translate', startX: '100%'} : {duration: 0});
             })}
             mountedStyle={mountedStyle || ((state, data, crumbs, _nextState, _nextData, from) => {
                 const trans = returnOrCall(from ? unmountStyle : crumbStyle, true, state, data, crumbs);
-                return { ...emptyStyle, duration: trans && typeof trans !== 'string' ? getStyle(trans).duration : undefined };
+                return {...emptyStyle, duration: trans && typeof trans !== 'string' ? getStyle(trans).duration : undefined};
             })}
             crumbStyle={crumbedStyle || ((state, data, crumbs, nextState, nextData) => {
                 const trans = returnOrCall(crumbStyle, true, state, data, crumbs, nextState, nextData);
-                return getStyle(trans && typeof trans !== 'string' ? trans : trans ? { type: 'translate', startX: '0%' } : { duration: 0 });
+                return getStyle(trans && typeof trans !== 'string' ? trans : trans ? {type: 'translate', startX: '0%'} : {duration: 0});
             })}
             sharedElementMotion={sharedElementTransition}
             duration={duration}
@@ -48,7 +48,7 @@ const NavigationStack = ({ unmountedStyle, mountedStyle, crumbedStyle, unmountSt
     );
 }
 
-const renderMotion = ({ translateX, translateX_pc, scaleX, scaleX_pc, alpha, rotate }, scene, key) => (
+const renderMotion = ({translateX, translateX_pc, scaleX, scaleX_pc, alpha, rotate}, scene, key) => (
     <View key={key}
         style={{
             transform: `
@@ -69,7 +69,7 @@ const renderMotion = ({ translateX, translateX_pc, scaleX, scaleX_pc, alpha, rot
 const cloneScenes = (children, nested = false) => (
     React.Children.map(children, scene => (
         (scene.type === Scene || nested)
-            ? React.cloneElement(scene, { crumbStyle: scene.props.crumbedStyle })
+            ? React.cloneElement(scene, {crumbStyle: scene.props.crumbedStyle})
             : React.cloneElement(scene, null, cloneScenes(scene.props.children, true))
     ))
 );

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -9,10 +9,11 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountSty
   // if !customRender then turn unmountStyle into unmounted style (and mountedStyle)
   // and crumbStyle into crumbStyle
   // (what about if they're empty like in the zoom sample?)
+  const emptyStyle = {duration, translateX: 0, translateX_pc: 0, scaleX: 1, scaleX_pc: 100, alpha: 1};
   const returnOrCall = (item, ...args) => typeof item !== 'function' ? item : item(...args);
   const getStyle = (trans) => {
     trans = !Array.isArray(trans) ? trans : {items: trans};
-    const transStyle = {duration, translateX: 0, translateX_pc: 0, scaleX: 1, scaleX_pc: 100, alpha: 1};
+    const transStyle = {...emptyStyle};
     const addStyle = (type: string, start: string | number) => {
       if (start === undefined) return;
       const percent = typeof start === 'string' && start.endsWith('%')
@@ -38,7 +39,7 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountSty
               trans = {type: 'translate',  startX: 100};
             return getStyle(trans);
           })}
-          mountedStyle={mountedStyle || {duration, translateX: 0, translateX_pc: 0, scaleX: 1, scaleX_pc: 100, alpha: 1}}
+          mountedStyle={mountedStyle || {...emptyStyle}}
           crumbStyle={crumbedStyle || ((state, data, crumbs, nextState, nextData) => {
             let trans = returnOrCall(crumbStyle, true, state, data, crumbs, nextState, nextData);
             if (!trans || typeof trans === 'string')

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -77,7 +77,6 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountSty
   );
 }
 
-// check for !== undefined instead to allow for 0 values
 const renderMotion = ({translateX, translateX_pc, scaleX, scaleX_pc}, scene, key) => (
   <View key={key}
     style={{

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -24,16 +24,12 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountSty
               transStyle[type + (percent ? '_pc' : '')] = percent ? +(start as string).slice(0, -1) : +start;
             }
             const convertTrans = ({type, start, from, startX, fromX, startY, fromY, items}) => {
-              if (type === 'translate') {
-                addStyle('translateX', startX ?? fromX);
-                addStyle('translateY', startY ?? fromY);
+              if (type === 'translate' || type === 'scale') {
+                addStyle(`${type}X`, startX ?? fromX);
+                addStyle(`${type}Y`, startY ?? fromY);
               }
-              if (type === 'scale') {
-                addStyle('scaleX', startX ?? fromX);
-                addStyle('scaleY', startY ?? fromY);
-              }
-              if (type === 'alpha') addStyle('alpha', start ?? from);
-              if (type === 'rotate') addStyle('rotate', start ?? from); // can do pivot? transform origin?
+              // can do pivot? transform origin?
+              if (type === 'alpha' || type === 'rotate') addStyle(type, start ?? from);
               items?.forEach(convertTrans);
             };
             convertTrans(trans);
@@ -53,16 +49,12 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountSty
               transStyle[type + (percent ? '_pc' : '')] = percent ? +(start as string).slice(0, -1) : +start;
             }
             const convertTrans = ({type, start, from, startX, fromX, startY, fromY, items}) => {
-              if (type === 'translate') {
-                addStyle('translateX', startX ?? fromX);
-                addStyle('translateY', startY ?? fromY);
+              if (type === 'translate' || type === 'scale') {
+                addStyle(`${type}X`, startX ?? fromX);
+                addStyle(`${type}Y`, startY ?? fromY);
               }
-              if (type === 'scale') {
-                addStyle('scaleX', startX ?? fromX);
-                addStyle('scaleY', startY ?? fromY);
-              }
-              if (type === 'alpha') addStyle('alpha', start ?? from);
-              if (type === 'rotate') addStyle('rotate', start ?? from); // can do pivot? transform origin?
+              // can do pivot? transform origin?
+              if (type === 'alpha' || type === 'rotate') addStyle(type, start ?? from);
               items?.forEach(convertTrans);
             };
             convertTrans(trans);

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -31,7 +31,10 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountSty
             let trans = returnOrCall(unmountStyle, true, state, data, crumbs);
             return getStyle(trans && typeof trans !== 'string' ? trans : trans ? {type: 'translate',  startX: '100%'} : {duration: 0});
           })}
-          mountedStyle={mountedStyle || {...emptyStyle}}
+          mountedStyle={mountedStyle || ((state, data, crumbs, _nextState, _nextData, from) => {
+            let trans = returnOrCall(from ? unmountStyle : crumbStyle, true, state, data, crumbs);
+            return {...emptyStyle, duration: trans && typeof trans !== 'string' ? getStyle(trans).duration : undefined};
+          })}
           crumbStyle={crumbedStyle || ((state, data, crumbs, nextState, nextData) => {
             let trans = returnOrCall(crumbStyle, true, state, data, crumbs, nextState, nextData);
             return getStyle(trans && typeof trans !== 'string' ? trans : trans ? {type: 'translate',  startX: '0%'} : {duration: 0});

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -9,7 +9,7 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountSty
   // if !customRender then turn unmountStyle into unmounted style (and mountedStyle)
   // and crumbStyle into crumbStyle
   // (what about if they're empty like in the zoom sample?)
-  const emptyStyle = {duration, translateX: 0, translateX_pc: 0, scaleX: 1, scaleX_pc: 100, alpha: 1};
+  const emptyStyle = {duration, translateX: 0, translateX_pc: 0, scaleX: 1, scaleX_pc: 100, alpha: 1, rotate: 0};
   const returnOrCall = (item, ...args) => typeof item !== 'function' ? item : item(...args);
   const getStyle = (trans) => {
     trans = !Array.isArray(trans) ? trans : {items: trans};
@@ -55,12 +55,13 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountSty
   );
 }
 
-const renderMotion = ({translateX, translateX_pc, scaleX, scaleX_pc, alpha}, scene, key) => (
+const renderMotion = ({translateX, translateX_pc, scaleX, scaleX_pc, alpha, rotate}, scene, key) => (
   <View key={key}
     style={{
       transform: `
         translate(${translateX ? `${translateX}px` : `${translateX_pc}%`})
         scale(${scaleX !== 1 ? `${scaleX}` : `${scaleX_pc / 100}`})
+        rotate(${rotate}deg)
       ` as any,
       opacity: alpha,
       position: 'absolute',

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -5,7 +5,7 @@ import { MobileHistoryManager } from 'navigation-react-mobile';
 
 const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountStyle = () => null, crumbStyle = () => null,
   sharedElementTransition, duration, renderScene, renderTransition, children}) => {
-  const emptyStyle = {duration, translateX: 0, translateX_pc: 0, scaleX: 1, scaleX_pc: 100, alpha: 1, rotate: 0};
+  const emptyStyle = {duration: undefined, translateX: 0, translateX_pc: 0, scaleX: 1, scaleX_pc: 100, alpha: 1, rotate: 0};
   const returnOrCall = (item, ...args) => typeof item !== 'function' ? item : item(...args);
   const getStyle = (trans) => {
     trans = !Array.isArray(trans) ? trans : {items: trans};
@@ -15,10 +15,11 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountSty
       const suffix = `${start}`.endsWith('%') ? '_pc' : '';
       transStyle[type + suffix] = +(suffix ? `${start}`.slice(0, -1) : start);
     }
-    const convertTrans = ({type, start, from, startX, fromX, startY, fromY, items}) => {
+    const convertTrans = ({type, start, from, startX, fromX, startY, fromY, items, duration}) => {
       if (type === 'translate' || type === 'scale') addStyle(`${type}X`, startX ?? fromX);
       if (type === 'translate' || type === 'scale') addStyle(`${type}Y`, startY ?? fromY);
       if (type === 'alpha' || type === 'rotate') addStyle(type, start ?? from);
+      if (duration !== undefined) transStyle.duration = Math.max(duration, transStyle.duration || 0);
       items?.forEach(convertTrans);
     };
     convertTrans(trans);
@@ -28,12 +29,12 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountSty
       <NavigationMotion
           unmountedStyle={unmountedStyle || ((state, data, crumbs) => {
             let trans = returnOrCall(unmountStyle, true, state, data, crumbs);
-            return getStyle(trans && typeof trans !== 'string' ? trans : {type: 'translate',  startX: '100%'});
+            return getStyle(trans && typeof trans !== 'string' ? trans : trans ? {type: 'translate',  startX: '100%'} : {duration: 0});
           })}
           mountedStyle={mountedStyle || {...emptyStyle}}
           crumbStyle={crumbedStyle || ((state, data, crumbs, nextState, nextData) => {
             let trans = returnOrCall(crumbStyle, true, state, data, crumbs, nextState, nextData);
-            return getStyle(trans && typeof trans !== 'string' ? trans : {type: 'translate',  startX: '0%'});
+            return getStyle(trans && typeof trans !== 'string' ? trans : trans ? {type: 'translate',  startX: '0%'} : {duration: 0});
           })}
           sharedElementMotion={sharedElementTransition}
           duration={duration}

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -76,10 +76,13 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountSty
   );
 }
 
-const renderMotion = ({translate}, scene, key) => (
+const renderMotion = ({translateX, translateX_pc, scaleX, scaleX_pc}, scene, key) => (
   <View key={key}
     style={{
-      transform: `translate(${translate}%)` as any,
+      transform: `
+        translate(${translateX ? `${translateX}px` : translateX_pc ? `${translateX_pc}%` : '0'})
+        scale(${scaleX ? `${scaleX}` : scaleX_pc ? `${scaleX_pc / 100}` : '1'})
+      ` as any,
       position: 'absolute',
       backgroundColor: '#fff',
       left: 0, right: 0, top: 0, bottom: 0,

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -52,9 +52,9 @@ const renderMotion = ({ translateX, translateX_pc, scaleX, scaleX_pc, alpha, rot
     <View key={key}
         style={{
             transform: `
-				translate(${translateX ? `${translateX}px` : `${translateX_pc}%`})
-				scale(${scaleX !== 1 ? `${scaleX}` : `${scaleX_pc / 100}`})
-				rotate(${rotate}deg)
+                translate(${translateX ? `${translateX}px` : `${translateX_pc}%`})
+                scale(${scaleX !== 1 ? `${scaleX}` : `${scaleX_pc / 100}`})
+                rotate(${rotate}deg)
 			` as any,
             opacity: alpha,
             position: 'absolute',

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -54,13 +54,14 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountSty
   );
 }
 
-const renderMotion = ({translateX, translateX_pc, scaleX, scaleX_pc}, scene, key) => (
+const renderMotion = ({translateX, translateX_pc, scaleX, scaleX_pc, alpha}, scene, key) => (
   <View key={key}
     style={{
       transform: `
-        translate(${translateX ? `${translateX}px` : translateX_pc ? `${translateX_pc}%` : '0'})
-        scale(${scaleX !== 1 ? `${scaleX}` : scaleX_pc ? `${scaleX_pc / 100}` : '1'})
+        translate(${translateX ? `${translateX}px` : `${translateX_pc}%`})
+        scale(${scaleX !== 1 ? `${scaleX}` : `${scaleX_pc / 100}`})
       ` as any,
+      opacity: alpha,
       position: 'absolute',
       backgroundColor: '#fff',
       left: 0, right: 0, top: 0, bottom: 0,

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -35,16 +35,12 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountSty
       <NavigationMotion
           unmountedStyle={unmountedStyle || ((state, data, crumbs) => {
             let trans = returnOrCall(unmountStyle, true, state, data, crumbs);
-            if (!trans || typeof trans === 'string')
-              trans = {type: 'translate',  startX: '100%'};
-            return getStyle(trans);
+            return getStyle(trans && typeof trans !== 'string' ? trans : {type: 'translate',  startX: '100%'});
           })}
           mountedStyle={mountedStyle || {...emptyStyle}}
           crumbStyle={crumbedStyle || ((state, data, crumbs, nextState, nextData) => {
             let trans = returnOrCall(crumbStyle, true, state, data, crumbs, nextState, nextData);
-            if (!trans || typeof trans === 'string')
-              trans = {type: 'translate',  startX: '0%'};
-            return getStyle(trans);
+            return getStyle(trans && typeof trans !== 'string' ? trans : {type: 'translate',  startX: '0%'});
           })}
           sharedElementMotion={sharedElementTransition}
           duration={duration}

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -36,14 +36,14 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountSty
           unmountedStyle={unmountedStyle || ((state, data, crumbs) => {
             let trans = returnOrCall(unmountStyle, true, state, data, crumbs);
             if (!trans || typeof trans === 'string')
-              trans = {type: 'translate',  startX: 100};
+              trans = {type: 'translate',  startX: '100%'};
             return getStyle(trans);
           })}
           mountedStyle={mountedStyle || {...emptyStyle}}
           crumbStyle={crumbedStyle || ((state, data, crumbs, nextState, nextData) => {
             let trans = returnOrCall(crumbStyle, true, state, data, crumbs, nextState, nextData);
             if (!trans || typeof trans === 'string')
-              trans = {type: 'translate',  startX: 0};
+              trans = {type: 'translate',  startX: '0%'};
             return getStyle(trans);
           })}
           sharedElementMotion={sharedElementTransition}

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -3,18 +3,78 @@ import { View } from 'react-native';
 import { NavigationMotion, Scene, SharedElementMotion } from 'navigation-react-mobile';
 import { MobileHistoryManager } from 'navigation-react-mobile';
 
-const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, sharedElementTransition, duration, renderScene, renderTransition, children}) => (
-    <NavigationMotion
-        unmountedStyle={unmountedStyle || {translate: 100}}
-        mountedStyle={mountedStyle || {translate: 0}}
-        crumbStyle={crumbedStyle || {translate: 0}}        
-        sharedElementMotion={sharedElementTransition}
-        duration={duration}
-        renderScene={renderScene}
-        renderMotion={typeof children !== 'function' ? renderTransition || renderMotion : undefined}>
-        {typeof children !== 'function' ? cloneScenes(children) : (children || renderMotion)}
-    </NavigationMotion>
-);
+const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountStyle = () => null, crumbStyle = () => null,
+  sharedElementTransition, duration, renderScene, renderTransition, children}) => {
+  const customRender = typeof children === 'function' || renderTransition;
+  // if !customRender then turn unmountStyle into unmounted style (and mountedStyle)
+  // and crumbStyle into crumbStyle
+  // (what about if they're empty like in the zoom sample?)
+  const returnOrCall = (item, ...args) => typeof item !== 'function' ? item : item(...args);
+  return (
+      <NavigationMotion
+          unmountedStyle={unmountedStyle || ((state, data, crumbs) => {
+            let trans = returnOrCall(unmountStyle, true, state, data, crumbs);
+            if (!trans || typeof trans === 'string')
+              trans = {type: 'translate',  startX: 100};
+            trans = !Array.isArray(trans) ? trans : {items: trans};
+            const transStyle = {duration};
+            const addStyle = (type: string, start: string | number) => {
+              if (start === undefined) return;
+              const percent = typeof start === 'string' && start.endsWith('%')
+              transStyle[type + (percent ? '_pc' : '')] = percent ? +(start as string).slice(0, -1) : +start;
+            }
+            const convertTrans = ({type, start, from, startX, fromX, startY, fromY, items}) => {
+              if (type === 'translate') {
+                addStyle('translateX', startX ?? fromX);
+                addStyle('translateY', startY ?? fromY);
+              }
+              if (type === 'scale') {
+                addStyle('scaleX', startX ?? fromX);
+                addStyle('scaleY', startY ?? fromY);
+              }
+              if (type === 'alpha') addStyle('alpha', start ?? from);
+              if (type === 'rotate') addStyle('rotate', start ?? from); // can do pivot? transform origin?
+              items?.forEach(convertTrans);
+            };
+            convertTrans(trans);
+            return transStyle;
+          })}
+          mountedStyle={mountedStyle || {translateX_pc: 0, alpha: 1, scaleX: 1, scaleY: 1}}
+          crumbStyle={crumbedStyle || ((state, data, crumbs, nextState, nextData) => {
+            let trans = returnOrCall(crumbStyle, true, state, data, crumbs, nextState, nextData);
+            if (!trans || typeof trans === 'string')
+              trans = {type: 'translate',  startX: 0};
+            trans = !Array.isArray(trans) ? trans : {items: trans};
+            const transStyle = {duration};
+            const addStyle = (type: string, start: string | number) => {
+              if (start === undefined) return;
+              const percent = typeof start === 'string' && start.endsWith('%')
+              transStyle[type + (percent ? '_pc' : '')] = percent ? +(start as string).slice(0, -1) : +start;
+            }
+            const convertTrans = ({type, start, from, startX, fromX, startY, fromY, items}) => {
+              if (type === 'translate') {
+                addStyle('translateX', startX ?? fromX);
+                addStyle('translateY', startY ?? fromY);
+              }
+              if (type === 'scale') {
+                addStyle('scaleX', startX ?? fromX);
+                addStyle('scaleY', startY ?? fromY);
+              }
+              if (type === 'alpha') addStyle('alpha', start ?? from);
+              if (type === 'rotate') addStyle('rotate', start ?? from); // can do pivot? transform origin?
+              items?.forEach(convertTrans);
+            };
+            convertTrans(trans);
+            return transStyle;
+          })}
+          sharedElementMotion={sharedElementTransition}
+          duration={duration}
+          renderScene={renderScene}
+          renderMotion={typeof children !== 'function' ? renderTransition || renderMotion : undefined}>
+          {typeof children !== 'function' ? cloneScenes(children) : (children || renderMotion)}
+      </NavigationMotion>
+  );
+}
 
 const renderMotion = ({translate}, scene, key) => (
   <View key={key}

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -10,55 +10,40 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountSty
   // and crumbStyle into crumbStyle
   // (what about if they're empty like in the zoom sample?)
   const returnOrCall = (item, ...args) => typeof item !== 'function' ? item : item(...args);
+  const getStyle = (trans) => {
+    trans = !Array.isArray(trans) ? trans : {items: trans};
+    const transStyle = {duration, translateX: 0, translateX_pc: 0, scaleX: 1, scaleX_pc: 100, alpha: 1};
+    const addStyle = (type: string, start: string | number) => {
+      if (start === undefined) return;
+      const percent = typeof start === 'string' && start.endsWith('%')
+      transStyle[type + (percent ? '_pc' : '')] = percent ? +(start as string).slice(0, -1) : +start;
+    }
+    const convertTrans = ({type, start, from, startX, fromX, startY, fromY, items}) => {
+      if (type === 'translate' || type === 'scale') {
+        addStyle(`${type}X`, startX ?? fromX);
+        addStyle(`${type}Y`, startY ?? fromY);
+      }
+      // can do pivot? transform origin?
+      if (type === 'alpha' || type === 'rotate') addStyle(type, start ?? from);
+      items?.forEach(convertTrans);
+    };
+    convertTrans(trans);
+    return transStyle;
+  }
   return (
       <NavigationMotion
           unmountedStyle={unmountedStyle || ((state, data, crumbs) => {
             let trans = returnOrCall(unmountStyle, true, state, data, crumbs);
             if (!trans || typeof trans === 'string')
               trans = {type: 'translate',  startX: 100};
-            trans = !Array.isArray(trans) ? trans : {items: trans};
-            const transStyle = {duration, translateX: 0, translateX_pc: 0, scaleX: 1, scaleX_pc: 100, alpha: 1};
-            const addStyle = (type: string, start: string | number) => {
-              if (start === undefined) return;
-              const percent = typeof start === 'string' && start.endsWith('%')
-              transStyle[type + (percent ? '_pc' : '')] = percent ? +(start as string).slice(0, -1) : +start;
-            }
-            const convertTrans = ({type, start, from, startX, fromX, startY, fromY, items}) => {
-              if (type === 'translate' || type === 'scale') {
-                addStyle(`${type}X`, startX ?? fromX);
-                addStyle(`${type}Y`, startY ?? fromY);
-              }
-              // can do pivot? transform origin?
-              if (type === 'alpha' || type === 'rotate') addStyle(type, start ?? from);
-              items?.forEach(convertTrans);
-            };
-            convertTrans(trans);
-            return transStyle;
+            return getStyle(trans);
           })}
-          // only return the exact ones needed
           mountedStyle={mountedStyle || {duration, translateX: 0, translateX_pc: 0, scaleX: 1, scaleX_pc: 100, alpha: 1}}
           crumbStyle={crumbedStyle || ((state, data, crumbs, nextState, nextData) => {
             let trans = returnOrCall(crumbStyle, true, state, data, crumbs, nextState, nextData);
             if (!trans || typeof trans === 'string')
               trans = {type: 'translate',  startX: 0};
-            trans = !Array.isArray(trans) ? trans : {items: trans};
-            const transStyle = {duration, translateX: 0, translateX_pc: 0, scaleX: 1, scaleX_pc: 100, alpha: 1};
-            const addStyle = (type: string, start: string | number) => {
-              if (start === undefined) return;
-              const percent = typeof start === 'string' && start.endsWith('%')
-              transStyle[type + (percent ? '_pc' : '')] = percent ? +(start as string).slice(0, -1) : +start;
-            }
-            const convertTrans = ({type, start, from, startX, fromX, startY, fromY, items}) => {
-              if (type === 'translate' || type === 'scale') {
-                addStyle(`${type}X`, startX ?? fromX);
-                addStyle(`${type}Y`, startY ?? fromY);
-              }
-              // can do pivot? transform origin?
-              if (type === 'alpha' || type === 'rotate') addStyle(type, start ?? from);
-              items?.forEach(convertTrans);
-            };
-            convertTrans(trans);
-            return transStyle;
+            return getStyle(trans);
           })}
           sharedElementMotion={sharedElementTransition}
           duration={duration}

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -3,75 +3,75 @@ import { View } from 'react-native';
 import { NavigationMotion, Scene, SharedElementMotion } from 'navigation-react-mobile';
 import { MobileHistoryManager } from 'navigation-react-mobile';
 
-const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountStyle = () => null, crumbStyle = () => null,
-  sharedElementTransition, duration, renderScene, renderTransition, children}) => {
-  const emptyStyle = {duration: undefined, translateX: 0, translateX_pc: 0, scaleX: 1, scaleX_pc: 100, alpha: 1, rotate: 0};
-  const returnOrCall = (item, ...args) => typeof item !== 'function' ? item : item(...args);
-  const getStyle = (trans) => {
-    trans = !Array.isArray(trans) ? trans : {items: trans};
-    const transStyle = {...emptyStyle};
-    const addStyle = (type: string, start: string | number) => {
-      if (start === undefined) return;
-      const suffix = `${start}`.endsWith('%') ? '_pc' : '';
-      transStyle[type + suffix] = +(suffix ? `${start}`.slice(0, -1) : start);
+const NavigationStack = ({ unmountedStyle, mountedStyle, crumbedStyle, unmountStyle = () => null, crumbStyle = () => null,
+    sharedElementTransition, duration, renderScene, renderTransition, children }) => {
+    const emptyStyle = { duration: undefined, translateX: 0, translateX_pc: 0, scaleX: 1, scaleX_pc: 100, alpha: 1, rotate: 0 };
+    const returnOrCall = (item, ...args) => typeof item !== 'function' ? item : item(...args);
+    const getStyle = (trans) => {
+        trans = !Array.isArray(trans) ? trans : { items: trans };
+        const transStyle = { ...emptyStyle };
+        const addStyle = (type: string, start: string | number) => {
+            if (start === undefined) return;
+            const suffix = `${start}`.endsWith('%') ? '_pc' : '';
+            transStyle[type + suffix] = +(suffix ? `${start}`.slice(0, -1) : start);
+        }
+        const convertTrans = ({ type, start, from, startX, fromX, startY, fromY, items, duration }) => {
+            if (type === 'translate' || type === 'scale') addStyle(`${type}X`, startX ?? fromX);
+            if (type === 'translate' || type === 'scale') addStyle(`${type}Y`, startY ?? fromY);
+            if (type === 'alpha' || type === 'rotate') addStyle(type, start ?? from);
+            if (duration !== undefined) transStyle.duration = Math.max(duration, transStyle.duration || 0);
+            items?.forEach(convertTrans);
+        };
+        convertTrans(trans);
+        return transStyle;
     }
-    const convertTrans = ({type, start, from, startX, fromX, startY, fromY, items, duration}) => {
-      if (type === 'translate' || type === 'scale') addStyle(`${type}X`, startX ?? fromX);
-      if (type === 'translate' || type === 'scale') addStyle(`${type}Y`, startY ?? fromY);
-      if (type === 'alpha' || type === 'rotate') addStyle(type, start ?? from);
-      if (duration !== undefined) transStyle.duration = Math.max(duration, transStyle.duration || 0);
-      items?.forEach(convertTrans);
-    };
-    convertTrans(trans);
-    return transStyle;
-  }
-  return (
-      <NavigationMotion
-          unmountedStyle={unmountedStyle || ((state, data, crumbs) => {
-            const trans = returnOrCall(unmountStyle, true, state, data, crumbs);
-            return getStyle(trans && typeof trans !== 'string' ? trans : trans ? {type: 'translate',  startX: '100%'} : {duration: 0});
-          })}
-          mountedStyle={mountedStyle || ((state, data, crumbs, _nextState, _nextData, from) => {
-            const trans = returnOrCall(from ? unmountStyle : crumbStyle, true, state, data, crumbs);
-            return {...emptyStyle, duration: trans && typeof trans !== 'string' ? getStyle(trans).duration : undefined};
-          })}
-          crumbStyle={crumbedStyle || ((state, data, crumbs, nextState, nextData) => {
-            const trans = returnOrCall(crumbStyle, true, state, data, crumbs, nextState, nextData);
-            return getStyle(trans && typeof trans !== 'string' ? trans : trans ? {type: 'translate',  startX: '0%'} : {duration: 0});
-          })}
-          sharedElementMotion={sharedElementTransition}
-          duration={duration}
-          renderScene={renderScene}
-          renderMotion={typeof children !== 'function' ? renderTransition || renderMotion : undefined}>
-          {typeof children !== 'function' ? cloneScenes(children) : (children || renderMotion)}
-      </NavigationMotion>
-  );
+    return (
+        <NavigationMotion
+            unmountedStyle={unmountedStyle || ((state, data, crumbs) => {
+                const trans = returnOrCall(unmountStyle, true, state, data, crumbs);
+                return getStyle(trans && typeof trans !== 'string' ? trans : trans ? { type: 'translate', startX: '100%' } : { duration: 0 });
+            })}
+            mountedStyle={mountedStyle || ((state, data, crumbs, _nextState, _nextData, from) => {
+                const trans = returnOrCall(from ? unmountStyle : crumbStyle, true, state, data, crumbs);
+                return { ...emptyStyle, duration: trans && typeof trans !== 'string' ? getStyle(trans).duration : undefined };
+            })}
+            crumbStyle={crumbedStyle || ((state, data, crumbs, nextState, nextData) => {
+                const trans = returnOrCall(crumbStyle, true, state, data, crumbs, nextState, nextData);
+                return getStyle(trans && typeof trans !== 'string' ? trans : trans ? { type: 'translate', startX: '0%' } : { duration: 0 });
+            })}
+            sharedElementMotion={sharedElementTransition}
+            duration={duration}
+            renderScene={renderScene}
+            renderMotion={typeof children !== 'function' ? renderTransition || renderMotion : undefined}>
+            {typeof children !== 'function' ? cloneScenes(children) : (children || renderMotion)}
+        </NavigationMotion>
+    );
 }
 
-const renderMotion = ({translateX, translateX_pc, scaleX, scaleX_pc, alpha, rotate}, scene, key) => (
-  <View key={key}
-    style={{
-      transform: `
-        translate(${translateX ? `${translateX}px` : `${translateX_pc}%`})
-        scale(${scaleX !== 1 ? `${scaleX}` : `${scaleX_pc / 100}`})
-        rotate(${rotate}deg)
-      ` as any,
-      opacity: alpha,
-      position: 'absolute',
-      backgroundColor: '#fff',
-      left: 0, right: 0, top: 0, bottom: 0,
-      overflow: 'hidden',
-    }}>
-    {scene}
-  </View>
+const renderMotion = ({ translateX, translateX_pc, scaleX, scaleX_pc, alpha, rotate }, scene, key) => (
+    <View key={key}
+        style={{
+            transform: `
+				translate(${translateX ? `${translateX}px` : `${translateX_pc}%`})
+				scale(${scaleX !== 1 ? `${scaleX}` : `${scaleX_pc / 100}`})
+				rotate(${rotate}deg)
+			` as any,
+            opacity: alpha,
+            position: 'absolute',
+            backgroundColor: '#fff',
+            left: 0, right: 0, top: 0, bottom: 0,
+            overflow: 'hidden',
+        }}>
+        {scene}
+    </View>
 );
 
 const cloneScenes = (children, nested = false) => (
-  React.Children.map(children, scene => (
-    (scene.type === Scene || nested)
-      ? React.cloneElement(scene, { crumbStyle: scene.props.crumbedStyle })
-      : React.cloneElement(scene, null, cloneScenes(scene.props.children, true))
-  ))
+    React.Children.map(children, scene => (
+        (scene.type === Scene || nested)
+            ? React.cloneElement(scene, { crumbStyle: scene.props.crumbedStyle })
+            : React.cloneElement(scene, null, cloneScenes(scene.props.children, true))
+    ))
 );
 
 NavigationStack.Scene = Scene;

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -5,7 +5,8 @@ import { MobileHistoryManager } from 'navigation-react-mobile';
 
 const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountStyle = () => null, crumbStyle = () => null,
     sharedElementTransition, duration, renderScene, renderTransition, children}) => {
-    const emptyStyle = {duration: undefined, translateX: 0, translateX_pc: 0, scaleX: 1, scaleX_pc: 100, alpha: 1, rotate: 0};
+    const emptyStyle = {duration: undefined, translateX: 0, translateX_pc: 0, translateY: 0, translateY_pc: 0,
+        scaleX: 1, scaleX_pc: 100, scaleY: 1, scaleY_pc: 100, alpha: 1, rotate: 0};
     const returnOrCall = (item, ...args) => typeof item !== 'function' ? item : item(...args);
     const getStyle = (trans) => {
         trans = !Array.isArray(trans) ? trans : {items: trans};
@@ -48,12 +49,14 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountSty
     );
 }
 
-const renderMotion = ({translateX, translateX_pc, scaleX, scaleX_pc, alpha, rotate}, scene, key) => (
+const renderMotion = ({translateX, translateX_pc, translateY, translateY_pc, scaleX, scaleX_pc, scaleY, scaleY_pc, alpha, rotate}, scene, key) => (
     <View key={key}
         style={{
             transform: `
-                translate(${translateX ? `${translateX}px` : `${translateX_pc}%`})
-                scale(${scaleX !== 1 ? `${scaleX}` : `${scaleX_pc / 100}`})
+                translate(${translateX ? `${translateX}px` : `${translateX_pc}%`},
+                    ${translateY ? `${translateY}px` : `${translateY_pc}%`})
+                scale(${scaleX !== 1 ? `${scaleX}` : `${scaleX_pc / 100}`},
+                    ${scaleY !== 1 ? `${scaleY}` : `${scaleY_pc / 100}`})
                 rotate(${rotate}deg)
 			` as any,
             opacity: alpha,

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -16,8 +16,8 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountSty
     const transStyle = {...emptyStyle};
     const addStyle = (type: string, start: string | number) => {
       if (start === undefined) return;
-      const percent = typeof start === 'string' && start.endsWith('%')
-      transStyle[type + (percent ? '_pc' : '')] = percent ? +(start as string).slice(0, -1) : +start;
+      const suffix = `${start}`.endsWith('%') ? '_pc' : '';
+      transStyle[type + suffix] = +(suffix ? `${start}`.slice(0, -1) : start);
     }
     const convertTrans = ({type, start, from, startX, fromX, startY, fromY, items}) => {
       if (type === 'translate' || type === 'scale') {

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -4,50 +4,28 @@ import { NavigationMotion, Scene, SharedElementMotion } from 'navigation-react-m
 import { MobileHistoryManager } from 'navigation-react-mobile';
 
 const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountStyle = () => null, crumbStyle = () => null,
-    sharedElementTransition, duration, renderScene, renderTransition, children}) => {
-    const emptyStyle = {duration: undefined, translateX: 0, translateX_pc: 0, translateY: 0, translateY_pc: 0,
-        scaleX: 1, scaleX_pc: 100, scaleY: 1, scaleY_pc: 100, alpha: 1, rotate: 0};
-    const returnOrCall = (item, ...args) => typeof item !== 'function' ? item : item(...args);
-    const getStyle = (trans) => {
-        trans = !Array.isArray(trans) ? trans : {items: trans};
-        const transStyle = {...emptyStyle};
-        const addStyle = (type: string, start: string | number) => {
-            if (start === undefined) return;
-            const suffix = `${start}`.endsWith('%') ? '_pc' : '';
-            transStyle[type + suffix] = +(suffix ? `${start}`.slice(0, -1) : start);
-        }
-        const convertTrans = ({type, start, from, startX, fromX, startY, fromY, items, duration}) => {
-            if (type === 'translate' || type === 'scale') addStyle(`${type}X`, startX ?? fromX);
-            if (type === 'translate' || type === 'scale') addStyle(`${type}Y`, startY ?? fromY);
-            if (type === 'alpha' || type === 'rotate') addStyle(type, start ?? from);
-            if (duration !== undefined) transStyle.duration = Math.max(duration, transStyle.duration || 0);
-            items?.forEach(convertTrans);
-        };
-        convertTrans(trans);
-        return transStyle;
-    }
-    return (
-        <NavigationMotion
-            unmountedStyle={unmountedStyle || ((state, data, crumbs) => {
-                const trans = returnOrCall(unmountStyle, true, state, data, crumbs);
-                return getStyle(trans && typeof trans !== 'string' ? trans : trans ? {type: 'translate', startX: '100%'} : {duration: 0});
-            })}
-            mountedStyle={mountedStyle || ((state, data, crumbs, _nextState, _nextData, from) => {
-                const trans = returnOrCall(from ? unmountStyle : crumbStyle, true, state, data, crumbs);
-                return {...emptyStyle, duration: trans && typeof trans !== 'string' ? getStyle(trans).duration : undefined};
-            })}
-            crumbStyle={crumbedStyle || ((state, data, crumbs, nextState, nextData) => {
-                const trans = returnOrCall(crumbStyle, true, state, data, crumbs, nextState, nextData);
-                return getStyle(trans && typeof trans !== 'string' ? trans : trans ? {type: 'translate', startX: '0%'} : {duration: 0});
-            })}
-            sharedElementMotion={sharedElementTransition}
-            duration={duration}
-            renderScene={renderScene}
-            renderMotion={typeof children !== 'function' ? renderTransition || renderMotion : undefined}>
-            {typeof children !== 'function' ? cloneScenes(children) : (children || renderMotion)}
-        </NavigationMotion>
-    );
-}
+    sharedElementTransition, duration, renderScene, renderTransition, children}) => (
+    <NavigationMotion
+        unmountedStyle={unmountedStyle || ((state, data, crumbs) => {
+            const trans = returnOrCall(unmountStyle, true, state, data, crumbs);
+            return getStyle(trans && typeof trans !== 'string' ? trans : trans ? {type: 'translate', startX: '100%'} : {duration: 0});
+        })}
+        mountedStyle={mountedStyle || ((state, data, crumbs, _nextState, _nextData, from) => {
+            const trans = returnOrCall(from ? unmountStyle : crumbStyle, true, state, data, crumbs);
+            return {...emptyStyle, duration: trans && typeof trans !== 'string' ? getStyle(trans).duration : undefined};
+        })}
+        crumbStyle={crumbedStyle || ((state, data, crumbs, nextState, nextData) => {
+            const trans = returnOrCall(crumbStyle, true, state, data, crumbs, nextState, nextData);
+            return getStyle(trans && typeof trans !== 'string' ? trans : trans ? {type: 'translate', startX: '0%'} : {duration: 0});
+        })}
+        sharedElementMotion={sharedElementTransition}
+        duration={duration}
+        renderScene={renderScene}
+        renderMotion={typeof children !== 'function' ? renderTransition || renderMotion : undefined}>
+        {typeof children !== 'function' ? cloneScenes(children, typeof children === 'function' || renderTransition) : (children || renderMotion)}
+    </NavigationMotion>
+);
+
 
 const renderMotion = ({translateX, translateX_pc, translateY, translateY_pc, scaleX, scaleX_pc, scaleY, scaleY_pc, alpha, rotate}, scene, key) => (
     <View key={key}
@@ -69,12 +47,48 @@ const renderMotion = ({translateX, translateX_pc, translateY, translateY_pc, sca
     </View>
 );
 
-const cloneScenes = (children, nested = false) => (
-    React.Children.map(children, scene => (
-        (scene.type === Scene || nested)
-            ? React.cloneElement(scene, {crumbStyle: scene.props.crumbedStyle})
-            : React.cloneElement(scene, null, cloneScenes(scene.props.children, true))
-    ))
+const emptyStyle = {duration: undefined, translateX: 0, translateX_pc: 0, translateY: 0, translateY_pc: 0,
+    scaleX: 1, scaleX_pc: 100, scaleY: 1, scaleY_pc: 100, alpha: 1, rotate: 0};
+
+const returnOrCall = (item, ...args) => typeof item !== 'function' ? item : item(...args);
+
+const getStyle = (trans) => {
+    trans = !Array.isArray(trans) ? trans : {items: trans};
+    const transStyle = {...emptyStyle};
+    const addStyle = (type: string, start: string | number) => {
+        if (start === undefined) return;
+        const suffix = `${start}`.endsWith('%') ? '_pc' : '';
+        transStyle[type + suffix] = +(suffix ? `${start}`.slice(0, -1) : start);
+    }
+    const convertTrans = ({type, start, from, startX, fromX, startY, fromY, items, duration}) => {
+        if (type === 'translate' || type === 'scale') addStyle(`${type}X`, startX ?? fromX);
+        if (type === 'translate' || type === 'scale') addStyle(`${type}Y`, startY ?? fromY);
+        if (type === 'alpha' || type === 'rotate') addStyle(type, start ?? from);
+        if (duration !== undefined) transStyle.duration = Math.max(duration, transStyle.duration || 0);
+        items?.forEach(convertTrans);
+    };
+    convertTrans(trans);
+    return transStyle;
+}
+
+const cloneScenes = (children, customRender, nested = false) => (
+    React.Children.map(children, scene => {
+        const {unmountedStyle, crumbedStyle, unmountStyle, crumbStyle, children} = scene.props;
+        return (
+            (scene.type === Scene || nested)
+                ? React.cloneElement(scene, {
+                    unmountedStyle: unmountedStyle || (!customRender && unmountStyle ? ((data, crumbs) => {
+                        const trans = returnOrCall(unmountStyle, true, data, crumbs);
+                        return getStyle(trans && typeof trans !== 'string' ? trans : trans ? {type: 'translate', startX: '100%'} : {duration: 0});
+                    }) : undefined),
+                    crumbStyle: crumbedStyle || (!customRender && crumbStyle ? ((data, crumbs, nextState, nextData) => {
+                        const trans = returnOrCall(crumbStyle, true, data, crumbs, nextState, nextData);
+                        return getStyle(trans && typeof trans !== 'string' ? trans : trans ? {type: 'translate', startX: '0%'} : {duration: 0});
+                    }) : undefined),
+                })
+                : React.cloneElement(scene, null, cloneScenes(children, customRender, true))
+        )
+    })
 );
 
 NavigationStack.Scene = Scene;


### PR DESCRIPTION
Brought the declarative animation api, already implemented on iOS and Android, to the Web. So don't need `unmountedStyle`, `mountedStyle` or `renderTransition` props anymore. The Navigation router translates from the native declarative props to the underlying web 'primitives' on `NavigationMotion`.

The following Twitter sample declarative animation now runs on Android, iOS and the Web.
```jsx
<NavigationStack
  customAnimation
  crumbStyle={[
    {type: 'alpha', start: 0},
    {type: 'scale', startX: 0.8, startY: '0.8'},
    {type: 'translate', startX: '5%'},
  ]}
  unmountStyle={{type: 'translate', startX: '100%'}}
>
```