### PR TITLE
Supported Web Animations Api for navigation animations (Mobile)

### DIFF
--- a/NavigationReactMobile/src/Freeze.tsx
+++ b/NavigationReactMobile/src/Freeze.tsx
@@ -1,41 +1,9 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2021 Software Mansion
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-import React, { Suspense, useRef } from 'react';
+import React, { Suspense } from 'react';
+
+const infiniteThenable = {then: () => {}};
 
 var Suspender = ({freeze, children}) => {
-    var promiseCache = useRef ? useRef<any>({}).current : {};
-    if (freeze && !promiseCache.promise) {
-        promiseCache.promise = new Promise((resolve) => {
-          promiseCache.resolve = resolve;
-        });
-        throw promiseCache.promise;
-    } else if (freeze) {
-        throw promiseCache.promise;
-    } else if (promiseCache.promise) {
-        promiseCache.resolve();
-        promiseCache.promise = undefined;
-    }
+    if (freeze) throw infiniteThenable;
     return children;
 };
 

--- a/NavigationReactMobile/src/NavigationAnimation.tsx
+++ b/NavigationReactMobile/src/NavigationAnimation.tsx
@@ -21,9 +21,10 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
             const afterPushEnter = scene.pushEnter?.finished || {then: (f) => f()};
             const afterPopEnter = scene.popEnter?.finished || {then: (f) => f()};
             afterPopEnter.then(() => {
-                if (cancel) return;
+                if (cancel || !unmountStyle) return;
                 if (!scene.pushEnter) {
                     const {duration = defaultDuration, keyframes = unmountStyle} = unmountStyle;
+                    if (!duration || !keyframes) return;
                     scene.pushEnter = scene.animate(keyframes, {duration, fill: 'forwards'});
                     scene.pushEnter.persist();
                 }
@@ -53,9 +54,10 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
                 });
             });
             afterPushEnter.then(() => {
-                if (cancel) return;
+                if (cancel || !crumbStyle) return;
                 if (!scene.popEnter && (pushExit || popEnter)) {       
                     const {duration = defaultDuration, keyframes = crumbStyle} = crumbStyle;
+                    if (!duration || !keyframes) return;
                     scene.popEnter = scene.animate(keyframes, {duration, fill: 'backwards'});
                     scene.popEnter.persist();
                 }
@@ -100,7 +102,7 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
                         return {...scene, ...nextScene};
                     })
                     .concat(scenes
-                        .filter(scene => !nextScenesByKey[scene.key])
+                        .filter(({key, unmountStyle}) => !nextScenesByKey[key] && unmountStyle?.keyframes && (unmountStyle?.duration ?? defaultDuration))
                         .map(scene => ({...scene, ...noAnim, popExit: !scene.pushExit, popEnter: scene.pushExit}))
                     )
                     .sort((a, b) => a.index !== b.index ? a.index - b.index : a.count - b.count)

--- a/NavigationReactMobile/src/NavigationAnimation.tsx
+++ b/NavigationReactMobile/src/NavigationAnimation.tsx
@@ -10,8 +10,7 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
             const prevNavState = scene.navState || scene.prevNavState;
             if (!scene.animate) {
                 if (popExit) setScenes(({all, ...rest}) => ({all: all.filter((_s, index) => index !== i), ...rest}));
-                if (pushEnter && prevNavState !== 'pushEnter') onRest({key});
-                if (popEnter && prevNavState !== 'popEnter') onRest({key});
+                if ((pushEnter && prevNavState !== 'pushEnter') || (popEnter && prevNavState !== 'popEnter')) onRest({key});
                 scene.prevNavState = pushEnter ? 'pushEnter' : popExit ? 'popExit' : pushExit ? 'pushExit' : 'popEnter';
                 return;
             };

--- a/NavigationReactMobile/src/NavigationAnimation.tsx
+++ b/NavigationReactMobile/src/NavigationAnimation.tsx
@@ -1,0 +1,111 @@
+import React, {useRef, useState, useLayoutEffect} from 'react';
+
+const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, duration: defaultDuration}) => {
+    const [scenes, setScenes] = useState({prev: null, all: [], count: 0});
+    const container = useRef(null);
+    useLayoutEffect(() => {
+        let cancel = false;
+        scenes.all.forEach(({key, pushEnter, popExit, pushExit, popEnter, unmountStyle, crumbStyle}, i) => {
+            const scene = container.current.children[i];
+            const prevNavState = scene.navState || scene.prevNavState;
+            if (!scene.animate) {
+                if (popExit)
+                    setScenes(({all, ...rest}) => ({all: all.filter((_s, index) => index !== i), ...rest}))
+                if (pushEnter && prevNavState !== 'pushEnter')
+                    onRest({key})
+                scene.prevNavState = pushEnter ? 'pushEnter' : popExit ? 'popExit' : 'popEnter';
+                return;
+            };
+            const afterPushEnter = scene.pushEnter?.finished || {then: (f) => f()};
+            const afterPopEnter = scene.popEnter?.finished || {then: (f) => f()};
+            afterPopEnter.then(() => {
+                if (cancel) return;
+                if (!scene.pushEnter) {
+                    const {duration = defaultDuration, keyframes = unmountStyle} = unmountStyle;
+                    scene.pushEnter = scene.animate(keyframes, {duration, fill: 'forwards'});
+                    scene.pushEnter.persist();
+                }
+                if (pushEnter && prevNavState !== 'pushEnter') {
+                    scene.navState = 'pushEnter';
+                    if (oldState) {
+                        if (prevNavState === 'popExit') scene.pushEnter.reverse();
+                        else if (prevNavState) scene.pushEnter.finish();
+                        else scene.pushEnter.play();
+                    } else {
+                        scene.pushEnter.finish();
+                    }
+                }
+                if (popExit && prevNavState !== 'popExit') {
+                    scene.navState = 'popExit';
+                    scene.pushEnter.reverse();
+                }
+                scene.pushEnter?.finished.then(() => {
+                    if (cancel || !scene.navState) return;
+                    if (popExit)
+                        setScenes(({all, ...rest}) => ({all: all.filter((_s, index) => index !== i), ...rest}))
+                    if (pushEnter || popExit) {
+                        onRest({key});
+                        scene.prevNavState = scene.navState;
+                        scene.navState = undefined;
+                    }
+                });
+            });
+            afterPushEnter.then(() => {
+                if (cancel) return;
+                if (!scene.popEnter && (pushExit || popEnter)) {       
+                    const {duration = defaultDuration, keyframes = crumbStyle} = crumbStyle;
+                    scene.popEnter = scene.animate(keyframes, {duration, fill: 'backwards'});
+                    scene.popEnter.persist();
+                }
+                if (popEnter && prevNavState !== 'popEnter') {
+                    scene.navState = 'popEnter';
+                    if (prevNavState === 'pushExit') scene.popEnter.reverse();
+                    else if (prevNavState) scene.popEnter.finish();
+                    else scene.popEnter.play();
+                }
+                if (pushExit && prevNavState !== 'pushExit') {
+                    scene.navState = 'pushExit';
+                    scene.popEnter.reverse();
+                }
+                scene.popEnter?.finished.then(() => {
+                    if (cancel || !scene.navState) return;
+                    if (pushExit || popEnter) {
+                        onRest({key});
+                        scene.prevNavState = scene.navState;
+                        scene.navState = undefined;
+                    }
+                });
+            });
+        });
+        return () => {cancel = true;}
+    }, [scenes]);
+    if (nextScenes !== scenes.prev) {
+        setScenes(({all: scenes, count}) => {
+            const scenesByKey = scenes.reduce((acc, scene) => ({...acc, [scene.key]: scene}), {});
+            const nextScenesByKey = nextScenes.reduce((acc, scene) => ({...acc, [scene.key]: scene}), {});
+            const noAnim = {pushEnter: false, pushExit: false, popEnter: false, popExit: false};
+            return {
+                prev: nextScenes,
+                count: count + 1,
+                all: nextScenes
+                    .map((nextScene) => {
+                        const scene = scenesByKey[nextScene.key];
+                        const wasMounted = !!scene?.pushEnter || !!scene?.popEnter;
+                        const noAnimScene = {...scene, ...nextScene, ...noAnim};
+                        if (!scene) return {...noAnimScene, pushEnter: true, count};
+                        if (nextScene.mount && !wasMounted) return {...noAnimScene, popEnter: !scene.popExit, pushEnter: scene.popExit};
+                        if (!nextScene.mount && wasMounted) return {...noAnimScene, pushExit: true};
+                        return {...scene, ...nextScene};
+                    })
+                    .concat(scenes
+                        .filter(scene => !nextScenesByKey[scene.key])
+                        .map(scene => ({...scene, ...noAnim, popExit: true}))
+                    )
+                    .sort((a, b) => a.index !== b.index ? a.index - b.index : a.count - b.count)
+            };
+        });
+    };
+    return <div ref={container}>{children(scenes.all)}</div>;
+}
+
+export default NavigationAnimation;

--- a/NavigationReactMobile/src/NavigationAnimation.tsx
+++ b/NavigationReactMobile/src/NavigationAnimation.tsx
@@ -13,7 +13,9 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
                     setScenes(({all, ...rest}) => ({all: all.filter((_s, index) => index !== i), ...rest}))
                 if (pushEnter && prevNavState !== 'pushEnter')
                     onRest({key})
-                scene.prevNavState = pushEnter ? 'pushEnter' : popExit ? 'popExit' : 'popEnter';
+                if (popEnter && prevNavState !== 'popEnter')
+                    onRest({key})
+                scene.prevNavState = pushEnter ? 'pushEnter' : popExit ? 'popExit' : pushExit ? 'pushExit' : 'popEnter';
                 return;
             };
             const afterPushEnter = scene.pushEnter?.finished || {then: (f) => f()};

--- a/NavigationReactMobile/src/NavigationAnimation.tsx
+++ b/NavigationReactMobile/src/NavigationAnimation.tsx
@@ -9,12 +9,9 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
             const scene = container.current.children[i];
             const prevNavState = scene.navState || scene.prevNavState;
             if (!scene.animate) {
-                if (popExit)
-                    setScenes(({all, ...rest}) => ({all: all.filter((_s, index) => index !== i), ...rest}))
-                if (pushEnter && prevNavState !== 'pushEnter')
-                    onRest({key})
-                if (popEnter && prevNavState !== 'popEnter')
-                    onRest({key})
+                if (popExit) setScenes(({all, ...rest}) => ({all: all.filter((_s, index) => index !== i), ...rest}));
+                if (pushEnter && prevNavState !== 'pushEnter') onRest({key});
+                if (popEnter && prevNavState !== 'popEnter') onRest({key});
                 scene.prevNavState = pushEnter ? 'pushEnter' : popExit ? 'popExit' : pushExit ? 'pushExit' : 'popEnter';
                 return;
             };

--- a/NavigationReactMobile/src/NavigationAnimation.tsx
+++ b/NavigationReactMobile/src/NavigationAnimation.tsx
@@ -99,7 +99,7 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
                     })
                     .concat(scenes
                         .filter(scene => !nextScenesByKey[scene.key])
-                        .map(scene => ({...scene, ...noAnim, popExit: true}))
+                        .map(scene => ({...scene, ...noAnim, popExit: !scene.pushExit, popEnter: scene.pushExit}))
                     )
                     .sort((a, b) => a.index !== b.index ? a.index - b.index : a.count - b.count)
             };

--- a/NavigationReactMobile/src/NavigationAnimation.tsx
+++ b/NavigationReactMobile/src/NavigationAnimation.tsx
@@ -102,7 +102,9 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
                         return {...scene, ...nextScene};
                     })
                     .concat(scenes
-                        .filter(({key, unmountStyle}) => !nextScenesByKey[key] && unmountStyle?.keyframes && (unmountStyle?.duration ?? defaultDuration))
+                        .filter(({key, unmountStyle}) => (
+                            !nextScenesByKey[key] && Array.isArray(unmountStyle?.keyframes || unmountStyle) && (unmountStyle.duration ?? defaultDuration)
+                        ))
                         .map(scene => ({...scene, ...noAnim, popExit: !scene.pushExit, popEnter: scene.pushExit}))
                     )
                     .sort((a, b) => a.index !== b.index ? a.index - b.index : a.count - b.count)

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -105,10 +105,10 @@ const NavigationMotion = ({unmountedStyle: unmountedStyleStack, mountedStyle: mo
             const {keys: prevKeys, stateNavigator: prevStateNavigator} = prevStackState;
             const {state, crumbs, nextCrumb} = stateNavigator.stateContext;
             const prevState = prevStateNavigator && prevStateNavigator.stateContext.state;
-            // need better way to build keys in case there's - in state key
-            const currentKeys = crumbs.concat(nextCrumb).reduce((acc, crumb) => (
-                [...acc, `${acc.slice(-1)[0] || ''}-${crumb.state.key}`]
-            ), []);
+            const currentKeys = crumbs.concat(nextCrumb).reduce((arr, {state: {key}}) => {
+                const prevKey = arr[arr.length - 1];
+                return [...arr, `${prevKey ? `${prevKey}->` : ''}${key.replace(/-/g, '-|')}`]
+            }, []);
             const newKeys = currentKeys.slice(prevKeys.length);
             const keys = prevKeys.slice(0, currentKeys.length).concat(newKeys);
             if (prevKeys.length === keys.length && prevState !== state)

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -245,7 +245,6 @@ const Animator  = ({children, data: nextScenes, onRest, oldState, duration: defa
             };
         });
     };
