### PR TITLE
Supported Web Animations Api for shared element transitions (Mobile)

### DIFF
--- a/NavigationReactMobile/src/NavigationAnimation.tsx
+++ b/NavigationReactMobile/src/NavigationAnimation.tsx
@@ -119,7 +119,11 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
             };
         });
     };
-    return <div ref={container}>{children(scenes.all)}</div>;
+    return (
+        <div ref={container} style={{display: 'flex', flexDirection: 'column', flex: 1}}>
+            {children(scenes.all)}
+        </div>
+    );
 }
 
 export default NavigationAnimation;

--- a/NavigationReactMobile/src/NavigationAnimation.tsx
+++ b/NavigationReactMobile/src/NavigationAnimation.tsx
@@ -73,6 +73,7 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
                 if (pushExit && prevNavState !== 'pushExit') {
                     scene.navState = 'pushExit';
                     scene.popEnter.reverse();
+                    if (!oldState) scene.popEnter.finish();
                 }
                 scene.popEnter?.finished.then(() => {
                     if (cancel || !scene.navState) return;

--- a/NavigationReactMobile/src/NavigationAnimation.tsx
+++ b/NavigationReactMobile/src/NavigationAnimation.tsx
@@ -5,12 +5,12 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
     const container = useRef(null);
     useLayoutEffect(() => {
         let cancel = false;
-        scenes.all.forEach(({key, pushEnter, popExit, pushExit, popEnter, unmountStyle, crumbStyle}, i) => {
+        scenes.all.forEach(({key, index, pushEnter, popExit, pushExit, popEnter, unmountStyle, crumbStyle}, i) => {
             const scene = container.current.children[i];
             const prevNavState = scene.navState || scene.prevNavState;
             if (!scene.animate) {
                 if (popExit) setScenes(({all, ...rest}) => ({all: all.filter((_s, index) => index !== i), ...rest}));
-                if ((pushEnter && prevNavState !== 'pushEnter') || (popEnter && prevNavState !== 'popEnter')) onRest({key});
+                if ((pushEnter && prevNavState !== 'pushEnter') || (popEnter && prevNavState !== 'popEnter')) onRest({key, index});
                 scene.prevNavState = pushEnter ? 'pushEnter' : popExit ? 'popExit' : pushExit ? 'pushExit' : 'popEnter';
                 return;
             };
@@ -45,7 +45,7 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
                     if (popExit)
                         setScenes(({all, ...rest}) => ({all: all.filter((_s, index) => index !== i), ...rest}))
                     if (pushEnter || popExit) {
-                        onRest({key});
+                        onRest({key, index});
                         scene.prevNavState = scene.navState;
                         scene.navState = undefined;
                     }
@@ -72,7 +72,7 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
                 scene.popEnter?.finished.then(() => {
                     if (cancel || !scene.navState) return;
                     if (pushExit || popEnter) {
-                        onRest({key});
+                        onRest({key, index});
                         scene.prevNavState = scene.navState;
                         scene.navState = undefined;
                     }

--- a/NavigationReactMobile/src/NavigationAnimation.tsx
+++ b/NavigationReactMobile/src/NavigationAnimation.tsx
@@ -50,6 +50,11 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
                         scene.navState = undefined;
                     }
                 });
+                scene.pushPlayState = undefined;
+                if (pause && scene.pushEnter?.playState === 'running') {
+                    scene.pushPlayState = 'running';
+                    scene.pushEnter.pause();
+                }
             });
             afterPushEnter.then(() => {
                 if (cancel || !crumbStyle) return;
@@ -77,17 +82,12 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
                         scene.navState = undefined;
                     }
                 });
+                scene.popPlayState = undefined;
+                if (pause && scene.popEnter?.playState === 'running') {
+                    scene.popPlayState = 'running';
+                    scene.popEnter.pause();
+                }
             });
-            scene.pushPlayState = undefined;
-            scene.popPlayState = undefined;
-            if (pause && scene.pushEnter?.playState === 'running') {
-                scene.pushPlayState = 'running';
-                scene.pushEnter.pause();
-            }
-            if (pause && scene.popEnter?.playState === 'running') {
-                scene.popPlayState = 'running';
-                scene.popEnter.pause();
-            }
     });
         return () => {cancel = true;}
     }, [scenes]);

--- a/NavigationReactMobile/src/NavigationAnimation.tsx
+++ b/NavigationReactMobile/src/NavigationAnimation.tsx
@@ -5,12 +5,12 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
     const container = useRef(null);
     useLayoutEffect(() => {
         let cancel = false;
-        scenes.all.forEach(({key, index, pushEnter, popExit, pushExit, popEnter, unmountStyle, crumbStyle}, i) => {
+        scenes.all.forEach(({key, url, pushEnter, popExit, pushExit, popEnter, unmountStyle, crumbStyle}, i) => {
             const scene = container.current.children[i];
             const prevNavState = scene.navState || scene.prevNavState;
             if (!scene.animate) {
                 if (popExit) setScenes(({all, ...rest}) => ({all: all.filter((_s, index) => index !== i), ...rest}));
-                if ((pushEnter && prevNavState !== 'pushEnter') || (popEnter && prevNavState !== 'popEnter')) onRest({key, index});
+                if ((pushEnter && prevNavState !== 'pushEnter') || (popEnter && prevNavState !== 'popEnter')) onRest({key, url});
                 scene.prevNavState = pushEnter ? 'pushEnter' : popExit ? 'popExit' : pushExit ? 'pushExit' : 'popEnter';
                 return;
             };
@@ -45,7 +45,7 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
                     if (popExit)
                         setScenes(({all, ...rest}) => ({all: all.filter((_s, index) => index !== i), ...rest}))
                     if (pushEnter || popExit) {
-                        onRest({key, index});
+                        onRest({key, url});
                         scene.prevNavState = scene.navState;
                         scene.navState = undefined;
                     }
@@ -77,7 +77,7 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
                 scene.popEnter?.finished.then(() => {
                     if (cancel || !scene.navState) return;
                     if (pushExit || popEnter) {
-                        onRest({key, index});
+                        onRest({key, url});
                         scene.prevNavState = scene.navState;
                         scene.navState = undefined;
                     }

--- a/NavigationReactMobile/src/NavigationAnimation.tsx
+++ b/NavigationReactMobile/src/NavigationAnimation.tsx
@@ -117,11 +117,7 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
             };
         });
     };
-    return (
-        <div ref={container} style={{display: 'flex', flexDirection: 'column', flex: 1}}>
-            {children(scenes.all)}
-        </div>
-    );
+    return <div ref={container}>{children(scenes.all)}</div>;
 }
 
 export default NavigationAnimation;

--- a/NavigationReactMobile/src/NavigationAnimation.tsx
+++ b/NavigationReactMobile/src/NavigationAnimation.tsx
@@ -28,13 +28,10 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
                 }
                 if (pushEnter && prevNavState !== 'pushEnter') {
                     scene.navState = 'pushEnter';
-                    if (oldState) {
-                        if (prevNavState === 'popExit') scene.pushEnter.reverse();
-                        else if (prevNavState) scene.pushEnter.finish();
-                        else scene.pushEnter.play();
-                    } else {
-                        scene.pushEnter.finish();
-                    }
+                    if (prevNavState === 'popExit') scene.pushEnter.reverse();
+                    else if (prevNavState) scene.pushEnter.finish();
+                    else scene.pushEnter.play();
+                    if (!oldState) scene.pushEnter.finish();
                 }
                 if (popExit && prevNavState !== 'popExit') {
                     scene.navState = 'popExit';

--- a/NavigationReactMobile/src/NavigationAnimation.tsx
+++ b/NavigationReactMobile/src/NavigationAnimation.tsx
@@ -1,6 +1,6 @@
 import React, {useRef, useState, useLayoutEffect} from 'react';
 
-const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, duration: defaultDuration}) => {
+const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, duration: defaultDuration, pause}) => {
     const [scenes, setScenes] = useState({prev: null, all: [], count: 0});
     const container = useRef(null);
     useLayoutEffect(() => {
@@ -14,6 +14,8 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
                 scene.prevNavState = pushEnter ? 'pushEnter' : popExit ? 'popExit' : pushExit ? 'pushExit' : 'popEnter';
                 return;
             };
+            if (scene.pushPlayState) scene.pushEnter.play();
+            if (scene.popPlayState) scene.popEnter.play();
             const afterPushEnter = scene.pushEnter?.finished || {then: (f) => f()};
             const afterPopEnter = scene.popEnter?.finished || {then: (f) => f()};
             afterPopEnter.then(() => {
@@ -76,7 +78,17 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
                     }
                 });
             });