-    console.log(scenes.all)
     return <div ref={container}>{children(scenes.all)}</div>;
 }
 

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -122,7 +122,7 @@ const NavigationMotion = ({unmountedStyle: unmountedStyleStack, mountedStyle: mo
                             const scene = <Scene crumb={crumb} rest renderScene={renderScene} />;
                             return (
                                 <Freeze key={key} enabled={motionState.rest && crumb < getScenes().length - 1}>
-                                    <div key={key} className="scene">
+                                    <div id={key} key={key} className="scene">
                                         {scene}
                                     </div>
                                 </Freeze>
@@ -147,6 +147,12 @@ const Animator  = ({children, data: nextScenes, onRest, oldState}) => {
         scenes.all.forEach(({key, pushEnter, popExit, pushExit, popEnter}, i) => {
             const scene = container.current.children[i];
             const prevNavState = scene.navState || scene.prevNavState;
+            if (!scene.animate) {
+                if (pushEnter && prevNavState !== 'pushEnter')
+                    onRest({key})
+                scene.prevNavState = pushEnter ? 'pushEnter' : popExit ? 'popExit' : 'popEnter';
+                return;
+            };
             if (pushEnter && prevNavState !== 'pushEnter') {
                 if (!scene.pushEnter) {
                     scene.pushEnter = scene.animate(
@@ -231,7 +237,7 @@ const Animator  = ({children, data: nextScenes, onRest, oldState}) => {
                         return {...scene, ...nextScene};
                     })
                     .concat(scenes
-                        .filter(scene => !nextScenesByKey[scene.key])
+                        .filter(scene => !nextScenesByKey[scene.key] && (typeof window !== 'undefined') && window.Element['animate'])
                         .map(scene => ({...scene, ...noAnim, popExit: true}))
                     )
                     .sort((a, b) => a.index !== b.index ? a.index - b.index : a.key.length - b.key.length)

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -124,12 +124,10 @@ const NavigationMotion = ({unmountedStyle: unmountedStyleStack, mountedStyle: mo
                     return (
                         scenes.map(({key, state, data}) => {
                             const crumb = +key.replace(/\++$/, '');
-                            const scene = <Scene crumb={crumb} rest renderScene={renderScene} />;
+                            const scene = <Scene crumb={crumb} id={key} rest renderScene={renderScene} />;
                             return (
                                 <Freeze key={key} enabled={motionState.rest && crumb < getScenes().length - 1}>
-                                    <div id={key} key={key} className="scene">
-                                        {scene}
-                                    </div>
+                                    {scene}
                                 </Freeze>
                             );
                         })
@@ -232,7 +230,7 @@ const Animator  = ({children, data: nextScenes, onRest, oldState, duration: defa
                         const isMounted = nextScene.index === nextScenes.length - 1;
                         const wasMounted = !!scene?.pushEnter || !!scene?.popEnter;
                         const noAnimScene = {...nextScene, ...noAnim};
-                        if (isMounted && !wasMounted && !scene) return {...noAnimScene, pushEnter: true};
+                        if (!scene) return {...noAnimScene, pushEnter: true};
                         if (isMounted && !wasMounted && scene && !scene.popExit) return {...noAnimScene, popEnter: true};
                         if (isMounted && !wasMounted && scene && scene.popExit) return {...noAnimScene, pushEnter: true};
                         if (!isMounted && wasMounted && scene) return {...noAnimScene, pushExit: true};

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -148,6 +148,8 @@ const Animator  = ({children, data: nextScenes, onRest, oldState}) => {
             const scene = container.current.children[i];
             const prevNavState = scene.navState || scene.prevNavState;
             if (!scene.animate) {
+                if (popExit)
+                    setScenes(({prev, all}) => ({prev, all: all.filter((_s, index) => index !== i)}))
                 if (pushEnter && prevNavState !== 'pushEnter')
                     onRest({key})
                 scene.prevNavState = pushEnter ? 'pushEnter' : popExit ? 'popExit' : 'popEnter';
@@ -237,7 +239,7 @@ const Animator  = ({children, data: nextScenes, onRest, oldState}) => {
                         return {...scene, ...nextScene};
                     })
                     .concat(scenes
-                        .filter(scene => !nextScenesByKey[scene.key] && (typeof window !== 'undefined') && window.Element['animate'])
+                        .filter(scene => !nextScenesByKey[scene.key])
                         .map(scene => ({...scene, ...noAnim, popExit: true}))
                     )
                     .sort((a, b) => a.index !== b.index ? a.index - b.index : a.key.length - b.key.length)

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -150,23 +150,32 @@ const Animator  = ({children, data: nextScenes, onRest}) => {
             if (pushEnter && prevNavState !== 'pushEnter') {
                 if (!scene.pushEnter) {
                     scene.pushEnter = scene.animate(
-                        [{transform: 'translateX(100%)'},{transform: 'translateX(0)'}],
+                        [
+                            {transform: 'translateX(100%)'},
+                            {transform: 'translateX(0)'}
+                        ],
                         {duration: 1000, fill: 'forwards'},
                     );
+                    scene.pushEnter.persist();
                 }
                 scene.navState = 'pushEnter';
                 if (prevNavState !== 'popExit') scene.pushEnter.play();
                 else scene.pushEnter.reverse();
             }
             if (popExit && prevNavState !== 'popExit') {
+                console.log(scene, key, 'xxx');
                 scene.navState = 'popExit';
                 scene.pushEnter.reverse();
             }
             if (!scene.pushExit && (pushExit || popEnter)) {
                 scene.pushExit = scene.animate(
-                    [{transform: 'translateX(-30%)'},{transform: 'translateX(0)'}],
+                    [
+                        {transform: 'translateX(5%) scale(0.8)', opacity: 0},
+                        {transform: 'translateX(0) scale(1)', opacity: 1}
+                    ],
                     {duration: 1000, fill: 'backwards'},
                 );
+                scene.pushExit.persist();
             }
             if (pushExit && prevNavState !== 'pushExit') {
                 scene.navState = 'pushExit';
@@ -182,15 +191,19 @@ const Animator  = ({children, data: nextScenes, onRest}) => {
                 if (cancel || !scene.navState) return;
                 if (popExit)
                     setScenes(({prev, all}) => ({prev, all: all.filter((_s, index) => index !== i)}))
-                if (pushEnter || popExit) onRest({key});
-                scene.prevNavState = scene.navState;
-                scene.navState = undefined;
+                if (pushEnter || popExit) {
+                    onRest({key});
+                    scene.prevNavState = scene.navState;
+                    scene.navState = undefined;
+                }
             });
             scene.pushExit?.finished.then(() => {
                 if (cancel || !scene.navState) return;
-                if (pushExit || popEnter) onRest({key});
-                scene.prevNavState = scene.navState;
-                scene.navState = undefined;
+                if (pushExit || popEnter) {
+                    onRest({key});
+                    scene.prevNavState = scene.navState;
+                    scene.navState = undefined;
+                }
             });
         });
         return () => {cancel = true;}

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -232,6 +232,8 @@ const Animator  = ({children, data: nextScenes, onRest}) => {
                         .map(scene => ({...scene, ...noAnim, popExit: true}))
                     )
                     .sort((a, b) => a.index !== b.index ? a.index - b.index : a.key.length - b.key.length)
+                    // might need to fix index - test replace navigation and see if sorted correctly
+                    // maybe need to take index from scene or nextScene?
             };
         });
     };

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -167,25 +167,25 @@ const Animator  = ({children, data: nextScenes, onRest}) => {
                 scene.navState = 'popExit';
                 scene.pushEnter.reverse();
             }
-            if (!scene.pushExit && (pushExit || popEnter)) {
-                scene.pushExit = scene.animate(
+            if (!scene.popEnter && (pushExit || popEnter)) {
+                scene.popEnter = scene.animate(
                     [
                         {transform: 'translateX(5%) scale(0.8)', opacity: 0},
                         {transform: 'translateX(0) scale(1)', opacity: 1}
                     ],
                     {duration: 1000, fill: 'backwards'},
                 );
-                scene.pushExit.persist();
+                scene.popEnter.persist();
             }
             if (pushExit && prevNavState !== 'pushExit') {
                 scene.navState = 'pushExit';
-                if (prevNavState !== 'popEnter') scene.pushExit.reverse();
-                else scene.pushExit.reverse();
+                if (prevNavState !== 'popEnter') scene.popEnter.reverse();
+                else scene.popEnter.reverse();
             }
             if (popEnter && prevNavState !== 'popEnter') {
                 scene.navState = 'popEnter';
-                if (prevNavState) scene.pushExit.reverse();
-                else scene.pushExit.play();
+                if (prevNavState) scene.popEnter.reverse();
+                else scene.popEnter.play();
             }
             scene.pushEnter?.finished.then(() => {
                 if (cancel || !scene.navState) return;
@@ -197,7 +197,7 @@ const Animator  = ({children, data: nextScenes, onRest}) => {
                     scene.navState = undefined;
                 }
             });
-            scene.pushExit?.finished.then(() => {
+            scene.popEnter?.finished.then(() => {
                 if (cancel || !scene.navState) return;
                 if (pushExit || popEnter) {
                     onRest({key});

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -161,12 +161,12 @@ const Animator  = ({children, data: nextScenes}) => {
             if (pushExit && scene.navState !== 'pushExit') {
                 if (!scene.pushExit) {
                     scene.pushExit = scene.animate(
-                        [{transform: 'translateX(0)'},{transform: 'translateX(-30%)'}],
-                        {duration: 1000, fill: 'forwards'},
+                        [{transform: 'translateX(-30%)'},{transform: 'translateX(0)'}],
+                        {duration: 1000, fill: 'backwards'},
                     );
                 }
                 scene.navState = 'pushExit';
-                if (oldNavState !== 'popEnter') scene.pushExit.play();
+                if (oldNavState !== 'popEnter') scene.pushExit.reverse();
                 else scene.pushExit.reverse();
             }
             if (popEnter && scene.navState !== 'popEnter') {

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -163,7 +163,6 @@ const Animator  = ({children, data: nextScenes, onRest}) => {
                 else scene.pushEnter.reverse();
             }
             if (popExit && prevNavState !== 'popExit') {
-                console.log(scene, key, 'xxx');
                 scene.navState = 'popExit';
                 scene.pushEnter.reverse();
             }

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -159,12 +159,12 @@ const Animator  = ({children, data: nextScenes, onRest, oldState, duration: defa
             const afterPopEnter = scene.popEnter?.finished || {then: (f) => f()};
             afterPopEnter.then(() => {
                 if (cancel) return;
+                if (!scene.pushEnter) {
+                    const {duration = defaultDuration, keyframes = unmountStyle} = unmountStyle;
+                    scene.pushEnter = scene.animate(keyframes, {duration, fill: 'forwards'});
+                    scene.pushEnter.persist();
+                }
                 if (pushEnter && prevNavState !== 'pushEnter') {
-                    if (!scene.pushEnter) {
-                        const {duration = defaultDuration, keyframes = unmountStyle} = unmountStyle;
-                        scene.pushEnter = scene.animate(keyframes, {duration, fill: 'forwards'});
-                        scene.pushEnter.persist();
-                    }
                     scene.navState = 'pushEnter';
                     if (oldState) {
                         if (prevNavState === 'popExit') scene.pushEnter.reverse();
@@ -196,15 +196,15 @@ const Animator  = ({children, data: nextScenes, onRest, oldState, duration: defa
                     scene.popEnter = scene.animate(keyframes, {duration, fill: 'backwards'});
                     scene.popEnter.persist();
                 }
-                if (pushExit && prevNavState !== 'pushExit') {
-                    scene.navState = 'pushExit';
-                    scene.popEnter.reverse();
-                }
                 if (popEnter && prevNavState !== 'popEnter') {
                     scene.navState = 'popEnter';
                     if (prevNavState === 'pushExit') scene.popEnter.reverse();
                     else if (prevNavState) scene.popEnter.finish();
                     else scene.popEnter.play();
+                }
+                if (pushExit && prevNavState !== 'pushExit') {
+                    scene.navState = 'pushExit';
+                    scene.popEnter.reverse();
                 }
                 scene.popEnter?.finished.then(() => {
                     if (cancel || !scene.navState) return;

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -113,7 +113,7 @@ const NavigationMotion = ({unmountedStyle: unmountedStyleStack, mountedStyle: mo
     renderScene = firstLink ? ({key}) => allScenes[key] : renderScene;
     return (stateContext.state &&
         <SharedElementContext.Provider value={sharedElementRegistry.current}>
-            <Animator data={getScenes()} onRest={({key}) => clearScene(key)}>
+            <Animator data={getScenes()} onRest={({key}) => clearScene(key)} oldState={!oldState}>
                 {scenes => {
                     // const {rest, mountRest, mountDuration, mountProgress} = getMotion(styles);
                     return (
@@ -135,7 +135,7 @@ const NavigationMotion = ({unmountedStyle: unmountedStyleStack, mountedStyle: mo
     )
 }
 
-const Animator  = ({children, data: nextScenes, onRest}) => {
+const Animator  = ({children, data: nextScenes, onRest, oldState}) => {
     const [scenes, setScenes] = useState({prev: null, all: []});
     const container = useRef(null);
     // Need to animate it after finish promise resolves, for example,
@@ -159,8 +159,12 @@ const Animator  = ({children, data: nextScenes, onRest}) => {
                     scene.pushEnter.persist();
                 }
                 scene.navState = 'pushEnter';
-                if (prevNavState !== 'popExit') scene.pushEnter.play();
-                else scene.pushEnter.reverse();
+                if (!oldState) {
+                    if (prevNavState !== 'popExit') scene.pushEnter.play();
+                    else scene.pushEnter.reverse();
+                } else {
+                    scene.pushEnter.finish();
+                }
             }
             if (popExit && prevNavState !== 'popExit') {
                 scene.navState = 'popExit';

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -118,7 +118,7 @@ const NavigationMotion = ({unmountedStyle: unmountedStyleStack, mountedStyle: mo
     renderScene = firstLink ? ({key}) => allScenes[key] : renderScene;
     return (stateContext.state &&
         <SharedElementContext.Provider value={sharedElementRegistry.current}>
-            <Animator data={getScenes()} onRest={({key}) => clearScene(key)} oldState={!oldState} duration={duration}>
+            <Animator data={getScenes()} onRest={({key}) => clearScene(key)} oldState={oldState} duration={duration}>
                 {scenes => {
                     // const {rest, mountRest, mountDuration, mountProgress} = getMotion(styles);
                     return (
@@ -167,9 +167,10 @@ const Animator  = ({children, data: nextScenes, onRest, oldState, duration: defa
                         scene.pushEnter.persist();
                     }
                     scene.navState = 'pushEnter';
-                    if (!oldState) {
-                        if (prevNavState !== 'popExit') scene.pushEnter.play();
-                        else scene.pushEnter.reverse();
+                    if (oldState) {
+                        if (prevNavState === 'popExit') scene.pushEnter.reverse();
+                        else if (prevNavState) scene.pushEnter.finish();
+                        else scene.pushEnter.play();
                     } else {
                         scene.pushEnter.finish();
                     }
@@ -198,12 +199,12 @@ const Animator  = ({children, data: nextScenes, onRest, oldState, duration: defa
                 }
                 if (pushExit && prevNavState !== 'pushExit') {
                     scene.navState = 'pushExit';
-                    if (prevNavState !== 'popEnter') scene.popEnter.reverse();
-                    else scene.popEnter.reverse();
+                    scene.popEnter.reverse();
                 }
                 if (popEnter && prevNavState !== 'popEnter') {
                     scene.navState = 'popEnter';
-                    if (prevNavState) scene.popEnter.reverse();
+                    if (prevNavState === 'pushExit') scene.popEnter.reverse();
+                    else if (prevNavState) scene.popEnter.finish();
                     else scene.popEnter.play();
                 }
                 scene.popEnter?.finished.then(() => {

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -231,9 +231,8 @@ const Animator  = ({children, data: nextScenes, onRest, oldState, duration: defa
                         const wasMounted = !!scene?.pushEnter || !!scene?.popEnter;
                         const noAnimScene = {...nextScene, ...noAnim};
                         if (!scene) return {...noAnimScene, pushEnter: true};
-                        if (isMounted && !wasMounted && scene && !scene.popExit) return {...noAnimScene, popEnter: true};
-                        if (isMounted && !wasMounted && scene && scene.popExit) return {...noAnimScene, pushEnter: true};
-                        if (!isMounted && wasMounted && scene) return {...noAnimScene, pushExit: true};
+                        if (isMounted && !wasMounted) return {...noAnimScene, popEnter: !scene.popExit, pushEnter: scene.popExit};
+                        if (!isMounted && wasMounted) return {...noAnimScene, pushExit: true};
                         return {...scene, ...nextScene};
                     })
                     .concat(scenes

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -70,7 +70,7 @@ const NavigationMotion = ({unmountedStyle: unmountedStyleStack, mountedStyle: mo
             const {state: nextState, data: nextData} = crumbsAndNext[index + 1] || {state: undefined, data: undefined};
             const mount = url === nextCrumb.url;
             const fromUnmounted = mount && !backward;
-            return {key: keys[index], index, state, data, url, crumbs: preCrumbs, nextState, nextData, mount, fromUnmounted };
+            return {key: keys[index], index, state, data, url, crumbs: preCrumbs, nextState, nextData, mount, fromUnmounted};
         });
     }
     const sceneProps = ({key}: State) => firstLink ? allScenes[key].props : null;

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -162,7 +162,7 @@ const Animator  = ({children, data: nextScenes, onRest, oldState, duration: defa
                 if (cancel) return;
                 if (pushEnter && prevNavState !== 'pushEnter') {
                     if (!scene.pushEnter) {
-                        const {duration = defaultDuration, keyframes} = unmountStyle;
+                        const {duration = defaultDuration, keyframes = unmountStyle} = unmountStyle;
                         scene.pushEnter = scene.animate(keyframes, {duration, fill: 'forwards'});
                         scene.pushEnter.persist();
                     }
@@ -193,7 +193,7 @@ const Animator  = ({children, data: nextScenes, onRest, oldState, duration: defa
             afterPushEnter.then(() => {
                 if (cancel) return;
                 if (!scene.popEnter && (pushExit || popEnter)) {       
-                    const {duration = defaultDuration, keyframes} = crumbStyle;             
+                    const {duration = defaultDuration, keyframes = crumbStyle} = crumbStyle;             
                     scene.popEnter = scene.animate(keyframes, {duration, fill: 'backwards'});
                     scene.popEnter.persist();
                 }

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -162,20 +162,21 @@ const Animator  = ({children, data: nextScenes, onRest}) => {
                 scene.navState = 'popExit';
                 scene.pushEnter.reverse();
             }
+            if (!scene.pushExit && (pushExit || popEnter)) {
+                scene.pushExit = scene.animate(
+                    [{transform: 'translateX(-30%)'},{transform: 'translateX(0)'}],
+                    {duration: 1000, fill: 'backwards'},
+                );
+            }
             if (pushExit && prevNavState !== 'pushExit') {
-                if (!scene.pushExit) {
-                    scene.pushExit = scene.animate(
-                        [{transform: 'translateX(-30%)'},{transform: 'translateX(0)'}],
-                        {duration: 1000, fill: 'backwards'},
-                    );
-                }
                 scene.navState = 'pushExit';
                 if (prevNavState !== 'popEnter') scene.pushExit.reverse();
                 else scene.pushExit.reverse();
             }
             if (popEnter && prevNavState !== 'popEnter') {
                 scene.navState = 'popEnter';
-                scene.pushExit.reverse();
+                if (prevNavState) scene.pushExit.reverse();
+                else scene.pushExit.play();
             }
             scene.pushEnter?.finished.then(() => {
                 if (cancel || !scene.navState) return;

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -111,7 +111,7 @@ const NavigationMotion = ({unmountedStyle: unmountedStyleStack, mountedStyle: mo
             const keys = prevKeys.slice(0, currentKeys.length).concat(newKeys);
             if (prevKeys.length === keys.length && prevState !== state)
                 keys[keys.length - 1] += '+';
-            return {keys, rest: false, stateNavigator};    
+            return {keys, rest: false, stateNavigator};
         })
     }
     const {stateContext: {crumbs, oldState}, stateContext} = stateNavigator;
@@ -193,7 +193,7 @@ const Animator  = ({children, data: nextScenes, onRest, oldState, duration: defa
             afterPushEnter.then(() => {
                 if (cancel) return;
                 if (!scene.popEnter && (pushExit || popEnter)) {       
-                    const {duration = defaultDuration, keyframes = crumbStyle} = crumbStyle;             
+                    const {duration = defaultDuration, keyframes = crumbStyle} = crumbStyle;
                     scene.popEnter = scene.animate(keyframes, {duration, fill: 'backwards'});
                     scene.popEnter.persist();
                 }

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -138,10 +138,6 @@ const NavigationMotion = ({unmountedStyle: unmountedStyleStack, mountedStyle: mo
 const Animator  = ({children, data: nextScenes, onRest, oldState}) => {
     const [scenes, setScenes] = useState({prev: null, all: []});
     const container = useRef(null);
-    // Need to animate it after finish promise resolves, for example,
-    // so can do popEnter then popExit after 2 browser backs in a row
-    // or pushEnter then pushExit after 2 browser forwards in a row
-    // Test this on twitter sample because need deep stack
     useLayoutEffect(() => {
         let cancel = false;
         scenes.all.forEach(({key, pushEnter, popExit, pushExit, popEnter}, i) => {

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -160,9 +160,12 @@ const Animator  = ({children, data: nextScenes}) => {
                 all: nextScenes
                     .map((nextScene) => {
                         const scene = scenesByKey[nextScene.key];
-                        const pushExit = scene?.index < nextScenes.length - 1 && scene?.index === scenes.length - 1 || scene?.pushExit;
-                        const popEnter = scene?.index === nextScenes.length - 1 && scene?.index < scenes.length - 1  || scene?.popEnter;
-                        return scene ? {...scene, pushExit, popEnter} : {...nextScene, ...noAnim, pushEnter: true};
+                        const pushExit = scene?.index < nextScenes.length - 1 && scene?.index === scenes.length - 1;
+                        const popEnter = scene?.index === nextScenes.length - 1 && scene?.index < scenes.length - 1;
+                        return pushExit ? {...nextScene, ...noAnim, pushExit: true}
+                            : popEnter ? {...nextScene, ...noAnim, popEnter: true}
+                            : !scene ? {...nextScene, ...noAnim, pushEnter: true}
+                            : {...scene, ...nextScene};
                     })
                     .concat(scenes
                         .filter(scene => !nextScenesByKey[scene.key])

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -148,7 +148,7 @@ const Animator  = ({children, data: nextScenes}) => {
                         return scene ? {...scene, pushExit, popEnter} : {...nextScene, ...noAnim, pushEnter: true};
                     })
                     .concat(scenes
-                        .filter(scene => nextScenesByKey[scene.key])
+                        .filter(scene => !nextScenesByKey[scene.key])
                         .map(scene => ({...scene, ...noAnim, popExit: true}))
                     )
                     .sort((a, b) => a.index !== b.index ? a.index - b.index : a.key.length - b.key.length)

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -6,6 +6,7 @@ import Scene from './Scene';
 import SharedElementContext from './SharedElementContext';
 import SharedElementRegistry from './SharedElementRegistry';
 import Freeze from './Freeze';
+import NavigationStack from './NavigationStack';
 import { NavigationMotionProps } from './Props';
 type NavigationMotionState = {stateNavigator: StateNavigator, keys: string[]};
 type SceneContext = {key: string, state: State, data: any, url: string, crumbs: Crumb[], nextState: State, nextData: any, mount: boolean, fromUnmounted: boolean};
@@ -21,7 +22,7 @@ const NavigationMotion = ({unmountedStyle: unmountedStyleStack, mountedStyle: mo
     const findScenes = (elements = children, nested = false) => {
         for(const scene of React.Children.toArray(elements) as ReactElement<any>[]) {
             const {stateKey, children} = scene.props;
-            if (scene.type === NavigationMotion.Scene) {
+            if (scene.type === NavigationStack.Scene) {
                 firstLink = firstLink || stateNavigator.fluent().navigate(stateKey).url;
                 scenes[stateKey] = scene;
             }
@@ -142,7 +143,5 @@ const NavigationMotion = ({unmountedStyle: unmountedStyleStack, mountedStyle: mo
         </SharedElementContext.Provider>
     )
 }
-
-NavigationMotion.Scene = ({children}) => children;
 
 export default NavigationMotion;

--- a/NavigationReactMobile/src/NavigationReactMobile.ts
+++ b/NavigationReactMobile/src/NavigationReactMobile.ts
@@ -1,10 +1,11 @@
 import MobileHistoryManager from './MobileHistoryManager';
 import NavigationMotion from './NavigationMotion';
+import NavigationStack from './NavigationStack';
 import SharedElement from './SharedElement';
 import SharedElementMotion from './SharedElementMotion';
 import useNavigating from './useNavigating';
 import useNavigated from './useNavigated';
 import useUnloading from './useUnloading';
 import useUnloaded from './useUnloaded';
-const Scene = NavigationMotion.Scene;
-export { MobileHistoryManager, Scene, NavigationMotion, SharedElement, SharedElementMotion, useNavigating, useNavigated, useUnloading, useUnloaded };
+const Scene = NavigationStack.Scene;
+export { MobileHistoryManager, Scene, NavigationStack, NavigationMotion, SharedElement, SharedElementMotion, useNavigating, useNavigated, useUnloading, useUnloaded };

--- a/NavigationReactMobile/src/NavigationStack.tsx
+++ b/NavigationReactMobile/src/NavigationStack.tsx
@@ -90,6 +90,7 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
     )
 }
 
+// extract this into NavigationAnimation component
 const Animator  = ({children, data: nextScenes, onRest, oldState, duration: defaultDuration}) => {
     const [scenes, setScenes] = useState({prev: null, all: [], count: 0});
     const container = useRef(null);
@@ -180,12 +181,11 @@ const Animator  = ({children, data: nextScenes, onRest, oldState, duration: defa
                 all: nextScenes
                     .map((nextScene) => {
                         const scene = scenesByKey[nextScene.key];
-                        const isMounted = nextScene.index === nextScenes.length - 1;
                         const wasMounted = !!scene?.pushEnter || !!scene?.popEnter;
                         const noAnimScene = {...scene, ...nextScene, ...noAnim};
                         if (!scene) return {...noAnimScene, pushEnter: true, count};
-                        if (isMounted && !wasMounted) return {...noAnimScene, popEnter: !scene.popExit, pushEnter: scene.popExit};
-                        if (!isMounted && wasMounted) return {...noAnimScene, pushExit: true};
+                        if (nextScene.mount && !wasMounted) return {...noAnimScene, popEnter: !scene.popExit, pushEnter: scene.popExit};
+                        if (!nextScene.mount && wasMounted) return {...noAnimScene, pushExit: true};
                         return {...scene, ...nextScene};
                     })
                     .concat(scenes

--- a/NavigationReactMobile/src/NavigationStack.tsx
+++ b/NavigationReactMobile/src/NavigationStack.tsx
@@ -1,8 +1,9 @@
-import React, {useRef, useState, useContext, useEffect, ReactElement, useLayoutEffect} from 'react';
-import { State, Crumb, StateNavigator } from 'navigation';
+import React, {useRef, useState, useContext, useEffect, ReactElement} from 'react';
+import { State, StateNavigator } from 'navigation';
 import { NavigationContext } from 'navigation-react';
 import Scene from './Scene';
 import Freeze from './Freeze';
+import NavigationAnimation from './NavigationAnimation';
 import { NavigationMotionProps as NavigationStackProps } from './Props';
 type NavigationStackState = {stateNavigator: StateNavigator, keys: string[], rest: boolean};
 
@@ -37,9 +38,9 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
         }
         return () => stateNavigator.offBeforeNavigate(validate);
     }, [children, stateNavigator, scenes, allScenes, stackInvalidatedLink]);
-    const clearScene = (index) => {
+    const clearScene = ({key}) => {
         setMotionState(({rest: prevRest, stateNavigator, keys}) => {
-            const scene = getScenes().filter(scene => scene.key === index)[0];
+            const scene = getScenes().filter(scene => scene.key === key)[0];
             var rest = prevRest || (scene && scene.mount);
             return {rest, stateNavigator, keys};
         });
@@ -78,7 +79,7 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
     const {stateContext: {oldState}, stateContext} = stateNavigator;
     renderScene = firstLink ? ({key}) => allScenes[key] : renderScene;
     return (stateContext.state &&
-        <Animator data={getScenes()} onRest={({key}) => clearScene(key)} oldState={oldState} duration={duration}>
+        <NavigationAnimation data={getScenes()} onRest={clearScene} oldState={oldState} duration={duration}>
             {scenes => (
                 scenes.map(({key, index: crumb}) => (
                     <Freeze key={key} enabled={motionState.rest && crumb < getScenes().length - 1}>
@@ -86,117 +87,8 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
                     </Freeze>
                 ))
             )}
-        </Animator>
+        </NavigationAnimation>
     )
-}
-
-// extract this into NavigationAnimation component
-const Animator  = ({children, data: nextScenes, onRest, oldState, duration: defaultDuration}) => {
-    const [scenes, setScenes] = useState({prev: null, all: [], count: 0});
-    const container = useRef(null);
-    useLayoutEffect(() => {
-        let cancel = false;
-        scenes.all.forEach(({key, pushEnter, popExit, pushExit, popEnter, unmountStyle, crumbStyle}, i) => {
-            const scene = container.current.children[i];
-            const prevNavState = scene.navState || scene.prevNavState;
-            if (!scene.animate) {
-                if (popExit)
-                    setScenes(({all, ...rest}) => ({all: all.filter((_s, index) => index !== i), ...rest}))
-                if (pushEnter && prevNavState !== 'pushEnter')
-                    onRest({key})
-                scene.prevNavState = pushEnter ? 'pushEnter' : popExit ? 'popExit' : 'popEnter';
-                return;
-            };
-            const afterPushEnter = scene.pushEnter?.finished || {then: (f) => f()};
-            const afterPopEnter = scene.popEnter?.finished || {then: (f) => f()};
-            afterPopEnter.then(() => {
-                if (cancel) return;
-                if (!scene.pushEnter) {
-                    const {duration = defaultDuration, keyframes = unmountStyle} = unmountStyle;
-                    scene.pushEnter = scene.animate(keyframes, {duration, fill: 'forwards'});
-                    scene.pushEnter.persist();
-                }
-                if (pushEnter && prevNavState !== 'pushEnter') {
-                    scene.navState = 'pushEnter';
-                    if (oldState) {
-                        if (prevNavState === 'popExit') scene.pushEnter.reverse();
-                        else if (prevNavState) scene.pushEnter.finish();
-                        else scene.pushEnter.play();
-                    } else {
-                        scene.pushEnter.finish();
-                    }
-                }
-                if (popExit && prevNavState !== 'popExit') {
-                    scene.navState = 'popExit';
-                    scene.pushEnter.reverse();
-                }
-                scene.pushEnter?.finished.then(() => {
-                    if (cancel || !scene.navState) return;
-                    if (popExit)
-                        setScenes(({all, ...rest}) => ({all: all.filter((_s, index) => index !== i), ...rest}))
-                    if (pushEnter || popExit) {
-                        onRest({key});
-                        scene.prevNavState = scene.navState;
-                        scene.navState = undefined;
-                    }
-                });
-            });
-            afterPushEnter.then(() => {
-                if (cancel) return;
-                if (!scene.popEnter && (pushExit || popEnter)) {       
-                    const {duration = defaultDuration, keyframes = crumbStyle} = crumbStyle;
-                    scene.popEnter = scene.animate(keyframes, {duration, fill: 'backwards'});
-                    scene.popEnter.persist();
-                }
-                if (popEnter && prevNavState !== 'popEnter') {
-                    scene.navState = 'popEnter';
-                    if (prevNavState === 'pushExit') scene.popEnter.reverse();
-                    else if (prevNavState) scene.popEnter.finish();
-                    else scene.popEnter.play();
-                }
-                if (pushExit && prevNavState !== 'pushExit') {
-                    scene.navState = 'pushExit';
-                    scene.popEnter.reverse();
-                }
-                scene.popEnter?.finished.then(() => {
-                    if (cancel || !scene.navState) return;
-                    if (pushExit || popEnter) {
-                        onRest({key});
-                        scene.prevNavState = scene.navState;
-                        scene.navState = undefined;
-                    }
-                });
-            });
-        });
-        return () => {cancel = true;}
-    }, [scenes]);
-    if (nextScenes !== scenes.prev) {
-        setScenes(({all: scenes, count}) => {
-            const scenesByKey = scenes.reduce((acc, scene) => ({...acc, [scene.key]: scene}), {});
-            const nextScenesByKey = nextScenes.reduce((acc, scene) => ({...acc, [scene.key]: scene}), {});
-            const noAnim = {pushEnter: false, pushExit: false, popEnter: false, popExit: false};
-            return {
-                prev: nextScenes,
-                count: count + 1,
-                all: nextScenes
-                    .map((nextScene) => {
-                        const scene = scenesByKey[nextScene.key];
-                        const wasMounted = !!scene?.pushEnter || !!scene?.popEnter;
-                        const noAnimScene = {...scene, ...nextScene, ...noAnim};
-                        if (!scene) return {...noAnimScene, pushEnter: true, count};
-                        if (nextScene.mount && !wasMounted) return {...noAnimScene, popEnter: !scene.popExit, pushEnter: scene.popExit};
-                        if (!nextScene.mount && wasMounted) return {...noAnimScene, pushExit: true};
-                        return {...scene, ...nextScene};
-                    })
-                    .concat(scenes
-                        .filter(scene => !nextScenesByKey[scene.key])
-                        .map(scene => ({...scene, ...noAnim, popExit: true}))
-                    )
-                    .sort((a, b) => a.index !== b.index ? a.index - b.index : a.count - b.count)
-            };
-        });
-    };
-    return <div ref={container}>{children(scenes.all)}</div>;
 }
 
 NavigationStack.Scene = ({children}) => children;

--- a/NavigationReactMobile/src/NavigationStack.tsx
+++ b/NavigationReactMobile/src/NavigationStack.tsx
@@ -1,0 +1,213 @@
+import React, {useRef, useState, useContext, useEffect, ReactElement, useLayoutEffect} from 'react';
+import { State, Crumb, StateNavigator } from 'navigation';
+import { NavigationContext } from 'navigation-react';
+import Scene from './Scene';
+import Freeze from './Freeze';
+import { NavigationMotionProps as NavigationStackProps } from './Props';
+type NavigationMotionState = {stateNavigator: StateNavigator, keys: string[], rest: boolean};
+type SceneContext = {key: string, state: State, data: any, url: string, crumbs: Crumb[], nextState: State, nextData: any, mount: boolean, fromUnmounted: boolean};
+
+const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyleStack, duration = 300, renderScene, children, stackInvalidatedLink, renderMotion = children}: NavigationStackProps) => {
+    const {stateNavigator} = useContext(NavigationContext);
+    const [motionState, setMotionState] = useState<NavigationMotionState>({stateNavigator: null, keys: [], rest: false});
+    const scenes = {};
+    let firstLink;
+    const findScenes = (elements = children, nested = false) => {
+        for(const scene of React.Children.toArray(elements) as ReactElement<any>[]) {
+            const {stateKey, children} = scene.props;
+            if (scene.type === NavigationStack.Scene) {
+                firstLink = firstLink || stateNavigator.fluent().navigate(stateKey).url;
+                scenes[stateKey] = scene;
+            }
+            else if (!nested) findScenes(children, true)
+        }
+    }
+    findScenes();
+    const prevScenes = useRef({});
+    const allScenes = {...prevScenes.current, ...scenes};
+    useEffect(() => {
+        prevScenes.current = allScenes;
+        const {state, crumbs, nextCrumb} = stateNavigator.stateContext;
+        const validate = ({key}) => !!scenes[key];
+        if (firstLink) {
+            stateNavigator.onBeforeNavigate(validate);
+            let resetLink = !state ? firstLink : undefined;
+            if (!resetLink && [...crumbs, nextCrumb].find(({state}) => !scenes[state.key]))
+                resetLink = stackInvalidatedLink != null ? stackInvalidatedLink : firstLink;
+            if (resetLink != null) stateNavigator.navigateLink(resetLink);
+        }
+        return () => stateNavigator.offBeforeNavigate(validate);
+    }, [children, stateNavigator, scenes, allScenes, stackInvalidatedLink]);
+    const clearScene = (index) => {
+        setMotionState(({rest: prevRest, stateNavigator, keys}) => {
+            const scene = getScenes().filter(scene => scene.key === index)[0];
+            var rest = prevRest || (scene && scene.mount);
+            return {rest, stateNavigator, keys};
+        });
+    }
+    const getScenes: () => SceneContext[] = () => {
+        const {keys} = motionState;
+        const {crumbs, nextCrumb, oldUrl} = stateNavigator.stateContext;
+        const backward = oldUrl && oldUrl.split('crumb=').length > crumbs.length + 1;
+        return crumbs.concat(nextCrumb).map(({state, data, url}, index, crumbsAndNext) => {
+            const preCrumbs = crumbsAndNext.slice(0, index);
+            const {state: nextState, data: nextData} = crumbsAndNext[index + 1] || {state: undefined, data: undefined};
+            const mount = url === nextCrumb.url;
+            const fromUnmounted = mount && !backward;
+            return {
+                key: keys[index], index, state, data, url, crumbs: preCrumbs, nextState, nextData, mount, fromUnmounted,
+                unmountStyle: unmountStyle(state, data, preCrumbs), crumbStyle: crumbStyle(state, data, preCrumbs, nextState, nextData)
+            };
+        });
+    }
+    const sceneProps = ({key}: State) => firstLink ? allScenes[key].props : null;
+    const returnOrCall = (item, ...args) => typeof item !== 'function' ? item : item(...args);
+    const unmountStyle = (state, ...rest) => sceneProps(state)?.unmountStyle ? returnOrCall(sceneProps(state)?.unmountStyle, ...rest) : returnOrCall(unmountStyleStack, state, ...rest);
+    const crumbStyle = (state, ...rest) => sceneProps(state)?.crumbStyle ? returnOrCall(sceneProps(state)?.crumbStyle, ...rest) : returnOrCall(crumbStyleStack, state, ...rest);
+    const {stateNavigator: prevStateNavigator} = motionState;
+    if (prevStateNavigator !== stateNavigator && stateNavigator.stateContext.state) {
+        setMotionState((prevStackState) => {
+            const {keys: prevKeys, stateNavigator: prevStateNavigator} = prevStackState;
+            const {state, crumbs, nextCrumb} = stateNavigator.stateContext;
+            const prevState = prevStateNavigator && prevStateNavigator.stateContext.state;
+            const currentKeys = crumbs.concat(nextCrumb).reduce((arr, {state: {key}}) => {
+                const prevKey = arr[arr.length - 1];
+                return [...arr, `${prevKey ? `${prevKey}->` : ''}${key.replace(/-/g, '-|')}`]
+            }, []);
+            const newKeys = currentKeys.slice(prevKeys.length);
+            const keys = prevKeys.slice(0, currentKeys.length).concat(newKeys);
+            if (prevKeys.length === keys.length && prevState !== state)
+                keys[keys.length - 1] = currentKeys[keys.length - 1];
+            return {keys, rest: false, stateNavigator};
+        })
+    }
+    const {stateContext: {oldState}, stateContext} = stateNavigator;
+    renderScene = firstLink ? ({key}) => allScenes[key] : renderScene;
+    return (stateContext.state &&
+        <Animator data={getScenes()} onRest={({key}) => clearScene(key)} oldState={oldState} duration={duration}>
+            {scenes => (
+                scenes.map(({key, index: crumb}) => {
+                    const scene = <Scene crumb={crumb} id={key} rest renderScene={renderScene} />;
+                    return (
+                        <Freeze key={key} enabled={motionState.rest && crumb < getScenes().length - 1}>
+                            {scene}
+                        </Freeze>
+                    );
+                })
+            )}
+        </Animator>
+    )
+}
+
+const Animator  = ({children, data: nextScenes, onRest, oldState, duration: defaultDuration}) => {
+    const [scenes, setScenes] = useState({prev: null, all: [], count: 0});
+    const container = useRef(null);
+    useLayoutEffect(() => {
+        let cancel = false;
+        scenes.all.forEach(({key, pushEnter, popExit, pushExit, popEnter, unmountStyle, crumbStyle}, i) => {
+            const scene = container.current.children[i];
+            const prevNavState = scene.navState || scene.prevNavState;
+            if (!scene.animate) {
+                if (popExit)
+                    setScenes(({all, ...rest}) => ({all: all.filter((_s, index) => index !== i), ...rest}))
+                if (pushEnter && prevNavState !== 'pushEnter')
+                    onRest({key})
+                scene.prevNavState = pushEnter ? 'pushEnter' : popExit ? 'popExit' : 'popEnter';
+                return;
+            };
+            const afterPushEnter = scene.pushEnter?.finished || {then: (f) => f()};
+            const afterPopEnter = scene.popEnter?.finished || {then: (f) => f()};
+            afterPopEnter.then(() => {
+                if (cancel) return;
+                if (!scene.pushEnter) {
+                    const {duration = defaultDuration, keyframes = unmountStyle} = unmountStyle;
+                    scene.pushEnter = scene.animate(keyframes, {duration, fill: 'forwards'});
+                    scene.pushEnter.persist();
+                }
+                if (pushEnter && prevNavState !== 'pushEnter') {
+                    scene.navState = 'pushEnter';
+                    if (oldState) {
+                        if (prevNavState === 'popExit') scene.pushEnter.reverse();
+                        else if (prevNavState) scene.pushEnter.finish();
+                        else scene.pushEnter.play();
+                    } else {
+                        scene.pushEnter.finish();
+                    }
+                }
+                if (popExit && prevNavState !== 'popExit') {
+                    scene.navState = 'popExit';
+                    scene.pushEnter.reverse();
+                }
+                scene.pushEnter?.finished.then(() => {
+                    if (cancel || !scene.navState) return;
+                    if (popExit)
+                        setScenes(({all, ...rest}) => ({all: all.filter((_s, index) => index !== i), ...rest}))
+                    if (pushEnter || popExit) {
+                        onRest({key});
+                        scene.prevNavState = scene.navState;
+                        scene.navState = undefined;
+                    }
+                });
+            });
+            afterPushEnter.then(() => {
+                if (cancel) return;
+                if (!scene.popEnter && (pushExit || popEnter)) {       
+                    const {duration = defaultDuration, keyframes = crumbStyle} = crumbStyle;
+                    scene.popEnter = scene.animate(keyframes, {duration, fill: 'backwards'});
+                    scene.popEnter.persist();
+                }
+                if (popEnter && prevNavState !== 'popEnter') {
+                    scene.navState = 'popEnter';
+                    if (prevNavState === 'pushExit') scene.popEnter.reverse();
+                    else if (prevNavState) scene.popEnter.finish();
+                    else scene.popEnter.play();
+                }
+                if (pushExit && prevNavState !== 'pushExit') {
+                    scene.navState = 'pushExit';
+                    scene.popEnter.reverse();
+                }
+                scene.popEnter?.finished.then(() => {
+                    if (cancel || !scene.navState) return;
+                    if (pushExit || popEnter) {
+                        onRest({key});
+                        scene.prevNavState = scene.navState;
+                        scene.navState = undefined;
+                    }
+                });
+            });
+        });
+        return () => {cancel = true;}
+    }, [scenes]);
+    if (nextScenes !== scenes.prev) {
+        setScenes(({all: scenes, count}) => {
+            const scenesByKey = scenes.reduce((acc, scene) => ({...acc, [scene.key]: scene}), {});
+            const nextScenesByKey = nextScenes.reduce((acc, scene) => ({...acc, [scene.key]: scene}), {});
+            const noAnim = {pushEnter: false, pushExit: false, popEnter: false, popExit: false};
+            return {
+                prev: nextScenes,
+                count: count + 1,
+                all: nextScenes
+                    .map((nextScene) => {
+                        const scene = scenesByKey[nextScene.key];
+                        const isMounted = nextScene.index === nextScenes.length - 1;
+                        const wasMounted = !!scene?.pushEnter || !!scene?.popEnter;
+                        const noAnimScene = {...scene, ...nextScene, ...noAnim};
+                        if (!scene) return {...noAnimScene, pushEnter: true, count};
+                        if (isMounted && !wasMounted) return {...noAnimScene, popEnter: !scene.popExit, pushEnter: scene.popExit};
+                        if (!isMounted && wasMounted) return {...noAnimScene, pushExit: true};
+                        return {...scene, ...nextScene};
+                    })
+                    .concat(scenes
+                        .filter(scene => !nextScenesByKey[scene.key])
+                        .map(scene => ({...scene, ...noAnim, popExit: true}))
+                    )
+                    .sort((a, b) => a.index !== b.index ? a.index - b.index : a.count - b.count)
+            };
+        });
+    };
+    return <div ref={container}>{children(scenes.all)}</div>;
+}
+
+NavigationStack.Scene = ({children}) => children;
+
+export default NavigationStack;

--- a/NavigationReactMobile/src/NavigationStack.tsx
+++ b/NavigationReactMobile/src/NavigationStack.tsx
@@ -8,7 +8,7 @@ import { NavigationMotionProps as NavigationStackProps } from './Props';
 type NavigationStackState = {stateNavigator: StateNavigator, keys: string[], rest: boolean};
 
 const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyleStack, className: sceneClassName,
-    duration = 300, renderScene, children, stackInvalidatedLink}: NavigationStackProps) => {
+    style: sceneStyle, duration = 300, renderScene, children, stackInvalidatedLink}: NavigationStackProps) => {
     const {stateNavigator} = useContext(NavigationContext);
     const [motionState, setMotionState] = useState<NavigationStackState>({stateNavigator: null, keys: [], rest: false});
     const scenes = {};
@@ -53,7 +53,8 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
             const preCrumbs = crumbsAndNext.slice(0, index);
             const {state: nextState, data: nextData} = crumbsAndNext[index + 1] || {state: undefined, data: undefined};
             const mount = url === nextCrumb.url;
-            return {key: keys[index], index, mount, className: className(state, data, preCrumbs),
+            return {key: keys[index], index, mount, style: style(state, data, preCrumbs),
+                className: className(state, data, preCrumbs),
                 unmountStyle: unmountStyle(state, data, preCrumbs),
                 crumbStyle: crumbStyle(state, data, preCrumbs, nextState, nextData)};
         });
@@ -63,6 +64,7 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
     const unmountStyle = (state, ...rest) => sceneProps(state)?.unmountStyle ? returnOrCall(sceneProps(state)?.unmountStyle, ...rest) : returnOrCall(unmountStyleStack, state, ...rest);
     const crumbStyle = (state, ...rest) => sceneProps(state)?.crumbStyle ? returnOrCall(sceneProps(state)?.crumbStyle, ...rest) : returnOrCall(crumbStyleStack, state, ...rest);
     const className = (state, ...rest) => sceneProps(state)?.className ? returnOrCall(sceneProps(state)?.className, ...rest) : returnOrCall(sceneClassName, state, ...rest);
+    const style = (state, ...rest) => sceneProps(state)?.style ? returnOrCall(sceneProps(state)?.style, ...rest) : returnOrCall(sceneStyle, state, ...rest);
     const {stateNavigator: prevStateNavigator} = motionState;
     if (prevStateNavigator !== stateNavigator && stateNavigator.stateContext.state) {
         setMotionState((prevStackState) => {
@@ -85,9 +87,9 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
     return (stateContext.state &&
         <NavigationAnimation data={getScenes()} onRest={clearScene} oldState={oldState} duration={duration}>
             {scenes => (
-                scenes.map(({key, index: crumb, className}) => (
+                scenes.map(({key, index: crumb, className, style}) => (
                     <Freeze key={key} enabled={motionState.rest && crumb < getScenes().length - 1}>
-                        <Scene crumb={crumb} rest className={className} renderScene={renderScene} />
+                        <Scene crumb={crumb} rest className={className} style={style} renderScene={renderScene} />
                     </Freeze>
                 ))
             )}

--- a/NavigationReactMobile/src/NavigationStack.tsx
+++ b/NavigationReactMobile/src/NavigationStack.tsx
@@ -7,7 +7,8 @@ import NavigationAnimation from './NavigationAnimation';
 import { NavigationMotionProps as NavigationStackProps } from './Props';
 type NavigationStackState = {stateNavigator: StateNavigator, keys: string[], rest: boolean};
 
-const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyleStack, duration = 300, renderScene, children, stackInvalidatedLink, renderMotion = children}: NavigationStackProps) => {
+const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyleStack, className: sceneClassName,
+    duration = 300, renderScene, children, stackInvalidatedLink}: NavigationStackProps) => {
     const {stateNavigator} = useContext(NavigationContext);
     const [motionState, setMotionState] = useState<NavigationStackState>({stateNavigator: null, keys: [], rest: false});
     const scenes = {};
@@ -52,13 +53,16 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
             const preCrumbs = crumbsAndNext.slice(0, index);
             const {state: nextState, data: nextData} = crumbsAndNext[index + 1] || {state: undefined, data: undefined};
             const mount = url === nextCrumb.url;
-            return {key: keys[index], index, mount, unmountStyle: unmountStyle(state, data, preCrumbs), crumbStyle: crumbStyle(state, data, preCrumbs, nextState, nextData)};
+            return {key: keys[index], index, mount, className: className(state, data, preCrumbs),
+                unmountStyle: unmountStyle(state, data, preCrumbs),
+                crumbStyle: crumbStyle(state, data, preCrumbs, nextState, nextData)};
         });
     }
     const sceneProps = ({key}: State) => firstLink ? allScenes[key].props : null;
     const returnOrCall = (item, ...args) => typeof item !== 'function' ? item : item(...args);
     const unmountStyle = (state, ...rest) => sceneProps(state)?.unmountStyle ? returnOrCall(sceneProps(state)?.unmountStyle, ...rest) : returnOrCall(unmountStyleStack, state, ...rest);
     const crumbStyle = (state, ...rest) => sceneProps(state)?.crumbStyle ? returnOrCall(sceneProps(state)?.crumbStyle, ...rest) : returnOrCall(crumbStyleStack, state, ...rest);
+    const className = (state, ...rest) => sceneProps(state)?.className ? returnOrCall(sceneProps(state)?.className, ...rest) : returnOrCall(sceneClassName, state, ...rest);
     const {stateNavigator: prevStateNavigator} = motionState;
     if (prevStateNavigator !== stateNavigator && stateNavigator.stateContext.state) {
         setMotionState((prevStackState) => {
@@ -81,9 +85,9 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
     return (stateContext.state &&
         <NavigationAnimation data={getScenes()} onRest={clearScene} oldState={oldState} duration={duration}>
             {scenes => (
-                scenes.map(({key, index: crumb}) => (
+                scenes.map(({key, index: crumb, className}) => (
                     <Freeze key={key} enabled={motionState.rest && crumb < getScenes().length - 1}>
-                        <Scene crumb={crumb} id={key} rest renderScene={renderScene} />
+                        <Scene crumb={crumb} rest className={className} renderScene={renderScene} />
                     </Freeze>
                 ))
             )}

--- a/NavigationReactMobile/src/Props.ts
+++ b/NavigationReactMobile/src/Props.ts
@@ -47,6 +47,7 @@ interface SharedElementMotionProps {
 interface NavigationMotionProps {
     unmountedStyle?: any;
     mountedStyle?: any;
+    unmountStyle?: any;
     crumbStyle?: any;
     duration?: number;
     stackInvalidatedLink?: string;

--- a/NavigationReactMobile/src/Props.ts
+++ b/NavigationReactMobile/src/Props.ts
@@ -60,6 +60,7 @@ interface NavigationMotionProps {
 
 interface SceneProps {
     crumb: number;
+    id: string;
     rest: boolean;
     renderScene?: (state: State, data: any) => ReactNode;
 }

--- a/NavigationReactMobile/src/Props.ts
+++ b/NavigationReactMobile/src/Props.ts
@@ -50,6 +50,7 @@ interface NavigationMotionProps {
     unmountStyle?: any;
     crumbStyle?: any;
     className?: any;
+    style?: any;
     duration?: number;
     stackInvalidatedLink?: string;
     sharedElementMotion?: (props: SharedElementNavigationMotionProps) => ReactElement<SharedElementMotion>;
@@ -64,6 +65,7 @@ interface SceneProps {
     id: string;
     rest: boolean;
     className: string;
+    style: any;
     renderScene?: (state: State, data: any) => ReactNode;
 }
 

--- a/NavigationReactMobile/src/Props.ts
+++ b/NavigationReactMobile/src/Props.ts
@@ -49,6 +49,7 @@ interface NavigationMotionProps {
     mountedStyle?: any;
     unmountStyle?: any;
     crumbStyle?: any;
+    className?: any;
     duration?: number;
     stackInvalidatedLink?: string;
     sharedElementMotion?: (props: SharedElementNavigationMotionProps) => ReactElement<SharedElementMotion>;
@@ -62,6 +63,7 @@ interface SceneProps {
     crumb: number;
     id: string;
     rest: boolean;
+    className: string;
     renderScene?: (state: State, data: any) => ReactNode;
 }
 

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -31,13 +31,13 @@ class Scene extends React.Component<SceneProps & {navigationEvent: NavigationEve
     }
     render() {
         var {navigationEvent} = this.state;
-        var {crumb, id, navigationEvent: {stateNavigator}} = this.props;
+        var {crumb, navigationEvent: {stateNavigator}, className} = this.props;
         var {crumbs} = stateNavigator.stateContext;
         var stateContext = navigationEvent?.stateNavigator?.stateContext;
         var {state, data} = stateContext || crumbs[crumb] || {};
         return (
             <NavigationContext.Provider value={navigationEvent}>
-                <div style={{display: navigationEvent ? 'block' : 'none'}}>
+                <div className={className} style={{display: navigationEvent ? 'block' : 'none'}}>
                     {navigationEvent && this.props.renderScene(state, data)}
                 </div>
             </NavigationContext.Provider>

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -37,7 +37,7 @@ class Scene extends React.Component<SceneProps & {navigationEvent: NavigationEve
         var {state, data} = stateContext || crumbs[crumb] || {};
         return (
             <NavigationContext.Provider value={navigationEvent}>
-                <div id={id} key={id} className="scene" style={{display: navigationEvent ? 'block' : 'none'}}>
+                <div id={id} className="scene" style={{display: navigationEvent ? 'block' : 'none'}}>
                     {navigationEvent && this.props.renderScene(state, data)}
                 </div>
             </NavigationContext.Provider>

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -37,7 +37,7 @@ class Scene extends React.Component<SceneProps & {navigationEvent: NavigationEve
         var {state, data} = stateContext || crumbs[crumb] || {};
         return (
             <NavigationContext.Provider value={navigationEvent}>
-                <div className="scene" style={{display: navigationEvent ? 'block' : 'none'}}>
+                <div style={{display: navigationEvent ? 'block' : 'none'}}>
                     {navigationEvent && this.props.renderScene(state, data)}
                 </div>
             </NavigationContext.Provider>

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -37,7 +37,7 @@ class Scene extends React.Component<SceneProps & {navigationEvent: NavigationEve
         var {state, data} = stateContext || crumbs[crumb] || {};
         return (
             <NavigationContext.Provider value={navigationEvent}>
-                <div id={id} className="scene" style={{display: navigationEvent ? 'block' : 'none'}}>
+                <div className="scene" style={{display: navigationEvent ? 'block' : 'none'}}>
                     {navigationEvent && this.props.renderScene(state, data)}
                 </div>
             </NavigationContext.Provider>

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -31,13 +31,15 @@ class Scene extends React.Component<SceneProps & {navigationEvent: NavigationEve
     }
     render() {
         var {navigationEvent} = this.state;
-        var {crumb, navigationEvent: {stateNavigator}} = this.props;
+        var {crumb, id, navigationEvent: {stateNavigator}} = this.props;
         var {crumbs} = stateNavigator.stateContext;
         var stateContext = navigationEvent?.stateNavigator?.stateContext;
         var {state, data} = stateContext || crumbs[crumb] || {};
         return (
             <NavigationContext.Provider value={navigationEvent}>
-                {navigationEvent && this.props.renderScene(state, data)}
+                <div id={id} key={id} className="scene" style={{display: navigationEvent ? 'block' : 'none'}}>
+                    {navigationEvent && this.props.renderScene(state, data)}
+                </div>
             </NavigationContext.Provider>
         );
     }

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -31,13 +31,13 @@ class Scene extends React.Component<SceneProps & {navigationEvent: NavigationEve
     }
     render() {
         var {navigationEvent} = this.state;
-        var {crumb, navigationEvent: {stateNavigator}, className} = this.props;
+        var {crumb, navigationEvent: {stateNavigator}, className, style} = this.props;
         var {crumbs} = stateNavigator.stateContext;
         var stateContext = navigationEvent?.stateNavigator?.stateContext;
         var {state, data} = stateContext || crumbs[crumb] || {};
         return (
             <NavigationContext.Provider value={navigationEvent}>
-                <div className={className} style={{display: navigationEvent ? 'block' : 'none'}}>
+                <div className={className} style={{...style, display: navigationEvent ? 'block' : 'none'}}>
                     {navigationEvent && this.props.renderScene(state, data)}
                 </div>
             </NavigationContext.Provider>

--- a/NavigationReactMobile/test/NavigatedHookTest.tsx
+++ b/NavigationReactMobile/test/NavigatedHookTest.tsx
@@ -2,7 +2,8 @@ import assert from 'assert';
 import 'mocha';
 import { StateNavigator } from 'navigation';
 import { NavigationContext, NavigationHandler } from 'navigation-react';
-import { NavigationMotion, useNavigated } from 'navigation-react-mobile';
+//@ts-ignore
+import { NavigationMotion, NavigationStack, useNavigated } from 'navigation-react-mobile';
 import React, { useState, useContext } from 'react';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
@@ -17,858 +18,1028 @@ global.document = window.document;
 
 describe('NavigatedHook', function () {
     describe('A', function () {
-        it('should call navigated hook', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA} = stateNavigator.states;
-            var navigatedA;
-            var SceneA = () => {
-                useNavigated(() => {
-                    navigatedA = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                navigatedA = false;
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should call navigated hook', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA} = stateNavigator.states;
+                var navigatedA;
+                var SceneA = () => {
+                    useNavigated(() => {
+                        navigatedA = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    navigatedA = false;
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                try {
+                    assert.equal(navigatedA, true);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            try {
-                assert.equal(navigatedA, true);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A -> B', function () {
-        it('should call navigated hook on B and not on A', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            stateNavigator.navigate('sceneB');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var navigatedA, navigatedB;
-            var SceneA = () => {
-                useNavigated(() => {
-                    navigatedA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useNavigated(() => {
-                    navigatedB = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                navigatedA = navigatedB = false;
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should call navigated hook on B and not on A', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                stateNavigator.navigate('sceneB');
+                var {sceneA, sceneB} = stateNavigator.states;
+                var navigatedA, navigatedB;
+                var SceneA = () => {
+                    useNavigated(() => {
+                        navigatedA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useNavigated(() => {
+                        navigatedB = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    navigatedA = navigatedB = false;
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                try {
+                    assert.equal(navigatedA, false);
+                    assert.equal(navigatedB, true);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            try {
-                assert.equal(navigatedA, false);
-                assert.equal(navigatedB, true);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A to A -> B', function () {
-        it('should call navigated hook on B and not on A', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var navigatedA, navigatedB;
-            var SceneA = () => {
-                useNavigated(() => {
-                    navigatedA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useNavigated(() => {
-                    navigatedB = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should call navigated hook on B and not on A', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB} = stateNavigator.states;
+                var navigatedA, navigatedB;
+                var SceneA = () => {
+                    useNavigated(() => {
+                        navigatedA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useNavigated(() => {
+                        navigatedB = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    navigatedA = navigatedB = false;
+                    stateNavigator.navigate('sceneB');
+                });
+                try {
+                    assert.equal(navigatedA, false);
+                    assert.equal(navigatedB, true);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                navigatedA = navigatedB = false;
-                stateNavigator.navigate('sceneB');
-            });
-            try {
-                assert.equal(navigatedA, false);
-                assert.equal(navigatedB, true);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A -> B to A', function () {
-        it('should call navigated hook on A and not on B', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var navigatedA, navigatedB;
-            var SceneA = () => {
-                useNavigated(() => {
-                    navigatedA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useNavigated(() => {
-                    navigatedB = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should call navigated hook on A and not on B', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB} = stateNavigator.states;
+                var navigatedA, navigatedB;
+                var SceneA = () => {
+                    useNavigated(() => {
+                        navigatedA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useNavigated(() => {
+                        navigatedB = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => stateNavigator.navigate('sceneB'));
+                act(() => {
+                    navigatedA = navigatedB = false;
+                    stateNavigator.navigateBack(1);
+                });
+                try {
+                    assert.equal(navigatedA, true);
+                    assert.equal(navigatedB, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => stateNavigator.navigate('sceneB'));
-            act(() => {
-                navigatedA = navigatedB = false;
-                stateNavigator.navigateBack(1);
-            });
-            try {
-                assert.equal(navigatedA, true);
-                assert.equal(navigatedB, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A to A', function () {
-        it('should call navigated hook', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA} = stateNavigator.states;
-            var navigatedA;
-            var SceneA = () => {
-                useNavigated(() => {
-                    navigatedA = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => {
-                navigatedA = false;
+        const test = stack => {
+            it('should call navigated hook', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' }
+                ]);
                 stateNavigator.navigate('sceneA');
+                var {sceneA} = stateNavigator.states;
+                var navigatedA;
+                var SceneA = () => {
+                    useNavigated(() => {
+                        navigatedA = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    navigatedA = false;
+                    stateNavigator.navigate('sceneA');
+                });
+                try {
+                    assert.equal(navigatedA, true);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            try {
-                assert.equal(navigatedA, true);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A to B', function () {
-        it('should call navigated hook on B and not on A', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB' }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var navigatedA, navigatedB;
-            var SceneA = () => {
-                useNavigated(() => {
-                    navigatedA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useNavigated(() => {
-                    navigatedB = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should call navigated hook on B and not on A', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB' }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB} = stateNavigator.states;
+                var navigatedA, navigatedB;
+                var SceneA = () => {
+                    useNavigated(() => {
+                        navigatedA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useNavigated(() => {
+                        navigatedB = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    navigatedA = navigatedB = false;
+                    stateNavigator.navigate('sceneB');
+                });
+                try {
+                    assert.equal(navigatedA, false);
+                    assert.equal(navigatedB, true);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                navigatedA = navigatedB = false;
-                stateNavigator.navigate('sceneB');
-            });
-            try {
-                assert.equal(navigatedA, false);
-                assert.equal(navigatedB, true);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A -> B to C -> B', function () {
-        it('should call navigated hook on B and not on A or C', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC' }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB, sceneC} = stateNavigator.states;
-            var navigatedA, navigatedB, navigatedC;
-            var SceneA = () => {
-                useNavigated(() => {
-                    navigatedA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useNavigated(() => {
-                    navigatedB = true;
-                })
-                return <div />;
-            };
-            var SceneC = () => {
-                useNavigated(() => {
-                    navigatedC = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should call navigated hook on B and not on A or C', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true },
+                    { key: 'sceneC' }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                var navigatedA, navigatedB, navigatedC;
+                var SceneA = () => {
+                    useNavigated(() => {
+                        navigatedA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useNavigated(() => {
+                        navigatedB = true;
+                    })
+                    return <div />;
+                };
+                var SceneC = () => {
+                    useNavigated(() => {
+                        navigatedC = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => stateNavigator.navigate('sceneB'));
+                act(() => {
+                    navigatedA = navigatedB = navigatedC = false;
+                    var url = stateNavigator.fluent()
+                        .navigate('sceneC')
+                        .navigate('sceneB').url;
+                    stateNavigator.navigateLink(url);
+                });
+                try {
+                    assert.equal(navigatedA, false);
+                    assert.equal(navigatedB, true);
+                    assert.equal(navigatedC, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => stateNavigator.navigate('sceneB'));
-            act(() => {
-                navigatedA = navigatedB = navigatedC = false;
-                var url = stateNavigator.fluent()
-                    .navigate('sceneC')
-                    .navigate('sceneB').url;
-                stateNavigator.navigateLink(url);
-            });
-            try {
-                assert.equal(navigatedA, false);
-                assert.equal(navigatedB, true);
-                assert.equal(navigatedC, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A -> B to C -> D', function () {
-        it('should call navigated hook on D and not on A, B or C', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC' },
-                { key: 'sceneD', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB, sceneC, sceneD} = stateNavigator.states;
-            var navigatedA, navigatedB, navigatedC, navigatedD;
-            var SceneA = () => {
-                useNavigated(() => {
-                    navigatedA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useNavigated(() => {
-                    navigatedB = true;
-                })
-                return <div />;
-            };
-            var SceneC = () => {
-                useNavigated(() => {
-                    navigatedC = true;
-                })
-                return <div />;
-            };
-            var SceneD = () => {
-                useNavigated(() => {
-                    navigatedD = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            sceneD.renderScene = () => <SceneD />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should call navigated hook on D and not on A, B or C', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true },
+                    { key: 'sceneC' },
+                    { key: 'sceneD', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB, sceneC, sceneD} = stateNavigator.states;
+                var navigatedA, navigatedB, navigatedC, navigatedD;
+                var SceneA = () => {
+                    useNavigated(() => {
+                        navigatedA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useNavigated(() => {
+                        navigatedB = true;
+                    })
+                    return <div />;
+                };
+                var SceneC = () => {
+                    useNavigated(() => {
+                        navigatedC = true;
+                    })
+                    return <div />;
+                };
+                var SceneD = () => {
+                    useNavigated(() => {
+                        navigatedD = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                sceneD.renderScene = () => <SceneD />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => stateNavigator.navigate('sceneB'));
+                act(() => {
+                    navigatedA = navigatedB = navigatedC = navigatedD = false;
+                    var url = stateNavigator.fluent()
+                        .navigate('sceneC')
+                        .navigate('sceneD').url;
+                    stateNavigator.navigateLink(url);
+                });
+                try {
+                    assert.equal(navigatedA, false);
+                    assert.equal(navigatedB, false);
+                    assert.equal(navigatedC, false);
+                    assert.equal(navigatedD, true);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => stateNavigator.navigate('sceneB'));
-            act(() => {
-                navigatedA = navigatedB = navigatedC = navigatedD = false;
-                var url = stateNavigator.fluent()
-                    .navigate('sceneC')
-                    .navigate('sceneD').url;
-                stateNavigator.navigateLink(url);
-            });
-            try {
-                assert.equal(navigatedA, false);
-                assert.equal(navigatedB, false);
-                assert.equal(navigatedC, false);
-                assert.equal(navigatedD, true);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A to A --> B -> C', function () {
-        it('should call navigated hook on C and not on A or B', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB, sceneC} = stateNavigator.states;
-            var navigatedA, navigatedB, navigatedC;
-            var SceneA = () => {
-                useNavigated(() => {
-                    navigatedA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useNavigated(() => {
-                    navigatedB = true;
-                })
-                return <div />;
-            };
-            var SceneC = () => {
-                useNavigated(() => {
-                    navigatedC = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should call navigated hook on C and not on A or B', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true },
+                    { key: 'sceneC', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                var navigatedA, navigatedB, navigatedC;
+                var SceneA = () => {
+                    useNavigated(() => {
+                        navigatedA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useNavigated(() => {
+                        navigatedB = true;
+                    })
+                    return <div />;
+                };
+                var SceneC = () => {
+                    useNavigated(() => {
+                        navigatedC = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    navigatedA = navigatedB = navigatedC = false;
+                    var url = stateNavigator.fluent(true)
+                        .navigate('sceneB')
+                        .navigate('sceneC').url;
+                    stateNavigator.navigateLink(url);
+                });
+                try {
+                    assert.equal(navigatedA, false);
+                    assert.equal(navigatedB, false);
+                    assert.equal(navigatedC, true);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                navigatedA = navigatedB = navigatedC = false;
-                var url = stateNavigator.fluent(true)
-                    .navigate('sceneB')
-                    .navigate('sceneC').url;
-                stateNavigator.navigateLink(url);
-            });
-            try {
-                assert.equal(navigatedA, false);
-                assert.equal(navigatedB, false);
-                assert.equal(navigatedC, true);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A to A -> B -> C to A -> B', function () {
-        it('should call navigated hook on B and not on A or C', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB, sceneC} = stateNavigator.states;
-            var navigatedA, navigatedB, navigatedC;
-            var SceneA = () => {
-                useNavigated(() => {
-                    navigatedA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useNavigated(() => {
-                    navigatedB = true;
-                })
-                return <div />;
-            };
-            var SceneC = () => {
-                useNavigated(() => {
-                    navigatedC = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should call navigated hook on B and not on A or C', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true },
+                    { key: 'sceneC', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                var navigatedA, navigatedB, navigatedC;
+                var SceneA = () => {
+                    useNavigated(() => {
+                        navigatedA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useNavigated(() => {
+                        navigatedB = true;
+                    })
+                    return <div />;
+                };
+                var SceneC = () => {
+                    useNavigated(() => {
+                        navigatedC = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    var url = stateNavigator.fluent(true)
+                        .navigate('sceneB')
+                        .navigate('sceneC').url;
+                    stateNavigator.navigateLink(url);
+                });
+                act(() => {
+                    navigatedA = navigatedB = navigatedC = false;
+                    stateNavigator.navigateBack(1);
+                });
+                try {
+                    assert.equal(navigatedA, false);
+                    assert.equal(navigatedB, true);
+                    assert.equal(navigatedC, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                var url = stateNavigator.fluent(true)
-                    .navigate('sceneB')
-                    .navigate('sceneC').url;
-                stateNavigator.navigateLink(url);
-            });
-            act(() => {
-                navigatedA = navigatedB = navigatedC = false;
-                stateNavigator.navigateBack(1);
-            });
-            try {
-                assert.equal(navigatedA, false);
-                assert.equal(navigatedB, true);
-                assert.equal(navigatedC, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A to A -> B to A to A -> B to A', function () {
-        it('should call navigated hook on A and not B', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var navigatedA, navigatedB;
-            var SceneA = () => {
-                useNavigated(() => {
-                    navigatedA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useNavigated(() => {
-                    navigatedB = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => {
-                stateNavigator.navigate('sceneB');
+        const test = stack => {
+            it('should call navigated hook on A and not B', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true }
+                ]);
                 stateNavigator.navigate('sceneA');
-                stateNavigator.navigate('sceneB');
+                var {sceneA, sceneB} = stateNavigator.states;
+                var navigatedA, navigatedB;
+                var SceneA = () => {
+                    useNavigated(() => {
+                        navigatedA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useNavigated(() => {
+                        navigatedB = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    stateNavigator.navigate('sceneB');
+                    stateNavigator.navigate('sceneA');
+                    stateNavigator.navigate('sceneB');
+                });
+                act(() => {
+                    navigatedA = navigatedB = false;
+                    stateNavigator.navigate('sceneA');
+                });
+                try {
+                    assert.equal(navigatedA, true);
+                    assert.equal(navigatedB, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                navigatedA = navigatedB = false;
-                stateNavigator.navigate('sceneA');
-            });
-            try {
-                assert.equal(navigatedA, true);
-                assert.equal(navigatedB, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A -> B -> C to A', function () {
-        it('should call navigated hook on A and not on B or C', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB, sceneC} = stateNavigator.states;
-            var navigatedA, navigatedB, navigatedC;
-            var SceneA = () => {
-                useNavigated(() => {
-                    navigatedA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useNavigated(() => {
-                    navigatedB = true;
-                })
-                return <div />;
-            };
-            var SceneC = () => {
-                useNavigated(() => {
-                    navigatedC = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should call navigated hook on A and not on B or C', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true },
+                    { key: 'sceneC', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                var navigatedA, navigatedB, navigatedC;
+                var SceneA = () => {
+                    useNavigated(() => {
+                        navigatedA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useNavigated(() => {
+                        navigatedB = true;
+                    })
+                    return <div />;
+                };
+                var SceneC = () => {
+                    useNavigated(() => {
+                        navigatedC = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    stateNavigator.navigate('sceneB');
+                    stateNavigator.navigate('sceneC');
+                });
+                act(() => {
+                    navigatedA = navigatedB = navigatedC = false;
+                    stateNavigator.navigateBack(2);
+                });
+                try {
+                    assert.equal(navigatedA, true);
+                    assert.equal(navigatedB, false);
+                    assert.equal(navigatedC, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                stateNavigator.navigate('sceneB');
-                stateNavigator.navigate('sceneC');
-            });
-            act(() => {
-                navigatedA = navigatedB = navigatedC = false;
-                stateNavigator.navigateBack(2);
-            });
-            try {
-                assert.equal(navigatedA, true);
-                assert.equal(navigatedB, false);
-                assert.equal(navigatedC, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A -> B -> C to B', function () {
-        it('should call navigated hook on B and not on A or C', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB, sceneC} = stateNavigator.states;
-            var navigatedA, navigatedB, navigatedC;
-            var SceneA = () => {
-                useNavigated(() => {
-                    navigatedA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useNavigated(() => {
-                    navigatedB = true;
-                })
-                return <div />;
-            };
-            var SceneC = () => {
-                useNavigated(() => {
-                    navigatedC = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should call navigated hook on B and not on A or C', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true },
+                    { key: 'sceneC', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                var navigatedA, navigatedB, navigatedC;
+                var SceneA = () => {
+                    useNavigated(() => {
+                        navigatedA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useNavigated(() => {
+                        navigatedB = true;
+                    })
+                    return <div />;
+                };
+                var SceneC = () => {
+                    useNavigated(() => {
+                        navigatedC = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    stateNavigator.navigate('sceneB');
+                    stateNavigator.navigate('sceneC');
+                });
+                act(() => {
+                    navigatedA = navigatedB = navigatedC = false;
+                    var url = stateNavigator.fluent()
+                        .navigate('sceneB').url;
+                    stateNavigator.navigateLink(url);
+                });
+                try {
+                    assert.equal(navigatedA, false);
+                    assert.equal(navigatedB, true);
+                    assert.equal(navigatedC, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                stateNavigator.navigate('sceneB');
-                stateNavigator.navigate('sceneC');
-            });
-            act(() => {
-                navigatedA = navigatedB = navigatedC = false;
-                var url = stateNavigator.fluent()
-                    .navigate('sceneB').url;
-                stateNavigator.navigateLink(url);
-            });
-            try {
-                assert.equal(navigatedA, false);
-                assert.equal(navigatedB, true);
-                assert.equal(navigatedC, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('Suspend navigation', function () {
-        it('should not call navigated hook', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var navigatedA, navigatedB;
-            var SceneA = () => {
-                useNavigated(() => {
-                    navigatedA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useNavigated(() => {
-                    navigatedB = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should not call navigated hook', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB} = stateNavigator.states;
+                var navigatedA, navigatedB;
+                var SceneA = () => {
+                    useNavigated(() => {
+                        navigatedA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useNavigated(() => {
+                        navigatedB = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    navigatedA = navigatedB = false;
+                    var url = stateNavigator.getNavigationLink('sceneB');
+                    stateNavigator.navigateLink(url, undefined, false, () => {});
+                });
+                try {
+                    assert.equal(navigatedA, false);
+                    assert.equal(navigatedB, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                navigatedA = navigatedB = false;
-                var url = stateNavigator.getNavigationLink('sceneB');
-                stateNavigator.navigateLink(url, undefined, false, () => {});
-            });
-            try {
-                assert.equal(navigatedA, false);
-                assert.equal(navigatedB, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('Set state', function () {
-        it('should not call navigated hook', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA} = stateNavigator.states;
-            var navigatedA;
-            var setCountA;
-            var SceneA = () => {
-                var [count, setCount]  = useState(0);
-                setCountA = setCount;
-                useNavigated(() => {
-                    navigatedA = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should not call navigated hook', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA} = stateNavigator.states;
+                var navigatedA;
+                var setCountA;
+                var SceneA = () => {
+                    var [count, setCount]  = useState(0);
+                    setCountA = setCount;
+                    useNavigated(() => {
+                        navigatedA = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    navigatedA = false;
+                    setCountA(1);
+                });
+                try {
+                    assert.equal(navigatedA, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                navigatedA = false;
-                setCountA(1);
-            });
-            try {
-                assert.equal(navigatedA, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('Navigated handler state', function () {
-        it('should access latest state', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA} = stateNavigator.states;
-            var countA, setCountA;
-            var SceneA = () => {
-                var [count, setCount]  = useState(0);
-                setCountA = setCount;
-                useNavigated(() => {
-                    countA = count;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => setCountA(1));
-            act(() => {
-                countA = 0;
+        const test = stack => {
+            it('should access latest state', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' }
+                ]);
                 stateNavigator.navigate('sceneA');
+                var {sceneA} = stateNavigator.states;
+                var countA, setCountA;
+                var SceneA = () => {
+                    var [count, setCount]  = useState(0);
+                    setCountA = setCount;
+                    useNavigated(() => {
+                        countA = count;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => setCountA(1));
+                act(() => {
+                    countA = 0;
+                    stateNavigator.navigate('sceneA');
+                });
+                try {
+                    assert.equal(countA, 1);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            try {
-                assert.equal(countA, 1);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('Navigated handler context', function () {
-        it('should access latest context', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' }
-            ]);
-            stateNavigator.navigate('sceneA', {x: 0});
-            var {sceneA} = stateNavigator.states;
-            var stateContextA;
-            var SceneA = () => {
-                var navigationEvent = useContext(NavigationContext);
-                useNavigated(() => {
-                    var {stateContext} = navigationEvent.stateNavigator;
-                    stateContextA = stateContext;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should access latest context', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' }
+                ]);
+                stateNavigator.navigate('sceneA', {x: 0});
+                var {sceneA} = stateNavigator.states;
+                var stateContextA;
+                var SceneA = () => {
+                    var navigationEvent = useContext(NavigationContext);
+                    useNavigated(() => {
+                        var {stateContext} = navigationEvent.stateNavigator;
+                        stateContextA = stateContext;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    stateContextA = null;
+                    stateNavigator.navigate('sceneA', {y: 1});
+                });
+                try {
+                    assert.equal(stateContextA.oldState, sceneA);
+                    assert.equal(stateContextA.oldData.x, 0);
+                    assert.equal(stateContextA.data.y, 1);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                stateContextA = null;
-                stateNavigator.navigate('sceneA', {y: 1});
-            });
-            try {
-                assert.equal(stateContextA.oldState, sceneA);
-                assert.equal(stateContextA.oldData.x, 0);
-                assert.equal(stateContextA.data.y, 1);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 });

--- a/NavigationReactMobile/test/NavigatingHookTest.tsx
+++ b/NavigationReactMobile/test/NavigatingHookTest.tsx
@@ -2,7 +2,8 @@ import assert from 'assert';
 import 'mocha';
 import { StateNavigator } from 'navigation';
 import { NavigationContext, NavigationHandler } from 'navigation-react';
-import { NavigationMotion, useNavigating } from 'navigation-react-mobile';
+//@ts-ignore
+import { NavigationMotion, NavigationStack, useNavigating } from 'navigation-react-mobile';
 import React, { useState, useContext } from 'react';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
@@ -17,904 +18,1102 @@ global.document = window.document;
 
 describe('NavigatingHook', function () {
     describe('A', function () {
-        it('should not call navigating hook', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA} = stateNavigator.states;
-            var navigatingA;
-            var SceneA = () => {
-                useNavigating(() => {
-                    navigatingA = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                navigatingA = false;
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should not call navigating hook', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA} = stateNavigator.states;
+                var navigatingA;
+                var SceneA = () => {
+                    useNavigating(() => {
+                        navigatingA = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    navigatingA = false;
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                try {
+                    assert.equal(navigatingA, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            try {
-                assert.equal(navigatingA, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
+
     });
 
     describe('A -> B', function () {
-        it('should not call navigating hook on on A or B', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            stateNavigator.navigate('sceneB');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var navigatingA, navigatingB;
-            var SceneA = () => {
-                useNavigating(() => {
-                    navigatingA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useNavigating(() => {
-                    navigatingB = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                navigatingA = navigatingB = false;
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should not call navigating hook on on A or B', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                stateNavigator.navigate('sceneB');
+                var {sceneA, sceneB} = stateNavigator.states;
+                var navigatingA, navigatingB;
+                var SceneA = () => {
+                    useNavigating(() => {
+                        navigatingA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useNavigating(() => {
+                        navigatingB = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    navigatingA = navigatingB = false;
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                try {
+                    assert.equal(navigatingA, false);
+                    assert.equal(navigatingB, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            try {
-                assert.equal(navigatingA, false);
-                assert.equal(navigatingB, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
+
     });
 
     describe('A to A -> B', function () {
-        it('should not call navigating hook on A or B', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var navigatingA, navigatingB;
-            var SceneA = () => {
-                useNavigating(() => {
-                    navigatingA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useNavigating(() => {
-                    navigatingB = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should not call navigating hook on A or B', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB} = stateNavigator.states;
+                var navigatingA, navigatingB;
+                var SceneA = () => {
+                    useNavigating(() => {
+                        navigatingA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useNavigating(() => {
+                        navigatingB = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    navigatingA = navigatingB = false;
+                    stateNavigator.navigate('sceneB');
+                });
+                try {
+                    assert.equal(navigatingA, false);
+                    assert.equal(navigatingB, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                navigatingA = navigatingB = false;
-                stateNavigator.navigate('sceneB');
-            });
-            try {
-                assert.equal(navigatingA, false);
-                assert.equal(navigatingB, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
+
     });
 
     describe('A -> B to A', function () {
-        it('should call navigating hook on A and not on B', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var navigatingA, navigatingB;
-            var SceneA = () => {
-                useNavigating(() => {
-                    navigatingA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useNavigating(() => {
-                    navigatingB = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should call navigating hook on A and not on B', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB} = stateNavigator.states;
+                var navigatingA, navigatingB;
+                var SceneA = () => {
+                    useNavigating(() => {
+                        navigatingA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useNavigating(() => {
+                        navigatingB = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => stateNavigator.navigate('sceneB'));
+                act(() => {
+                    navigatingA = navigatingB = false;
+                    stateNavigator.navigateBack(1);
+                });
+                try {
+                    assert.equal(navigatingA, true);
+                    assert.equal(navigatingB, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => stateNavigator.navigate('sceneB'));
-            act(() => {
-                navigatingA = navigatingB = false;
-                stateNavigator.navigateBack(1);
-            });
-            try {
-                assert.equal(navigatingA, true);
-                assert.equal(navigatingB, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
+
     });
 
     describe('A to A', function () {
-        it('should call navigating hook', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA} = stateNavigator.states;
-            var navigatingA;
-            var SceneA = () => {
-                useNavigating(() => {
-                    navigatingA = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => {
-                navigatingA = false;
+        const test = stack => {
+            it('should call navigating hook', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' }
+                ]);
                 stateNavigator.navigate('sceneA');
+                var {sceneA} = stateNavigator.states;
+                var navigatingA;
+                var SceneA = () => {
+                    useNavigating(() => {
+                        navigatingA = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    navigatingA = false;
+                    stateNavigator.navigate('sceneA');
+                });
+                try {
+                    assert.equal(navigatingA, true);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            try {
-                assert.equal(navigatingA, true);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
+
     });
 
     describe('A to B', function () {
-        it('should not call navigating hook on A or B', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB' }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var navigatingA, navigatingB;
-            var SceneA = () => {
-                useNavigating(() => {
-                    navigatingA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useNavigating(() => {
-                    navigatingB = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should not call navigating hook on A or B', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB' }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB} = stateNavigator.states;
+                var navigatingA, navigatingB;
+                var SceneA = () => {
+                    useNavigating(() => {
+                        navigatingA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useNavigating(() => {
+                        navigatingB = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    navigatingA = navigatingB = false;
+                    stateNavigator.navigate('sceneB');
+                });
+                try {
+                    assert.equal(navigatingA, false);
+                    assert.equal(navigatingB, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                navigatingA = navigatingB = false;
-                stateNavigator.navigate('sceneB');
-            });
-            try {
-                assert.equal(navigatingA, false);
-                assert.equal(navigatingB, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
+
     });
 
     describe('A -> B to C -> B', function () {
-        it('should call navigating hook on B and not on A or C', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC' }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB, sceneC} = stateNavigator.states;
-            var navigatingA, navigatingB, navigatingC;
-            var SceneA = () => {
-                useNavigating(() => {
-                    navigatingA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useNavigating(() => {
-                    navigatingB = true;
-                })
-                return <div />;
-            };
-            var SceneC = () => {
-                useNavigating(() => {
-                    navigatingC = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should call navigating hook on B and not on A or C', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true },
+                    { key: 'sceneC' }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                var navigatingA, navigatingB, navigatingC;
+                var SceneA = () => {
+                    useNavigating(() => {
+                        navigatingA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useNavigating(() => {
+                        navigatingB = true;
+                    })
+                    return <div />;
+                };
+                var SceneC = () => {
+                    useNavigating(() => {
+                        navigatingC = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => stateNavigator.navigate('sceneB'));
+                act(() => {
+                    navigatingA = navigatingB = navigatingC = false;
+                    var url = stateNavigator.fluent()
+                        .navigate('sceneC')
+                        .navigate('sceneB').url;
+                    stateNavigator.navigateLink(url);
+                });
+                try {
+                    assert.equal(navigatingA, false);
+                    assert.equal(navigatingB, true);
+                    assert.equal(navigatingC, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => stateNavigator.navigate('sceneB'));
-            act(() => {
-                navigatingA = navigatingB = navigatingC = false;
-                var url = stateNavigator.fluent()
-                    .navigate('sceneC')
-                    .navigate('sceneB').url;
-                stateNavigator.navigateLink(url);
-            });
-            try {
-                assert.equal(navigatingA, false);
-                assert.equal(navigatingB, true);
-                assert.equal(navigatingC, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
+
     });
 
     describe('A -> B to C -> D', function () {
-        it('should not call navigating hook on A, B, C or D', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC' },
-                { key: 'sceneD', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB, sceneC, sceneD} = stateNavigator.states;
-            var navigatingA, navigatingB, navigatingC, navigatingD;
-            var SceneA = () => {
-                useNavigating(() => {
-                    navigatingA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useNavigating(() => {
-                    navigatingB = true;
-                })
-                return <div />;
-            };
-            var SceneC = () => {
-                useNavigating(() => {
-                    navigatingC = true;
-                })
-                return <div />;
-            };
-            var SceneD = () => {
-                useNavigating(() => {
-                    navigatingD = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            sceneD.renderScene = () => <SceneD />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should not call navigating hook on A, B, C or D', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true },
+                    { key: 'sceneC' },
+                    { key: 'sceneD', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB, sceneC, sceneD} = stateNavigator.states;
+                var navigatingA, navigatingB, navigatingC, navigatingD;
+                var SceneA = () => {
+                    useNavigating(() => {
+                        navigatingA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useNavigating(() => {
+                        navigatingB = true;
+                    })
+                    return <div />;
+                };
+                var SceneC = () => {
+                    useNavigating(() => {
+                        navigatingC = true;
+                    })
+                    return <div />;
+                };
+                var SceneD = () => {
+                    useNavigating(() => {
+                        navigatingD = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                sceneD.renderScene = () => <SceneD />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => stateNavigator.navigate('sceneB'));
+                act(() => {
+                    navigatingA = navigatingB = navigatingC = navigatingD = false;
+                    var url = stateNavigator.fluent()
+                        .navigate('sceneC')
+                        .navigate('sceneD').url;
+                    stateNavigator.navigateLink(url);
+                });
+                try {
+                    assert.equal(navigatingA, false);
+                    assert.equal(navigatingB, false);
+                    assert.equal(navigatingC, false);
+                    assert.equal(navigatingD, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => stateNavigator.navigate('sceneB'));
-            act(() => {
-                navigatingA = navigatingB = navigatingC = navigatingD = false;
-                var url = stateNavigator.fluent()
-                    .navigate('sceneC')
-                    .navigate('sceneD').url;
-                stateNavigator.navigateLink(url);
-            });
-            try {
-                assert.equal(navigatingA, false);
-                assert.equal(navigatingB, false);
-                assert.equal(navigatingC, false);
-                assert.equal(navigatingD, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
+
     });
 
     describe('A to A --> B -> C', function () {
-        it('should not call navigating hook on A, B or C', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB, sceneC} = stateNavigator.states;
-            var navigatingA, navigatingB, navigatingC;
-            var SceneA = () => {
-                useNavigating(() => {
-                    navigatingA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useNavigating(() => {
-                    navigatingB = true;
-                })
-                return <div />;
-            };
-            var SceneC = () => {
-                useNavigating(() => {
-                    navigatingC = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should not call navigating hook on A, B or C', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true },
+                    { key: 'sceneC', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                var navigatingA, navigatingB, navigatingC;
+                var SceneA = () => {
+                    useNavigating(() => {
+                        navigatingA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useNavigating(() => {
+                        navigatingB = true;
+                    })
+                    return <div />;
+                };
+                var SceneC = () => {
+                    useNavigating(() => {
+                        navigatingC = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    navigatingA = navigatingB = navigatingC = false;
+                    var url = stateNavigator.fluent(true)
+                        .navigate('sceneB')
+                        .navigate('sceneC').url;
+                    stateNavigator.navigateLink(url);
+                });
+                try {
+                    assert.equal(navigatingA, false);
+                    assert.equal(navigatingB, false);
+                    assert.equal(navigatingC, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                navigatingA = navigatingB = navigatingC = false;
-                var url = stateNavigator.fluent(true)
-                    .navigate('sceneB')
-                    .navigate('sceneC').url;
-                stateNavigator.navigateLink(url);
-            });
-            try {
-                assert.equal(navigatingA, false);
-                assert.equal(navigatingB, false);
-                assert.equal(navigatingC, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
+
     });
 
     describe('A to A -> B -> C to A -> B', function () {
-        it('should not call navigating hook on A, B or C', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB, sceneC} = stateNavigator.states;
-            var navigatingA, navigatingB, navigatingC;
-            var SceneA = () => {
-                useNavigating(() => {
-                    navigatingA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useNavigating(() => {
-                    navigatingB = true;
-                })
-                return <div />;
-            };
-            var SceneC = () => {
-                useNavigating(() => {
-                    navigatingC = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should not call navigating hook on A, B or C', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true },
+                    { key: 'sceneC', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                var navigatingA, navigatingB, navigatingC;
+                var SceneA = () => {
+                    useNavigating(() => {
+                        navigatingA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useNavigating(() => {
+                        navigatingB = true;
+                    })
+                    return <div />;
+                };
+                var SceneC = () => {
+                    useNavigating(() => {
+                        navigatingC = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    var url = stateNavigator.fluent(true)
+                        .navigate('sceneB')
+                        .navigate('sceneC').url;
+                    stateNavigator.navigateLink(url);
+                });
+                act(() => {
+                    navigatingA = navigatingB = navigatingC = false;
+                    stateNavigator.navigateBack(1);
+                });
+                try {
+                    assert.equal(navigatingA, false);
+                    assert.equal(navigatingB, false);
+                    assert.equal(navigatingC, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                var url = stateNavigator.fluent(true)
-                    .navigate('sceneB')
-                    .navigate('sceneC').url;
-                stateNavigator.navigateLink(url);
-            });
-            act(() => {
-                navigatingA = navigatingB = navigatingC = false;
-                stateNavigator.navigateBack(1);
-            });
-            try {
-                assert.equal(navigatingA, false);
-                assert.equal(navigatingB, false);
-                assert.equal(navigatingC, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
+
     });
 
     describe('A to A -> B to A to A -> B to A', function () {
-        it('should call navigating hook on A and not B', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var navigatingA, navigatingB;
-            var SceneA = () => {
-                useNavigating(() => {
-                    navigatingA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useNavigating(() => {
-                    navigatingB = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => {
-                stateNavigator.navigate('sceneB');
+        const test = stack => {
+            it('should call navigating hook on A and not B', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true }
+                ]);
                 stateNavigator.navigate('sceneA');
-                stateNavigator.navigate('sceneB');
-            })
-            act(() => {
-                navigatingA = navigatingB = false;
-                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB} = stateNavigator.states;
+                var navigatingA, navigatingB;
+                var SceneA = () => {
+                    useNavigating(() => {
+                        navigatingA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useNavigating(() => {
+                        navigatingB = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    stateNavigator.navigate('sceneB');
+                    stateNavigator.navigate('sceneA');
+                    stateNavigator.navigate('sceneB');
+                })
+                act(() => {
+                    navigatingA = navigatingB = false;
+                    stateNavigator.navigate('sceneA');
+                });
+                try {
+                    assert.equal(navigatingA, true);
+                    assert.equal(navigatingB, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            try {
-                assert.equal(navigatingA, true);
-                assert.equal(navigatingB, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
+
     });
 
     describe('A -> B -> C to A', function () {
-        it('should call navigating hook on A and not on B or C', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB, sceneC} = stateNavigator.states;
-            var navigatingA, navigatingB, navigatingC;
-            var SceneA = () => {
-                useNavigating(() => {
-                    navigatingA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useNavigating(() => {
-                    navigatingB = true;
-                })
-                return <div />;
-            };
-            var SceneC = () => {
-                useNavigating(() => {
-                    navigatingC = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should call navigating hook on A and not on B or C', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true },
+                    { key: 'sceneC', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                var navigatingA, navigatingB, navigatingC;
+                var SceneA = () => {
+                    useNavigating(() => {
+                        navigatingA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useNavigating(() => {
+                        navigatingB = true;
+                    })
+                    return <div />;
+                };
+                var SceneC = () => {
+                    useNavigating(() => {
+                        navigatingC = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    stateNavigator.navigate('sceneB');
+                    stateNavigator.navigate('sceneC');
+                });
+                act(() => {
+                    navigatingA = navigatingB = navigatingC = false;
+                    stateNavigator.navigateBack(2);
+                });
+                try {
+                    assert.equal(navigatingA, true);
+                    assert.equal(navigatingB, false);
+                    assert.equal(navigatingC, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                stateNavigator.navigate('sceneB');
-                stateNavigator.navigate('sceneC');
-            });
-            act(() => {
-                navigatingA = navigatingB = navigatingC = false;
-                stateNavigator.navigateBack(2);
-            });
-            try {
-                assert.equal(navigatingA, true);
-                assert.equal(navigatingB, false);
-                assert.equal(navigatingC, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
+
     });
 
     describe('A -> B -> C to B', function () {
-        it('should not call navigating hook on A, B or C', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB, sceneC} = stateNavigator.states;
-            var navigatingA, navigatingB, navigatingC;
-            var SceneA = () => {
-                useNavigating(() => {
-                    navigatingA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useNavigating(() => {
-                    navigatingB = true;
-                })
-                return <div />;
-            };
-            var SceneC = () => {
-                useNavigating(() => {
-                    navigatingC = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should not call navigating hook on A, B or C', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true },
+                    { key: 'sceneC', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                var navigatingA, navigatingB, navigatingC;
+                var SceneA = () => {
+                    useNavigating(() => {
+                        navigatingA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useNavigating(() => {
+                        navigatingB = true;
+                    })
+                    return <div />;
+                };
+                var SceneC = () => {
+                    useNavigating(() => {
+                        navigatingC = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    stateNavigator.navigate('sceneB');
+                    stateNavigator.navigate('sceneC');
+                });
+                act(() => {
+                    navigatingA = navigatingB = navigatingC = false;
+                    var url = stateNavigator.fluent()
+                        .navigate('sceneB').url;
+                    stateNavigator.navigateLink(url);
+                });
+                try {
+                    assert.equal(navigatingA, false);
+                    assert.equal(navigatingB, false);
+                    assert.equal(navigatingC, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                stateNavigator.navigate('sceneB');
-                stateNavigator.navigate('sceneC');
-            });
-            act(() => {
-                navigatingA = navigatingB = navigatingC = false;
-                var url = stateNavigator.fluent()
-                    .navigate('sceneB').url;
-                stateNavigator.navigateLink(url);
-            });
-            try {
-                assert.equal(navigatingA, false);
-                assert.equal(navigatingB, false);
-                assert.equal(navigatingC, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
+
     });
 
     describe('Suspend navigation', function () {
-        it('should call navigating hook', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var navigatingA, navigatingB;
-            var SceneA = () => {
-                useNavigating(() => {
-                    navigatingA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useNavigating(() => {
-                    navigatingB = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should call navigating hook', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB} = stateNavigator.states;
+                var navigatingA, navigatingB;
+                var SceneA = () => {
+                    useNavigating(() => {
+                        navigatingA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useNavigating(() => {
+                        navigatingB = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => stateNavigator.navigate('sceneB'));
+                act(() => {
+                    navigatingA = navigatingB = false;
+                    var url = stateNavigator.getNavigationBackLink(1);
+                    stateNavigator.navigateLink(url, undefined, false, () => {});
+                });
+                try {
+                    assert.equal(navigatingA, true);
+                    assert.equal(navigatingB, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => stateNavigator.navigate('sceneB'));
-            act(() => {
-                navigatingA = navigatingB = false;
-                var url = stateNavigator.getNavigationBackLink(1);
-                stateNavigator.navigateLink(url, undefined, false, () => {});
-            });
-            try {
-                assert.equal(navigatingA, true);
-                assert.equal(navigatingB, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
+
     });
 
     describe('Set state', function () {
-        it('should not call navigating hook', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA} = stateNavigator.states;
-            var navigatingA;
-            var setCountA;
-            var SceneA = () => {
-                var [count, setCount]  = useState(0);
-                setCountA = setCount;
-                useNavigating(() => {
-                    navigatingA = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should not call navigating hook', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA} = stateNavigator.states;
+                var navigatingA;
+                var setCountA;
+                var SceneA = () => {
+                    var [count, setCount]  = useState(0);
+                    setCountA = setCount;
+                    useNavigating(() => {
+                        navigatingA = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    navigatingA = false;
+                    setCountA(1);
+                });
+                try {
+                    assert.equal(navigatingA, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                navigatingA = false;
-                setCountA(1);
-            });
-            try {
-                assert.equal(navigatingA, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
+
     });
 
     describe('Navigating handler state', function () {
-        it('should access latest state', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA} = stateNavigator.states;
-            var countA, setCountA;
-            var SceneA = () => {
-                var [count, setCount]  = useState(0);
-                setCountA = setCount;
-                useNavigating(() => {
-                    countA = count;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => setCountA(1));
-            act(() => {
-                countA = 0;
+        const test = stack => {
+            it('should access latest state', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' }
+                ]);
                 stateNavigator.navigate('sceneA');
+                var {sceneA} = stateNavigator.states;
+                var countA, setCountA;
+                var SceneA = () => {
+                    var [count, setCount]  = useState(0);
+                    setCountA = setCount;
+                    useNavigating(() => {
+                        countA = count;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => setCountA(1));
+                act(() => {
+                    countA = 0;
+                    stateNavigator.navigate('sceneA');
+                });
+                try {
+                    assert.equal(countA, 1);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            try {
-                assert.equal(countA, 1);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
+
     });
 
     describe('Navigating handler context', function () {
-        it('should access current context', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' }
-            ]);
-            stateNavigator.navigate('sceneA', {x: 0});
-            var {sceneA} = stateNavigator.states;
-            var stateContextA;
-            var SceneA = () => {
-                var navigationEvent = useContext(NavigationContext);
-                useNavigating(() => {
-                    var {stateContext} = navigationEvent.stateNavigator;
-                    stateContextA = stateContext;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should access current context', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' }
+                ]);
+                stateNavigator.navigate('sceneA', {x: 0});
+                var {sceneA} = stateNavigator.states;
+                var stateContextA;
+                var SceneA = () => {
+                    var navigationEvent = useContext(NavigationContext);
+                    useNavigating(() => {
+                        var {stateContext} = navigationEvent.stateNavigator;
+                        stateContextA = stateContext;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    stateContextA = null;
+                    stateNavigator.navigate('sceneA', {y: 1});
+                });
+                try {
+                    assert.equal(stateContextA.oldState, null);
+                    assert.equal(stateContextA.oldData.x, undefined);
+                    assert.equal(stateContextA.data.x, 0);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                stateContextA = null;
-                stateNavigator.navigate('sceneA', {y: 1});
-            });
-            try {
-                assert.equal(stateContextA.oldState, null);
-                assert.equal(stateContextA.oldData.x, undefined);
-                assert.equal(stateContextA.data.x, 0);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
+
     });
 
     describe('Navigating handler data', function () {
-        it('should access data', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA', defaultTypes: {x: 'number', y:'number'} }
-            ]);
-            stateNavigator.navigate('sceneA', {x: 0});
-            var {sceneA} = stateNavigator.states;
-            var dataA, urlA, historyA, currentContextA;
-            var SceneA = () => {
-                useNavigating((data, url, history, currentContext) => {
-                    dataA = data;
-                    urlA = url;
-                    historyA = history;
-                    currentContextA = currentContext;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should access data', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA', defaultTypes: {x: 'number', y:'number'} }
+                ]);
+                stateNavigator.navigate('sceneA', {x: 0});
+                var {sceneA} = stateNavigator.states;
+                var dataA, urlA, historyA, currentContextA;
+                var SceneA = () => {
+                    useNavigating((data, url, history, currentContext) => {
+                        dataA = data;
+                        urlA = url;
+                        historyA = history;
+                        currentContextA = currentContext;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    dataA = urlA = historyA = currentContextA = null;
+                    stateNavigator.navigate('sceneA', {y: 1});
+                });
+                try {
+                    assert.equal(dataA.y, 1);
+                    assert.equal(urlA, '/sceneA?y=1');
+                    assert.equal(historyA, false);
+                    assert.equal(currentContextA.data.x, 0);
+                    assert.equal(currentContextA.url, '/sceneA?x=0');
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                dataA = urlA = historyA = currentContextA = null;
-                stateNavigator.navigate('sceneA', {y: 1});
-            });
-            try {
-                assert.equal(dataA.y, 1);
-                assert.equal(urlA, '/sceneA?y=1');
-                assert.equal(historyA, false);
-                assert.equal(currentContextA.data.x, 0);
-                assert.equal(currentContextA.url, '/sceneA?x=0');
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
+
     });
 });

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -3072,6 +3072,46 @@ describe('NavigationMotion', function () {
         })
     });
 
+    describe('Register new scene Stack', function () {
+        it('should not clear stack', async function(){
+            var stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+                { key: 'sceneC', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            var SceneA = () => <div id='sceneA' />;
+            var SceneB = () => <div id='sceneB' />;
+            var SceneC = () => <div id='sceneC' />;
+            var update;
+            var App = () => {
+                var [updated, setUpdated] = useState(false);
+                update = setUpdated;
+                return (
+                    <NavigationHandler stateNavigator={stateNavigator}>
+                        <NavigationStack>
+                            <Scene stateKey="sceneA"><SceneA /></Scene>
+                            <Scene stateKey="sceneB"><SceneB /></Scene>
+                            {updated && <Scene stateKey="sceneC"><SceneC /></Scene>}
+                        </NavigationStack>
+                    </NavigationHandler>
+                );
+            }
+            var container = document.createElement('div');
+            var root = createRoot(container)
+            act(() => root.render(<App />));
+            act(() => stateNavigator.navigate('sceneB'));
+            await act(async () => update(true));
+            try {
+                assert.notEqual(container.querySelector("#sceneA"), null);
+                assert.notEqual(container.querySelector("#sceneB"), null);
+                assert.equal(container.querySelector("#sceneC"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        })
+    });
+
     describe('Unregister current scene in stack', function () {
         it('should clear stack', async function(){
             var stateNavigator = new StateNavigator([
@@ -3097,6 +3137,47 @@ describe('NavigationMotion', function () {
                             <Scene stateKey="sceneB"><SceneB /></Scene>
                             {!updated && <Scene stateKey="sceneC"><SceneC /></Scene>}
                         </NavigationMotion>
+                    </NavigationHandler>
+                );
+            }
+            var container = document.createElement('div');
+            var root = createRoot(container)
+            act(() => root.render(<App />));
+            act(() => stateNavigator.navigate('sceneB'));
+            act(() => stateNavigator.navigate('sceneC'));
+            await act(async () => update(true));
+            try {
+                assert.notEqual(container.querySelector("#sceneA"), null);
+                assert.equal(container.querySelector("#sceneB"), null);
+                assert.equal(container.querySelector("#sceneC"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        })
+    });
+
+    describe('Unregister current scene in stack Stack', function () {
+        it('should clear stack', async function(){
+            var stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+                { key: 'sceneC', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            var SceneA = () => <div id='sceneA' />;
+            var SceneB = () => <div id='sceneB' />;
+            var SceneC = () => <div id='sceneC' />;
+            var update;
+            var App = () => {
+                var [updated, setUpdated] = useState(false);
+                update = setUpdated;
+                return (
+                    <NavigationHandler stateNavigator={stateNavigator}>
+                        <NavigationStack>
+                            <Scene stateKey="sceneA"><SceneA /></Scene>
+                            <Scene stateKey="sceneB"><SceneB /></Scene>
+                            {!updated && <Scene stateKey="sceneC"><SceneC /></Scene>}
+                        </NavigationStack>
                     </NavigationHandler>
                 );
             }
@@ -3160,6 +3241,48 @@ describe('NavigationMotion', function () {
         })
     });
 
+    describe('Unregister crumb scene in stack Stack', function () {
+        it('should clear stack', async function(){
+            var stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+                { key: 'sceneC', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            var SceneA = () => <div id='sceneA' />;
+            var SceneB = () => <div id='sceneB' />;
+            var SceneC = () => <div id='sceneC' />;
+            var update;
+            var App = () => {
+                var [updated, setUpdated] = useState(false);
+                update = setUpdated;
+                return (
+                    <NavigationHandler stateNavigator={stateNavigator}>
+                        <NavigationStack>
+                            <Scene stateKey="sceneA"><SceneA /></Scene>
+                            {!updated && <Scene stateKey="sceneB"><SceneB /></Scene>}
+                            <Scene stateKey="sceneC"><SceneC /></Scene>
+                        </NavigationStack>
+                    </NavigationHandler>
+                );
+            }
+            var container = document.createElement('div');
+            var root = createRoot(container)
+            act(() => root.render(<App />));
+            act(() => stateNavigator.navigate('sceneB'));
+            act(() => stateNavigator.navigate('sceneC'));
+            await act(async () => update(true));
+            try {
+                assert.notEqual(container.querySelector("#sceneA"), null);
+                assert.equal(container.querySelector("#sceneB"), null);
+                assert.equal(container.querySelector("#sceneC"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        })
+    });
+
+    // up to here
     describe('Unregister scene not in stack', function () {
         it('should not clear stack', async function(){
             var stateNavigator = new StateNavigator([

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -34,7 +34,6 @@ describe('NavigationMotion', function () {
             container = document.createElement('div');
             root = createRoot(container)
         });
-
         describe('Static', () => {
             it('should render', function(){
                 act(() => {
@@ -51,7 +50,6 @@ describe('NavigationMotion', function () {
                 test();
             });
         });
-
         describe('Dynamic', () => {
             it('should render', function(){
                 act(() => {
@@ -68,7 +66,6 @@ describe('NavigationMotion', function () {
                 test();
             });
         });
-
         describe('Static Stack', () => {
             it('should render', function(){
                 act(() => {
@@ -81,8 +78,6 @@ describe('NavigationMotion', function () {
                 test();
             });
         });
-
-
         const test = () => {
             try {
                 var scenes = container.querySelectorAll(".scene");
@@ -103,7 +98,6 @@ describe('NavigationMotion', function () {
             container = document.createElement('div');
             root = createRoot(container)
         });
-
         describe('Static', () => {
             it('should render', function(){
                 var {sceneA} = stateNavigator.states;
@@ -122,7 +116,6 @@ describe('NavigationMotion', function () {
                 test();
             });
         });
-
         describe('Dynamic', () => {
             it('should render', function(){
                 act(() => {
@@ -140,7 +133,6 @@ describe('NavigationMotion', function () {
                 test();
             });
         });
-
         describe('Static Stack', () => {
             it('should render', function(){
                 var {sceneA} = stateNavigator.states;
@@ -155,7 +147,6 @@ describe('NavigationMotion', function () {
                 test();
             });
         });
-
         describe('Dynamic Stack', () => {
             it('should render', function(){
                 act(() => {
@@ -193,7 +184,6 @@ describe('NavigationMotion', function () {
             container = document.createElement('div');
             root = createRoot(container)
         });
-
         describe('Static', () => {
             it('should render A', function(){
                 var {sceneA} = stateNavigator.states;
@@ -212,7 +202,6 @@ describe('NavigationMotion', function () {
                 test();
             });
         });
-
         describe('Dynamic', () => {
             it('should render A', function(){
                 act(() => {
@@ -230,7 +219,34 @@ describe('NavigationMotion', function () {
                 test();
             });
         });
-
+        describe('Static Stack', () => {
+            it('should render A', function(){
+                var {sceneA} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render A', function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
         const test = () => {
             try {
                 var scenes = container.querySelectorAll(".scene");
@@ -293,6 +309,36 @@ describe('NavigationMotion', function () {
                 test();
             });
         });
+        describe('Static Stack', () => {
+            it('should render _ -> B', function(){
+                var {sceneA, sceneB} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render _ -> B', function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
         const test = () => {
             try {
                 var scenes = container.querySelectorAll(".scene");
@@ -349,6 +395,36 @@ describe('NavigationMotion', function () {
                                 <Scene stateKey="sceneA"><SceneA /></Scene>
                                 <Scene stateKey="sceneB"><SceneB /></Scene>
                             </NavigationMotion>
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
+        describe('Static Stack', () => {
+            it('should render A -> B', function(){
+                var {sceneA, sceneB} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render A -> B', function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                            </NavigationStack>
                         </NavigationHandler>
                     );
                 });
@@ -419,6 +495,36 @@ describe('NavigationMotion', function () {
                 await test();
             });
         });
+        describe('Static Stack', () => {
+            it('should render A', async function(){
+                var {sceneA, sceneB} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render A', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
         const test = async () => {
             await act(async () => stateNavigator.navigateBack(1));
             try {
@@ -476,6 +582,36 @@ describe('NavigationMotion', function () {
                                 <Scene stateKey="sceneA"><SceneA /></Scene>
                                 <Scene stateKey="sceneB"><SceneB /></Scene>
                             </NavigationMotion>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Static Stack', () => {
+            it('should render A', async function(){
+                var {sceneA, sceneB} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render A', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                            </NavigationStack>
                         </NavigationHandler>
                     );
                 });
@@ -544,6 +680,34 @@ describe('NavigationMotion', function () {
                 test();
             });
         });
+        describe('Static Stack', () => {
+            it('should render A', function(){
+                var {sceneA} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render A', function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
         const test = () => {
             act(() => stateNavigator.navigate('sceneA'));
             try {
@@ -600,6 +764,73 @@ describe('NavigationMotion', function () {
                                 <Scene stateKey="sceneA"><SceneA /></Scene>
                                 <Scene stateKey="sceneB"><SceneB /></Scene>
                             </NavigationMotion>
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
+        describe('Static', () => {
+            it('should render B+', function(){
+                var {sceneA, sceneB} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationMotion>
+                                {(_style, scene, key) =>  (
+                                    <div className="scene" id={key} key={key}>{scene}</div>
+                                )}
+                            </NavigationMotion>
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
+        describe('Dynamic', () => {
+            it('should render B+', function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationMotion
+                                renderMotion={(_style, scene, key) =>  (
+                                    <div className="scene" id={key} key={key}>{scene}</div>
+                                )}>
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                            </NavigationMotion>
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
+        describe('Static Stack', () => {
+            it('should render B+', function(){
+                var {sceneA, sceneB} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render B+', function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                            </NavigationStack>
                         </NavigationHandler>
                     );
                 });
@@ -667,6 +898,38 @@ describe('NavigationMotion', function () {
                                 <Scene stateKey="sceneB"><SceneB /></Scene>
                                 <Scene stateKey="sceneC"><SceneC /></Scene>
                             </NavigationMotion>
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
+        describe('Static Stack', () => {
+            it('should render C++', function(){
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render C++', function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                                <Scene stateKey="sceneC"><SceneC /></Scene>
+                            </NavigationStack>
                         </NavigationHandler>
                     );
                 });

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -4642,4 +4642,307 @@ describe('NavigationMotion', function () {
             }
         });
     });
+
+    describe('Stack style state', function () {
+        var stateNavigator, root, container;
+        var SceneA = () => <div id="sceneA" />;
+        beforeEach(() => {
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' }
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
+        describe('Static Stack', () => {
+            it('should render style', function(){
+                var {sceneA} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" style={(state) => (
+                                state.key === 'sceneA' ? {backgroundColor: 'red'} : null
+                            )} />
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render style', function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" style={(state) => (
+                                state.key === 'sceneA' ? {backgroundColor: 'red'} : null
+                            )}>
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
+        const test = () => {
+            try {
+                var scenes = container.querySelectorAll(".scene");
+                assert.equal(scenes.length, 1);
+                assert.equal(scenes[0].style.backgroundColor, 'red');
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
+
+    describe('Dynamic Stack scene style state', function () {
+        it('should render style', function(){
+            var SceneA = () => <div id="sceneA" />;
+            var stateNavigator = new StateNavigator([
+                { key: 'sceneA' }
+            ]);
+            stateNavigator.navigate('sceneA');
+            var container = document.createElement('div');
+            var root = createRoot(container)
+            act(() => {
+                root.render(
+                    <NavigationHandler stateNavigator={stateNavigator}>
+                        <NavigationStack>
+                            {/*@ts-ignore*/}
+                            <Scene stateKey="sceneA" className="scene" style={{backgroundColor: 'red'}}><SceneA /></Scene>
+                        </NavigationStack>
+                    </NavigationHandler>
+                );
+            });
+            try {
+                var scenes = container.querySelectorAll(".scene") as any;
+                assert.equal(scenes.length, 1);
+                assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+                assert.equal(scenes[0].style.backgroundColor, 'red');
+            } finally {
+                act(() => root.unmount());
+            }
+        });
+    });
+
+    describe('Stack style data', function () {
+        var stateNavigator, root, container;
+        var SceneA = () => <div id="sceneA" />;
+        beforeEach(() => {
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' }
+            ]);
+            stateNavigator.navigate('sceneA', {x: 1});
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
+        describe('Static Stack', () => {
+            it('should render style', function(){
+                var {sceneA} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" style={(_state, data) => (
+                                data.x === 1 ? {backgroundColor: 'red'} : null
+                            )} />
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render style', function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" style={(_state, data) => (
+                                data.x === 1 ? {backgroundColor: 'red'} : null
+                            )}>
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
+        const test = () => {
+            try {
+                var scenes = container.querySelectorAll(".scene");
+                assert.equal(scenes.length, 1);
+                assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+                assert.equal(scenes[0].style.backgroundColor, 'red');
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
+
+    describe('Dynamic Stack scene style data', function () {
+        it('should render style', function(){
+            var SceneA = () => <div id="sceneA" />;
+            var stateNavigator = new StateNavigator([
+                { key: 'sceneA' }
+            ]);
+            stateNavigator.navigate('sceneA', {x: 1});
+            var container = document.createElement('div');
+            var root = createRoot(container)
+            act(() => {
+                root.render(
+                    <NavigationHandler stateNavigator={stateNavigator}>
+                        <NavigationStack>
+                            {/*@ts-ignore*/}
+                            <Scene stateKey="sceneA" className="scene" style={(data) => (
+                                data.x === 1 ? {backgroundColor: 'red'} : null
+                            )}><SceneA /></Scene>
+                        </NavigationStack>
+                    </NavigationHandler>
+                );
+            });
+            try {
+                var scenes = container.querySelectorAll(".scene") as any;
+                assert.equal(scenes.length, 1);
+                assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+                assert.equal(scenes[0].style.backgroundColor, 'red');
+            } finally {
+                act(() => root.unmount());
+            }
+        });
+    });
+
+    describe('Stack style crumb', function () {
+        var stateNavigator, root, container;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => <div id="sceneB" />;
+        beforeEach(() => {
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
+        describe('Static Stack', () => {
+            it('should render style', async function(){
+                var {sceneA, sceneB} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" style={(_state, _data, crumbs) => (
+                                crumbs?.[0]?.state.key === 'sceneA' ? {backgroundColor: 'red'} : null
+                            )} />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render style', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" style={(_state, _data, crumbs) => (
+                                crumbs?.[0]?.state.key === 'sceneA' ? {backgroundColor: 'red'} : null
+                            )}>
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        const test = async () => {
+            await act(async () => stateNavigator.navigate('sceneB'));
+            try {
+                var scenes = container.querySelectorAll(".scene");
+                assert.equal(scenes.length, 2);
+                assert.notEqual(container.querySelector("#sceneA"), null);
+                assert.notEqual(container.querySelector("#sceneB"), null);
+                assert.equal(scenes[1].style.backgroundColor, 'red');
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
+
+    describe('Dynamic Stack scene style crumb', function () {
+        it('should render style', async function(){
+            var SceneA = () => <div id="sceneA" />;
+            var SceneB = () => <div id="sceneB" />;
+            var stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            var container = document.createElement('div');
+            var root = createRoot(container)
+            act(() => {
+                root.render(
+                    <NavigationHandler stateNavigator={stateNavigator}>
+                        <NavigationStack className="scene">
+                            <Scene stateKey="sceneA"><SceneA /></Scene>
+                            {/*@ts-ignore*/}
+                            <Scene stateKey="sceneB" style={(_data, crumbs) => (
+                                crumbs?.[0]?.state.key === 'sceneA' ? {backgroundColor: 'red'} : null
+                            )}><SceneB /></Scene>
+                        </NavigationStack>
+                    </NavigationHandler>
+                );
+            });
+            await act(async () => stateNavigator.navigate('sceneB'));
+            try {
+                var scenes = container.querySelectorAll(".scene") as any;
+                assert.equal(scenes.length, 2);
+                assert.notEqual(container.querySelector("#sceneA"), null);
+                assert.notEqual(container.querySelector("#sceneB"), null);
+                assert.equal(scenes[1].style.backgroundColor, 'red');
+            } finally {
+                act(() => root.unmount());
+            }
+        });
+    });
+
+    describe('Dynamic Stack scene style override', function () {
+        it('should render style', async function(){
+            var SceneA = () => <div id="sceneA" />;
+            var SceneB = () => <div id="sceneB" />;
+            var stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            var container = document.createElement('div');
+            var root = createRoot(container)
+            act(() => {
+                root.render(
+                    <NavigationHandler stateNavigator={stateNavigator}>
+                        <NavigationStack className="scene" style={{backgroundColor: 'red'}}>
+                            <Scene stateKey="sceneA"><SceneA /></Scene>
+                            {/*@ts-ignore*/}
+                            <Scene stateKey="sceneB" style={{backgroundColor: 'blue'}}><SceneB /></Scene>
+                        </NavigationStack>
+                    </NavigationHandler>
+                );
+            });
+            await act(async () => stateNavigator.navigate('sceneB'));
+            try {
+                var scenes = container.querySelectorAll(".scene") as any;
+                assert.equal(scenes.length, 2);
+                assert.equal(scenes[0].style.backgroundColor, 'red');
+                assert.equal(scenes[1].style.backgroundColor, 'blue');
+            } finally {
+                act(() => root.unmount());
+            }
+        });
+    });
 });

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -12,15 +12,9 @@ import { JSDOM } from 'jsdom';
 declare var global: any;
 global.IS_REACT_ACT_ENVIRONMENT = true;
 var { window } = new JSDOM('<!doctype html><html><body></body></html>');
-window.addEventListener = () => {};
 global.window = window;
 global.document = window.document;
-var now = window.performance.now()
-window.performance.now = () => now+=500;
-window.requestAnimationFrame = callback => {
-    callback(window.performance.now())
-};
-window.cancelAnimationFrame = () => {};
+React.useLayoutEffect = React.useEffect;
 
 describe('NavigationMotion', function () {
     describe('Blank state context', function () {
@@ -2044,6 +2038,8 @@ describe('NavigationMotion', function () {
             act(() => root.render(<App />));
             await act(async () => {
                 stateNavigator.navigate('sceneB');
+            });
+            await act(async () => {
                 update(true);
             });
             try {
@@ -2087,6 +2083,8 @@ describe('NavigationMotion', function () {
             act(() => root.render(<App />));
             await act(async () => {
                 stateNavigator.navigate('sceneB');
+            });
+            await act(async () => {
                 update(true);
             });
             try {

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -123,7 +123,6 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 1);
-                assert.equal(scenes[0].id, "0");
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
             } finally {
                 act(() => root.unmount());
@@ -184,7 +183,6 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 1);
-                assert.equal(scenes[0].id, "0");
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
             } finally {
                 act(() => root.unmount());
@@ -247,9 +245,7 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 2);
-                assert.equal(scenes[0].id, "0");
                 assert.equal(container.querySelector("#sceneA"), null);
-                assert.equal(scenes[1].id, "1");
                 assert.notEqual(scenes[1].querySelector("#sceneB"), null);
             } finally {
                 act(() => root.unmount());
@@ -312,9 +308,7 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 2);
-                assert.equal(scenes[0].id, "0");
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
-                assert.equal(scenes[1].id, "1");
                 assert.notEqual(scenes[1].querySelector("#sceneB"), null);
             } finally {
                 act(() => root.unmount());
@@ -378,7 +372,6 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 1);
-                assert.equal(scenes[0].id, "0");
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
                 assert.equal(container.querySelector("#sceneB"), null);
             } finally {
@@ -445,7 +438,6 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 1);
-                assert.equal(scenes[0].id, "0");
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
                 assert.equal(container.querySelector("#sceneB"), null);
             } finally {
@@ -505,7 +497,6 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 1);
-                assert.equal(scenes[0].id, "0");
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
             } finally {
                 act(() => root.unmount());
@@ -568,7 +559,6 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 1);
-                assert.equal(scenes[0].id, "0+");
                 assert.notEqual(scenes[0].querySelector("#sceneB"), null);
                 assert.equal(container.querySelector("#sceneA"), null);
             } finally {
@@ -637,7 +627,6 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 1);
-                assert.equal(scenes[0].id, "0++");
                 assert.notEqual(scenes[0].querySelector("#sceneC"), null);
                 assert.equal(container.querySelector("#sceneA"), null);
                 assert.equal(container.querySelector("#sceneB"), null);
@@ -712,8 +701,6 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 2);
-                assert.equal(scenes[0].id, "0");
-                assert.equal(scenes[1].id, "1");
                 assert.notEqual(scenes[1].querySelector("#sceneB"), null);
                 assert.equal(container.querySelector("#sceneA"), null);
                 assert.equal(container.querySelector("#sceneC"), null);
@@ -789,7 +776,6 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 1);
-                assert.equal(scenes[0].id, "0");
                 assert.notEqual(scenes[0].querySelector("#sceneC"), null);
                 assert.equal(container.querySelector("#sceneA"), null);
                 assert.equal(container.querySelector("#sceneB"), null);
@@ -864,9 +850,7 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 2);
-                assert.equal(scenes[0].id, "0");
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
-                assert.equal(scenes[1].id, "1");
                 assert.notEqual(scenes[1].querySelector("#sceneB"), null);
                 assert.equal(container.querySelector("#sceneC"), null);
             } finally {
@@ -941,7 +925,6 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 1);
-                assert.equal(scenes[0].id, "0");
                 assert.notEqual(scenes[0].querySelector("#sceneC"), null);
                 assert.equal(container.querySelector("#sceneA"), null);
                 assert.equal(container.querySelector("#sceneB"), null);
@@ -1020,9 +1003,7 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 2);
-                assert.equal(scenes[0].id, "0");
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
-                assert.equal(scenes[1].id, "1+");
                 assert.notEqual(scenes[1].querySelector("#sceneD"), null);
                 assert.equal(container.querySelector("#sceneB"), null);
                 assert.equal(container.querySelector("#sceneC"), null);
@@ -1096,10 +1077,7 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 3);
-                assert.equal(scenes[0].id, "0");
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
-                assert.equal(scenes[1].id, "1");
-                assert.equal(scenes[2].id, "2");
                 assert.notEqual(scenes[2].querySelector("#sceneC"), null);
                 assert.equal(container.querySelector("#sceneB"), null);
             } finally {
@@ -1173,9 +1151,7 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 2);
-                assert.equal(scenes[0].id, "0");
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
-                assert.equal(scenes[1].id, "1");
                 assert.notEqual(scenes[1].querySelector("#sceneB"), null);
                 assert.equal(container.querySelector("#sceneC"), null);
             } finally {
@@ -1257,10 +1233,7 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 3);
-                assert.equal(scenes[0].id, "0");
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
-                assert.equal(scenes[1].id, "1");
-                assert.equal(scenes[2].id, "2");
                 assert.notEqual(scenes[2].querySelector("#sceneC"), null);
                 assert.equal(container.querySelector("#sceneB"), null);
                 assert.equal(container.querySelector("#sceneD"), null);
@@ -1344,9 +1317,7 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 2);
-                assert.equal(scenes[0].id, "0");
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
-                assert.equal(scenes[1].id, "1");
                 assert.notEqual(scenes[1].querySelector("#sceneD"), null);
                 assert.equal(container.querySelector("#sceneB"), null);
                 assert.equal(container.querySelector("#sceneC"), null);
@@ -1421,7 +1392,6 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 1);
-                assert.equal(scenes[0].id, "0");
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
                 assert.equal(container.querySelector("#sceneB"), null);
                 assert.equal(container.querySelector("#sceneC"), null);
@@ -1492,7 +1462,6 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 1);
-                assert.equal(scenes[0].id, "0");
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
                 assert.equal(container.querySelector("#sceneB"), null);
                 assert.equal(container.querySelector("#sceneC"), null);
@@ -1567,7 +1536,6 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 1);
-                assert.equal(scenes[0].id, "0");
                 assert.notEqual(scenes[0].querySelector("#sceneB"), null);
                 assert.equal(container.querySelector("#sceneA"), null);
                 assert.equal(container.querySelector("#sceneC"), null);
@@ -1628,9 +1596,7 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 2);
-                assert.equal(scenes[0].id, "0");
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
-                assert.equal(scenes[1].id, "1");
                 assert.notEqual(scenes[1].querySelector("#sceneA"), null);
             } finally {
                 act(() => root.unmount());
@@ -1699,9 +1665,7 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 2);
-                assert.equal(scenes[0].id, "0");
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
-                assert.equal(scenes[1].id, "1+");
                 assert.notEqual(scenes[1].querySelector("#sceneB"), null);
             } finally {
                 act(() => root.unmount());
@@ -1782,9 +1746,7 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 2);
-                assert.equal(scenes[0].id, "0");
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
-                assert.equal(scenes[1].id, "1++");
                 assert.notEqual(scenes[1].querySelector("#sceneC"), null);
                 assert.equal(container.querySelector("#sceneB"), null);
             } finally {
@@ -2736,7 +2698,6 @@ describe('NavigationMotion', function () {
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 1);
-                assert.equal(scenes[0].id, "0");
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
             } finally {
                 act(() => root.unmount());
@@ -2792,7 +2753,6 @@ describe('NavigationMotion', function () {
             container.innerHTML = html;
             var scenes = container.querySelectorAll(".scene");
             assert.equal(scenes.length, 1);
-            assert.equal(scenes[0].id, "0");
             assert.notEqual(scenes[0].querySelector("#sceneA"), null);
     };
     });

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -1006,6 +1006,38 @@ describe('NavigationMotion', function () {
                 await test();
             });
         });
+        describe('Static Stack', () => {
+            it('should render _ -> B', async function(){
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render _ -> B', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                                <Scene stateKey="sceneC"><SceneC /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
         const test = async () => {
             await act(async () => {
                 var url = stateNavigator.fluent()
@@ -1074,6 +1106,38 @@ describe('NavigationMotion', function () {
                                 <Scene stateKey="sceneB"><SceneB /></Scene>
                                 <Scene stateKey="sceneC"><SceneC /></Scene>
                             </NavigationMotion>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Static Stack', () => {
+            it('should render C', async function(){
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render C', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                                <Scene stateKey="sceneC"><SceneC /></Scene>
+                            </NavigationStack>
                         </NavigationHandler>
                     );
                 });
@@ -1154,6 +1218,38 @@ describe('NavigationMotion', function () {
                 await test();
             });
         });
+        describe('Static Stack', () => {
+            it('should render A -> B', async function(){
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render A -> B', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                                <Scene stateKey="sceneC"><SceneC /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
         const test = async () => {
             await act(async () => {
                 stateNavigator.navigate('sceneB');
@@ -1222,6 +1318,38 @@ describe('NavigationMotion', function () {
                                 <Scene stateKey="sceneB"><SceneB /></Scene>
                                 <Scene stateKey="sceneC"><SceneC /></Scene>
                             </NavigationMotion>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Static Stack', () => {
+            it('should render C', async function(){
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render C', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                                <Scene stateKey="sceneC"><SceneC /></Scene>
+                            </NavigationStack>
                         </NavigationHandler>
                     );
                 });
@@ -1307,6 +1435,40 @@ describe('NavigationMotion', function () {
                 await test();
             });
         });
+        describe('Static Stack', () => {
+            it('should render A -> D+', async function(){
+                var {sceneA, sceneB, sceneC, sceneD} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                sceneD.renderScene = () => <SceneD />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render A -> D+', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                                <Scene stateKey="sceneC"><SceneC /></Scene>
+                                <Scene stateKey="sceneD"><SceneD /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
         const test = async () => {
             act(() => stateNavigator.navigate('sceneB'));
             await act(async () => {
@@ -1382,6 +1544,38 @@ describe('NavigationMotion', function () {
                 test();
             });
         });
+        describe('Static Stack', () => {
+            it('should render A -> _ -> C', function(){
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                })
+                test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render A -> _ -> C', function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                                <Scene stateKey="sceneC"><SceneC /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                })
+                test();
+            });
+        });
         const test = () => {
             act(() => {
                 var url = stateNavigator.fluent(true)
@@ -1436,7 +1630,7 @@ describe('NavigationMotion', function () {
                 await test();
             });
         });
-        describe('Dynammic', () => {
+        describe('Dynamic', () => {
             it('should render A -> B', async function(){
                 act(() => {
                     root.render(
@@ -1449,6 +1643,38 @@ describe('NavigationMotion', function () {
                                 <Scene stateKey="sceneB"><SceneB /></Scene>
                                 <Scene stateKey="sceneC"><SceneC /></Scene>
                             </NavigationMotion>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Static Stack', () => {
+            it('should render A -> B', async function(){
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render A -> B', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                                <Scene stateKey="sceneC"><SceneC /></Scene>
+                            </NavigationStack>
                         </NavigationHandler>
                     );
                 });
@@ -1527,6 +1753,40 @@ describe('NavigationMotion', function () {
                                 <Scene stateKey="sceneC"><SceneC /></Scene>
                                 <Scene stateKey="sceneD"><SceneD /></Scene>
                             </NavigationMotion>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Static Stack', () => {
+            it('should render A -> _ -> C', async function(){
+                var {sceneA, sceneB, sceneC, sceneD} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                sceneD.renderScene = () => <SceneD />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render A -> _ -> C', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                                <Scene stateKey="sceneC"><SceneC /></Scene>
+                                <Scene stateKey="sceneD"><SceneD /></Scene>
+                            </NavigationStack>
                         </NavigationHandler>
                     );
                 });
@@ -1616,6 +1876,40 @@ describe('NavigationMotion', function () {
                 await test();
             });
         });
+        describe('Static Stack', () => {
+            it('should render A -> D', async function(){
+                var {sceneA, sceneB, sceneC, sceneD} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                sceneD.renderScene = () => <SceneD />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render A -> D', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                                <Scene stateKey="sceneC"><SceneC /></Scene>
+                                <Scene stateKey="sceneD"><SceneD /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
         const test = async () => {
             await act(async () => {
                 var url = stateNavigator.fluent(true)
@@ -1696,6 +1990,38 @@ describe('NavigationMotion', function () {
                 await test();
             })
         });
+        describe('Static Stack', () => {            
+            it('should render A', async function(){
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            })
+        });
+        describe('Dynamic Stack', () => {            
+            it('should render A', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                                <Scene stateKey="sceneC"><SceneC /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            })
+        });
         const test = async () => {
             await act(async () => {
                 var url = stateNavigator.fluent(true)
@@ -1733,7 +2059,7 @@ describe('NavigationMotion', function () {
             container = document.createElement('div');
             root = createRoot(container)
         });
-        describe('Static', () => {            
+        describe('Static', () => {
             it('should render A', async function(){
                 var {sceneA, sceneB, sceneC} = stateNavigator.states;
                 sceneA.renderScene = () => <SceneA />;
@@ -1766,6 +2092,38 @@ describe('NavigationMotion', function () {
                                 <Scene stateKey="sceneB"><SceneB /></Scene>
                                 <Scene stateKey="sceneC"><SceneC /></Scene>
                             </NavigationMotion>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Static Stack', () => {
+            it('should render A', async function(){
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {            
+            it('should render A', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                                <Scene stateKey="sceneC"><SceneC /></Scene>
+                            </NavigationStack>
                         </NavigationHandler>
                     );
                 });
@@ -1842,6 +2200,38 @@ describe('NavigationMotion', function () {
                 await test();
             });
         });
+        describe('Static Stack', () => {
+            it('should render B', async function(){
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render B', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                                <Scene stateKey="sceneC"><SceneC /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
         const test = async () => {
             await act(async () => {
                 var url = stateNavigator.fluent()
@@ -1900,6 +2290,34 @@ describe('NavigationMotion', function () {
                                 )}>
                                 <Scene stateKey="sceneA"><SceneA /></Scene>
                             </NavigationMotion>
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
+        describe('Static Stack', () => {
+            it('should render A -> A', function(){
+                var {sceneA} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render A -> A', function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                            </NavigationStack>
                         </NavigationHandler>
                     );
                 });
@@ -1969,6 +2387,36 @@ describe('NavigationMotion', function () {
                 await test();
             });
         });
+        describe('Static Stack', () => {
+            it('should render A -> B+', async function(){
+                var {sceneA, sceneB} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render A -> B+', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
         const test = async () => {
             act(() => stateNavigator.navigate('sceneA'));
             await act(async () => {
@@ -1988,6 +2436,7 @@ describe('NavigationMotion', function () {
         };
     });
 
+    // up to here
     describe('A to A -> A to A -> B to A -> B -> C to A -> B to A -> C', function () {
         var stateNavigator, root, container;
         var SceneA = () => <div id="sceneA" />;

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -2436,7 +2436,6 @@ describe('NavigationMotion', function () {
         };
     });
 
-    // up to here
     describe('A to A -> A to A -> B to A -> B -> C to A -> B to A -> C', function () {
         var stateNavigator, root, container;
         var SceneA = () => <div id="sceneA" />;
@@ -2485,6 +2484,38 @@ describe('NavigationMotion', function () {
                                 <Scene stateKey="sceneB"><SceneB /></Scene>
                                 <Scene stateKey="sceneC"><SceneC /></Scene>
                             </NavigationMotion>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Static Stack', () => {            
+            it('should render A -> C++', async function(){
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            < NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {            
+            it('should render A -> C++', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                                <Scene stateKey="sceneC"><SceneC /></Scene>
+                            </NavigationStack>
                         </NavigationHandler>
                     );
                 });
@@ -2574,6 +2605,36 @@ describe('NavigationMotion', function () {
                 test();
             })
         });
+        describe('Static Stack', () => {
+            it('should render', function(){
+                var {sceneA, sceneB} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack />
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            })
+        });
+        describe('Dynamic Stack', () => {
+            it('should render', function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack>
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            })
+        });
         const test = () => {
             act(() => {
                 stateNavigator.navigate('sceneB');
@@ -2595,7 +2656,7 @@ describe('NavigationMotion', function () {
         var SceneA = () => {
             var [updated, setUpdated] = useState(false)
             update = setUpdated;
-            return <div id='sceneA' data-updated={updated} />;
+            return <div id="sceneA" data-updated={updated} />;
         };
         var SceneB = () => <div id="sceneB" />;
         beforeEach(() => {
@@ -2639,6 +2700,36 @@ describe('NavigationMotion', function () {
                                 <Scene stateKey="sceneA"><SceneA /></Scene>
                                 <Scene stateKey="sceneB"><SceneB /></Scene>
                             </NavigationMotion>
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            })
+        });
+        describe('Static Stack', () => {
+            it('should not render', function(){
+                var {sceneA, sceneB} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack />
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            })
+        });
+        describe('Dynamic Stack', () => {
+            it('should not render', function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack>
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                            </NavigationStack>
                         </NavigationHandler>
                     );
                 });
@@ -2666,7 +2757,7 @@ describe('NavigationMotion', function () {
         var SceneA = () => {
             var [updated, setUpdated] = useState(false)
             update = setUpdated;
-            return <div id='sceneA' data-updated={updated} />;
+            return <div id="sceneA" data-updated={updated} />;
         };
         var SceneB = () => <div id="sceneB" />;
         beforeEach(() => {
@@ -2716,6 +2807,36 @@ describe('NavigationMotion', function () {
                 await test();
             })
         });
+        describe('Static Stack', () => {
+            it('should render', async function(){
+                var {sceneA, sceneB} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            })
+        });
+        describe('Dynamic Stack', () => {
+            it('should render', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack>
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            })
+        });
         const test = async () => {
             await act(async () => {
                 stateNavigator.navigate('sceneB');
@@ -2733,6 +2854,7 @@ describe('NavigationMotion', function () {
         };
     });
 
+    // up to here
     describe('Re-render NavigationStack static', function () {
         it('should only re-render current scene', async function(){
             var stateNavigator = new StateNavigator([

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -4279,58 +4279,6 @@ describe('NavigationMotion', function () {
             ]);
             stateNavigator.navigate('sceneA');
         });
-
-        describe('Static', () => {
-            it('should render A', function(){
-                var {sceneA} = stateNavigator.states;
-                sceneA.renderScene = () => <SceneA />;
-                html = ReactDOMServer.renderToString(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  (
-                                <div className="scene" id={key} key={key}>{scene}</div>
-                            )}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-                test();
-            });
-        });
-
-        describe('Dynamic', () => {
-            it('should render A', function(){
-                html = ReactDOMServer.renderToString(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion
-                            renderMotion={(_style, scene, key) =>  (
-                                <div className="scene" id={key} key={key}>{scene}</div>
-                            )}>
-                            <Scene stateKey="sceneA"><SceneA /></Scene>
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-                test();
-            });
-        });
-
-        const test = () => {
-            var container = document.createElement('div');
-            container.innerHTML = html;
-            var scenes = container.querySelectorAll(".scene");
-            assert.equal(scenes.length, 1);
-            assert.notEqual(scenes[0].querySelector("#sceneA"), null);
-    };
-    });
-
-    describe('Server A', function () {
-        var stateNavigator, html;
-        var SceneA = () => <div id="sceneA" />;
-        beforeEach(() => {
-            stateNavigator = new StateNavigator([
-                { key: 'sceneA' }
-            ]);
-            stateNavigator.navigate('sceneA');
-        });
         describe('Static', () => {
             it('should render A', function(){
                 var {sceneA} = stateNavigator.states;

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -2854,8 +2854,7 @@ describe('NavigationMotion', function () {
         };
     });
 
-    // up to here
-    describe('Re-render NavigationStack static', function () {
+    describe('Re-render NavigationMotion static', function () {
         it('should only re-render current scene', async function(){
             var stateNavigator = new StateNavigator([
                 { key: 'sceneA' },
@@ -2863,8 +2862,8 @@ describe('NavigationMotion', function () {
             ]);
             stateNavigator.navigate('sceneA');
             var {sceneA, sceneB} = stateNavigator.states;
-            var SceneA = ({updated}) => <div id='sceneA' data-updated={updated} />;
-            var SceneB = ({updated}) => <div id='sceneB' data-updated={updated} />;
+            var SceneA = ({updated}) => <div id="sceneA" data-updated={updated} />;
+            var SceneB = ({updated}) => <div id="sceneB" data-updated={updated} />;
             sceneA.renderScene = (updated) => <SceneA updated={updated} />;
             sceneB.renderScene = (updated) => <SceneB updated={updated} />;
             var update;
@@ -2901,15 +2900,57 @@ describe('NavigationMotion', function () {
         })
     });
 
-    describe('Re-render NavigationStack dynamic', function () {
+    describe('Re-render NavigationStack static', function () {
         it('should only re-render current scene', async function(){
             var stateNavigator = new StateNavigator([
                 { key: 'sceneA' },
                 { key: 'sceneB', trackCrumbTrail: true },
             ]);
             stateNavigator.navigate('sceneA');
-            var SceneA = ({updated}) => <div id='sceneA' data-updated={updated} />;
-            var SceneB = ({updated}) => <div id='sceneB' data-updated={updated} />;
+            var {sceneA, sceneB} = stateNavigator.states;
+            var SceneA = ({updated}) => <div id="sceneA" data-updated={updated} />;
+            var SceneB = ({updated}) => <div id="sceneB" data-updated={updated} />;
+            sceneA.renderScene = (updated) => <SceneA updated={updated} />;
+            sceneB.renderScene = (updated) => <SceneB updated={updated} />;
+            var update;
+            var App = () => {
+                var [updated, setUpdated] = useState(false);
+                update = setUpdated;
+                return (
+                    <NavigationHandler stateNavigator={stateNavigator}>
+                        <NavigationStack renderScene={(state) => state.renderScene(updated)} />
+                    </NavigationHandler>
+                );
+            }
+            var container = document.createElement('div');
+            var root = createRoot(container)
+            act(() => root.render(<App />));
+            await act(async () => {
+                stateNavigator.navigate('sceneB');
+            });
+            await act(async () => {
+                update(true);
+            });
+            try {
+                var scene = container.querySelector<HTMLDivElement>("#sceneA");
+                assert.strictEqual(scene.dataset.updated, 'false');
+                scene = container.querySelector<HTMLDivElement>("#sceneB");
+                assert.strictEqual(scene.dataset.updated, 'true');
+            } finally {
+                act(() => root.unmount());
+            }
+        })
+    });
+
+    describe('Re-render NavigationMotion dynamic', function () {
+        it('should only re-render current scene', async function(){
+            var stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            var SceneA = ({updated}) => <div id="sceneA" data-updated={updated} />;
+            var SceneB = ({updated}) => <div id="sceneB" data-updated={updated} />;
             var update;
             var App = () => {
                 var [updated, setUpdated] = useState(false);
@@ -2923,6 +2964,48 @@ describe('NavigationMotion', function () {
                             <Scene stateKey="sceneA"><SceneA updated={updated} /></Scene>
                             <Scene stateKey="sceneB"><SceneB updated={updated} /></Scene>
                         </NavigationMotion>
+                    </NavigationHandler>
+                );
+            }
+            var container = document.createElement('div');
+            var root = createRoot(container)
+            act(() => root.render(<App />));
+            await act(async () => {
+                stateNavigator.navigate('sceneB');
+            });
+            await act(async () => {
+                update(true);
+            });
+            try {
+                var scene = container.querySelector<HTMLDivElement>("#sceneA");
+                assert.strictEqual(scene.dataset.updated, 'false');
+                scene = container.querySelector<HTMLDivElement>("#sceneB");
+                assert.strictEqual(scene.dataset.updated, 'true');
+            } finally {
+                act(() => root.unmount());
+            }
+        })
+    });
+
+    describe('Re-render NavigationStack dynamic', function () {
+        it('should only re-render current scene', async function(){
+            var stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            var SceneA = ({updated}) => <div id="sceneA" data-updated={updated} />;
+            var SceneB = ({updated}) => <div id="sceneB" data-updated={updated} />;
+            var update;
+            var App = () => {
+                var [updated, setUpdated] = useState(false);
+                update = setUpdated;
+                return (
+                    <NavigationHandler stateNavigator={stateNavigator}>
+                        <NavigationStack>
+                            <Scene stateKey="sceneA"><SceneA updated={updated} /></Scene>
+                            <Scene stateKey="sceneB"><SceneB updated={updated} /></Scene>
+                        </NavigationStack>
                     </NavigationHandler>
                 );
             }

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -2,7 +2,8 @@ import assert from 'assert';
 import 'mocha';
 import { StateNavigator } from 'navigation';
 import { NavigationHandler } from 'navigation-react';
-import { NavigationMotion, Scene } from 'navigation-react-mobile';
+// @ts-ignore
+import { NavigationMotion, NavigationStack, Scene } from 'navigation-react-mobile';
 import React, {useState} from 'react';
 import { createRoot } from 'react-dom/client';
 import ReactDOMServer from 'react-dom/server';
@@ -68,6 +69,20 @@ describe('NavigationMotion', function () {
             });
         });
 
+        describe('Static Stack', () => {
+            it('should render', function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
+
+
         const test = () => {
             try {
                 var scenes = container.querySelectorAll(".scene");
@@ -119,6 +134,36 @@ describe('NavigationMotion', function () {
                                 )}>
                                 <Scene stateKey="sceneA"><SceneA /></Scene>
                             </NavigationMotion>
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
+
+        describe('Static Stack', () => {
+            it('should render', function(){
+                var {sceneA} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
+
+        describe('Dynamic Stack', () => {
+            it('should render', function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                            </NavigationStack>
                         </NavigationHandler>
                     );
                 });

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -365,7 +365,7 @@ describe('NavigationMotion', function () {
             root = createRoot(container)
         });
         describe('Static', () => {
-            it('should render A -> B', function(){
+            it('should render A -> B', async function(){
                 var {sceneA, sceneB} = stateNavigator.states;
                 sceneA.renderScene = () => <SceneA />;
                 sceneB.renderScene = () => <SceneB />;
@@ -380,11 +380,11 @@ describe('NavigationMotion', function () {
                         </NavigationHandler>
                     );
                 });
-                test();
+                await test();
             });
         });
         describe('Dynamic', () => {
-            it('should render A -> B', function(){
+            it('should render A -> B', async function(){
                 act(() => {
                     root.render(
                         <NavigationHandler stateNavigator={stateNavigator}>
@@ -398,11 +398,11 @@ describe('NavigationMotion', function () {
                         </NavigationHandler>
                     );
                 });
-                test();
+                await test();
             });
         });
         describe('Static Stack', () => {
-            it('should render A -> B', function(){
+            it('should render A -> B', async function(){
                 var {sceneA, sceneB} = stateNavigator.states;
                 sceneA.renderScene = () => <SceneA />;
                 sceneB.renderScene = () => <SceneB />;
@@ -413,11 +413,11 @@ describe('NavigationMotion', function () {
                         </NavigationHandler>
                     );
                 });
-                test();
+                await test();
             });
         });
         describe('Dynamic Stack', () => {
-            it('should render A -> B', function(){
+            it('should render A -> B', async function(){
                 act(() => {
                     root.render(
                         <NavigationHandler stateNavigator={stateNavigator}>
@@ -428,11 +428,11 @@ describe('NavigationMotion', function () {
                         </NavigationHandler>
                     );
                 });
-                test();
+                await test();
             });
         });
-        const test = () => {
-            act(() => stateNavigator.navigate('sceneB'));
+        const test = async () => {
+            await act(async () => stateNavigator.navigate('sceneB'));
             try {
                 var scenes = container.querySelectorAll(".scene");
                 assert.equal(scenes.length, 2);
@@ -4392,6 +4392,306 @@ describe('NavigationMotion', function () {
             var scenes = container.querySelectorAll(".scene");
             assert.equal(scenes.length, 1);
             assert.notEqual(scenes[0].querySelector("#sceneA"), null);
-    };
+        };
+    });
+
+    describe('Stack class state', function () {
+        var stateNavigator, root, container;
+        var SceneA = () => <div id="sceneA" />;
+        beforeEach(() => {
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' }
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
+        describe('Static Stack', () => {
+            it('should render class', function(){
+                var {sceneA} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className={(state) => (
+                                state.key === 'sceneA' ? 'scene' : null
+                            )} />
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render class', function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className={(state) => (
+                                state.key === 'sceneA' ? 'scene' : null
+                            )}>
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
+        const test = () => {
+            try {
+                var scenes = container.querySelectorAll(".scene");
+                assert.equal(scenes.length, 1);
+                assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
+
+    describe('Dynamic Stack scene class state', function () {
+        it('should render class', function(){
+            var SceneA = () => <div id="sceneA" />;
+            var stateNavigator = new StateNavigator([
+                { key: 'sceneA' }
+            ]);
+            stateNavigator.navigate('sceneA');
+            var container = document.createElement('div');
+            var root = createRoot(container)
+            act(() => {
+                root.render(
+                    <NavigationHandler stateNavigator={stateNavigator}>
+                        <NavigationStack>
+                            {/*@ts-ignore*/}
+                            <Scene stateKey="sceneA" className="scene"><SceneA /></Scene>
+                        </NavigationStack>
+                    </NavigationHandler>
+                );
+            });
+            try {
+                var scenes = container.querySelectorAll(".scene");
+                assert.equal(scenes.length, 1);
+                assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        });
+    });
+
+    describe('Stack class data', function () {
+        var stateNavigator, root, container;
+        var SceneA = () => <div id="sceneA" />;
+        beforeEach(() => {
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' }
+            ]);
+            stateNavigator.navigate('sceneA', {x: 1});
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
+        describe('Static Stack', () => {
+            it('should render class', function(){
+                var {sceneA} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className={(_state, data) => (
+                                data.x === 1 ? 'scene' : null
+                            )} />
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render class', function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className={(_state, data) => (
+                                data.x === 1 ? 'scene' : null
+                            )}>
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                test();
+            });
+        });
+        const test = () => {
+            try {
+                var scenes = container.querySelectorAll(".scene");
+                assert.equal(scenes.length, 1);
+                assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
+
+    describe('Dynamic Stack scene class data', function () {
+        it('should render class', function(){
+            var SceneA = () => <div id="sceneA" />;
+            var stateNavigator = new StateNavigator([
+                { key: 'sceneA' }
+            ]);
+            stateNavigator.navigate('sceneA', {x: 1});
+            var container = document.createElement('div');
+            var root = createRoot(container)
+            act(() => {
+                root.render(
+                    <NavigationHandler stateNavigator={stateNavigator}>
+                        <NavigationStack>
+                            {/*@ts-ignore*/}
+                            <Scene stateKey="sceneA" className={(data) => (
+                                data.x === 1 ? 'scene' : null
+                            )}><SceneA /></Scene>
+                        </NavigationStack>
+                    </NavigationHandler>
+                );
+            });
+            try {
+                var scenes = container.querySelectorAll(".scene");
+                assert.equal(scenes.length, 1);
+                assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        });
+    });
+
+    describe('Stack class crumb', function () {
+        var stateNavigator, root, container;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => <div id="sceneB" />;
+        beforeEach(() => {
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
+        describe('Static Stack', () => {
+            it('should render class', async function(){
+                var {sceneA, sceneB} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className={(_state, _data, crumbs) => (
+                                crumbs?.[0]?.state.key === 'sceneA' ? 'scene' : null
+                            )} />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should render class', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className={(_state, _data, crumbs) => (
+                                crumbs?.[0]?.state.key === 'sceneA' ? 'scene' : null
+                            )}>
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        const test = async () => {
+            await act(async () => stateNavigator.navigate('sceneB'));
+            try {
+                var scenes = container.querySelectorAll(".scene");
+                assert.equal(scenes.length, 1);
+                assert.notEqual(container.querySelector("#sceneA"), null);
+                assert.notEqual(scenes[0].querySelector("#sceneB"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
+
+    describe('Dynamic Stack scene class crumb', function () {
+        it('should render class', async function(){
+            var SceneA = () => <div id="sceneA" />;
+            var SceneB = () => <div id="sceneB" />;
+            var stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            var container = document.createElement('div');
+            var root = createRoot(container)
+            act(() => {
+                root.render(
+                    <NavigationHandler stateNavigator={stateNavigator}>
+                        <NavigationStack>
+                            <Scene stateKey="sceneA"><SceneA /></Scene>
+                            {/*@ts-ignore*/}
+                            <Scene stateKey="sceneB" className={(_data, crumbs) => (
+                                crumbs?.[0]?.state.key === 'sceneA' ? 'scene' : null
+                            )}><SceneB /></Scene>
+                        </NavigationStack>
+                    </NavigationHandler>
+                );
+            });
+            await act(async () => stateNavigator.navigate('sceneB'));
+            try {
+                var scenes = container.querySelectorAll(".scene");
+                assert.equal(scenes.length, 1);
+                assert.notEqual(container.querySelector("#sceneA"), null);
+                assert.notEqual(scenes[0].querySelector("#sceneB"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        });
+    });
+
+    describe('Dynamic Stack scene class override', function () {
+        it('should render class', async function(){
+            var SceneA = () => <div id="sceneA" />;
+            var SceneB = () => <div id="sceneB" />;
+            var stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            var container = document.createElement('div');
+            var root = createRoot(container)
+            act(() => {
+                root.render(
+                    <NavigationHandler stateNavigator={stateNavigator}>
+                        <NavigationStack className="scene">
+                            <Scene stateKey="sceneA"><SceneA /></Scene>
+                            {/*@ts-ignore*/}
+                            <Scene stateKey="sceneB" className="otherScene"><SceneB /></Scene>
+                        </NavigationStack>
+                    </NavigationHandler>
+                );
+            });
+            await act(async () => stateNavigator.navigate('sceneB'));
+            try {
+                var scenes = container.querySelectorAll(".scene");
+                assert.equal(scenes.length, 1);
+                assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+                scenes = container.querySelectorAll(".otherScene");
+                assert.equal(scenes.length, 1);
+                assert.notEqual(scenes[0].querySelector("#sceneB"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        });
     });
 });

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -3282,7 +3282,6 @@ describe('NavigationMotion', function () {
         })
     });
 
-    // up to here
     describe('Unregister scene not in stack', function () {
         it('should not clear stack', async function(){
             var stateNavigator = new StateNavigator([
@@ -3311,6 +3310,50 @@ describe('NavigationMotion', function () {
                             <Scene stateKey="sceneC"><SceneC /></Scene>
                             {!updated && <Scene stateKey="sceneD"><SceneD /></Scene>}
                         </NavigationMotion>
+                    </NavigationHandler>
+                );
+            }
+            var container = document.createElement('div');
+            var root = createRoot(container)
+            act(() => root.render(<App />));
+            act(() => stateNavigator.navigate('sceneB'));
+            act(() => stateNavigator.navigate('sceneC'));
+            await act(async () => update(true));
+            try {
+                assert.notEqual(container.querySelector("#sceneA"), null);
+                assert.notEqual(container.querySelector("#sceneB"), null);
+                assert.notEqual(container.querySelector("#sceneC"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        })
+    });
+
+    describe('Unregister scene not in stack Stack', function () {
+        it('should not clear stack', async function(){
+            var stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+                { key: 'sceneC', trackCrumbTrail: true },
+                { key: 'sceneD', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            var SceneA = () => <div id='sceneA' />;
+            var SceneB = () => <div id='sceneB' />;
+            var SceneC = () => <div id='sceneC' />;
+            var SceneD = () => <div id='sceneD' />;
+            var update;
+            var App = () => {
+                var [updated, setUpdated] = useState(false);
+                update = setUpdated;
+                return (
+                    <NavigationHandler stateNavigator={stateNavigator}>
+                        <NavigationStack>
+                            <Scene stateKey="sceneA"><SceneA /></Scene>
+                            <Scene stateKey="sceneB"><SceneB /></Scene>
+                            <Scene stateKey="sceneC"><SceneC /></Scene>
+                            {!updated && <Scene stateKey="sceneD"><SceneD /></Scene>}
+                        </NavigationStack>
                     </NavigationHandler>
                 );
             }
@@ -3383,6 +3426,56 @@ describe('NavigationMotion', function () {
         })
     });
 
+    describe('Unregister stack Stack', function () {
+        it('should start new stack', async function(){
+            var stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+                { key: 'sceneC', trackCrumbTrail: true },
+                { key: 'sceneD', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            var SceneA = () => <div id='sceneA' />;
+            var SceneB = () => <div id='sceneB' />;
+            var SceneC = () => <div id='sceneC' />;
+            var SceneD = () => <div id='sceneD' />;
+            var update;
+            var App = () => {
+                var [updated, setUpdated] = useState(false);
+                update = setUpdated;
+                return (
+                    <NavigationHandler stateNavigator={stateNavigator}>
+                        <NavigationStack>
+                            {!updated ? (
+                                <>
+                                    <Scene stateKey="sceneA"><SceneA /></Scene>
+                                    <Scene stateKey="sceneB"><SceneB /></Scene>
+                                </>
+                            ) : (
+                                <>
+                                    <Scene stateKey="sceneC"><SceneC /></Scene>
+                                    <Scene stateKey="sceneD"><SceneD /></Scene>
+                                </>
+                            )}
+                        </NavigationStack>
+                    </NavigationHandler>
+                );
+            }
+            var container = document.createElement('div');
+            var root = createRoot(container)
+            act(() => root.render(<App />));
+            act(() => stateNavigator.navigate('sceneB'));
+            await act(async () => update(true));
+            try {
+                assert.equal(container.querySelector("#sceneA"), null);
+                assert.equal(container.querySelector("#sceneB"), null);
+                assert.notEqual(container.querySelector("#sceneC"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        })
+    });
+
     describe('Blank state context dynamic', function () {
         it('should start stack with first scene', async function(){
             var stateNavigator = new StateNavigator([
@@ -3414,6 +3507,35 @@ describe('NavigationMotion', function () {
         })
     });
 
+    describe('Blank state context dynamic Stack', function () {
+        it('should start stack with first scene', async function(){
+            var stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+            ]);
+            var SceneA = () => <div id='sceneA' />;
+            var SceneB = () => <div id='sceneB' />;
+            stateNavigator.navigate('sceneA');
+            var App = () => (
+                <NavigationHandler stateNavigator={stateNavigator}>
+                    <NavigationStack>
+                            <Scene stateKey="sceneA"><SceneA /></Scene>
+                            <Scene stateKey="sceneB"><SceneB /></Scene>
+                    </NavigationStack>
+                </NavigationHandler>
+            );
+            var container = document.createElement('div');
+            var root = createRoot(container)
+            act(() => root.render(<App />));
+            try {
+                assert.notEqual(container.querySelector("#sceneA"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        })
+    });
+
+    // up to here
     describe('Navigate unregistered scene dynamic', function () {
         it('should cancel', async function(){
             var stateNavigator = new StateNavigator([

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -12,8 +12,15 @@ import { JSDOM } from 'jsdom';
 declare var global: any;
 global.IS_REACT_ACT_ENVIRONMENT = true;
 var { window } = new JSDOM('<!doctype html><html><body></body></html>');
+window.addEventListener = () => {};
 global.window = window;
 global.document = window.document;
+var now = window.performance.now()
+window.performance.now = () => now+=500;
+window.requestAnimationFrame = callback => {
+    callback(window.performance.now())
+};
+window.cancelAnimationFrame = () => {};
 React.useLayoutEffect = React.useEffect;
 
 describe('NavigationMotion', function () {

--- a/NavigationReactMobile/test/UnloadedHookTest.tsx
+++ b/NavigationReactMobile/test/UnloadedHookTest.tsx
@@ -630,314 +630,374 @@ describe('UnloadedHook', function () {
         });
     });
 
-    // up to here
     describe('A to A -> B to A to A -> B to A', function () {
-        it('should call unloaded hook on B and not A', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var unloadedA, unloadedB;
-            var SceneA = () => {
-                useUnloaded(() => {
-                    unloadedA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useUnloaded(() => {
-                    unloadedB = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => {
-                stateNavigator.navigate('sceneB');
+        const test = stack => {
+            it('should call unloaded hook on B and not A', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true }
+                ]);
                 stateNavigator.navigate('sceneA');
-                stateNavigator.navigate('sceneB');
+                var {sceneA, sceneB} = stateNavigator.states;
+                var unloadedA, unloadedB;
+                var SceneA = () => {
+                    useUnloaded(() => {
+                        unloadedA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useUnloaded(() => {
+                        unloadedB = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    stateNavigator.navigate('sceneB');
+                    stateNavigator.navigate('sceneA');
+                    stateNavigator.navigate('sceneB');
+                });
+                act(() => {
+                    unloadedA = unloadedB = false;
+                    stateNavigator.navigate('sceneA');
+                });
+                try {
+                    assert.equal(unloadedA, false);
+                    assert.equal(unloadedB, true);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                unloadedA = unloadedB = false;
-                stateNavigator.navigate('sceneA');
-            });
-            try {
-                assert.equal(unloadedA, false);
-                assert.equal(unloadedB, true);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A -> B -> C to A', function () {
-        it('should call unloaded hook on C and not on A or B', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB, sceneC} = stateNavigator.states;
-            var unloadedA, unloadedB, unloadedC;
-            var SceneA = () => {
-                useUnloaded(() => {
-                    unloadedA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useUnloaded(() => {
-                    unloadedB = true;
-                })
-                return <div />;
-            };
-            var SceneC = () => {
-                useUnloaded(() => {
-                    unloadedC = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should call unloaded hook on C and not on A or B', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true },
+                    { key: 'sceneC', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                var unloadedA, unloadedB, unloadedC;
+                var SceneA = () => {
+                    useUnloaded(() => {
+                        unloadedA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useUnloaded(() => {
+                        unloadedB = true;
+                    })
+                    return <div />;
+                };
+                var SceneC = () => {
+                    useUnloaded(() => {
+                        unloadedC = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    stateNavigator.navigate('sceneB');
+                    stateNavigator.navigate('sceneC');
+                });
+                act(() => {
+                    unloadedA = unloadedB = unloadedC = false;
+                    stateNavigator.navigateBack(2);
+                });
+                try {
+                    assert.equal(unloadedA, false);
+                    assert.equal(unloadedB, false);
+                    assert.equal(unloadedC, true);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                stateNavigator.navigate('sceneB');
-                stateNavigator.navigate('sceneC');
-            });
-            act(() => {
-                unloadedA = unloadedB = unloadedC = false;
-                stateNavigator.navigateBack(2);
-            });
-            try {
-                assert.equal(unloadedA, false);
-                assert.equal(unloadedB, false);
-                assert.equal(unloadedC, true);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A -> B -> C to B', function () {
-        it('should call unloaded hook on C and not on A or B', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB, sceneC} = stateNavigator.states;
-            var unloadedA, unloadedB, unloadedC;
-            var SceneA = () => {
-                useUnloaded(() => {
-                    unloadedA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useUnloaded(() => {
-                    unloadedB = true;
-                })
-                return <div />;
-            };
-            var SceneC = () => {
-                useUnloaded(() => {
-                    unloadedC = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should call unloaded hook on C and not on A or B', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true },
+                    { key: 'sceneC', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                var unloadedA, unloadedB, unloadedC;
+                var SceneA = () => {
+                    useUnloaded(() => {
+                        unloadedA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useUnloaded(() => {
+                        unloadedB = true;
+                    })
+                    return <div />;
+                };
+                var SceneC = () => {
+                    useUnloaded(() => {
+                        unloadedC = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    stateNavigator.navigate('sceneB');
+                    stateNavigator.navigate('sceneC');
+                });
+                act(() => {
+                    unloadedA = unloadedB = unloadedC = false;
+                    var url = stateNavigator.fluent()
+                        .navigate('sceneB').url;
+                    stateNavigator.navigateLink(url);
+                });
+                try {
+                    assert.equal(unloadedA, false);
+                    assert.equal(unloadedB, false);
+                    assert.equal(unloadedC, true);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                stateNavigator.navigate('sceneB');
-                stateNavigator.navigate('sceneC');
-            });
-            act(() => {
-                unloadedA = unloadedB = unloadedC = false;
-                var url = stateNavigator.fluent()
-                    .navigate('sceneB').url;
-                stateNavigator.navigateLink(url);
-            });
-            try {
-                assert.equal(unloadedA, false);
-                assert.equal(unloadedB, false);
-                assert.equal(unloadedC, true);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('Suspend navigation', function () {
-        it('should not call unloaded hook', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var unloadedA, unloadedB;
-            var SceneA = () => {
-                useUnloaded(() => {
-                    unloadedA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useUnloaded(() => {
-                    unloadedB = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should not call unloaded hook', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB} = stateNavigator.states;
+                var unloadedA, unloadedB;
+                var SceneA = () => {
+                    useUnloaded(() => {
+                        unloadedA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useUnloaded(() => {
+                        unloadedB = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    unloadedA = unloadedB = false;
+                    var url = stateNavigator.getNavigationLink('sceneB');
+                    stateNavigator.navigateLink(url, undefined, false, () => {});
+                });
+                try {
+                    assert.equal(unloadedA, false);
+                    assert.equal(unloadedB, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                unloadedA = unloadedB = false;
-                var url = stateNavigator.getNavigationLink('sceneB');
-                stateNavigator.navigateLink(url, undefined, false, () => {});
-            });
-            try {
-                assert.equal(unloadedA, false);
-                assert.equal(unloadedB, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('Set state', function () {
-        it('should not call unloaded hook', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA} = stateNavigator.states;
-            var unloadedA;
-            var setCountA;
-            var SceneA = () => {
-                var [count, setCount]  = useState(0);
-                setCountA = setCount;
-                useUnloaded(() => {
-                    unloadedA = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should not call unloaded hook', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA} = stateNavigator.states;
+                var unloadedA;
+                var setCountA;
+                var SceneA = () => {
+                    var [count, setCount]  = useState(0);
+                    setCountA = setCount;
+                    useUnloaded(() => {
+                        unloadedA = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    unloadedA = false;
+                    setCountA(1);
+                });
+                try {
+                    assert.equal(unloadedA, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                unloadedA = false;
-                setCountA(1);
-            });
-            try {
-                assert.equal(unloadedA, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('Unloaded handler state', function () {
-        it('should access latest state', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var countA, setCountA;
-            var SceneA = () => {
-                var [count, setCount]  = useState(0);
-                setCountA = setCount;
-                useUnloaded(() => {
-                    countA = count;
-                })
-                return <div />;
-            };
-            var SceneB = () => <div />;
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should access latest state', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB} = stateNavigator.states;
+                var countA, setCountA;
+                var SceneA = () => {
+                    var [count, setCount]  = useState(0);
+                    setCountA = setCount;
+                    useUnloaded(() => {
+                        countA = count;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => <div />;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => setCountA(1));
+                act(() => {
+                    countA = 0;
+                    stateNavigator.navigate('sceneB');
+                });
+                try {
+                    assert.equal(countA, 1);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => setCountA(1));
-            act(() => {
-                countA = 0;
-                stateNavigator.navigate('sceneB');
-            });
-            try {
-                assert.equal(countA, 1);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
+    // up to here
     describe('Unloaded handler context', function () {
         it('should access current context', function(){
             var stateNavigator = new StateNavigator([

--- a/NavigationReactMobile/test/UnloadedHookTest.tsx
+++ b/NavigationReactMobile/test/UnloadedHookTest.tsx
@@ -2,7 +2,8 @@ import assert from 'assert';
 import 'mocha';
 import { StateNavigator } from 'navigation';
 import { NavigationContext, NavigationHandler } from 'navigation-react';
-import { NavigationMotion, useUnloaded } from 'navigation-react-mobile';
+//@ts-ignore
+import { NavigationMotion, NavigationStack, useUnloaded } from 'navigation-react-mobile';
 import React, { useState, useContext } from 'react';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
@@ -15,517 +16,621 @@ window.addEventListener = () => {};
 global.window = window;
 global.document = window.document;
 
+// why isn't there raf stuff?
+// why aren't the act's async/await?
+
 describe('UnloadedHook', function () {
     describe('A', function () {
-        it('should not call unloaded hook', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA} = stateNavigator.states;
-            var unloadedA;
-            var SceneA = () => {
-                useUnloaded(() => {
-                    unloadedA = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                unloadedA = false;
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should not call unloaded hook', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA} = stateNavigator.states;
+                var unloadedA;
+                var SceneA = () => {
+                    useUnloaded(() => {
+                        unloadedA = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    unloadedA = false;
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                try {
+                    assert.equal(unloadedA, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            try {
-                assert.equal(unloadedA, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A -> B', function () {
-        it('should not call unloaded hook on on A or B', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            stateNavigator.navigate('sceneB');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var unloadedA, unloadedB;
-            var SceneA = () => {
-                useUnloaded(() => {
-                    unloadedA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useUnloaded(() => {
-                    unloadedB = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                unloadedA = unloadedB = false;
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should not call unloaded hook on on A or B', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                stateNavigator.navigate('sceneB');
+                var {sceneA, sceneB} = stateNavigator.states;
+                var unloadedA, unloadedB;
+                var SceneA = () => {
+                    useUnloaded(() => {
+                        unloadedA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useUnloaded(() => {
+                        unloadedB = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    unloadedA = unloadedB = false;
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                try {
+                    assert.equal(unloadedA, false);
+                    assert.equal(unloadedB, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            try {
-                assert.equal(unloadedA, false);
-                assert.equal(unloadedB, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A to A -> B', function () {
-        it('should call unloaded hook on A and not B', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var unloadedA, unloadedB;
-            var SceneA = () => {
-                useUnloaded(() => {
-                    unloadedA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useUnloaded(() => {
-                    unloadedB = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should call unloaded hook on A and not B', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB} = stateNavigator.states;
+                var unloadedA, unloadedB;
+                var SceneA = () => {
+                    useUnloaded(() => {
+                        unloadedA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useUnloaded(() => {
+                        unloadedB = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    unloadedA = unloadedB = false;
+                    stateNavigator.navigate('sceneB');
+                });
+                try {
+                    assert.equal(unloadedA, true);
+                    assert.equal(unloadedB, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                unloadedA = unloadedB = false;
-                stateNavigator.navigate('sceneB');
-            });
-            try {
-                assert.equal(unloadedA, true);
-                assert.equal(unloadedB, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A -> B to A', function () {
-        it('should call unloaded hook on B and not on A', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var unloadedA, unloadedB;
-            var SceneA = () => {
-                useUnloaded(() => {
-                    unloadedA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useUnloaded(() => {
-                    unloadedB = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should call unloaded hook on B and not on A', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB} = stateNavigator.states;
+                var unloadedA, unloadedB;
+                var SceneA = () => {
+                    useUnloaded(() => {
+                        unloadedA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useUnloaded(() => {
+                        unloadedB = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => stateNavigator.navigate('sceneB'));
+                act(() => {
+                    unloadedA = unloadedB = false;
+                    stateNavigator.navigateBack(1);
+                });
+                try {
+                    assert.equal(unloadedA, false);
+                    assert.equal(unloadedB, true);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => stateNavigator.navigate('sceneB'));
-            act(() => {
-                unloadedA = unloadedB = false;
-                stateNavigator.navigateBack(1);
-            });
-            try {
-                assert.equal(unloadedA, false);
-                assert.equal(unloadedB, true);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A to A', function () {
-        it('should not call unloaded hook', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA} = stateNavigator.states;
-            var unloadedA;
-            var SceneA = () => {
-                useUnloaded(() => {
-                    unloadedA = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => {
-                unloadedA = false;
+        const test = stack => {
+            it('should not call unloaded hook', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' }
+                ]);
                 stateNavigator.navigate('sceneA');
+                var {sceneA} = stateNavigator.states;
+                var unloadedA;
+                var SceneA = () => {
+                    useUnloaded(() => {
+                        unloadedA = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    unloadedA = false;
+                    stateNavigator.navigate('sceneA');
+                });
+                try {
+                    assert.equal(unloadedA, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            try {
-                assert.equal(unloadedA, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A to B', function () {
-        it('should call unloaded hook on A and not on B', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB' }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var unloadedA, unloadedB;
-            var SceneA = () => {
-                useUnloaded(() => {
-                    unloadedA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useUnloaded(() => {
-                    unloadedB = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should call unloaded hook on A and not on B', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB' }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB} = stateNavigator.states;
+                var unloadedA, unloadedB;
+                var SceneA = () => {
+                    useUnloaded(() => {
+                        unloadedA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useUnloaded(() => {
+                        unloadedB = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    unloadedA = unloadedB = false;
+                    stateNavigator.navigate('sceneB');
+                });
+                try {
+                    assert.equal(unloadedA, true);
+                    assert.equal(unloadedB, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                unloadedA = unloadedB = false;
-                stateNavigator.navigate('sceneB');
-            });
-            try {
-                assert.equal(unloadedA, true);
-                assert.equal(unloadedB, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A -> B to C -> B', function () {
-        it('should not call unloaded hook on A, B or C', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC' }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB, sceneC} = stateNavigator.states;
-            var unloadedA, unloadedB, unloadedC;
-            var SceneA = () => {
-                useUnloaded(() => {
-                    unloadedA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useUnloaded(() => {
-                    unloadedB = true;
-                })
-                return <div />;
-            };
-            var SceneC = () => {
-                useUnloaded(() => {
-                    unloadedC = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should not call unloaded hook on A, B or C', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true },
+                    { key: 'sceneC' }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                var unloadedA, unloadedB, unloadedC;
+                var SceneA = () => {
+                    useUnloaded(() => {
+                        unloadedA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useUnloaded(() => {
+                        unloadedB = true;
+                    })
+                    return <div />;
+                };
+                var SceneC = () => {
+                    useUnloaded(() => {
+                        unloadedC = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => stateNavigator.navigate('sceneB'));
+                act(() => {
+                    unloadedA = unloadedB = unloadedC = false;
+                    var url = stateNavigator.fluent()
+                        .navigate('sceneC')
+                        .navigate('sceneB').url;
+                    stateNavigator.navigateLink(url);
+                });
+                try {
+                    assert.equal(unloadedA, false);
+                    assert.equal(unloadedB, false);
+                    assert.equal(unloadedC, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => stateNavigator.navigate('sceneB'));
-            act(() => {
-                unloadedA = unloadedB = unloadedC = false;
-                var url = stateNavigator.fluent()
-                    .navigate('sceneC')
-                    .navigate('sceneB').url;
-                stateNavigator.navigateLink(url);
-            });
-            try {
-                assert.equal(unloadedA, false);
-                assert.equal(unloadedB, false);
-                assert.equal(unloadedC, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A -> B to C -> D', function () {
-        it('should call unloaded hook on B and not on A, C, or D', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC' },
-                { key: 'sceneD', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB, sceneC, sceneD} = stateNavigator.states;
-            var unloadedA, unloadedB, unloadedC, unloadedD;
-            var SceneA = () => {
-                useUnloaded(() => {
-                    unloadedA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useUnloaded(() => {
-                    unloadedB = true;
-                })
-                return <div />;
-            };
-            var SceneC = () => {
-                useUnloaded(() => {
-                    unloadedC = true;
-                })
-                return <div />;
-            };
-            var SceneD = () => {
-                useUnloaded(() => {
-                    unloadedD = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            sceneD.renderScene = () => <SceneD />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should call unloaded hook on B and not on A, C, or D', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true },
+                    { key: 'sceneC' },
+                    { key: 'sceneD', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB, sceneC, sceneD} = stateNavigator.states;
+                var unloadedA, unloadedB, unloadedC, unloadedD;
+                var SceneA = () => {
+                    useUnloaded(() => {
+                        unloadedA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useUnloaded(() => {
+                        unloadedB = true;
+                    })
+                    return <div />;
+                };
+                var SceneC = () => {
+                    useUnloaded(() => {
+                        unloadedC = true;
+                    })
+                    return <div />;
+                };
+                var SceneD = () => {
+                    useUnloaded(() => {
+                        unloadedD = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                sceneD.renderScene = () => <SceneD />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => stateNavigator.navigate('sceneB'));
+                act(() => {
+                    unloadedA = unloadedB = unloadedC = unloadedD = false;
+                    var url = stateNavigator.fluent()
+                        .navigate('sceneC')
+                        .navigate('sceneD').url;
+                    stateNavigator.navigateLink(url);
+                });
+                try {
+                    assert.equal(unloadedA, false);
+                    assert.equal(unloadedB, true);
+                    assert.equal(unloadedC, false);
+                    assert.equal(unloadedD, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => stateNavigator.navigate('sceneB'));
-            act(() => {
-                unloadedA = unloadedB = unloadedC = unloadedD = false;
-                var url = stateNavigator.fluent()
-                    .navigate('sceneC')
-                    .navigate('sceneD').url;
-                stateNavigator.navigateLink(url);
-            });
-            try {
-                assert.equal(unloadedA, false);
-                assert.equal(unloadedB, true);
-                assert.equal(unloadedC, false);
-                assert.equal(unloadedD, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A to A --> B -> C', function () {
-        it('should call unloaded hook on A and not on B or C', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB, sceneC} = stateNavigator.states;
-            var unloadedA, unloadedB, unloadedC;
-            var SceneA = () => {
-                useUnloaded(() => {
-                    unloadedA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useUnloaded(() => {
-                    unloadedB = true;
-                })
-                return <div />;
-            };
-            var SceneC = () => {
-                useUnloaded(() => {
-                    unloadedC = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should call unloaded hook on A and not on B or C', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true },
+                    { key: 'sceneC', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                var unloadedA, unloadedB, unloadedC;
+                var SceneA = () => {
+                    useUnloaded(() => {
+                        unloadedA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useUnloaded(() => {
+                        unloadedB = true;
+                    })
+                    return <div />;
+                };
+                var SceneC = () => {
+                    useUnloaded(() => {
+                        unloadedC = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    unloadedA = unloadedB = unloadedC = false;
+                    var url = stateNavigator.fluent(true)
+                        .navigate('sceneB')
+                        .navigate('sceneC').url;
+                    stateNavigator.navigateLink(url);
+                });
+                try {
+                    assert.equal(unloadedA, true);
+                    assert.equal(unloadedB, false);
+                    assert.equal(unloadedC, false);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                unloadedA = unloadedB = unloadedC = false;
-                var url = stateNavigator.fluent(true)
-                    .navigate('sceneB')
-                    .navigate('sceneC').url;
-                stateNavigator.navigateLink(url);
-            });
-            try {
-                assert.equal(unloadedA, true);
-                assert.equal(unloadedB, false);
-                assert.equal(unloadedC, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A to A -> B -> C to A -> B', function () {
-        it('should call unloaded hook on C and not A or B', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB, sceneC} = stateNavigator.states;
-            var unloadedA, unloadedB, unloadedC;
-            var SceneA = () => {
-                useUnloaded(() => {
-                    unloadedA = true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useUnloaded(() => {
-                    unloadedB = true;
-                })
-                return <div />;
-            };
-            var SceneC = () => {
-                useUnloaded(() => {
-                    unloadedC = true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
+        const test = stack => {
+            it('should call unloaded hook on C and not A or B', function(){
+                var stateNavigator = new StateNavigator([
+                    { key: 'sceneA' },
+                    { key: 'sceneB', trackCrumbTrail: true },
+                    { key: 'sceneC', trackCrumbTrail: true }
+                ]);
+                stateNavigator.navigate('sceneA');
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                var unloadedA, unloadedB, unloadedC;
+                var SceneA = () => {
+                    useUnloaded(() => {
+                        unloadedA = true;
+                    })
+                    return <div />;
+                };
+                var SceneB = () => {
+                    useUnloaded(() => {
+                        unloadedB = true;
+                    })
+                    return <div />;
+                };
+                var SceneC = () => {
+                    useUnloaded(() => {
+                        unloadedC = true;
+                    })
+                    return <div />;
+                };
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                var container = document.createElement('div');
+                var root = createRoot(container)
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            {stack}
+                        </NavigationHandler>
+                    );
+                });
+                act(() => {
+                    var url = stateNavigator.fluent(true)
+                        .navigate('sceneB')
+                        .navigate('sceneC').url;
+                    stateNavigator.navigateLink(url);
+                });
+                act(() => {
+                    unloadedA = unloadedB = unloadedC = false;
+                    stateNavigator.navigateBack(1);
+                });
+                try {
+                    assert.equal(unloadedA, false);
+                    assert.equal(unloadedB, false);
+                    assert.equal(unloadedC, true);
+                } finally {
+                    act(() => root.unmount());
+                }
             });
-            act(() => {
-                var url = stateNavigator.fluent(true)
-                    .navigate('sceneB')
-                    .navigate('sceneC').url;
-                stateNavigator.navigateLink(url);
-            });
-            act(() => {
-                unloadedA = unloadedB = unloadedC = false;
-                stateNavigator.navigateBack(1);
-            });
-            try {
-                assert.equal(unloadedA, false);
-                assert.equal(unloadedB, false);
-                assert.equal(unloadedC, true);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
+    // up to here
     describe('A to A -> B to A to A -> B to A', function () {
         it('should call unloaded hook on B and not A', function(){
             var stateNavigator = new StateNavigator([

--- a/NavigationReactMobile/test/UnloadedHookTest.tsx
+++ b/NavigationReactMobile/test/UnloadedHookTest.tsx
@@ -16,9 +16,6 @@ window.addEventListener = () => {};
 global.window = window;
 global.document = window.document;
 
-// why isn't there raf stuff?
-// why aren't the act's async/await?
-
 describe('UnloadedHook', function () {
     describe('A', function () {
         const test = stack => {

--- a/NavigationReactMobile/test/UnloadingHookTest.tsx
+++ b/NavigationReactMobile/test/UnloadingHookTest.tsx
@@ -2,7 +2,8 @@ import assert from 'assert';
 import 'mocha';
 import { StateNavigator } from 'navigation';
 import { NavigationContext, NavigationHandler } from 'navigation-react';
-import { NavigationMotion, useUnloading } from 'navigation-react-mobile';
+//@ts-ignore
+import { NavigationMotion, NavigationStack, useUnloading } from 'navigation-react-mobile';
 import React, { useState, useContext } from 'react';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
@@ -17,1039 +18,1239 @@ global.document = window.document;
 
 describe('UnloadingHook', function () {
     describe('A', function () {
-        it('should not call unloading hook', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA} = stateNavigator.states;
-            var unloadingA;
-            var SceneA = () => {
-                useUnloading(() => {
-                    unloadingA = true;
-                    return true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                unloadingA = false;
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            try {
-                assert.equal(unloadingA, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        const test = stack => {
+            it('should not call unloading hook', function(){
+                    var stateNavigator = new StateNavigator([
+                        { key: 'sceneA' }
+                    ]);
+                    stateNavigator.navigate('sceneA');
+                    var {sceneA} = stateNavigator.states;
+                    var unloadingA;
+                    var SceneA = () => {
+                        useUnloading(() => {
+                            unloadingA = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    sceneA.renderScene = () => <SceneA />;
+                    var container = document.createElement('div');
+                    var root = createRoot(container)
+                    act(() => {
+                        unloadingA = false;
+                        root.render(
+                            <NavigationHandler stateNavigator={stateNavigator}>
+                                {stack}
+                            </NavigationHandler>
+                        );
+                    });
+                    try {
+                        assert.equal(unloadingA, false);
+                    } finally {
+                        act(() => root.unmount());
+                    }
+            })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A -> B', function () {
-        it('should not call unloading hook on on A or B', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            stateNavigator.navigate('sceneB');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var unloadingA, unloadingB;
-            var SceneA = () => {
-                useUnloading(() => {
-                    unloadingA = true;
-                    return true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useUnloading(() => {
-                    unloadingB = true;
-                    return true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                unloadingA = unloadingB = false;
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            try {
-                assert.equal(unloadingA, false);
-                assert.equal(unloadingB, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        const test = stack => {
+            it('should not call unloading hook on on A or B', function(){
+                    var stateNavigator = new StateNavigator([
+                        { key: 'sceneA' },
+                        { key: 'sceneB', trackCrumbTrail: true }
+                    ]);
+                    stateNavigator.navigate('sceneA');
+                    stateNavigator.navigate('sceneB');
+                    var {sceneA, sceneB} = stateNavigator.states;
+                    var unloadingA, unloadingB;
+                    var SceneA = () => {
+                        useUnloading(() => {
+                            unloadingA = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    var SceneB = () => {
+                        useUnloading(() => {
+                            unloadingB = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    sceneA.renderScene = () => <SceneA />;
+                    sceneB.renderScene = () => <SceneB />;
+                    var container = document.createElement('div');
+                    var root = createRoot(container)
+                    act(() => {
+                        unloadingA = unloadingB = false;
+                        root.render(
+                            <NavigationHandler stateNavigator={stateNavigator}>
+                                {stack}
+                            </NavigationHandler>
+                        );
+                    });
+                    try {
+                        assert.equal(unloadingA, false);
+                        assert.equal(unloadingB, false);
+                    } finally {
+                        act(() => root.unmount());
+                    }
+            })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A to A -> B', function () {
-        it('should call unloading hook on A and not B', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var unloadingA, unloadingB;
-            var SceneA = () => {
-                useUnloading(() => {
-                    unloadingA = true;
-                    return true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useUnloading(() => {
-                    unloadingB = true;
-                    return true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => {
-                unloadingA = unloadingB = false;
-                stateNavigator.navigate('sceneB');
-            });
-            try {
-                assert.equal(unloadingA, true);
-                assert.equal(unloadingB, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        const test = stack => {
+            it('should call unloading hook on A and not B', function(){
+                    var stateNavigator = new StateNavigator([
+                        { key: 'sceneA' },
+                        { key: 'sceneB', trackCrumbTrail: true }
+                    ]);
+                    stateNavigator.navigate('sceneA');
+                    var {sceneA, sceneB} = stateNavigator.states;
+                    var unloadingA, unloadingB;
+                    var SceneA = () => {
+                        useUnloading(() => {
+                            unloadingA = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    var SceneB = () => {
+                        useUnloading(() => {
+                            unloadingB = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    sceneA.renderScene = () => <SceneA />;
+                    sceneB.renderScene = () => <SceneB />;
+                    var container = document.createElement('div');
+                    var root = createRoot(container)
+                    act(() => {
+                        root.render(
+                            <NavigationHandler stateNavigator={stateNavigator}>
+                                {stack}
+                            </NavigationHandler>
+                        );
+                    });
+                    act(() => {
+                        unloadingA = unloadingB = false;
+                        stateNavigator.navigate('sceneB');
+                    });
+                    try {
+                        assert.equal(unloadingA, true);
+                        assert.equal(unloadingB, false);
+                    } finally {
+                        act(() => root.unmount());
+                    }
+            })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A -> B to A', function () {
-        it('should call unloading hook on B and not on A', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var unloadingA, unloadingB;
-            var SceneA = () => {
-                useUnloading(() => {
-                    unloadingA = true;
-                    return true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useUnloading(() => {
-                    unloadingB = true;
-                    return true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => stateNavigator.navigate('sceneB'));
-            act(() => {
-                unloadingA = unloadingB = false;
-                stateNavigator.navigateBack(1);
-            });
-            try {
-                assert.equal(unloadingA, false);
-                assert.equal(unloadingB, true);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        const test = stack => {
+            it('should call unloading hook on B and not on A', function(){
+                    var stateNavigator = new StateNavigator([
+                        { key: 'sceneA' },
+                        { key: 'sceneB', trackCrumbTrail: true }
+                    ]);
+                    stateNavigator.navigate('sceneA');
+                    var {sceneA, sceneB} = stateNavigator.states;
+                    var unloadingA, unloadingB;
+                    var SceneA = () => {
+                        useUnloading(() => {
+                            unloadingA = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    var SceneB = () => {
+                        useUnloading(() => {
+                            unloadingB = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    sceneA.renderScene = () => <SceneA />;
+                    sceneB.renderScene = () => <SceneB />;
+                    var container = document.createElement('div');
+                    var root = createRoot(container)
+                    act(() => {
+                        root.render(
+                            <NavigationHandler stateNavigator={stateNavigator}>
+                                {stack}
+                            </NavigationHandler>
+                        );
+                    });
+                    act(() => stateNavigator.navigate('sceneB'));
+                    act(() => {
+                        unloadingA = unloadingB = false;
+                        stateNavigator.navigateBack(1);
+                    });
+                    try {
+                        assert.equal(unloadingA, false);
+                        assert.equal(unloadingB, true);
+                    } finally {
+                        act(() => root.unmount());
+                    }
+            })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A to A', function () {
-        it('should not call unloading hook', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA} = stateNavigator.states;
-            var unloadingA;
-            var SceneA = () => {
-                useUnloading(() => {
-                    unloadingA = true;
-                    return true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => {
-                unloadingA = false;
-                stateNavigator.navigate('sceneA');
-            });
-            try {
-                assert.equal(unloadingA, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        const test = stack => {
+            it('should not call unloading hook', function(){
+                    var stateNavigator = new StateNavigator([
+                        { key: 'sceneA' }
+                    ]);
+                    stateNavigator.navigate('sceneA');
+                    var {sceneA} = stateNavigator.states;
+                    var unloadingA;
+                    var SceneA = () => {
+                        useUnloading(() => {
+                            unloadingA = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    sceneA.renderScene = () => <SceneA />;
+                    var container = document.createElement('div');
+                    var root = createRoot(container)
+                    act(() => {
+                        root.render(
+                            <NavigationHandler stateNavigator={stateNavigator}>
+                                {stack}
+                            </NavigationHandler>
+                        );
+                    });
+                    act(() => {
+                        unloadingA = false;
+                        stateNavigator.navigate('sceneA');
+                    });
+                    try {
+                        assert.equal(unloadingA, false);
+                    } finally {
+                        act(() => root.unmount());
+                    }
+            })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A to B', function () {
-        it('should call unloading hook on A and not on B', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB' }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var unloadingA, unloadingB;
-            var SceneA = () => {
-                useUnloading(() => {
-                    unloadingA = true;
-                    return true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useUnloading(() => {
-                    unloadingB = true;
-                    return true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => {
-                unloadingA = unloadingB = false;
-                stateNavigator.navigate('sceneB');
-            });
-            try {
-                assert.equal(unloadingA, true);
-                assert.equal(unloadingB, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        const test = stack => {
+            it('should call unloading hook on A and not on B', function(){
+                    var stateNavigator = new StateNavigator([
+                        { key: 'sceneA' },
+                        { key: 'sceneB' }
+                    ]);
+                    stateNavigator.navigate('sceneA');
+                    var {sceneA, sceneB} = stateNavigator.states;
+                    var unloadingA, unloadingB;
+                    var SceneA = () => {
+                        useUnloading(() => {
+                            unloadingA = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    var SceneB = () => {
+                        useUnloading(() => {
+                            unloadingB = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    sceneA.renderScene = () => <SceneA />;
+                    sceneB.renderScene = () => <SceneB />;
+                    var container = document.createElement('div');
+                    var root = createRoot(container)
+                    act(() => {
+                        root.render(
+                            <NavigationHandler stateNavigator={stateNavigator}>
+                                {stack}
+                            </NavigationHandler>
+                        );
+                    });
+                    act(() => {
+                        unloadingA = unloadingB = false;
+                        stateNavigator.navigate('sceneB');
+                    });
+                    try {
+                        assert.equal(unloadingA, true);
+                        assert.equal(unloadingB, false);
+                    } finally {
+                        act(() => root.unmount());
+                    }
+            })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A -> B to C -> B', function () {
-        it('should not call unloading hook on A, B or C', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC' }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB, sceneC} = stateNavigator.states;
-            var unloadingA, unloadingB, unloadingC;
-            var SceneA = () => {
-                useUnloading(() => {
-                    unloadingA = true;
-                    return true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useUnloading(() => {
-                    unloadingB = true;
-                    return true;
-                })
-                return <div />;
-            };
-            var SceneC = () => {
-                useUnloading(() => {
-                    unloadingC = true;
-                    return true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => stateNavigator.navigate('sceneB'));
-            act(() => {
-                unloadingA = unloadingB = unloadingC = false;
-                var url = stateNavigator.fluent()
-                    .navigate('sceneC')
-                    .navigate('sceneB').url;
-                stateNavigator.navigateLink(url);
-            });
-            try {
-                assert.equal(unloadingA, false);
-                assert.equal(unloadingB, false);
-                assert.equal(unloadingC, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        const test = stack => {
+            it('should not call unloading hook on A, B or C', function(){
+                    var stateNavigator = new StateNavigator([
+                        { key: 'sceneA' },
+                        { key: 'sceneB', trackCrumbTrail: true },
+                        { key: 'sceneC' }
+                    ]);
+                    stateNavigator.navigate('sceneA');
+                    var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                    var unloadingA, unloadingB, unloadingC;
+                    var SceneA = () => {
+                        useUnloading(() => {
+                            unloadingA = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    var SceneB = () => {
+                        useUnloading(() => {
+                            unloadingB = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    var SceneC = () => {
+                        useUnloading(() => {
+                            unloadingC = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    sceneA.renderScene = () => <SceneA />;
+                    sceneB.renderScene = () => <SceneB />;
+                    sceneC.renderScene = () => <SceneC />;
+                    var container = document.createElement('div');
+                    var root = createRoot(container)
+                    act(() => {
+                        root.render(
+                            <NavigationHandler stateNavigator={stateNavigator}>
+                                {stack}
+                            </NavigationHandler>
+                        );
+                    });
+                    act(() => stateNavigator.navigate('sceneB'));
+                    act(() => {
+                        unloadingA = unloadingB = unloadingC = false;
+                        var url = stateNavigator.fluent()
+                            .navigate('sceneC')
+                            .navigate('sceneB').url;
+                        stateNavigator.navigateLink(url);
+                    });
+                    try {
+                        assert.equal(unloadingA, false);
+                        assert.equal(unloadingB, false);
+                        assert.equal(unloadingC, false);
+                    } finally {
+                        act(() => root.unmount());
+                    }
+            })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A -> B to C -> D', function () {
-        it('should call unloading hook on B and not on A, C, or D', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC' },
-                { key: 'sceneD', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB, sceneC, sceneD} = stateNavigator.states;
-            var unloadingA, unloadingB, unloadingC, unloadingD;
-            var SceneA = () => {
-                useUnloading(() => {
-                    unloadingA = true;
-                    return true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useUnloading(() => {
-                    unloadingB = true;
-                    return true;
-                })
-                return <div />;
-            };
-            var SceneC = () => {
-                useUnloading(() => {
-                    unloadingC = true;
-                    return true;
-                })
-                return <div />;
-            };
-            var SceneD = () => {
-                useUnloading(() => {
-                    unloadingD = true;
-                    return true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            sceneD.renderScene = () => <SceneD />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => stateNavigator.navigate('sceneB'));
-            act(() => {
-                unloadingA = unloadingB = unloadingC = unloadingD = false;
-                var url = stateNavigator.fluent()
-                    .navigate('sceneC')
-                    .navigate('sceneD').url;
-                stateNavigator.navigateLink(url);
-            });
-            try {
-                assert.equal(unloadingA, false);
-                assert.equal(unloadingB, true);
-                assert.equal(unloadingC, false);
-                assert.equal(unloadingD, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        const test = stack => {
+            it('should call unloading hook on B and not on A, C, or D', function(){
+                    var stateNavigator = new StateNavigator([
+                        { key: 'sceneA' },
+                        { key: 'sceneB', trackCrumbTrail: true },
+                        { key: 'sceneC' },
+                        { key: 'sceneD', trackCrumbTrail: true }
+                    ]);
+                    stateNavigator.navigate('sceneA');
+                    var {sceneA, sceneB, sceneC, sceneD} = stateNavigator.states;
+                    var unloadingA, unloadingB, unloadingC, unloadingD;
+                    var SceneA = () => {
+                        useUnloading(() => {
+                            unloadingA = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    var SceneB = () => {
+                        useUnloading(() => {
+                            unloadingB = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    var SceneC = () => {
+                        useUnloading(() => {
+                            unloadingC = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    var SceneD = () => {
+                        useUnloading(() => {
+                            unloadingD = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    sceneA.renderScene = () => <SceneA />;
+                    sceneB.renderScene = () => <SceneB />;
+                    sceneC.renderScene = () => <SceneC />;
+                    sceneD.renderScene = () => <SceneD />;
+                    var container = document.createElement('div');
+                    var root = createRoot(container)
+                    act(() => {
+                        root.render(
+                            <NavigationHandler stateNavigator={stateNavigator}>
+                                {stack}
+                            </NavigationHandler>
+                        );
+                    });
+                    act(() => stateNavigator.navigate('sceneB'));
+                    act(() => {
+                        unloadingA = unloadingB = unloadingC = unloadingD = false;
+                        var url = stateNavigator.fluent()
+                            .navigate('sceneC')
+                            .navigate('sceneD').url;
+                        stateNavigator.navigateLink(url);
+                    });
+                    try {
+                        assert.equal(unloadingA, false);
+                        assert.equal(unloadingB, true);
+                        assert.equal(unloadingC, false);
+                        assert.equal(unloadingD, false);
+                    } finally {
+                        act(() => root.unmount());
+                    }
+            })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A to A --> B -> C', function () {
-        it('should call unloading hook on A and not on B or C', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB, sceneC} = stateNavigator.states;
-            var unloadingA, unloadingB, unloadingC;
-            var SceneA = () => {
-                useUnloading(() => {
-                    unloadingA = true;
-                    return true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useUnloading(() => {
-                    unloadingB = true;
-                    return true;
-                })
-                return <div />;
-            };
-            var SceneC = () => {
-                useUnloading(() => {
-                    unloadingC = true;
-                    return true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => {
-                unloadingA = unloadingB = unloadingC = false;
-                var url = stateNavigator.fluent(true)
-                    .navigate('sceneB')
-                    .navigate('sceneC').url;
-                stateNavigator.navigateLink(url);
-            });
-            try {
-                assert.equal(unloadingA, true);
-                assert.equal(unloadingB, false);
-                assert.equal(unloadingC, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        const test = stack => {
+            it('should call unloading hook on A and not on B or C', function(){
+                    var stateNavigator = new StateNavigator([
+                        { key: 'sceneA' },
+                        { key: 'sceneB', trackCrumbTrail: true },
+                        { key: 'sceneC', trackCrumbTrail: true }
+                    ]);
+                    stateNavigator.navigate('sceneA');
+                    var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                    var unloadingA, unloadingB, unloadingC;
+                    var SceneA = () => {
+                        useUnloading(() => {
+                            unloadingA = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    var SceneB = () => {
+                        useUnloading(() => {
+                            unloadingB = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    var SceneC = () => {
+                        useUnloading(() => {
+                            unloadingC = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    sceneA.renderScene = () => <SceneA />;
+                    sceneB.renderScene = () => <SceneB />;
+                    sceneC.renderScene = () => <SceneC />;
+                    var container = document.createElement('div');
+                    var root = createRoot(container)
+                    act(() => {
+                        root.render(
+                            <NavigationHandler stateNavigator={stateNavigator}>
+                                {stack}
+                            </NavigationHandler>
+                        );
+                    });
+                    act(() => {
+                        unloadingA = unloadingB = unloadingC = false;
+                        var url = stateNavigator.fluent(true)
+                            .navigate('sceneB')
+                            .navigate('sceneC').url;
+                        stateNavigator.navigateLink(url);
+                    });
+                    try {
+                        assert.equal(unloadingA, true);
+                        assert.equal(unloadingB, false);
+                        assert.equal(unloadingC, false);
+                    } finally {
+                        act(() => root.unmount());
+                    }
+            })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A to A -> B -> C to A -> B', function () {
-        it('should call unloading hook on C and not A or B', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB, sceneC} = stateNavigator.states;
-            var unloadingA, unloadingB, unloadingC;
-            var SceneA = () => {
-                useUnloading(() => {
-                    unloadingA = true;
-                    return true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useUnloading(() => {
-                    unloadingB = true;
-                    return true;
-                })
-                return <div />;
-            };
-            var SceneC = () => {
-                useUnloading(() => {
-                    unloadingC = true;
-                    return true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => {
-                var url = stateNavigator.fluent(true)
-                    .navigate('sceneB')
-                    .navigate('sceneC').url;
-                stateNavigator.navigateLink(url);
-            });
-            act(() => {
-                unloadingA = unloadingB = unloadingC = false;
-                stateNavigator.navigateBack(1);
-            });
-            try {
-                assert.equal(unloadingA, false);
-                assert.equal(unloadingB, false);
-                assert.equal(unloadingC, true);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        const test = stack => {
+            it('should call unloading hook on C and not A or B', function(){
+                    var stateNavigator = new StateNavigator([
+                        { key: 'sceneA' },
+                        { key: 'sceneB', trackCrumbTrail: true },
+                        { key: 'sceneC', trackCrumbTrail: true }
+                    ]);
+                    stateNavigator.navigate('sceneA');
+                    var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                    var unloadingA, unloadingB, unloadingC;
+                    var SceneA = () => {
+                        useUnloading(() => {
+                            unloadingA = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    var SceneB = () => {
+                        useUnloading(() => {
+                            unloadingB = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    var SceneC = () => {
+                        useUnloading(() => {
+                            unloadingC = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    sceneA.renderScene = () => <SceneA />;
+                    sceneB.renderScene = () => <SceneB />;
+                    sceneC.renderScene = () => <SceneC />;
+                    var container = document.createElement('div');
+                    var root = createRoot(container)
+                    act(() => {
+                        root.render(
+                            <NavigationHandler stateNavigator={stateNavigator}>
+                                {stack}
+                            </NavigationHandler>
+                        );
+                    });
+                    act(() => {
+                        var url = stateNavigator.fluent(true)
+                            .navigate('sceneB')
+                            .navigate('sceneC').url;
+                        stateNavigator.navigateLink(url);
+                    });
+                    act(() => {
+                        unloadingA = unloadingB = unloadingC = false;
+                        stateNavigator.navigateBack(1);
+                    });
+                    try {
+                        assert.equal(unloadingA, false);
+                        assert.equal(unloadingB, false);
+                        assert.equal(unloadingC, true);
+                    } finally {
+                        act(() => root.unmount());
+                    }
+            })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A to A -> B to A to A -> B to A', function () {
-        it('should call unloading hook on B and not A', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var unloadingA, unloadingB;
-            var SceneA = () => {
-                useUnloading(() => {
-                    unloadingA = true;
-                    return true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useUnloading(() => {
-                    unloadingB = true;
-                    return true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => {
-                stateNavigator.navigate('sceneB');
-                stateNavigator.navigate('sceneA');
-                stateNavigator.navigate('sceneB');
-            });
-            act(() => {
-                unloadingA = unloadingB = false;
-                stateNavigator.navigate('sceneA');
-            });
-            try {
-                assert.equal(unloadingA, false);
-                assert.equal(unloadingB, true);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        const test = stack => {
+            it('should call unloading hook on B and not A', function(){
+                    var stateNavigator = new StateNavigator([
+                        { key: 'sceneA' },
+                        { key: 'sceneB', trackCrumbTrail: true }
+                    ]);
+                    stateNavigator.navigate('sceneA');
+                    var {sceneA, sceneB} = stateNavigator.states;
+                    var unloadingA, unloadingB;
+                    var SceneA = () => {
+                        useUnloading(() => {
+                            unloadingA = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    var SceneB = () => {
+                        useUnloading(() => {
+                            unloadingB = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    sceneA.renderScene = () => <SceneA />;
+                    sceneB.renderScene = () => <SceneB />;
+                    var container = document.createElement('div');
+                    var root = createRoot(container)
+                    act(() => {
+                        root.render(
+                            <NavigationHandler stateNavigator={stateNavigator}>
+                                {stack}
+                            </NavigationHandler>
+                        );
+                    });
+                    act(() => {
+                        stateNavigator.navigate('sceneB');
+                        stateNavigator.navigate('sceneA');
+                        stateNavigator.navigate('sceneB');
+                    });
+                    act(() => {
+                        unloadingA = unloadingB = false;
+                        stateNavigator.navigate('sceneA');
+                    });
+                    try {
+                        assert.equal(unloadingA, false);
+                        assert.equal(unloadingB, true);
+                    } finally {
+                        act(() => root.unmount());
+                    }
+            })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A -> B -> C to A', function () {
-        it('should call unloading hook on C and not on A or B', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB, sceneC} = stateNavigator.states;
-            var unloadingA, unloadingB, unloadingC;
-            var SceneA = () => {
-                useUnloading(() => {
-                    unloadingA = true;
-                    return true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useUnloading(() => {
-                    unloadingB = true;
-                    return true;
-                })
-                return <div />;
-            };
-            var SceneC = () => {
-                useUnloading(() => {
-                    unloadingC = true;
-                    return true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => {
-                stateNavigator.navigate('sceneB');
-                stateNavigator.navigate('sceneC');
-            });
-            act(() => {
-                unloadingA = unloadingB = unloadingC = false;
-                stateNavigator.navigateBack(2);
-            });
-            try {
-                assert.equal(unloadingA, false);
-                assert.equal(unloadingB, false);
-                assert.equal(unloadingC, true);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        const test = stack => {
+            it('should call unloading hook on C and not on A or B', function(){
+                    var stateNavigator = new StateNavigator([
+                        { key: 'sceneA' },
+                        { key: 'sceneB', trackCrumbTrail: true },
+                        { key: 'sceneC', trackCrumbTrail: true }
+                    ]);
+                    stateNavigator.navigate('sceneA');
+                    var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                    var unloadingA, unloadingB, unloadingC;
+                    var SceneA = () => {
+                        useUnloading(() => {
+                            unloadingA = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    var SceneB = () => {
+                        useUnloading(() => {
+                            unloadingB = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    var SceneC = () => {
+                        useUnloading(() => {
+                            unloadingC = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    sceneA.renderScene = () => <SceneA />;
+                    sceneB.renderScene = () => <SceneB />;
+                    sceneC.renderScene = () => <SceneC />;
+                    var container = document.createElement('div');
+                    var root = createRoot(container)
+                    act(() => {
+                        root.render(
+                            <NavigationHandler stateNavigator={stateNavigator}>
+                                {stack}
+                            </NavigationHandler>
+                        );
+                    });
+                    act(() => {
+                        stateNavigator.navigate('sceneB');
+                        stateNavigator.navigate('sceneC');
+                    });
+                    act(() => {
+                        unloadingA = unloadingB = unloadingC = false;
+                        stateNavigator.navigateBack(2);
+                    });
+                    try {
+                        assert.equal(unloadingA, false);
+                        assert.equal(unloadingB, false);
+                        assert.equal(unloadingC, true);
+                    } finally {
+                        act(() => root.unmount());
+                    }
+            })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('A -> B -> C to B', function () {
-        it('should call unloading hook on C and not on A or B', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB, sceneC} = stateNavigator.states;
-            var unloadingA, unloadingB, unloadingC;
-            var SceneA = () => {
-                useUnloading(() => {
-                    unloadingA = true;
-                    return true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useUnloading(() => {
-                    unloadingB = true;
-                    return true;
-                })
-                return <div />;
-            };
-            var SceneC = () => {
-                useUnloading(() => {
-                    unloadingC = true;
-                    return true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => {
-                stateNavigator.navigate('sceneB');
-                stateNavigator.navigate('sceneC');
-            });
-            act(() => {
-                unloadingA = unloadingB = unloadingC = false;
-                var url = stateNavigator.fluent()
-                    .navigate('sceneB').url;
-                stateNavigator.navigateLink(url);
-            });
-            try {
-                assert.equal(unloadingA, false);
-                assert.equal(unloadingB, false);
-                assert.equal(unloadingC, true);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        const test = stack => {
+            it('should call unloading hook on C and not on A or B', function(){
+                    var stateNavigator = new StateNavigator([
+                        { key: 'sceneA' },
+                        { key: 'sceneB', trackCrumbTrail: true },
+                        { key: 'sceneC', trackCrumbTrail: true }
+                    ]);
+                    stateNavigator.navigate('sceneA');
+                    var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                    var unloadingA, unloadingB, unloadingC;
+                    var SceneA = () => {
+                        useUnloading(() => {
+                            unloadingA = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    var SceneB = () => {
+                        useUnloading(() => {
+                            unloadingB = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    var SceneC = () => {
+                        useUnloading(() => {
+                            unloadingC = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    sceneA.renderScene = () => <SceneA />;
+                    sceneB.renderScene = () => <SceneB />;
+                    sceneC.renderScene = () => <SceneC />;
+                    var container = document.createElement('div');
+                    var root = createRoot(container)
+                    act(() => {
+                        root.render(
+                            <NavigationHandler stateNavigator={stateNavigator}>
+                                {stack}
+                            </NavigationHandler>
+                        );
+                    });
+                    act(() => {
+                        stateNavigator.navigate('sceneB');
+                        stateNavigator.navigate('sceneC');
+                    });
+                    act(() => {
+                        unloadingA = unloadingB = unloadingC = false;
+                        var url = stateNavigator.fluent()
+                            .navigate('sceneB').url;
+                        stateNavigator.navigateLink(url);
+                    });
+                    try {
+                        assert.equal(unloadingA, false);
+                        assert.equal(unloadingB, false);
+                        assert.equal(unloadingC, true);
+                    } finally {
+                        act(() => root.unmount());
+                    }
+            })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('Suspend navigation', function () {
-        it('should call unloading hook', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var unloadingA, unloadingB;
-            var SceneA = () => {
-                useUnloading(() => {
-                    unloadingA = true;
-                    return true;
-                })
-                return <div />;
-            };
-            var SceneB = () => {
-                useUnloading(() => {
-                    unloadingB = true;
-                    return true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => {
-                unloadingA = unloadingB = false;
-                var url = stateNavigator.getNavigationLink('sceneB');
-                stateNavigator.navigateLink(url, undefined, false, () => {});
-            });
-            try {
-                assert.equal(unloadingA, true);
-                assert.equal(unloadingB, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        const test = stack => {
+            it('should call unloading hook', function(){
+                    var stateNavigator = new StateNavigator([
+                        { key: 'sceneA' },
+                        { key: 'sceneB', trackCrumbTrail: true }
+                    ]);
+                    stateNavigator.navigate('sceneA');
+                    var {sceneA, sceneB} = stateNavigator.states;
+                    var unloadingA, unloadingB;
+                    var SceneA = () => {
+                        useUnloading(() => {
+                            unloadingA = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    var SceneB = () => {
+                        useUnloading(() => {
+                            unloadingB = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    sceneA.renderScene = () => <SceneA />;
+                    sceneB.renderScene = () => <SceneB />;
+                    var container = document.createElement('div');
+                    var root = createRoot(container)
+                    act(() => {
+                        root.render(
+                            <NavigationHandler stateNavigator={stateNavigator}>
+                                {stack}
+                            </NavigationHandler>
+                        );
+                    });
+                    act(() => {
+                        unloadingA = unloadingB = false;
+                        var url = stateNavigator.getNavigationLink('sceneB');
+                        stateNavigator.navigateLink(url, undefined, false, () => {});
+                    });
+                    try {
+                        assert.equal(unloadingA, true);
+                        assert.equal(unloadingB, false);
+                    } finally {
+                        act(() => root.unmount());
+                    }
+            })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('Set state', function () {
-        it('should not call unloading hook', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA} = stateNavigator.states;
-            var unloadingA;
-            var setCountA;
-            var SceneA = () => {
-                var [count, setCount]  = useState(0);
-                setCountA = setCount;
-                useUnloading(() => {
-                    unloadingA = true;
-                    return true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => {
-                unloadingA = false;
-                setCountA(1);
-            });
-            try {
-                assert.equal(unloadingA, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        const test = stack => {
+            it('should not call unloading hook', function(){
+                    var stateNavigator = new StateNavigator([
+                        { key: 'sceneA' }
+                    ]);
+                    stateNavigator.navigate('sceneA');
+                    var {sceneA} = stateNavigator.states;
+                    var unloadingA;
+                    var setCountA;
+                    var SceneA = () => {
+                        var [count, setCount]  = useState(0);
+                        setCountA = setCount;
+                        useUnloading(() => {
+                            unloadingA = true;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    sceneA.renderScene = () => <SceneA />;
+                    var container = document.createElement('div');
+                    var root = createRoot(container)
+                    act(() => {
+                        root.render(
+                            <NavigationHandler stateNavigator={stateNavigator}>
+                                {stack}
+                            </NavigationHandler>
+                        );
+                    });
+                    act(() => {
+                        unloadingA = false;
+                        setCountA(1);
+                    });
+                    try {
+                        assert.equal(unloadingA, false);
+                    } finally {
+                        act(() => root.unmount());
+                    }
+            })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('Unloading handler state', function () {
-        it('should access latest state', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var countA, setCountA;
-            var SceneA = () => {
-                var [count, setCount]  = useState(0);
-                setCountA = setCount;
-                useUnloading(() => {
-                    countA = count;
-                    return true;
-                })
-                return <div />;
-            };
-            var SceneB = () => <div />;
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => setCountA(1));
-            act(() => {
-                countA = 0;
-                stateNavigator.navigate('sceneB');
-            });
-            try {
-                assert.equal(countA, 1);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        const test = stack => {
+            it('should access latest state', function(){
+                    var stateNavigator = new StateNavigator([
+                        { key: 'sceneA' },
+                        { key: 'sceneB', trackCrumbTrail: true }
+                    ]);
+                    stateNavigator.navigate('sceneA');
+                    var {sceneA, sceneB} = stateNavigator.states;
+                    var countA, setCountA;
+                    var SceneA = () => {
+                        var [count, setCount]  = useState(0);
+                        setCountA = setCount;
+                        useUnloading(() => {
+                            countA = count;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    var SceneB = () => <div />;
+                    sceneA.renderScene = () => <SceneA />;
+                    sceneB.renderScene = () => <SceneB />;
+                    var container = document.createElement('div');
+                    var root = createRoot(container)
+                    act(() => {
+                        root.render(
+                            <NavigationHandler stateNavigator={stateNavigator}>
+                                {stack}
+                            </NavigationHandler>
+                        );
+                    });
+                    act(() => setCountA(1));
+                    act(() => {
+                        countA = 0;
+                        stateNavigator.navigate('sceneB');
+                    });
+                    try {
+                        assert.equal(countA, 1);
+                    } finally {
+                        act(() => root.unmount());
+                    }
+            })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('Unloading handler context', function () {
-        it('should access current context', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var stateContextA;
-            var SceneA = () => {
-                var navigationEvent = useContext(NavigationContext);
-                useUnloading(() => {
-                    var {stateContext} = navigationEvent.stateNavigator;
-                    stateContextA = stateContext;
-                    return true;
-                })
-                return <div />;
-            };
-            var SceneB = () => <div />;
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => {
-                stateContextA = null;
-                stateNavigator.navigate('sceneB');
-            });
-            try {
-                assert.equal(stateContextA.oldState, null);
-                assert.equal(stateContextA.state, sceneA);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        const test = stack => {
+            it('should access current context', function(){
+                    var stateNavigator = new StateNavigator([
+                        { key: 'sceneA' },
+                        { key: 'sceneB', trackCrumbTrail: true }
+                    ]);
+                    stateNavigator.navigate('sceneA');
+                    var {sceneA, sceneB} = stateNavigator.states;
+                    var stateContextA;
+                    var SceneA = () => {
+                        var navigationEvent = useContext(NavigationContext);
+                        useUnloading(() => {
+                            var {stateContext} = navigationEvent.stateNavigator;
+                            stateContextA = stateContext;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    var SceneB = () => <div />;
+                    sceneA.renderScene = () => <SceneA />;
+                    sceneB.renderScene = () => <SceneB />;
+                    var container = document.createElement('div');
+                    var root = createRoot(container)
+                    act(() => {
+                        root.render(
+                            <NavigationHandler stateNavigator={stateNavigator}>
+                                {stack}
+                            </NavigationHandler>
+                        );
+                    });
+                    act(() => {
+                        stateContextA = null;
+                        stateNavigator.navigate('sceneB');
+                    });
+                    try {
+                        assert.equal(stateContextA.oldState, null);
+                        assert.equal(stateContextA.state, sceneA);
+                    } finally {
+                        act(() => root.unmount());
+                    }
+            })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('Unloading handler data', function () {
-        it('should access data', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA', defaultTypes: {x: 'number'} },
-                { key: 'sceneB', defaultTypes: {y: 'number'}, trackCrumbTrail: true },
-                { key: 'sceneC', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA', {x: 0});
-            var {sceneA, sceneB, sceneC} = stateNavigator.states;
-            var stateC, dataC, urlC, crumbsC, historyC;
-            var SceneA = () => <div />;
-            var SceneB = () => <div />;
-            var SceneC = () => {
-                useUnloading((state, data, url, history, crumbs) => {
-                    stateC = state;
-                    dataC = data;
-                    urlC = url;
-                    historyC = history;
-                    crumbsC = crumbs;
-                    return true;
-                })
-                return <div />;
-            };
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            sceneC.renderScene = () => <SceneC />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => {
-                stateNavigator.navigate('sceneB', {y: 1});
-                stateNavigator.navigate('sceneC');
-            });
-            act(() => {
-                stateC = dataC = urlC = crumbsC = historyC = null;
-                stateNavigator.navigateBack(1);
-            });
-            try {
-                assert.equal(stateC, sceneB);
-                assert.equal(dataC.y, 1);
-                assert.equal(urlC, '/sceneB?y=1&crumb=%2FsceneA%3Fx%3D0');
-                assert.equal(crumbsC.length, 1);
-                assert.equal(crumbsC[0].state, sceneA);
-                assert.equal(crumbsC[0].data.x, 0);
-                assert.equal(historyC, false);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        const test = stack => {
+            it('should access data', function(){
+                    var stateNavigator = new StateNavigator([
+                        { key: 'sceneA', defaultTypes: {x: 'number'} },
+                        { key: 'sceneB', defaultTypes: {y: 'number'}, trackCrumbTrail: true },
+                        { key: 'sceneC', trackCrumbTrail: true }
+                    ]);
+                    stateNavigator.navigate('sceneA', {x: 0});
+                    var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                    var stateC, dataC, urlC, crumbsC, historyC;
+                    var SceneA = () => <div />;
+                    var SceneB = () => <div />;
+                    var SceneC = () => {
+                        useUnloading((state, data, url, history, crumbs) => {
+                            stateC = state;
+                            dataC = data;
+                            urlC = url;
+                            historyC = history;
+                            crumbsC = crumbs;
+                            return true;
+                        })
+                        return <div />;
+                    };
+                    sceneA.renderScene = () => <SceneA />;
+                    sceneB.renderScene = () => <SceneB />;
+                    sceneC.renderScene = () => <SceneC />;
+                    var container = document.createElement('div');
+                    var root = createRoot(container)
+                    act(() => {
+                        root.render(
+                            <NavigationHandler stateNavigator={stateNavigator}>
+                                {stack}
+                            </NavigationHandler>
+                        );
+                    });
+                    act(() => {
+                        stateNavigator.navigate('sceneB', {y: 1});
+                        stateNavigator.navigate('sceneC');
+                    });
+                    act(() => {
+                        stateC = dataC = urlC = crumbsC = historyC = null;
+                        stateNavigator.navigateBack(1);
+                    });
+                    try {
+                        assert.equal(stateC, sceneB);
+                        assert.equal(dataC.y, 1);
+                        assert.equal(urlC, '/sceneB?y=1&crumb=%2FsceneA%3Fx%3D0');
+                        assert.equal(crumbsC.length, 1);
+                        assert.equal(crumbsC[0].state, sceneA);
+                        assert.equal(crumbsC[0].data.x, 0);
+                        assert.equal(historyC, false);
+                    } finally {
+                        act(() => root.unmount());
+                    }
+            })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('Cancel navigation', function () {
-        it('should not navigate', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var SceneA = () => {
-                useUnloading(() => {
-                    return false;
-                })
-                return <div />;
-            };
-            var SceneB = () =>  <div />;
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => {
-                stateNavigator.navigate('sceneB');
-            });
-            try {
-                assert.equal(stateNavigator.stateContext.state, sceneA);
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        const test = stack => {
+            it('should not navigate', function(){
+                    var stateNavigator = new StateNavigator([
+                        { key: 'sceneA' },
+                        { key: 'sceneB', trackCrumbTrail: true }
+                    ]);
+                    stateNavigator.navigate('sceneA');
+                    var {sceneA, sceneB} = stateNavigator.states;
+                    var SceneA = () => {
+                        useUnloading(() => {
+                            return false;
+                        })
+                        return <div />;
+                    };
+                    var SceneB = () =>  <div />;
+                    sceneA.renderScene = () => <SceneA />;
+                    sceneB.renderScene = () => <SceneB />;
+                    var container = document.createElement('div');
+                    var root = createRoot(container)
+                    act(() => {
+                        root.render(
+                            <NavigationHandler stateNavigator={stateNavigator}>
+                                {stack}
+                            </NavigationHandler>
+                        );
+                    });
+                    act(() => {
+                        stateNavigator.navigate('sceneB');
+                    });
+                    try {
+                        assert.equal(stateNavigator.stateContext.state, sceneA);
+                    } finally {
+                        act(() => root.unmount());
+                    }
+            })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 
     describe('Unloading set state', function () {
-        it('should render', function(){
-            var stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true }
-            ]);
-            stateNavigator.navigate('sceneA');
-            var {sceneA, sceneB} = stateNavigator.states;
-            var SceneA = () => {
-                var [unloading, setUnloading] = useState(false)
-                useUnloading(() => {
-                    setUnloading(true);
-                    return true;
-                })
-                return <div id='sceneA' data-unloading={unloading} />;
-            };
-            var SceneB = () => <div />;
-            sceneA.renderScene = () => <SceneA />;
-            sceneB.renderScene = () => <SceneB />;
-            var container = document.createElement('div');
-            var root = createRoot(container)
-            act(() => {
-                root.render(
-                    <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationMotion>
-                            {(_style, scene, key) =>  <div key={key}>{scene}</div>}
-                        </NavigationMotion>
-                    </NavigationHandler>
-                );
-            });
-            act(() => {
-                stateNavigator.navigate('sceneB');
-            });
-            try {
-                var scene = container.querySelector<HTMLDivElement>("#sceneA");                
-                assert.strictEqual(scene.dataset.unloading, 'true');
-            } finally {
-                act(() => root.unmount());
-            }
-        })
+        const test = stack => {
+            it('should render', function(){
+                    var stateNavigator = new StateNavigator([
+                        { key: 'sceneA' },
+                        { key: 'sceneB', trackCrumbTrail: true }
+                    ]);
+                    stateNavigator.navigate('sceneA');
+                    var {sceneA, sceneB} = stateNavigator.states;
+                    var SceneA = () => {
+                        var [unloading, setUnloading] = useState(false)
+                        useUnloading(() => {
+                            setUnloading(true);
+                            return true;
+                        })
+                        return <div id='sceneA' data-unloading={unloading} />;
+                    };
+                    var SceneB = () => <div />;
+                    sceneA.renderScene = () => <SceneA />;
+                    sceneB.renderScene = () => <SceneB />;
+                    var container = document.createElement('div');
+                    var root = createRoot(container)
+                    act(() => {
+                        root.render(
+                            <NavigationHandler stateNavigator={stateNavigator}>
+                                {stack}
+                            </NavigationHandler>
+                        );
+                    });
+                    act(() => {
+                        stateNavigator.navigate('sceneB');
+                    });
+                    try {
+                        var scene = container.querySelector<HTMLDivElement>("#sceneA");                
+                        assert.strictEqual(scene.dataset.unloading, 'true');
+                    } finally {
+                        act(() => root.unmount());
+                    }
+            })
+        }
+        describe('Motion', () => {
+            test(
+                <NavigationMotion>
+                    {(_style, scene, key) =>  <div key={key}>{scene}</div>}
+                </NavigationMotion>
+            );
+        });
+        describe('Stack', () => {
+            test(<NavigationStack />);
+        });
     });
 });

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -38,10 +38,10 @@ const renderMotion = ({translateX, translateX_pc, translateY, translateY_pc, sca
                 rotate(${rotate}deg)
 			` as any,
             opacity: alpha,
-            position: 'absolute',
+            position: 'fixed' as any,
             backgroundColor: '#fff',
             left: 0, right: 0, top: 0, bottom: 0,
-            overflow: 'hidden',
+            overflow: 'auto' as any,
         }}>
         {scene}
     </View>

--- a/build/npm/navigation-react-mobile/navigation.react.mobile.d.ts
+++ b/build/npm/navigation-react-mobile/navigation.react.mobile.d.ts
@@ -124,6 +124,44 @@ export interface NavigationMotionProps {
 }
 
 /**
+ * Defines the Navigation Stack Props contract
+ */
+export interface NavigationStackProps {
+    /**
+     * A Scene's unmount animation
+     */
+    unmountStyle?: any;
+    /**
+     * A Scene's crumb trail animation
+     */
+    crumbStyle?: any;
+    /**
+     * The animation duration
+     */
+    duration?: number;
+    /**
+     * The link to navigate to when Scenes in the stack are unregistered
+     */
+    stackInvalidatedLink?: string;
+    /**
+     * A Scene's class name
+     */
+    className?: any;
+    /**
+     * A Scene's style
+     */
+    style?: any;
+    /**
+     * The Scenes
+     */
+    children?: any;
+    /**
+     * Renders the Scene for the State and data
+     */
+    renderScene?: (state: State, data: any) => ReactNode;
+}
+
+/**
  * Defines the Scene Props contract
  */
  export interface SceneProps<NavigationInfo extends { [index: string]: any } = any> {
@@ -136,13 +174,25 @@ export interface NavigationMotionProps {
      */
     unmountedStyle?: any;
     /**
+     * The Scene's unmount animation
+     */
+    unmountStyle?: any;
+    /**
      * The Scene's mounted style
      */
     mountedStyle?: any;
     /**
-     * The Scene's crumb trail style
+     * The Scene's crumb trail style or animation
      */
     crumbStyle?: any;
+    /**
+     * The Scene's class name
+     */
+    className?: any;
+    /**
+     * The Scene's style
+     */
+    style?: any;
      /**
      * The Scene content
      */
@@ -163,6 +213,11 @@ export class SharedElementMotion extends Component<SharedElementNavigationMotion
  * Animates Scenes when navigating
  */
 export class NavigationMotion extends Component<NavigationMotionProps> { }
+
+/**
+ * Renders a stack of Scenes and animates them when navigating
+ */
+export class NavigationStack extends Component<NavigationStackProps> { }
 
 /**
  * Configures the Scene for a State

--- a/types/navigation-react-mobile.d.ts
+++ b/types/navigation-react-mobile.d.ts
@@ -124,6 +124,44 @@ export interface NavigationMotionProps {
 }
 
 /**
+ * Defines the Navigation Stack Props contract
+ */
+export interface NavigationStackProps {
+    /**
+     * A Scene's unmount animation
+     */
+    unmountStyle?: any;
+    /**
+     * A Scene's crumb trail animation
+     */
+    crumbStyle?: any;
+    /**
+     * The animation duration
+     */
+    duration?: number;
+    /**
+     * The link to navigate to when Scenes in the stack are unregistered
+     */
+    stackInvalidatedLink?: string;
+    /**
+     * A Scene's class name
+     */
+    className?: any;
+    /**
+     * A Scene's style
+     */
+    style?: any;
+    /**
+     * The Scenes
+     */
+    children?: any;
+    /**
+     * Renders the Scene for the State and data
+     */
+    renderScene?: (state: State, data: any) => ReactNode;
+}
+
+/**
  * Defines the Scene Props contract
  */
  export interface SceneProps<NavigationInfo extends { [index: string]: any } = any> {
@@ -136,13 +174,25 @@ export interface NavigationMotionProps {
      */
     unmountedStyle?: any;
     /**
+     * The Scene's unmount animation
+     */
+    unmountStyle?: any;
+    /**
      * The Scene's mounted style
      */
     mountedStyle?: any;
     /**
-     * The Scene's crumb trail style
+     * The Scene's crumb trail style or animation
      */
     crumbStyle?: any;
+    /**
+     * The Scene's class name
+     */
+    className?: any;
+    /**
+     * The Scene's style
+     */
+    style?: any;
      /**
      * The Scene content
      */
@@ -163,6 +213,11 @@ export class SharedElementMotion extends Component<SharedElementNavigationMotion
  * Animates Scenes when navigating
  */
 export class NavigationMotion extends Component<NavigationMotionProps> { }
+
+/**
+ * Renders a stack of Scenes and animates them when navigating
+ */
+export class NavigationStack extends Component<NavigationStackProps> { }
 
 /**
  * Configures the Scene for a State


### PR DESCRIPTION
Added the `NavigationStack` component that uses the [Web Animations Api](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API) for navigation animations. The `unmountStyle` and `crumbStyle` props accept the keyframes array.  Here's what the props look like for the Twitter example.
```jsx
  <NavigationStack
    unmountStyle={[
        {transform: 'translateX(100%)'},
        {transform: 'translateX(0)'}
      ]}
    crumbStyle={[
        {transform: 'translateX(5%) scale(0.8)', opacity: 0},
        {transform: 'translateX(0) scale(1)', opacity: 1}
      ]}>
```
Using the Web Animations Api is better than the `NavigationMotion` approach because it doesn’t require React state updates to run the animation. It should play nicely with the dev tools Animations tab. Also it doesn't need a `renderMotion` prop anymore so native and web components are more aligned.

Considered View Transitions Api but it's not up to the job. Only the entering scene is a live view so the user couldn't run a custom animation in the exiting scene. Also they don't all play smoothly together if the user presses multiple browser backs at once.  For example, A → B → C then cmd + ← twice should play B and C exiting together. If C takes 0.5s to exit then it must still take 0.5s even if 'interrupted' with that second browser back. View transitions don't do that. C would disappear as soon as the second browser back is pressed.