-        });
+            scene.pushPlayState = undefined;
+            scene.popPlayState = undefined;
+            if (pause && scene.pushEnter?.playState === 'running') {
+                scene.pushPlayState = 'running';
+                scene.pushEnter.pause();
+            }
+            if (pause && scene.popEnter?.playState === 'running') {
+                scene.popPlayState = 'running';
+                scene.popEnter.pause();
+            }
+    });
         return () => {cancel = true;}
     }, [scenes]);
     if (nextScenes !== scenes.prev) {

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -46,17 +46,16 @@ const NavigationMotion = ({unmountedStyle: unmountedStyleStack, mountedStyle: mo
         return () => stateNavigator.offBeforeNavigate(validate);
     }, [children, stateNavigator, scenes, allScenes, stackInvalidatedLink]);
     const getSharedElements = () => {
-        const {crumbs, oldUrl} = stateNavigator.stateContext;
+        const {url, oldUrl} = stateNavigator.stateContext;
         if (oldUrl !== null) {
-            const oldScene = oldUrl.split('crumb=').length - 1;
-            return sharedElementRegistry.current.getSharedElements(crumbs.length, oldScene);
+            return sharedElementRegistry.current.getSharedElements(url, oldUrl);
         }
         return [];
     }
-    const clearScene = (index) => {
-        const scene = getScenes().filter(scene => scene.key === index)[0];
+    const clearScene = (url) => {
+        const scene = getScenes().filter(scene => scene.url === url)[0];
         if (!scene)
-            sharedElementRegistry.current.unregisterSharedElement(index);
+            sharedElementRegistry.current.unregisterSharedElement(url);
     }
     const getScenes: () => SceneContext[] = () => {
         const {keys} = motionState;
@@ -116,7 +115,7 @@ const NavigationMotion = ({unmountedStyle: unmountedStyleStack, mountedStyle: mo
                 enter={scene => getStyle(!oldState, scene)}
                 update={scene => getStyle(true, scene)}
                 leave={scene => getStyle(false, scene)}
-                onRest={({key}) => clearScene(key)}
+                onRest={({url}) => clearScene(url)}
                 duration={duration}>
                 {styles => {
                     const {rest, mountRest, mountDuration, mountProgress} = getMotion(styles);

--- a/NavigationReactMobile/src/NavigationMotion.tsx
+++ b/NavigationReactMobile/src/NavigationMotion.tsx
@@ -120,9 +120,9 @@ const NavigationMotion = ({unmountedStyle: unmountedStyleStack, mountedStyle: mo
                 {styles => {
                     const {rest, mountRest, mountDuration, mountProgress} = getMotion(styles);
                     return (
-                        styles.map(({data: {key, state, data}, style: {duration, ...style}}) => {
+                        styles.map(({data: {key, url, state, data}, style: {duration, ...style}}) => {
                             const crumb = +key.replace(/\++$/, '');
-                            const scene = <Scene crumb={crumb} rest={rest} renderScene={renderScene} />;
+                            const scene = <Scene crumb={crumb} url={url} rest={rest} renderScene={renderScene} />;
                             return (
                                 <Freeze key={key} enabled={rest && crumb < getScenes().length - 1}>
                                     {renderMotion(style, scene, key, crumbs.length === crumb, state, data)}

--- a/NavigationReactMobile/src/NavigationStack.tsx
+++ b/NavigationReactMobile/src/NavigationStack.tsx
@@ -123,7 +123,7 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
                 {scenes => (
                     scenes.map(({key, index: crumb, url, className, style}) => (
                         <Freeze key={key} enabled={rest && crumb < getScenes().length - 1}>
-                            <Scene crumb={crumb} url={url} rest className={className} style={style} renderScene={renderScene} />
+                            <Scene crumb={crumb} url={url} rest={rest} className={className} style={style} renderScene={renderScene} />
                         </Freeze>
                     )).concat(
                         !rest && !!sharedEls.length &&

--- a/NavigationReactMobile/src/NavigationStack.tsx
+++ b/NavigationReactMobile/src/NavigationStack.tsx
@@ -126,8 +126,7 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
                             <Scene crumb={crumb} url={url} rest={rest} className={className} style={style} renderScene={renderScene} />
                         </Freeze>
                     )).concat(
-                        !rest && !!sharedEls.length &&
-                            <SharedElementAnimation key="sharedElements-" sharedElements={sharedEls} />
+                        <SharedElementAnimation key="sharedElements-" sharedElements={!rest ? sharedEls : []} />
                     )
                 )}
             </NavigationAnimation>

--- a/NavigationReactMobile/src/NavigationStack.tsx
+++ b/NavigationReactMobile/src/NavigationStack.tsx
@@ -125,7 +125,7 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
                 {scenes => (
                     scenes.map(({key, index: crumb, url, className, style}) => (
                         <Freeze key={key} enabled={rest && crumb < sceneData.length - 1}>
-                            <Scene crumb={crumb} url={url} rest={rest} className={className} style={style} renderScene={renderScene} />
+                            <Scene crumb={crumb} url={url} rest={rest} className={className} style={style} wrap renderScene={renderScene} />
                         </Freeze>
                     )).concat(
                         <SharedElementAnimation key="sharedElements-" sharedElements={!rest ? sharedEls : []}

--- a/NavigationReactMobile/src/NavigationStack.tsx
+++ b/NavigationReactMobile/src/NavigationStack.tsx
@@ -47,6 +47,8 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
         const {url, state, data, crumbs, oldUrl, oldState, oldData} = stateNavigator.stateContext;
         if (oldUrl) {
             const {crumbs: oldCrumbs} = stateNavigator.parseLink(oldUrl);
+            if (Math.abs(oldCrumbs.length - crumbs.length) !== 1)
+                return {pause: null, sharedEls: []}; 
             const sharedElementNames: string[] = oldCrumbs.length < crumbs.length
                 ? sharedElements(state, data, crumbs) : crumbs.length < oldCrumbs.length
                 ? sharedElements(oldState, oldData, oldCrumbs) : null;

--- a/NavigationReactMobile/src/NavigationStack.tsx
+++ b/NavigationReactMobile/src/NavigationStack.tsx
@@ -12,7 +12,9 @@ type NavigationStackState = {stateNavigator: StateNavigator, keys: string[], res
 
 const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyleStack, className: sceneClassName,
     style: sceneStyle, duration = 300, renderScene, children, stackInvalidatedLink}: NavigationStackProps) => {
-    const sharedElementRegistry = useRef(new SharedElementRegistry());
+    // Move shared element cache useState here so automatically rerenders
+    const [x, setX] = useState({});
+    const sharedElementRegistry = useRef(new SharedElementRegistry(() => setX({})));
     const {stateNavigator} = useContext(NavigationContext);
     const [motionState, setMotionState] = useState<NavigationStackState>({stateNavigator: null, keys: [], rest: false});
     const scenes = {};
@@ -100,7 +102,7 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
     renderScene = firstLink ? ({key}) => allScenes[key] : renderScene;
     return (stateContext.state &&
         <SharedElementContext.Provider value={sharedElementRegistry.current}>
-            <NavigationAnimation data={getScenes()} onRest={clearScene} oldState={oldState} duration={duration}>
+            <NavigationAnimation data={getScenes()} onRest={clearScene} oldState={oldState} duration={duration} pause={stateContext.crumbs.length && !getSharedElements().length}>
                 {scenes => (
                     scenes.map(({key, index: crumb, className, style}) => (
                         <Freeze key={key} enabled={motionState.rest && crumb < getScenes().length - 1}>

--- a/NavigationReactMobile/src/NavigationStack.tsx
+++ b/NavigationReactMobile/src/NavigationStack.tsx
@@ -117,16 +117,18 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
         }, 300);
         return () => clearTimeout(timer);
     }, [pause]);
+    const sceneData = stateContext.state ? getScenes() : [];
     return (stateContext.state &&
         <SharedElementContext.Provider value={sharedElementRegistry as any}>
-            <NavigationAnimation data={getScenes()} onRest={clearScene} oldState={oldState} duration={duration} pause={!ignorePause && pause !== null}>
+            <NavigationAnimation data={sceneData} onRest={clearScene} oldState={oldState} duration={duration} pause={!ignorePause && pause !== null}>
                 {scenes => (
                     scenes.map(({key, index: crumb, url, className, style}) => (
-                        <Freeze key={key} enabled={rest && crumb < getScenes().length - 1}>
+                        <Freeze key={key} enabled={rest && crumb < sceneData.length - 1}>
                             <Scene crumb={crumb} url={url} rest={rest} className={className} style={style} renderScene={renderScene} />
                         </Freeze>
                     )).concat(
-                        <SharedElementAnimation key="sharedElements-" sharedElements={!rest ? sharedEls : []} />
+                        <SharedElementAnimation key="sharedElements-" sharedElements={!rest ? sharedEls : []}
+                            unmountStyle={sceneData[sceneData.length - 1].unmountStyle} duration={duration} />
                     )
                 )}
             </NavigationAnimation>

--- a/NavigationReactMobile/src/NavigationStack.tsx
+++ b/NavigationReactMobile/src/NavigationStack.tsx
@@ -109,8 +109,8 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
                             <Scene crumb={crumb} rest className={className} style={style} renderScene={renderScene} />
                         </Freeze>
                     )).concat(
-                        // only show this when the shared elements are ready (delay)
-                        <SharedElementAnimation key="sharedElements-" sharedElements={getSharedElements()} />
+                        !motionState.rest &&
+                            <SharedElementAnimation key="sharedElements-" sharedElements={getSharedElements()} />
                     )
                 )}
             </NavigationAnimation>

--- a/NavigationReactMobile/src/NavigationStack.tsx
+++ b/NavigationReactMobile/src/NavigationStack.tsx
@@ -4,16 +4,15 @@ import { NavigationContext } from 'navigation-react';
 import Scene from './Scene';
 import Freeze from './Freeze';
 import SharedElementContext from './SharedElementContext';
-import SharedElementRegistry from './SharedElementRegistry';
 import NavigationAnimation from './NavigationAnimation';
 import { NavigationMotionProps as NavigationStackProps } from './Props';
 import SharedElementAnimation from './SharedElementAnimation';
+import useSharedElementRegistry from './useSharedElementRegistry';
 type NavigationStackState = {stateNavigator: StateNavigator, keys: string[], rest: boolean};
 
 const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyleStack, className: sceneClassName,
     style: sceneStyle, duration = 300, renderScene, children, stackInvalidatedLink}: NavigationStackProps) => {
-    const [x, setX] = useState({});
-    const sharedElementRegistry = useRef(new SharedElementRegistry(() => setX({})));
+    const sharedElementRegistry = useSharedElementRegistry();
     const {stateNavigator} = useContext(NavigationContext);
     const [motionState, setMotionState] = useState<NavigationStackState>({stateNavigator: null, keys: [], rest: false});
     const scenes = {};
@@ -48,7 +47,7 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
         const {crumbs, oldUrl} = stateNavigator.stateContext;
         if (oldUrl !== null) {
             const oldScene = oldUrl.split('crumb=').length - 1;
-            return sharedElementRegistry.current.getSharedElements(crumbs.length, oldScene);
+            return sharedElementRegistry.getSharedElements(crumbs.length, oldScene);
         }
         return [];
     }
@@ -56,7 +55,7 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
         setMotionState(({rest: prevRest, stateNavigator, keys}) => {
             const scene = getScenes().filter(scene => scene.key === key)[0];
             if (!scene)
-                sharedElementRegistry.current.unregisterSharedElement(index);
+                sharedElementRegistry.unregisterSharedElement(index);
             var rest = prevRest || (scene && scene.mount);
             return {rest, stateNavigator, keys};
         });
@@ -100,7 +99,7 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
     const {stateContext: {oldState}, stateContext} = stateNavigator;
     renderScene = firstLink ? ({key}) => allScenes[key] : renderScene;
     return (stateContext.state &&
-        <SharedElementContext.Provider value={sharedElementRegistry.current}>
+        <SharedElementContext.Provider value={sharedElementRegistry as any}>
             <NavigationAnimation data={getScenes()} onRest={clearScene} oldState={oldState} duration={duration} pause={stateContext.crumbs.length && !getSharedElements().length}>
                 {scenes => (
                     scenes.map(({key, index: crumb, className, style}) => (

--- a/NavigationReactMobile/src/NavigationStack.tsx
+++ b/NavigationReactMobile/src/NavigationStack.tsx
@@ -53,11 +53,11 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
         }
         return [];
     }
-    const clearScene = ({key}) => {
+    const clearScene = ({key, index}) => {
         setMotionState(({rest: prevRest, stateNavigator, keys}) => {
             const scene = getScenes().filter(scene => scene.key === key)[0];
-            //if (!scene)
-                //sharedElementRegistry.current.unregisterSharedElement(scene.index);
+            if (!scene)
+                sharedElementRegistry.current.unregisterSharedElement(index);
             var rest = prevRest || (scene && scene.mount);
             return {rest, stateNavigator, keys};
         });

--- a/NavigationReactMobile/src/NavigationStack.tsx
+++ b/NavigationReactMobile/src/NavigationStack.tsx
@@ -54,8 +54,8 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
     const clearScene = ({key}) => {
         setMotionState(({rest: prevRest, stateNavigator, keys}) => {
             const scene = getScenes().filter(scene => scene.key === key)[0];
-            if (!scene)
-                sharedElementRegistry.current.unregisterSharedElement(scene.index);
+            //if (!scene)
+                //sharedElementRegistry.current.unregisterSharedElement(scene.index);
             var rest = prevRest || (scene && scene.mount);
             return {rest, stateNavigator, keys};
         });

--- a/NavigationReactMobile/src/NavigationStack.tsx
+++ b/NavigationReactMobile/src/NavigationStack.tsx
@@ -12,7 +12,6 @@ type NavigationStackState = {stateNavigator: StateNavigator, keys: string[], res
 
 const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyleStack, className: sceneClassName,
     style: sceneStyle, duration = 300, renderScene, children, stackInvalidatedLink}: NavigationStackProps) => {
-    // Move shared element cache useState here so automatically rerenders
     const [x, setX] = useState({});
     const sharedElementRegistry = useRef(new SharedElementRegistry(() => setX({})));
     const {stateNavigator} = useContext(NavigationContext);

--- a/NavigationReactMobile/src/NavigationStack.tsx
+++ b/NavigationReactMobile/src/NavigationStack.tsx
@@ -73,6 +73,7 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
     const getScenes = () => {
         const {keys} = motionState;
         const {crumbs, nextCrumb} = stateNavigator.stateContext;
+        if (!nextCrumb) return null;
         return crumbs.concat(nextCrumb).map(({state, data, url}, index, crumbsAndNext) => {
             const preCrumbs = crumbsAndNext.slice(0, index);
             const {state: nextState, data: nextData} = crumbsAndNext[index + 1] || {state: undefined, data: undefined};
@@ -117,7 +118,7 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
         }, 300);
         return () => clearTimeout(timer);
     }, [pause]);
-    const sceneData = stateContext.state ? getScenes() : [];
+    const sceneData = getScenes();
     return (stateContext.state &&
         <SharedElementContext.Provider value={sharedElementRegistry as any}>
             <NavigationAnimation data={sceneData} onRest={clearScene} oldState={oldState} duration={duration} pause={!ignorePause && pause !== null}>

--- a/NavigationReactMobile/src/Props.ts
+++ b/NavigationReactMobile/src/Props.ts
@@ -26,8 +26,8 @@ interface SharedElementProps {
 
 interface SharedItem {
     name: string;
-    oldElement: {ref: HTMLElement; data: any};
-    mountedElement: {ref: HTMLElement; data: any};
+    oldElement: HTMLElement;
+    mountedElement: HTMLElement;
 }
 
 interface SharedElementNavigationMotionProps {

--- a/NavigationReactMobile/src/Props.ts
+++ b/NavigationReactMobile/src/Props.ts
@@ -26,8 +26,8 @@ interface SharedElementProps {
 
 interface SharedItem {
     name: string;
-    oldElement: HTMLElement;
-    mountedElement: HTMLElement;
+    oldElement: {ref: HTMLElement; data: any};
+    mountedElement: {ref: HTMLElement; data: any};
 }
 
 interface SharedElementNavigationMotionProps {

--- a/NavigationReactMobile/src/Props.ts
+++ b/NavigationReactMobile/src/Props.ts
@@ -63,6 +63,7 @@ interface NavigationMotionProps {
 
 interface SceneProps {
     crumb: number;
+    url: string;
     id: string;
     rest: boolean;
     className: string;

--- a/NavigationReactMobile/src/Props.ts
+++ b/NavigationReactMobile/src/Props.ts
@@ -49,6 +49,7 @@ interface NavigationMotionProps {
     mountedStyle?: any;
     unmountStyle?: any;
     crumbStyle?: any;
+    sharedElements?: any;
     className?: any;
     style?: any;
     duration?: number;

--- a/NavigationReactMobile/src/Props.ts
+++ b/NavigationReactMobile/src/Props.ts
@@ -68,6 +68,7 @@ interface SceneProps {
     rest: boolean;
     className: string;
     style: any;
+    wrap?: boolean;
     renderScene?: (state: State, data: any) => ReactNode;
 }
 

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -37,7 +37,8 @@ class Scene extends React.Component<SceneProps & {navigationEvent: NavigationEve
         var {state, data} = stateContext || crumbs[crumb] || {};
         return (
             <NavigationContext.Provider value={navigationEvent}>
-                <div data-scene="true" className={className} style={{...style, display: navigationEvent ? 'block' : 'none'}}>
+                <div data-scene="true" className={className}
+                    style={{...style, display: navigationEvent ? 'flex' : 'none', height: '100%', flexDirection: 'column'}}>
                     {navigationEvent && this.props.renderScene(state, data)}
                 </div>
             </NavigationContext.Provider>

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -14,15 +14,9 @@ class Scene extends React.Component<SceneProps & {navigationEvent: NavigationEve
         renderScene: (state: State, data: any) => state.renderScene(data)
     }
     static getDerivedStateFromProps(props: SceneProps & {navigationEvent: NavigationEvent}, {navigationEvent: prevNavigationEvent}: SceneState) {
-        var {url, crumb, navigationEvent} = props;
-        var {url: currentUrl, state, oldState, oldUrl} = navigationEvent.stateNavigator.stateContext;
-        if (!state || url !== currentUrl)
-            return null;
-        if (!oldUrl || !prevNavigationEvent)
-            return {navigationEvent};
-        var {crumbs: oldCrumbs} = navigationEvent.stateNavigator.parseLink(oldUrl);
-        var replace = oldCrumbs.length === crumb && oldState !== state;
-        return !replace ? {navigationEvent} : null;
+        var {url, navigationEvent} = props;
+        var {url: currentUrl, state} = navigationEvent.stateNavigator.stateContext;
+        return (!state || url !== currentUrl) ? null : {navigationEvent};
     }
     shouldComponentUpdate({crumb, rest, navigationEvent: {stateNavigator}}, nextState) {
         var {crumbs} = stateNavigator.stateContext;

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -31,10 +31,14 @@ class Scene extends React.Component<SceneProps & {navigationEvent: NavigationEve
         var {state, data} = stateContext || crumbs[crumb] || {};
         return (
             <NavigationContext.Provider value={navigationEvent}>
-                <div data-scene="true" className={className}
-                    style={{...style, display: navigationEvent ? 'flex' : 'none', height: '100%', flexDirection: 'column'}}>
-                    {navigationEvent && this.props.renderScene(state, data)}
-                </div>
+                {(style || className) ? (
+                    <div data-scene="true" className={className}
+                        style={{...style, display: navigationEvent ? style?.display || undefined : 'none'}}>
+                        {navigationEvent && this.props.renderScene(state, data)}
+                    </div>
+                ) : (
+                    navigationEvent && this.props.renderScene(state, data)
+                )}
             </NavigationContext.Provider>
         );
     }

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -25,13 +25,13 @@ class Scene extends React.Component<SceneProps & {navigationEvent: NavigationEve
     }
     render() {
         var {navigationEvent} = this.state;
-        var {crumb, navigationEvent: {stateNavigator}, className, style} = this.props;
+        var {crumb, navigationEvent: {stateNavigator}, className, style, wrap} = this.props;
         var {crumbs} = stateNavigator.stateContext;
         var stateContext = navigationEvent?.stateNavigator?.stateContext;
         var {state, data} = stateContext || crumbs[crumb] || {};
         return (
             <NavigationContext.Provider value={navigationEvent}>
-                {(style || className) ? (
+                {wrap ? (
                     <div data-scene="true" className={className}
                         style={{...style, display: navigationEvent ? style?.display || undefined : 'none'}}>
                         {navigationEvent && this.props.renderScene(state, data)}

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -14,9 +14,9 @@ class Scene extends React.Component<SceneProps & {navigationEvent: NavigationEve
         renderScene: (state: State, data: any) => state.renderScene(data)
     }
     static getDerivedStateFromProps(props: SceneProps & {navigationEvent: NavigationEvent}, {navigationEvent: prevNavigationEvent}: SceneState) {
-        var {crumb, navigationEvent} = props;
-        var {state, oldState, oldUrl, crumbs} = navigationEvent.stateNavigator.stateContext;
-        if (!state || crumbs.length !== crumb)
+        var {url, crumb, navigationEvent} = props;
+        var {url: currentUrl, state, oldState, oldUrl} = navigationEvent.stateNavigator.stateContext;
+        if (!state || url !== currentUrl)
             return null;
         if (!oldUrl || !prevNavigationEvent)
             return {navigationEvent};

--- a/NavigationReactMobile/src/Scene.tsx
+++ b/NavigationReactMobile/src/Scene.tsx
@@ -37,7 +37,7 @@ class Scene extends React.Component<SceneProps & {navigationEvent: NavigationEve
         var {state, data} = stateContext || crumbs[crumb] || {};
         return (
             <NavigationContext.Provider value={navigationEvent}>
-                <div className={className} style={{...style, display: navigationEvent ? 'block' : 'none'}}>
+                <div data-scene="true" className={className} style={{...style, display: navigationEvent ? 'block' : 'none'}}>
                     {navigationEvent && this.props.renderScene(state, data)}
                 </div>
             </NavigationContext.Provider>

--- a/NavigationReactMobile/src/SharedElement.tsx
+++ b/NavigationReactMobile/src/SharedElement.tsx
@@ -14,22 +14,24 @@ class SharedElement extends React.Component<SharedElementProps, any> {
     }
     componentDidUpdate(prevProps) {
         var {stateNavigator, sharedElementRegistry} = this.props;
-        var scene = stateNavigator.stateContext.crumbs.length;
+        var scene = stateNavigator.stateContext.url;
         if (prevProps.unshare !== this.props.unshare
             || prevProps.name !== this.props.name
-            || prevProps.data !== this.props.data) {
-            sharedElementRegistry.unregisterSharedElement(scene, prevProps.name);
+            || prevProps.data !== this.props.data
+            || prevProps.stateNavigator !== this.props.stateNavigator) {
+            var prevScene = prevProps.stateNavigator.stateContext.url;
+            sharedElementRegistry.unregisterSharedElement(prevScene, prevProps.name);
             this.register();
         }
     }
     componentWillUnmount() {
         var {stateNavigator, sharedElementRegistry} = this.props;
-        var scene = stateNavigator.stateContext.crumbs.length;
+        var scene = stateNavigator.stateContext.url;
         sharedElementRegistry.unregisterSharedElement(scene, this.props.name);
     }
     register() {
         var {unshare, name, data, stateNavigator, sharedElementRegistry} = this.props;
-        var scene = stateNavigator.stateContext.crumbs.length;
+        var scene = stateNavigator.stateContext.url;
         if (!unshare)
             sharedElementRegistry.registerSharedElement(scene, name, this.ref.current, data);
         else

--- a/NavigationReactMobile/src/SharedElement.tsx
+++ b/NavigationReactMobile/src/SharedElement.tsx
@@ -15,8 +15,12 @@ class SharedElement extends React.Component<SharedElementProps, any> {
     componentDidUpdate(prevProps) {
         var {stateNavigator, sharedElementRegistry} = this.props;
         var scene = stateNavigator.stateContext.crumbs.length;
-        sharedElementRegistry.unregisterSharedElement(scene, prevProps.name);
-        this.register();
+        if (prevProps.unshare !== this.props.unshare
+            || prevProps.name !== this.props.name
+            || prevProps.data !== this.props.data) {
+            sharedElementRegistry.unregisterSharedElement(scene, prevProps.name);
+            this.register();
+        }
     }
     componentWillUnmount() {
         var {stateNavigator, sharedElementRegistry} = this.props;

--- a/NavigationReactMobile/src/SharedElement.tsx
+++ b/NavigationReactMobile/src/SharedElement.tsx
@@ -18,9 +18,7 @@ class SharedElement extends React.Component<SharedElementProps, any> {
     }
     componentDidUpdate(prevProps) {
         var {sharedElementRegistry} = this.props;
-        this.ref.current['sharedElement'] = {
-            data: this.props.name
-        };
+        this.ref.current['sharedElement'] = this.props.data;
         if (prevProps.unshare !== this.props.unshare
             || prevProps.name !== this.props.name
             || prevProps.stateNavigator !== this.props.stateNavigator) {

--- a/NavigationReactMobile/src/SharedElement.tsx
+++ b/NavigationReactMobile/src/SharedElement.tsx
@@ -34,7 +34,10 @@ class SharedElement extends React.Component<SharedElementProps, any> {
         this.resizeObserver?.unobserve(this.ref.current);
     }
     onResize() {
-        this.register();
+        if (this.ref.current.offsetWidth && this.ref.current.offsetHeight) {
+            this.register();
+            this.resizeObserver.observe(this.ref.current);
+        }
     }
     register() {
         var {unshare, name, data, stateNavigator, sharedElementRegistry} = this.props;

--- a/NavigationReactMobile/src/SharedElement.tsx
+++ b/NavigationReactMobile/src/SharedElement.tsx
@@ -18,7 +18,7 @@ class SharedElement extends React.Component<SharedElementProps, any> {
     }
     componentDidUpdate(prevProps) {
         var {sharedElementRegistry} = this.props;
-        this.ref.current['sharedElement'] = this.props.data;
+        this.ref.current['sharedElementData'] = this.props.data;
         if (prevProps.unshare !== this.props.unshare
             || prevProps.name !== this.props.name
             || prevProps.stateNavigator !== this.props.stateNavigator) {

--- a/NavigationReactMobile/src/SharedElement.tsx
+++ b/NavigationReactMobile/src/SharedElement.tsx
@@ -18,9 +18,11 @@ class SharedElement extends React.Component<SharedElementProps, any> {
     }
     componentDidUpdate(prevProps) {
         var {sharedElementRegistry} = this.props;
+        this.ref.current['sharedElement'] = {
+            data: this.props.name
+        };
         if (prevProps.unshare !== this.props.unshare
             || prevProps.name !== this.props.name
-            || prevProps.data !== this.props.data
             || prevProps.stateNavigator !== this.props.stateNavigator) {
             var prevScene = prevProps.stateNavigator.stateContext.url;
             sharedElementRegistry.unregisterSharedElement(prevScene, prevProps.name);
@@ -40,10 +42,10 @@ class SharedElement extends React.Component<SharedElementProps, any> {
         }
     }
     register() {
-        var {unshare, name, data, stateNavigator, sharedElementRegistry} = this.props;
+        var {unshare, name, stateNavigator, sharedElementRegistry} = this.props;
         var scene = stateNavigator.stateContext.url;
         if (!unshare && this.ref.current.offsetWidth && this.ref.current.offsetHeight)
-            sharedElementRegistry.registerSharedElement(scene, name, this.ref.current, data);
+            sharedElementRegistry.registerSharedElement(scene, name, this.ref.current);
         if (unshare)
             sharedElementRegistry.unregisterSharedElement(scene, name);
     }

--- a/NavigationReactMobile/src/SharedElement.tsx
+++ b/NavigationReactMobile/src/SharedElement.tsx
@@ -19,6 +19,7 @@ class SharedElement extends React.Component<SharedElementProps, any> {
     componentDidUpdate(prevProps) {
         var {sharedElementRegistry} = this.props;
         this.ref.current['sharedElementData'] = this.props.data;
+        this.ref.current.dataset.sharedElement = 'true';
         if (prevProps.unshare !== this.props.unshare
             || prevProps.name !== this.props.name
             || prevProps.stateNavigator !== this.props.stateNavigator) {

--- a/NavigationReactMobile/src/SharedElement.tsx
+++ b/NavigationReactMobile/src/SharedElement.tsx
@@ -14,6 +14,8 @@ class SharedElement extends React.Component<SharedElementProps, any> {
     }
     componentDidMount() {
         this.register();
+        this.ref.current['sharedElementData'] = this.props.data;
+        this.ref.current.dataset.sharedElement = 'true';
         this.resizeObserver?.observe(this.ref.current);
     }
     componentDidUpdate(prevProps) {

--- a/NavigationReactMobile/src/SharedElement.tsx
+++ b/NavigationReactMobile/src/SharedElement.tsx
@@ -5,16 +5,19 @@ import { SharedElementProps } from './Props';
 
 class SharedElement extends React.Component<SharedElementProps, any> {
     private ref: React.RefObject<HTMLElement>;
+    private resizeObserver: ResizeObserver;
     constructor(props) {
         super(props);
-        this.ref = React.createRef(); 
+        this.ref = React.createRef();
+        this.onResize = this.onResize.bind(this);
+        if (typeof ResizeObserver !== 'undefined') this.resizeObserver = new ResizeObserver(this.onResize);
     }
     componentDidMount() {
         this.register();
+        this.resizeObserver?.observe(this.ref.current);
     }
     componentDidUpdate(prevProps) {
-        var {stateNavigator, sharedElementRegistry} = this.props;
-        var scene = stateNavigator.stateContext.url;
+        var {sharedElementRegistry} = this.props;
         if (prevProps.unshare !== this.props.unshare
             || prevProps.name !== this.props.name
             || prevProps.data !== this.props.data
@@ -28,13 +31,17 @@ class SharedElement extends React.Component<SharedElementProps, any> {
         var {stateNavigator, sharedElementRegistry} = this.props;
         var scene = stateNavigator.stateContext.url;
         sharedElementRegistry.unregisterSharedElement(scene, this.props.name);
+        this.resizeObserver?.unobserve(this.ref.current);
+    }
+    onResize() {
+        this.register();
     }
     register() {
         var {unshare, name, data, stateNavigator, sharedElementRegistry} = this.props;
         var scene = stateNavigator.stateContext.url;
-        if (!unshare)
+        if (!unshare && this.ref.current.offsetWidth && this.ref.current.offsetHeight)
             sharedElementRegistry.registerSharedElement(scene, name, this.ref.current, data);
-        else
+        if (unshare)
             sharedElementRegistry.unregisterSharedElement(scene, name);
     }
     render() {

--- a/NavigationReactMobile/src/SharedElementAnimation.tsx
+++ b/NavigationReactMobile/src/SharedElementAnimation.tsx
@@ -43,11 +43,7 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements}: any) => {
             })
         ));
     }
-    return (
-        <div ref={container}>
-            {sharedElements.map(({name}) => <div key={name} style={{position: 'absolute'}} />)}
-        </div>
-    );
+    return <div ref={container}>{sharedElements.map(({name}) => <div key={name} />)}</div>;
 };
 
 export default SharedElementAnimation;

--- a/NavigationReactMobile/src/SharedElementAnimation.tsx
+++ b/NavigationReactMobile/src/SharedElementAnimation.tsx
@@ -17,7 +17,7 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements}: any) => {
                 const toLeft = to.left - toScene.left;
                 const toTop = to.top - toScene.top;
                 elementContainer.appendChild(element);
-                element.style.position = 'absolute';
+                element.style.position = 'fixed';
                 element.style.width = `${from.width}px`;
                 element.style.height = `${from.height}px`;
                 element.style.top = `${fromTop}px`;

--- a/NavigationReactMobile/src/SharedElementAnimation.tsx
+++ b/NavigationReactMobile/src/SharedElementAnimation.tsx
@@ -24,10 +24,8 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements}: any) => {
                 element.style.transformOrigin = 'top left';
                 element.transition = element.animate([
                     {transform: 'translate(0, 0) scale(1)'},
-                    {transform: `
-                        translate(${toLeft - fromLeft}px, ${toTop - fromTop}px)
-                        scale(${to.width / from.width}, ${to.height / from.height})
-                    `}
+                    {transform: `translate(${toLeft - fromLeft}px, ${toTop - fromTop}px)
+                        scale(${to.width / from.width}, ${to.height / from.height})`}
                 ], {duration: 1000, fill: 'forwards'});
             } else {
                 element.transition.reverse();

--- a/NavigationReactMobile/src/SharedElementAnimation.tsx
+++ b/NavigationReactMobile/src/SharedElementAnimation.tsx
@@ -7,20 +7,20 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements, unmountStyl
     useLayoutEffect(() => {
         sharedElements.forEach(({oldElement, mountedElement, element, action}, i) => {
             const elementContainer = container.current.children[i];
-            const from = oldElement.ref.getBoundingClientRect();
-            const fromScene = oldElement.ref.closest('[data-scene="true"').getBoundingClientRect();
-            const to = mountedElement.ref.getBoundingClientRect();
-            const toScene = mountedElement.ref.closest('[data-scene="true"').getBoundingClientRect();
+            const from = oldElement.getBoundingClientRect();
+            const fromScene = oldElement.closest('[data-scene="true"').getBoundingClientRect();
+            const to = mountedElement.getBoundingClientRect();
+            const toScene = mountedElement.closest('[data-scene="true"').getBoundingClientRect();
             if (action === 'play') {
-                const toWidth = mountedElement.ref.offsetWidth;
-                const toHeight = mountedElement.ref.offsetHeight;
+                const toWidth = mountedElement.offsetWidth;
+                const toHeight = mountedElement.offsetHeight;
                 const fromLeft = from.left - fromScene.left;
                 const fromTop = from.top - fromScene.top;
                 const toLeft = (to.left - toScene.left) * (toWidth / to.width);
                 const toTop = (to.top - toScene.top) * (toHeight / to.height);
                 elementContainer.appendChild(element);
-                oldElement.ref.style.visibility = 'hidden';
-                mountedElement.ref.style.visibility = 'hidden';
+                oldElement.style.visibility = 'hidden';
+                mountedElement.style.visibility = 'hidden';
                 element.style.position = 'fixed';
                 element.style.visibility = 'visible';
                 element.style.width = `${from.width}px`;
@@ -40,21 +40,21 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements, unmountStyl
     }, [sharedElements]);
     useEffect(() => {
         const changed = sharedElements.reduce((changed, {oldElement}, i) => (
-            changed || oldElement.ref !== nextSharedElements[i].oldElement.ref
+            changed || oldElement !== nextSharedElements[i].oldElement
         ), nextSharedElements.length !== sharedElements.length);
         if (changed) {
-            if (nextSharedElements[0]?.oldElement.ref !== sharedElements[0]?.mountedElement.ref) {
+            if (nextSharedElements[0]?.oldElement !== sharedElements[0]?.mountedElement) {
                 sharedElements.forEach(({oldElement, mountedElement}) => {
-                    oldElement.ref.style.visibility = 'visible';
-                    mountedElement.ref.style.visibility = 'visible';
+                    oldElement.style.visibility = 'visible';
+                    mountedElement.style.visibility = 'visible';
                 })
             }
             setSharedElements(sharedElements => {
                 if (!duration || !keyframes) return [];
                 return nextSharedElements.map((nextSharedElement, i) => {
-                    if (nextSharedElement.oldElement.ref === sharedElements[i]?.mountedElement.ref)
+                    if (nextSharedElement.oldElement === sharedElements[i]?.mountedElement)
                         return {...nextSharedElement, element: sharedElements[i].element, action: 'reverse'};
-                    const element = nextSharedElement.oldElement.ref.cloneNode(true);
+                    const element = nextSharedElement.oldElement.cloneNode(true);
                     return {...nextSharedElement, element, action: 'play'};
                 })
             });

--- a/NavigationReactMobile/src/SharedElementAnimation.tsx
+++ b/NavigationReactMobile/src/SharedElementAnimation.tsx
@@ -29,9 +29,9 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements, unmountStyl
                 element.style.left = `${fromLeft}px`;
                 element.style.transformOrigin = 'top left';
                 element.transition = element.animate([
-                    {transform: 'translate(0, 0) scale(1)'},
+                    {transform: 'translate(0, 0) scale(1)', ...oldElement.sharedElementData},
                     {transform: `translate(${toLeft - fromLeft}px, ${toTop - fromTop}px)
-                        scale(${toWidth / from.width}, ${toHeight / from.height})`}
+                        scale(${toWidth / from.width}, ${toHeight / from.height})`, ...mountedElement.sharedElementData}
                 ], {duration, fill: 'forwards'});
             } else {
                 element.transition.reverse();

--- a/NavigationReactMobile/src/SharedElementAnimation.tsx
+++ b/NavigationReactMobile/src/SharedElementAnimation.tsx
@@ -11,10 +11,12 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements}: any) => {
             const to = mountedElement.ref.getBoundingClientRect();
             const toScene = mountedElement.ref.closest('[data-scene="true"').getBoundingClientRect();
             if (action === 'play') {
+                const toWidth = mountedElement.ref.offsetWidth;
+                const toHeight = mountedElement.ref.offsetHeight;
                 const fromLeft = from.left - fromScene.left;
                 const fromTop = from.top - fromScene.top;
-                const toLeft = to.left - toScene.left;
-                const toTop = to.top - toScene.top;
+                const toLeft = (to.left - toScene.left) * (toWidth / to.width);
+                const toTop = (to.top - toScene.top) * (toHeight / to.height);
                 elementContainer.appendChild(element);
                 element.style.position = 'fixed';
                 element.style.width = `${from.width}px`;
@@ -25,7 +27,7 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements}: any) => {
                 element.transition = element.animate([
                     {transform: 'translate(0, 0) scale(1)'},
                     {transform: `translate(${toLeft - fromLeft}px, ${toTop - fromTop}px)
-                        scale(${to.width / from.width}, ${to.height / from.height})`}
+                        scale(${toWidth / from.width}, ${toHeight / from.height})`}
                 ], {duration: 1000, fill: 'forwards'});
             } else {
                 element.transition.reverse();

--- a/NavigationReactMobile/src/SharedElementAnimation.tsx
+++ b/NavigationReactMobile/src/SharedElementAnimation.tsx
@@ -45,7 +45,11 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements}: any) => {
             })
         ));
     }
-    return <div ref={container}>{sharedElements.map(({name}) => <div key={name} />)}</div>;
+    return (
+        <div ref={container} style={{display: 'flex', flexDirection: 'column', flex: 1}}>
+            {sharedElements.map(({name}) => <div key={name} />)}
+        </div>
+    );
 };
 
 export default SharedElementAnimation;

--- a/NavigationReactMobile/src/SharedElementAnimation.tsx
+++ b/NavigationReactMobile/src/SharedElementAnimation.tsx
@@ -40,7 +40,6 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements}: any) => {
             nextSharedElements.map((nextSharedElement, i) => {
                 if (nextSharedElement.oldElement.ref === sharedElements[i]?.mountedElement.ref)
                     return {...nextSharedElement, element: sharedElements[i].element, action: 'reverse'};
-                // need to remove ids to prevent duplicates?!
                 const element = nextSharedElement.oldElement.ref.cloneNode(true);
                 return {...nextSharedElement, element, action: 'play'};
             })

--- a/NavigationReactMobile/src/SharedElementAnimation.tsx
+++ b/NavigationReactMobile/src/SharedElementAnimation.tsx
@@ -21,13 +21,10 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements, unmountStyl
                 elementContainer.appendChild(element);
                 oldElement.style.visibility = 'hidden';
                 mountedElement.style.visibility = 'hidden';
-                element.style.position = 'fixed';
-                element.style.visibility = 'visible';
                 element.style.width = `${from.width}px`;
                 element.style.height = `${from.height}px`;
                 element.style.top = `${fromTop}px`;
                 element.style.left = `${fromLeft}px`;
-                element.style.transformOrigin = 'top left';
                 element.transition = element.animate([
                     {transform: 'translate(0, 0) scale(1)', ...oldElement.sharedElementData},
                     {transform: `translate(${toLeft - fromLeft}px, ${toTop - fromTop}px)
@@ -55,6 +52,10 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements, unmountStyl
                     if (nextSharedElement.oldElement === sharedElements[i]?.mountedElement)
                         return {...nextSharedElement, element: sharedElements[i].element, action: 'reverse'};
                     const element = nextSharedElement.oldElement.cloneNode(true);
+                    element.style.margin = '0';
+                    element.style.position = 'fixed';
+                    element.style.visibility = 'visible';
+                    element.style.transformOrigin = 'top left';
                     [...element.querySelectorAll('[data-shared-element="true"')]
                         .forEach(subSharedElement => {subSharedElement.style.visibility = 'hidden';});
                     return {...nextSharedElement, element, action: 'play'};

--- a/NavigationReactMobile/src/SharedElementAnimation.tsx
+++ b/NavigationReactMobile/src/SharedElementAnimation.tsx
@@ -11,14 +11,14 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements}: any) => {
             if (action === 'play') {
                 elementContainer.appendChild(element);
                 element.style.position = 'absolute';
-                element.style.width = from.width;
-                element.style.height = from.height;
-                element.style.top = from.top;
-                element.style.left = from.left;
+                element.style.width = `${from.width}px`;
+                element.style.height = `${from.height}px`;
+                element.style.top = `${from.top}px`;
+                element.style.left = `${from.left}px`;
                 element.transition = element.animate([
                     {transform: 'translate(0, 0) scale(1)'},
                     {transform: `
-                        translate(${to.left - from.left}, ${to.top - from.top})
+                        translate(${to.left - from.left}px, ${to.top - from.top}px)
                         scale(${to.width / from.width}, ${to.height / from.height})
                     `}
                 ], {duration: 1000, fill: 'forwards'});

--- a/NavigationReactMobile/src/SharedElementAnimation.tsx
+++ b/NavigationReactMobile/src/SharedElementAnimation.tsx
@@ -16,6 +16,7 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements}: any) => {
                 element.style.height = `${from.height}px`;
                 element.style.top = `${from.top}px`;
                 element.style.left = `${from.left}px`;
+                element.style.transformOrigin = 'top left';
                 element.transition = element.animate([
                     {transform: 'translate(0, 0) scale(1)'},
                     {transform: `

--- a/NavigationReactMobile/src/SharedElementAnimation.tsx
+++ b/NavigationReactMobile/src/SharedElementAnimation.tsx
@@ -55,6 +55,8 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements, unmountStyl
                     if (nextSharedElement.oldElement === sharedElements[i]?.mountedElement)
                         return {...nextSharedElement, element: sharedElements[i].element, action: 'reverse'};
                     const element = nextSharedElement.oldElement.cloneNode(true);
+                    [...element.querySelectorAll('[data-shared-element="true"')]
+                        .forEach(subSharedElement => {subSharedElement.style.visibility = 'hidden';});
                     return {...nextSharedElement, element, action: 'play'};
                 })
             });

--- a/NavigationReactMobile/src/SharedElementAnimation.tsx
+++ b/NavigationReactMobile/src/SharedElementAnimation.tsx
@@ -11,7 +11,6 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements}: any) => {
             const to = mountedElement.ref.getBoundingClientRect();
             const toScene = mountedElement.ref.closest('[data-scene="true"').getBoundingClientRect();
             if (action === 'play') {
-                // need to allow for the position of the scene - the transform?! how?
                 const fromLeft = from.left - fromScene.left;
                 const fromTop = from.top - fromScene.top;
                 const toLeft = to.left - toScene.left;

--- a/NavigationReactMobile/src/SharedElementAnimation.tsx
+++ b/NavigationReactMobile/src/SharedElementAnimation.tsx
@@ -7,20 +7,26 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements}: any) => {
         sharedElements.forEach(({oldElement, mountedElement, element, action}, i) => {
             const elementContainer = container.current.children[i];
             const from = oldElement.ref.getBoundingClientRect();
+            const fromScene = oldElement.ref.closest('[data-scene="true"').getBoundingClientRect();
             const to = mountedElement.ref.getBoundingClientRect();
+            const toScene = mountedElement.ref.closest('[data-scene="true"').getBoundingClientRect();
             if (action === 'play') {
                 // need to allow for the position of the scene - the transform?! how?
+                const fromLeft = from.left - fromScene.left;
+                const fromTop = from.top - fromScene.top;
+                const toLeft = to.left - toScene.left;
+                const toTop = to.top - toScene.top;
                 elementContainer.appendChild(element);
                 element.style.position = 'absolute';
                 element.style.width = `${from.width}px`;
                 element.style.height = `${from.height}px`;
-                element.style.top = `${from.top}px`;
-                element.style.left = `${from.left}px`;
+                element.style.top = `${fromTop}px`;
+                element.style.left = `${fromLeft}px`;
                 element.style.transformOrigin = 'top left';
                 element.transition = element.animate([
                     {transform: 'translate(0, 0) scale(1)'},
                     {transform: `
-                        translate(${to.left - from.left}px, ${to.top - from.top}px)
+                        translate(${toLeft - fromLeft}px, ${toTop - fromTop}px)
                         scale(${to.width / from.width}, ${to.height / from.height})
                     `}
                 ], {duration: 1000, fill: 'forwards'});

--- a/NavigationReactMobile/src/SharedElementAnimation.tsx
+++ b/NavigationReactMobile/src/SharedElementAnimation.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useRef, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 const SharedElementAnimation = ({sharedElements: nextSharedElements}: any) => {
     const [sharedElements, setSharedElements] = useState([]);
@@ -18,7 +18,10 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements}: any) => {
                 const toLeft = (to.left - toScene.left) * (toWidth / to.width);
                 const toTop = (to.top - toScene.top) * (toHeight / to.height);
                 elementContainer.appendChild(element);
+                oldElement.ref.style.visibility = 'hidden';
+                mountedElement.ref.style.visibility = 'hidden';
                 element.style.position = 'fixed';
+                element.style.visibility = 'visible';
                 element.style.width = `${from.width}px`;
                 element.style.height = `${from.height}px`;
                 element.style.top = `${fromTop}px`;
@@ -34,19 +37,28 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements}: any) => {
             }
         });
     }, [sharedElements]);
-    const changed = sharedElements.reduce((changed, {oldElement}, i) => (
-        changed || oldElement.ref !== nextSharedElements[i].oldElement.ref
-    ), nextSharedElements.length !== sharedElements.length)
-    if (changed) {
-        setSharedElements(sharedElements => (
-            nextSharedElements.map((nextSharedElement, i) => {
-                if (nextSharedElement.oldElement.ref === sharedElements[i]?.mountedElement.ref)
-                    return {...nextSharedElement, element: sharedElements[i].element, action: 'reverse'};
-                const element = nextSharedElement.oldElement.ref.cloneNode(true);
-                return {...nextSharedElement, element, action: 'play'};
-            })
-        ));
-    }
+    useEffect(() => {
+        const changed = sharedElements.reduce((changed, {oldElement}, i) => (
+            changed || oldElement.ref !== nextSharedElements[i].oldElement.ref
+        ), nextSharedElements.length !== sharedElements.length)
+        if (changed) {
+            if (nextSharedElements[0]?.oldElement.ref !== sharedElements[0]?.mountedElement.ref) {
+                sharedElements.forEach(({oldElement, mountedElement}) => {
+                    oldElement.ref.style.visibility = 'visible';
+                    mountedElement.ref.style.visibility = 'visible';
+                })
+            }
+            setSharedElements(sharedElements => (
+                nextSharedElements.map((nextSharedElement, i) => {
+                    if (nextSharedElement.oldElement.ref === sharedElements[i]?.mountedElement.ref)
+                        return {...nextSharedElement, element: sharedElements[i].element, action: 'reverse'};
+                    const element = nextSharedElement.oldElement.ref.cloneNode(true);
+                    return {...nextSharedElement, element, action: 'play'};
+                })
+            ));
+        }
+    }, [sharedElements, nextSharedElements])
+    if (!sharedElements.length) return null;
     return (
         <div ref={container} style={{display: 'flex', flexDirection: 'column', flex: 1}}>
             {sharedElements.map(({name}) => <div key={name} />)}

--- a/NavigationReactMobile/src/SharedElementAnimation.tsx
+++ b/NavigationReactMobile/src/SharedElementAnimation.tsx
@@ -7,28 +7,28 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements, unmountStyl
     useLayoutEffect(() => {
         sharedElements.forEach(({oldElement, mountedElement, element, action}, i) => {
             const elementContainer = container.current.children[i];
-            const from = oldElement.getBoundingClientRect();
-            const fromScene = oldElement.closest('[data-scene="true"').getBoundingClientRect();
-            const to = mountedElement.getBoundingClientRect();
-            const toScene = mountedElement.closest('[data-scene="true"').getBoundingClientRect();
+            const from = oldElement.ref.getBoundingClientRect();
+            const fromScene = oldElement.ref.closest('[data-scene="true"').getBoundingClientRect();
+            const to = mountedElement.ref.getBoundingClientRect();
+            const toScene = mountedElement.ref.closest('[data-scene="true"').getBoundingClientRect();
             if (action === 'play') {
-                const toWidth = mountedElement.offsetWidth;
-                const toHeight = mountedElement.offsetHeight;
+                const toWidth = mountedElement.ref.offsetWidth;
+                const toHeight = mountedElement.ref.offsetHeight;
                 const fromLeft = from.left - fromScene.left;
                 const fromTop = from.top - fromScene.top;
                 const toLeft = (to.left - toScene.left) * (toWidth / to.width);
                 const toTop = (to.top - toScene.top) * (toHeight / to.height);
                 elementContainer.appendChild(element);
-                oldElement.style.visibility = 'hidden';
-                mountedElement.style.visibility = 'hidden';
+                oldElement.ref.style.visibility = 'hidden';
+                mountedElement.ref.style.visibility = 'hidden';
                 element.style.width = `${from.width}px`;
                 element.style.height = `${from.height}px`;
                 element.style.top = `${fromTop}px`;
                 element.style.left = `${fromLeft}px`;
                 element.transition = element.animate([
-                    {transform: 'translate(0, 0) scale(1)', ...oldElement.sharedElementData},
+                    {transform: 'translate(0, 0) scale(1)', ...oldElement.data},
                     {transform: `translate(${toLeft - fromLeft}px, ${toTop - fromTop}px)
-                        scale(${toWidth / from.width}, ${toHeight / from.height})`, ...mountedElement.sharedElementData}
+                        scale(${toWidth / from.width}, ${toHeight / from.height})`, ...mountedElement.data}
                 ], {duration, fill: 'forwards'});
             } else {
                 element.transition.reverse();
@@ -37,21 +37,21 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements, unmountStyl
     }, [sharedElements]);
     useEffect(() => {
         const changed = sharedElements.reduce((changed, {oldElement}, i) => (
-            changed || oldElement !== nextSharedElements[i].oldElement
+            changed || oldElement.ref !== nextSharedElements[i].oldElement.ref
         ), nextSharedElements.length !== sharedElements.length);
         if (changed) {
-            if (nextSharedElements[0]?.oldElement !== sharedElements[0]?.mountedElement) {
+            if (nextSharedElements[0]?.oldElement.ref !== sharedElements[0]?.mountedElement.ref) {
                 sharedElements.forEach(({oldElement, mountedElement}) => {
-                    oldElement.style.visibility = 'visible';
-                    mountedElement.style.visibility = 'visible';
+                    oldElement.ref.style.visibility = 'visible';
+                    mountedElement.ref.style.visibility = 'visible';
                 })
             }
             setSharedElements(sharedElements => {
                 if (!duration || !keyframes) return [];
                 return nextSharedElements.map((nextSharedElement, i) => {
-                    if (nextSharedElement.oldElement === sharedElements[i]?.mountedElement)
+                    if (nextSharedElement.oldElement.ref === sharedElements[i]?.mountedElement.ref)
                         return {...nextSharedElement, element: sharedElements[i].element, action: 'reverse'};
-                    const element = nextSharedElement.oldElement.cloneNode(true);
+                    const element = nextSharedElement.oldElement.ref.cloneNode(true);
                     element.style.margin = '0';
                     element.style.position = 'fixed';
                     element.style.visibility = 'visible';

--- a/NavigationReactMobile/src/SharedElementAnimation.tsx
+++ b/NavigationReactMobile/src/SharedElementAnimation.tsx
@@ -64,11 +64,7 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements, unmountStyl
         }
     }, [sharedElements, nextSharedElements])
     if (!sharedElements.length) return null;
-    return (
-        <div ref={container} style={{display: 'flex', flexDirection: 'column', flex: 1}}>
-            {sharedElements.map(({name}) => <div key={name} />)}
-        </div>
-    );
+    return <div ref={container}>{sharedElements.map(({name}) => <div key={name} />)}</div>;
 };
 
 export default SharedElementAnimation;

--- a/NavigationReactMobile/src/SharedElementAnimation.tsx
+++ b/NavigationReactMobile/src/SharedElementAnimation.tsx
@@ -21,7 +21,7 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements}: any) => {
                         translate(${to.left - from.left}, ${to.top - from.top})
                         scale(${to.width / from.width}, ${to.height / from.height})
                     `}
-                ]);
+                ], {duration: 1000, fill: 'forwards'});
             } else {
                 element.transition.reverse();
             }
@@ -34,7 +34,7 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements}: any) => {
         setSharedElements(sharedElements => (
             nextSharedElements.map((nextSharedElement, i) => {
                 if (nextSharedElement.oldElement.ref === sharedElements[i]?.mountedElement.ref)
-                    return {...sharedElements[i], action: 'reverse'};
+                    return {...nextSharedElement, element: sharedElements[i].element, action: 'reverse'};
                 // need to remove ids to prevent duplicates?!
                 const element = nextSharedElement.oldElement.ref.cloneNode(true);
                 return {...nextSharedElement, element, action: 'play'};

--- a/NavigationReactMobile/src/SharedElementAnimation.tsx
+++ b/NavigationReactMobile/src/SharedElementAnimation.tsx
@@ -9,6 +9,7 @@ const SharedElementAnimation = ({sharedElements: nextSharedElements}: any) => {
             const from = oldElement.ref.getBoundingClientRect();
             const to = mountedElement.ref.getBoundingClientRect();
             if (action === 'play') {
+                // need to allow for the position of the scene - the transform?! how?
                 elementContainer.appendChild(element);
                 element.style.position = 'absolute';
                 element.style.width = `${from.width}px`;

--- a/NavigationReactMobile/src/SharedElementAnimation.tsx
+++ b/NavigationReactMobile/src/SharedElementAnimation.tsx
@@ -1,0 +1,51 @@
+import React, { useLayoutEffect, useRef, useState } from 'react';
+
+const SharedElementAnimation = ({sharedElements: nextSharedElements}: any) => {
+    const [sharedElements, setSharedElements] = useState([]);
+    const container = useRef(null);
+    useLayoutEffect(() => {
+        sharedElements.forEach(({oldElement, mountedElement, element, action}, i) => {
+            const elementContainer = container.current.children[i];
+            const from = oldElement.ref.getBoundingClientRect();
+            const to = mountedElement.ref.getBoundingClientRect();
+            if (action === 'play') {
+                elementContainer.appendChild(element);
+                element.style.position = 'absolute';
+                element.style.width = from.width;
+                element.style.height = from.height;
+                element.style.top = from.top;
+                element.style.left = from.left;
+                element.transition = element.animate([
+                    {transform: 'translate(0, 0) scale(1)'},
+                    {transform: `
+                        translate(${to.left - from.left}, ${to.top - from.top})
+                        scale(${to.width / from.width}, ${to.height / from.height})
+                    `}
+                ]);
+            } else {
+                element.transition.reverse();
+            }
+        });
+    }, [sharedElements]);
+    const changed = sharedElements.reduce((changed, {oldElement}, i) => (
+        changed || oldElement.ref !== nextSharedElements[i].oldElement.ref
+    ), nextSharedElements.length !== sharedElements.length)
+    if (changed) {
+        setSharedElements(sharedElements => (
+            nextSharedElements.map((nextSharedElement, i) => {
+                if (nextSharedElement.oldElement.ref === sharedElements[i]?.mountedElement.ref)
+                    return {...sharedElements[i], action: 'reverse'};
+                // need to remove ids to prevent duplicates?!
+                const element = nextSharedElement.oldElement.ref.cloneNode(true);
+                return {...nextSharedElement, element, action: 'play'};
+            })
+        ));
+    }
+    return (
+        <div ref={container}>
+            {sharedElements.map(({name}) => <div key={name} style={{position: 'absolute'}} />)}
+        </div>
+    );
+};
+
+export default SharedElementAnimation;

--- a/NavigationReactMobile/src/SharedElementMotion.tsx
+++ b/NavigationReactMobile/src/SharedElementMotion.tsx
@@ -5,7 +5,7 @@ import { SharedItem, SharedElementNavigationMotionProps, SharedElementMotionProp
 class SharedElementMotion extends React.Component<SharedElementNavigationMotionProps & SharedElementMotionProps, any> {
     static defaultProps = {
         duration: 300,
-        elementStyle: (name, ref, data) => data
+        elementStyle: (_name, _ref, data) => data
     }
     componentDidUpdate(prevProps) {
         var prevSharedElements = this.getSharedElements(prevProps.sharedElements);
@@ -32,7 +32,7 @@ class SharedElementMotion extends React.Component<SharedElementNavigationMotionP
     }
     getStyle(name, {ref, data}) {
         var {top, left, width, height} = ref.getBoundingClientRect();
-        return this.props.elementStyle(name, ref, { top, left, width, height, ...data});
+        return this.props.elementStyle(name, ref, {top, left, width, height, ...data});
     }
     getPropValue(prop, name) {
         return typeof prop === 'function' ? prop(name) : prop;

--- a/NavigationReactMobile/src/SharedElementMotion.tsx
+++ b/NavigationReactMobile/src/SharedElementMotion.tsx
@@ -21,9 +21,9 @@ class SharedElementMotion extends React.Component<SharedElementNavigationMotionP
             var to = toSharedElements[name];
             if (!to || from.mountedElement !== to.mountedElement) {
                 if (action)
-                    action(name, from.oldElement, from.oldElement['sharedElement'].data);
+                    action(name, from.oldElement, from.oldElement['sharedElement']);
                 if (action)
-                    action(name, from.mountedElement, from.mountedElement['sharedElement'].data);
+                    action(name, from.mountedElement, from.mountedElement['sharedElement']);
             }
         }
     }
@@ -32,7 +32,7 @@ class SharedElementMotion extends React.Component<SharedElementNavigationMotionP
     }
     getStyle(name, ref) {
         var {top, left, width, height} = ref.getBoundingClientRect();
-        return this.props.elementStyle(name, ref, {top, left, width, height, ...ref['sharedElement'].data});
+        return this.props.elementStyle(name, ref, {top, left, width, height, ...ref['sharedElement']});
     }
     getPropValue(prop, name) {
         return typeof prop === 'function' ? prop(name) : prop;
@@ -49,7 +49,7 @@ class SharedElementMotion extends React.Component<SharedElementNavigationMotionP
                 duration={duration}>
                 {styles => (
                     styles.map(({data: {name, oldElement, mountedElement}, style, start, end}) => (
-                        children(style, name, {...start, ...oldElement['sharedElement'].data}, {...end, ...mountedElement['sharedElement'].data})
+                        children(style, name, {...start, ...oldElement['sharedElement']}, {...end, ...mountedElement['sharedElement']})
                     ))
                 )}
             </Motion>

--- a/NavigationReactMobile/src/SharedElementMotion.tsx
+++ b/NavigationReactMobile/src/SharedElementMotion.tsx
@@ -21,9 +21,9 @@ class SharedElementMotion extends React.Component<SharedElementNavigationMotionP
             var to = toSharedElements[name];
             if (!to || from.mountedElement !== to.mountedElement) {
                 if (action)
-                    action(name, from.oldElement, from.oldElement['sharedElement']);
+                    action(name, from.oldElement, from.oldElement['sharedElementData']);
                 if (action)
-                    action(name, from.mountedElement, from.mountedElement['sharedElement']);
+                    action(name, from.mountedElement, from.mountedElement['sharedElementData']);
             }
         }
     }
@@ -32,7 +32,7 @@ class SharedElementMotion extends React.Component<SharedElementNavigationMotionP
     }
     getStyle(name, ref) {
         var {top, left, width, height} = ref.getBoundingClientRect();
-        return this.props.elementStyle(name, ref, {top, left, width, height, ...ref['sharedElement']});
+        return this.props.elementStyle(name, ref, {top, left, width, height, ...ref['sharedElementData']});
     }
     getPropValue(prop, name) {
         return typeof prop === 'function' ? prop(name) : prop;
@@ -49,7 +49,7 @@ class SharedElementMotion extends React.Component<SharedElementNavigationMotionP
                 duration={duration}>
                 {styles => (
                     styles.map(({data: {name, oldElement, mountedElement}, style, start, end}) => (
-                        children(style, name, {...start, ...oldElement['sharedElement']}, {...end, ...mountedElement['sharedElement']})
+                        children(style, name, {...start, ...oldElement['sharedElementData']}, {...end, ...mountedElement['sharedElementData']})
                     ))
                 )}
             </Motion>

--- a/NavigationReactMobile/src/SharedElementMotion.tsx
+++ b/NavigationReactMobile/src/SharedElementMotion.tsx
@@ -5,7 +5,7 @@ import { SharedItem, SharedElementNavigationMotionProps, SharedElementMotionProp
 class SharedElementMotion extends React.Component<SharedElementNavigationMotionProps & SharedElementMotionProps, any> {
     static defaultProps = {
         duration: 300,
-        elementStyle: (_name, _ref, data) => data
+        elementStyle: (name, ref, data) => data
     }
     componentDidUpdate(prevProps) {
         var prevSharedElements = this.getSharedElements(prevProps.sharedElements);
@@ -19,20 +19,20 @@ class SharedElementMotion extends React.Component<SharedElementNavigationMotionP
         for(var name in fromSharedElements) {
             var from = fromSharedElements[name];
             var to = toSharedElements[name];
-            if (!to || from.mountedElement !== to.mountedElement) {
+            if (!to || from.mountedElement.ref !== to.mountedElement.ref) {
                 if (action)
-                    action(name, from.oldElement, from.oldElement['sharedElementData']);
+                    action(name, from.oldElement.ref, from.oldElement.data);
                 if (action)
-                    action(name, from.mountedElement, from.mountedElement['sharedElementData']);
+                    action(name, from.mountedElement.ref, from.mountedElement.data);
             }
         }
     }
     getSharedElements(sharedElements: SharedItem[]): { [name: string]: SharedItem } {
         return sharedElements.reduce((elements, element) => ({...elements, [element.name]: element}), {});
     }
-    getStyle(name, ref) {
+    getStyle(name, {ref, data}) {
         var {top, left, width, height} = ref.getBoundingClientRect();
-        return this.props.elementStyle(name, ref, {top, left, width, height, ...ref['sharedElementData']});
+        return this.props.elementStyle(name, ref, { top, left, width, height, ...data});
     }
     getPropValue(prop, name) {
         return typeof prop === 'function' ? prop(name) : prop;
@@ -49,7 +49,7 @@ class SharedElementMotion extends React.Component<SharedElementNavigationMotionP
                 duration={duration}>
                 {styles => (
                     styles.map(({data: {name, oldElement, mountedElement}, style, start, end}) => (
-                        children(style, name, {...start, ...oldElement['sharedElementData']}, {...end, ...mountedElement['sharedElementData']})
+                        children(style, name, {...start, ...oldElement.data}, {...end, ...mountedElement.data})
                     ))
                 )}
             </Motion>

--- a/NavigationReactMobile/src/SharedElementMotion.tsx
+++ b/NavigationReactMobile/src/SharedElementMotion.tsx
@@ -19,20 +19,20 @@ class SharedElementMotion extends React.Component<SharedElementNavigationMotionP
         for(var name in fromSharedElements) {
             var from = fromSharedElements[name];
             var to = toSharedElements[name];
-            if (!to || from.mountedElement.ref !== to.mountedElement.ref) {
+            if (!to || from.mountedElement !== to.mountedElement) {
                 if (action)
-                    action(name, from.oldElement.ref, from.oldElement.data);
+                    action(name, from.oldElement, from.oldElement['sharedElement'].data);
                 if (action)
-                    action(name, from.mountedElement.ref, from.mountedElement.data);
+                    action(name, from.mountedElement, from.mountedElement['sharedElement'].data);
             }
         }
     }
     getSharedElements(sharedElements: SharedItem[]): { [name: string]: SharedItem } {
         return sharedElements.reduce((elements, element) => ({...elements, [element.name]: element}), {});
     }
-    getStyle(name, {ref, data}) {
+    getStyle(name, ref) {
         var {top, left, width, height} = ref.getBoundingClientRect();
-        return this.props.elementStyle(name, ref, {top, left, width, height, ...data});
+        return this.props.elementStyle(name, ref, {top, left, width, height, ...ref['sharedElement'].data});
     }
     getPropValue(prop, name) {
         return typeof prop === 'function' ? prop(name) : prop;
@@ -49,7 +49,7 @@ class SharedElementMotion extends React.Component<SharedElementNavigationMotionP
                 duration={duration}>
                 {styles => (
                     styles.map(({data: {name, oldElement, mountedElement}, style, start, end}) => (
-                        children(style, name, {...start, ...oldElement.data}, {...end, ...mountedElement.data})
+                        children(style, name, {...start, ...oldElement['sharedElement'].data}, {...end, ...mountedElement['sharedElement'].data})
                     ))
                 )}
             </Motion>

--- a/NavigationReactMobile/src/SharedElementRegistry.ts
+++ b/NavigationReactMobile/src/SharedElementRegistry.ts
@@ -2,9 +2,14 @@ import { SharedItem } from './Props';
 
 class SharedElementRegistry {
     private sharedElements: { [scene: number]: { [name: string]: { ref: HTMLElement, data: any } } } = {};
+    private update;
+    constructor(update = () => {}) {
+        this.update = update;
+    }
     registerSharedElement(scene: number, name: string, ref: HTMLElement, data) {
         this.sharedElements[scene] = this.sharedElements[scene] || {};
         this.sharedElements[scene][name] = {ref, data};
+        this.update();
     }
     unregisterSharedElement(scene: number, name?: string) {
         if (this.sharedElements[scene]) {

--- a/NavigationReactMobile/src/SharedElementRegistry.ts
+++ b/NavigationReactMobile/src/SharedElementRegistry.ts
@@ -17,6 +17,7 @@ class SharedElementRegistry {
                 delete this.sharedElements[scene][name];
             else
                 delete this.sharedElements[scene];
+            this.update();
         }
     }
     getSharedElements(scene: number, oldScene: number) {

--- a/NavigationReactMobile/src/SharedElementRegistry.ts
+++ b/NavigationReactMobile/src/SharedElementRegistry.ts
@@ -2,14 +2,9 @@ import { SharedItem } from './Props';
 
 class SharedElementRegistry {
     private sharedElements: { [scene: number]: { [name: string]: { ref: HTMLElement, data: any } } } = {};
-    private update;
-    constructor(update = () => {}) {
-        this.update = update;
-    }
     registerSharedElement(scene: number, name: string, ref: HTMLElement, data) {
         this.sharedElements[scene] = this.sharedElements[scene] || {};
         this.sharedElements[scene][name] = {ref, data};
-        this.update();
     }
     unregisterSharedElement(scene: number, name?: string) {
         if (this.sharedElements[scene]) {
@@ -17,7 +12,6 @@ class SharedElementRegistry {
                 delete this.sharedElements[scene][name];
             else
                 delete this.sharedElements[scene];
-            this.update();
         }
     }
     getSharedElements(scene: number, oldScene: number) {
@@ -35,7 +29,7 @@ class SharedElementRegistry {
                 });
             }
         }
-        return sharedElements.sort((a, b) => a.name.localeCompare(b.name));
+        return sharedElements;
     }
 }
 export default SharedElementRegistry;

--- a/NavigationReactMobile/src/SharedElementRegistry.ts
+++ b/NavigationReactMobile/src/SharedElementRegistry.ts
@@ -29,7 +29,7 @@ class SharedElementRegistry {
                 });
             }
         }
-        return sharedElements;
+        return sharedElements.sort((a, b) => a.name.localeCompare(b.name));
     }
 }
 export default SharedElementRegistry;

--- a/NavigationReactMobile/src/SharedElementRegistry.ts
+++ b/NavigationReactMobile/src/SharedElementRegistry.ts
@@ -24,8 +24,8 @@ class SharedElementRegistry {
             if (oldSharedElements && oldSharedElements[name]) {
                 sharedElements.push({
                     name,
-                    oldElement: oldSharedElements[name],
-                    mountedElement: mountedSharedElements[name]
+                    oldElement: {ref: oldSharedElements[name], data: oldSharedElements[name]['sharedElementData']},
+                    mountedElement: {ref: mountedSharedElements[name], data: mountedSharedElements[name]['sharedElementData']}
                 });
             }
         }

--- a/NavigationReactMobile/src/SharedElementRegistry.ts
+++ b/NavigationReactMobile/src/SharedElementRegistry.ts
@@ -1,10 +1,10 @@
 import { SharedItem } from './Props';
 
 class SharedElementRegistry {
-    private sharedElements: { [scene: number]: { [name: string]: { ref: HTMLElement, data: any } } } = {};
-    registerSharedElement(scene: string, name: string, ref: HTMLElement, data) {
+    private sharedElements: { [scene: string]: { [name: string]: HTMLElement } } = {};
+    registerSharedElement(scene: string, name: string, ref: HTMLElement) {
         this.sharedElements[scene] = this.sharedElements[scene] || {};
-        this.sharedElements[scene][name] = {ref, data};
+        this.sharedElements[scene][name] = ref;
     }
     unregisterSharedElement(scene: string, name?: string) {
         if (this.sharedElements[scene]) {

--- a/NavigationReactMobile/src/SharedElementRegistry.ts
+++ b/NavigationReactMobile/src/SharedElementRegistry.ts
@@ -2,11 +2,11 @@ import { SharedItem } from './Props';
 
 class SharedElementRegistry {
     private sharedElements: { [scene: number]: { [name: string]: { ref: HTMLElement, data: any } } } = {};
-    registerSharedElement(scene: number, name: string, ref: HTMLElement, data) {
+    registerSharedElement(scene: string, name: string, ref: HTMLElement, data) {
         this.sharedElements[scene] = this.sharedElements[scene] || {};
         this.sharedElements[scene][name] = {ref, data};
     }
-    unregisterSharedElement(scene: number, name?: string) {
+    unregisterSharedElement(scene: string, name?: string) {
         if (this.sharedElements[scene]) {
             if (name)
                 delete this.sharedElements[scene][name];
@@ -14,7 +14,7 @@ class SharedElementRegistry {
                 delete this.sharedElements[scene];
         }
     }
-    getSharedElements(scene: number, oldScene: number) {
+    getSharedElements(scene: string, oldScene: string) {
         if (scene === oldScene)
             return [];
         var oldSharedElements = this.sharedElements[oldScene];

--- a/NavigationReactMobile/src/useSharedElementRegistry.ts
+++ b/NavigationReactMobile/src/useSharedElementRegistry.ts
@@ -1,0 +1,48 @@
+import { useCallback, useMemo, useState } from 'react';
+import { SharedItem } from './Props';
+
+const useSharedElementRegistry = () => {
+    const [sharedElements, setSharedElements] = useState({});
+    const registerSharedElement = useCallback((scene: number, name: string, ref: HTMLElement, data) => {
+        setSharedElements(prevSharedElements => {
+            const nextSharedElements = {...prevSharedElements};
+            nextSharedElements[scene] = nextSharedElements[scene] || {};
+            nextSharedElements[scene][name] = {ref, data};
+            return nextSharedElements;
+        })
+    }, []);
+    const unregisterSharedElement = useCallback((scene: number, name?: string) => {
+        setSharedElements(prevSharedElements => {
+            if (!prevSharedElements[scene]) return prevSharedElements;
+            const nextSharedElements = {...prevSharedElements};
+            if (name) delete nextSharedElements[scene][name];
+            else delete nextSharedElements[scene];
+            return nextSharedElements;
+        })
+    }, []);
+    const getSharedElements = useCallback((scene: number, oldScene: number) => {
+        if (scene === oldScene)
+            return [];
+        var oldSharedElements = sharedElements[oldScene];
+        var mountedSharedElements = sharedElements[scene];
+        var sharedEls: SharedItem[] = [];
+        for(var name in mountedSharedElements) {
+            if (oldSharedElements && oldSharedElements[name]) {
+                sharedEls.push({
+                    name,
+                    oldElement: oldSharedElements[name],
+                    mountedElement: mountedSharedElements[name]
+                });
+            }
+        }
+        return sharedEls.sort((a, b) => a.name.localeCompare(b.name));
+    }, [sharedElements]);
+    const sharedElementRegistry = useMemo(() => ({
+        registerSharedElement,
+        unregisterSharedElement,
+        getSharedElements
+    }), [registerSharedElement, unregisterSharedElement, getSharedElements]);
+    return sharedElementRegistry;
+}
+
+export default useSharedElementRegistry;

--- a/NavigationReactMobile/src/useSharedElementRegistry.ts
+++ b/NavigationReactMobile/src/useSharedElementRegistry.ts
@@ -3,11 +3,11 @@ import { SharedItem } from './Props';
 
 const useSharedElementRegistry = () => {
     const [sharedElements, setSharedElements] = useState({});
-    const registerSharedElement = useCallback((scene: string, name: string, ref: HTMLElement, data) => {
+    const registerSharedElement = useCallback((scene: string, name: string, ref: HTMLElement) => {
         setSharedElements(prevSharedElements => {
             const nextSharedElements = {...prevSharedElements};
             nextSharedElements[scene] = nextSharedElements[scene] || {};
-            nextSharedElements[scene][name] = {ref, data};
+            nextSharedElements[scene][name] = ref;
             return nextSharedElements;
         })
     }, []);

--- a/NavigationReactMobile/src/useSharedElementRegistry.ts
+++ b/NavigationReactMobile/src/useSharedElementRegistry.ts
@@ -3,7 +3,7 @@ import { SharedItem } from './Props';
 
 const useSharedElementRegistry = () => {
     const [sharedElements, setSharedElements] = useState({});
-    const registerSharedElement = useCallback((scene: number, name: string, ref: HTMLElement, data) => {
+    const registerSharedElement = useCallback((scene: string, name: string, ref: HTMLElement, data) => {
         setSharedElements(prevSharedElements => {
             const nextSharedElements = {...prevSharedElements};
             nextSharedElements[scene] = nextSharedElements[scene] || {};
@@ -11,7 +11,7 @@ const useSharedElementRegistry = () => {
             return nextSharedElements;
         })
     }, []);
-    const unregisterSharedElement = useCallback((scene: number, name?: string) => {
+    const unregisterSharedElement = useCallback((scene: string, name?: string) => {
         setSharedElements(prevSharedElements => {
             if (!prevSharedElements[scene]) return prevSharedElements;
             const nextSharedElements = {...prevSharedElements};
@@ -20,7 +20,7 @@ const useSharedElementRegistry = () => {
             return nextSharedElements;
         })
     }, []);
-    const getSharedElements = useCallback((scene: number, oldScene: number) => {
+    const getSharedElements = useCallback((scene: string, oldScene: string) => {
         if (scene === oldScene)
             return [];
         var oldSharedElements = sharedElements[oldScene];

--- a/NavigationReactMobile/src/useSharedElementRegistry.ts
+++ b/NavigationReactMobile/src/useSharedElementRegistry.ts
@@ -30,8 +30,8 @@ const useSharedElementRegistry = () => {
             if (oldSharedElements && oldSharedElements[name]) {
                 sharedEls.push({
                     name,
-                    oldElement: oldSharedElements[name],
-                    mountedElement: mountedSharedElements[name]
+                    oldElement: {ref: oldSharedElements[name], data: oldSharedElements[name]['sharedElementData']},
+                    mountedElement: {ref: mountedSharedElements[name], data: mountedSharedElements[name]['sharedElementData']}
                 });
             }
         }

--- a/NavigationReactMobile/test/NavigatedHookTest.tsx
+++ b/NavigationReactMobile/test/NavigatedHookTest.tsx
@@ -2,7 +2,6 @@ import assert from 'assert';
 import 'mocha';
 import { StateNavigator } from 'navigation';
 import { NavigationContext, NavigationHandler } from 'navigation-react';
-//@ts-ignore
 import { NavigationMotion, NavigationStack, useNavigated } from 'navigation-react-mobile';
 import React, { useState, useContext } from 'react';
 import { createRoot } from 'react-dom/client';

--- a/NavigationReactMobile/test/NavigatingHookTest.tsx
+++ b/NavigationReactMobile/test/NavigatingHookTest.tsx
@@ -2,7 +2,6 @@ import assert from 'assert';
 import 'mocha';
 import { StateNavigator } from 'navigation';
 import { NavigationContext, NavigationHandler } from 'navigation-react';
-//@ts-ignore
 import { NavigationMotion, NavigationStack, useNavigating } from 'navigation-react-mobile';
 import React, { useState, useContext } from 'react';
 import { createRoot } from 'react-dom/client';

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -2,7 +2,6 @@ import assert from 'assert';
 import 'mocha';
 import { StateNavigator } from 'navigation';
 import { NavigationHandler } from 'navigation-react';
-// @ts-ignore
 import { NavigationMotion, NavigationStack, Scene } from 'navigation-react-mobile';
 import React, {useState} from 'react';
 import { createRoot } from 'react-dom/client';
@@ -4410,7 +4409,6 @@ describe('NavigationMotion', function () {
                 root.render(
                     <NavigationHandler stateNavigator={stateNavigator}>
                         <NavigationStack>
-                            {/*@ts-ignore*/}
                             <Scene stateKey="sceneA" className="scene"><SceneA /></Scene>
                         </NavigationStack>
                     </NavigationHandler>
@@ -4493,7 +4491,6 @@ describe('NavigationMotion', function () {
                 root.render(
                     <NavigationHandler stateNavigator={stateNavigator}>
                         <NavigationStack>
-                            {/*@ts-ignore*/}
                             <Scene stateKey="sceneA" className={(data) => (
                                 data.x === 1 ? 'scene' : null
                             )}><SceneA /></Scene>
@@ -4587,7 +4584,6 @@ describe('NavigationMotion', function () {
                     <NavigationHandler stateNavigator={stateNavigator}>
                         <NavigationStack>
                             <Scene stateKey="sceneA"><SceneA /></Scene>
-                            {/*@ts-ignore*/}
                             <Scene stateKey="sceneB" className={(_data, crumbs) => (
                                 crumbs?.[0]?.state.key === 'sceneA' ? 'scene' : null
                             )}><SceneB /></Scene>
@@ -4623,7 +4619,6 @@ describe('NavigationMotion', function () {
                     <NavigationHandler stateNavigator={stateNavigator}>
                         <NavigationStack className="scene">
                             <Scene stateKey="sceneA"><SceneA /></Scene>
-                            {/*@ts-ignore*/}
                             <Scene stateKey="sceneB" className="otherScene"><SceneB /></Scene>
                         </NavigationStack>
                     </NavigationHandler>
@@ -4710,7 +4705,6 @@ describe('NavigationMotion', function () {
                 root.render(
                     <NavigationHandler stateNavigator={stateNavigator}>
                         <NavigationStack>
-                            {/*@ts-ignore*/}
                             <Scene stateKey="sceneA" className="scene" style={{backgroundColor: 'red'}}><SceneA /></Scene>
                         </NavigationStack>
                     </NavigationHandler>
@@ -4795,7 +4789,6 @@ describe('NavigationMotion', function () {
                 root.render(
                     <NavigationHandler stateNavigator={stateNavigator}>
                         <NavigationStack>
-                            {/*@ts-ignore*/}
                             <Scene stateKey="sceneA" className="scene" style={(data) => (
                                 data.x === 1 ? {backgroundColor: 'red'} : null
                             )}><SceneA /></Scene>
@@ -4891,7 +4884,6 @@ describe('NavigationMotion', function () {
                     <NavigationHandler stateNavigator={stateNavigator}>
                         <NavigationStack className="scene">
                             <Scene stateKey="sceneA"><SceneA /></Scene>
-                            {/*@ts-ignore*/}
                             <Scene stateKey="sceneB" style={(_data, crumbs) => (
                                 crumbs?.[0]?.state.key === 'sceneA' ? {backgroundColor: 'red'} : null
                             )}><SceneB /></Scene>
@@ -4928,7 +4920,6 @@ describe('NavigationMotion', function () {
                     <NavigationHandler stateNavigator={stateNavigator}>
                         <NavigationStack className="scene" style={{backgroundColor: 'red'}}>
                             <Scene stateKey="sceneA"><SceneA /></Scene>
-                            {/*@ts-ignore*/}
                             <Scene stateKey="sceneB" style={{backgroundColor: 'blue'}}><SceneB /></Scene>
                         </NavigationStack>
                     </NavigationHandler>

--- a/NavigationReactMobile/test/UnloadedHookTest.tsx
+++ b/NavigationReactMobile/test/UnloadedHookTest.tsx
@@ -2,7 +2,6 @@ import assert from 'assert';
 import 'mocha';
 import { StateNavigator } from 'navigation';
 import { NavigationContext, NavigationHandler } from 'navigation-react';
-//@ts-ignore
 import { NavigationMotion, NavigationStack, useUnloaded } from 'navigation-react-mobile';
 import React, { useState, useContext } from 'react';
 import { createRoot } from 'react-dom/client';

--- a/NavigationReactMobile/test/UnloadingHookTest.tsx
+++ b/NavigationReactMobile/test/UnloadingHookTest.tsx
@@ -2,7 +2,6 @@ import assert from 'assert';
 import 'mocha';
 import { StateNavigator } from 'navigation';
 import { NavigationContext, NavigationHandler } from 'navigation-react';
-//@ts-ignore
 import { NavigationMotion, NavigationStack, useUnloading } from 'navigation-react-mobile';
 import React, { useState, useContext } from 'react';
 import { createRoot } from 'react-dom/client';

--- a/NavigationReactMobile/test/navigation-react-mobile-tests.tsx
+++ b/NavigationReactMobile/test/navigation-react-mobile-tests.tsx
@@ -1,7 +1,7 @@
-// npx tsc --jsx react --target es3 --lib ES2015,DOM --esModuleInterop --baseUrl ../../types --noImplicitAny true --strict true navigation-react-mobile-tests.tsx
+// npx tsc --jsx react --target es5 --lib ES2015,DOM --esModuleInterop --baseUrl ../../types --noImplicitAny true --strict true navigation-react-mobile-tests.tsx
 import { StateNavigator } from 'navigation';
 import { NavigationContext, NavigationEvent, NavigationLink } from 'navigation-react';
-import { NavigationMotion, Scene, MobileHistoryManager, SharedElement, SharedElementMotion } from 'navigation-react-mobile';
+import { Scene, MobileHistoryManager, SharedElement, NavigationStack } from 'navigation-react-mobile';
 import React, { useContext } from 'react';
 import ReactDOM from 'react-dom';
 
@@ -46,42 +46,18 @@ const Person = () => {
 
 stateNavigator.start();
 
-const Zoom = (props: any) => (
-    <SharedElementMotion
-        {...props}
-        onAnimating={(_, ref) => {ref.style.opacity = '0'}}
-        onAnimated={(_, ref) => {ref.style.opacity = '1'}}>
-        {({ left, top, width, height }, name, { id }) => (
-            <div
-                key={name}
-                style={{
-                    position: 'absolute',
-                    left, top, width, height,
-                }}>
-                {id}
-            </div>
-        )}
-    </SharedElementMotion>
-);
-
 ReactDOM.render(
-    <NavigationMotion
-        unmountedStyle={{opacity: 1, translate: 100}}
-        mountedStyle={{opacity: 1, translate: 0}}
-        crumbStyle={{opacity: 0, translate: 0}}
-        sharedElementMotion={props => <Zoom {...props} />}
-        renderMotion={({ opacity, translate }, scene, key) => (
-            <div
-                key={key}
-                style={{
-                    opacity,
-                    transform: `translate(${translate}%)`,
-                }}>
-                {scene}
-            </div>
-        )}>
-        <Scene stateKey="people"><People /></Scene>
+    <NavigationStack
+        unmountStyle={[
+            {transform: 'translateX(100%)'},
+            {transform: 'translateX(0)'}
+          ]}
+        crumbStyle={[
+            {transform: 'translateX(5%) scale(0.8)', opacity: 0},
+            {transform: 'translateX(0) scale(1)', opacity: 1}
+          ]}>
+        <Scene stateKey="people" sharedElements={({id}) => [id]}><People /></Scene>
         <Scene stateKey="person"><Person /></Scene>
-    </NavigationMotion>,
+    </NavigationStack>,
     document.getElementById('root')
 );

--- a/NavigationReactMobile/test/navigation-react-mobile-tests.tsx
+++ b/NavigationReactMobile/test/navigation-react-mobile-tests.tsx
@@ -53,8 +53,8 @@ ReactDOM.render(
             {transform: 'translateX(0)'}
           ]}
         crumbStyle={[
-            {transform: 'translateX(5%) scale(0.8)', opacity: 0},
-            {transform: 'translateX(0) scale(1)', opacity: 1}
+            {transform: 'translateX(-60%)'},
+            {transform: 'translateX(0)'}
           ]}>
         <Scene stateKey="people" sharedElements={({id}) => [id]}><People /></Scene>
         <Scene stateKey="person"><Person /></Scene>

--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -41,7 +41,7 @@ const renderMotion = ({translateX, translateX_pc, translateY, translateY_pc, sca
             position: 'fixed' as any,
             backgroundColor: '#fff',
             left: 0, right: 0, top: 0, bottom: 0,
-            overflow: 'auto' as any,
+            overflow: 'hidden' as any,
         }}>
         {scene}
     </View>

--- a/build/npm/navigation-react-mobile/navigation.react.mobile.d.ts
+++ b/build/npm/navigation-react-mobile/navigation.react.mobile.d.ts
@@ -156,6 +156,10 @@ export interface NavigationStackProps {
      */
     children?: any;
     /**
+     * A Scene's shared elements 
+     */
+    sharedElements?: string[] | ((state: State, data: any, crumbs: Crumb[]) => string[]);
+    /**
      * Renders the Scene for the State and data
      */
     renderScene?: (state: State, data: any) => ReactNode;
@@ -193,6 +197,10 @@ export interface NavigationStackProps {
      * The Scene's style
      */
     style?: any;
+    /**
+     * The Scene's shared elements
+     */
+    sharedElements?: string[] | ((data: any, crumbs: Crumb[]) => string[]);
      /**
      * The Scene content
      */

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,11 +31,11 @@
         "rollup": "^2.11.2",
         "rollup-plugin-cleanup": "^3.1.1",
         "tslib": "^2.0.0",
-        "typescript": "^3.9.3"
+        "typescript": "^5.6.2"
       }
     },
     "build/npm/navigation": {
-      "version": "6.1.0",
+      "version": "6.2.0",
       "integrity": "sha512-FlhpzwFBrWEqXx7kT9YJZ/b50r3XWQwGWnmTt22SGFNwwxDuGUYAHMMdqU0U21G62VNmG0h91FiydB22wsJAEA==",
       "license": "Apache-2.0"
     },
@@ -49,7 +49,7 @@
       }
     },
     "build/npm/navigation-react-mobile": {
-      "version": "3.8.1",
+      "version": "3.10.1",
       "integrity": "sha512-F/eWJyzE+Um/8Z52LB4GGI77t4tE0D/rHZm52FqL60RrVWfZCZISV5Rokr8yAJ0dxbyj7I61MPa3NW70o3yLwg==",
       "dev": true,
       "license": "Apache-2.0",
@@ -12693,16 +12693,17 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
-      "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/uglify-es": {
@@ -23319,9 +23320,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
-      "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true
     },
     "uglify-es": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@rollup/plugin-sucrase": "^3.0.2",
         "@rollup/plugin-typescript": "^4.1.2",
-        "@types/node": "^17.0.23",
+        "@types/node": "^18.19.53",
         "del": "^6.0.0",
         "gulp": "^4.0.2",
         "gulp-cli": "^2.3.0",
@@ -3279,9 +3279,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "17.0.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
+      "version": "18.19.53",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.53.tgz",
+      "integrity": "sha512-GLxgUgHhDKO1Edw9Q0lvMbiO/IQXJwJlMaqxSGBXMpPy8uhkCs2iiPFaB2Q/gmobnFkckD3rqTBMVjXdwq+nKg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "16.0.4",
@@ -12776,6 +12780,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -15846,9 +15856,12 @@
       }
     },
     "@types/node": {
-      "version": "17.0.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
+      "version": "18.19.53",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.53.tgz",
+      "integrity": "sha512-GLxgUgHhDKO1Edw9Q0lvMbiO/IQXJwJlMaqxSGBXMpPy8uhkCs2iiPFaB2Q/gmobnFkckD3rqTBMVjXdwq+nKg==",
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/yargs": {
       "version": "16.0.4",
@@ -23377,6 +23390,11 @@
       "resolved": "https://registry.npmjs.org/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
       "integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=",
       "dev": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "@rollup/plugin-sucrase": "^3.0.2",
     "@rollup/plugin-typescript": "^4.1.2",
-    "@types/node": "^17.0.23",
+    "@types/node": "^18.19.53",
     "del": "^6.0.0",
     "gulp": "^4.0.2",
     "gulp-cli": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "rollup": "^2.11.2",
     "rollup-plugin-cleanup": "^3.1.1",
     "tslib": "^2.0.0",
-    "typescript": "^3.9.3"
+    "typescript": "^5.6.2"
   },
   "scripts": {
     "test": "gulp test",

--- a/types/navigation-react-mobile.d.ts
+++ b/types/navigation-react-mobile.d.ts
@@ -156,6 +156,10 @@ export interface NavigationStackProps {
      */
     children?: any;
     /**
+     * A Scene's shared elements 
+     */
+    sharedElements?: string[] | ((state: State, data: any, crumbs: Crumb[]) => string[]);
+    /**
      * Renders the Scene for the State and data
      */
     renderScene?: (state: State, data: any) => ReactNode;
@@ -193,6 +197,10 @@ export interface NavigationStackProps {
      * The Scene's style
      */
     style?: any;
+    /**
+     * The Scene's shared elements
+     */
+    sharedElements?: string[] | ((data: any, crumbs: Crumb[]) => string[]);
      /**
      * The Scene content
      */


### PR DESCRIPTION
Introduced the `NavigationStack` component and its Web Animations Api support in #808. It supersedes `NavigationMotion’s` outmoded animation approach. But, without shared element transitions, it's not a drop-in replacement. With this PR can update the docs and samples to use `NavigationStack` throughout.

Like in #808, using the Web Animations Api means smoother shared element animations because they doesn’t require any React state updates. It also brings the web and native Api in closer alignment. Don't need the `SharedElementMotion` component anymore and added the matching ‘sharedElements’ prop to the `NavigationStack/Scene` so the user can decide which elements to share.

Also matched the postpone behaviour of Android where the navigation doesn't begin until the shared elements on the next scene have rendered. This prevents the jump caused by `SharedElementMotion` starting the shared elements part way when they’re first rendered.
