### PR TITLE
Documented the Web Animations Api (Mobile)

### DIFF
--- a/documentation/mobile/animated-navigation.html
+++ b/documentation/mobile/animated-navigation.html
@@ -57,22 +57,14 @@
 ]);</code></pre>
             <h2>Animating</h2>
             <p>
-                The <code>NavigationMotion</code> component renders the scenes in the stack. It lets you animate the scenes as they progress through the stack. A scene is said to be either unmounted, mounted or a crumb. It's unmounted when it's not on the stack; it's mounted when it's at the top of the stack; and it's a crumb when it's anywhere else in the stack (in the breadcrumb trail).
+                The <code>NavigationStack</code> component renders the scenes in the stack. It lets you animate the scenes as they progress through the stack. Any scene that isn't the current one is either unmounted or a crumb. It's unmounted when it's not on the stack yet and it's a crumb when it's anywhere in the stack apart from on top (in the breadcrumb trail).
             </p>
             <p>
-                You assign a style <code>prop</code> to each of these three stages and the <code>NavigationMotion</code> component calls you back with the interpolated values so you can animate the scenes. In our email example, we'll give the unmounted and crumb styles an opacity of 0 and the mounted style an opacity of 1. When the user opens a mail, the 'inbox' scene fades out as it becomes a crumb and the 'mail' scene fades in as it's mounted.
+                You assign keyframe animations to the unmount and crumb style props. The <code>NavigationStack</code> runs the animations as the scene moves from unmounted or crumb to current and back again. In our email example, we'll make the unmount and crumb keyframes start at opacity 0 and finish at 1. When the user opens a mail, the 'inbox' scene fades out as it becomes a crumb and the 'mail' scene fades in as it's mounted.
             </p>
-            <pre><code class="language-jsx">&lt;NavigationMotion
-  unmountedStyle={{opacity: 0}}
-  mountedStyle={{opacity: 1}}
-  crumbStyle={{opacity: 0}}
-  renderMotion={(style, scene, key) => (
-    &lt;div
-      key={key}
-      style={{...sceneStyle, opacity: style.opacity}}>
-      {scene}
-    &lt;/div>
-  )}></code></pre>
+            <pre><code class="language-jsx">&lt;NavigationStack
+  unmountStyle={[{opacity: 0}, {opacity: 1}]}
+  crumbStyle={[{opacity: 0}, {opacity: 1}]}></code></pre>
             <h2 id="navigating-back">Navigating Back</h2>
             <p>
                 You can navigate back to a visited scene using the <code>NavigationBackLink</code>. The <code>distance</code> prop indicates how many scenes to go back. In our email example, we add a <code>NavigationBackLink</code> to the 'mail' scene. A <code>distance</code> of 1 allows the user to return to their inbox. When they tap the Hyperlink, the 'mail' scene fades out as it's unmounted and the 'inbox' scene fades back in as it's mounted.

--- a/documentation/mobile/hello-world.html
+++ b/documentation/mobile/hello-world.html
@@ -70,41 +70,36 @@ const Hello = () => (
 
 const World = () => &lt;div>World&lt;/div>;</code></pre>
             <p>
-                We'll wrap each scene inside a <code>Scene</code> component and assign the matching <code>State</code> to the <code>stateKey prop</code>. The <code>NavigationMotion</code> component renders each scene when the associated <code>State</code> becomes active. When we visit the 'world' scene the 'hello' scene doesn't unmount. It stays in the stack like in a native app.
+                We'll wrap each scene inside a <code>Scene</code> component and assign the matching <code>State</code> to the <code>stateKey prop</code>. The <code>NavigationStack</code> component renders each scene when the associated <code>State</code> becomes active. When we visit the 'world' scene the 'hello' scene doesn't unmount. It stays in the stack like in a native app.
             </p>
             <pre><code class="language-jsx">import {Scene} from 'navigation-react-mobile';
 
-&lt;NavigationMotion>
+&lt;NavigationStack>
   &lt;Scene stateKey="hello">&lt;Hello />&lt;/Scene>
   &lt;Scene stateKey="world">&lt;World />&lt;/Scene>
-&lt;/NavigationMotion></code></pre>
+&lt;/NavigationStack></code></pre>
 
             <p>
             </p>
             <h2>Animation</h2>
             <p>
-                We'll use the <code>NavigationMotion</code> component to animate the scenes as they come and go. Each scene can exist in one of three stages - unmounted, mounted or crumb. At the start, the 'home' scene is mounted and the 'world' scene is unmounted. When we click the 'home' Hyperlink the 'home' scene becomes a crumb (in the breadcrumb trail) and the 'world' scene is mounted.
+                We'll use the <code>NavigationStack</code> component to animate the scenes as they come and go. Each scene can exist in one of three stages - unmounted, current or crumb. At the start, the 'home' scene is current and the 'world' scene is unmounted. When we click the 'home' Hyperlink the 'home' scene becomes a crumb (in the breadcrumb trail) and the 'world' scene is current.
             </p>
             <p>
-                We'll assign each of these stages a different translation style <code>prop</code>. The <code>NavigationMotion</code> component provides a <code>renderMotion</code> callback prop that lets us animate between these styles as a scene moves from one stage to another. We'll use the callback's parameters to style the scene with the interpolated translation value. A value of 100% for the <code>unmountedStyle</code>, for example, means the 'world' scene will slide in from the right.
+                The <code>NavigationStack</code> has an <code>unmountStyle</code> prop. It accepts the keyframes for the animation that runs when a scene moves from unmounted to current. It also has a <code>crumbStyle</code> prop for the keyframe animation that runs when the scene moves from a crumb to current. To slide the 'world' scene in the from the right we'll assign keyframes that translate horizontally from 100% to 0.
             </p>
-            <pre><code class="language-jsx">&lt;NavigationMotion
-  unmountedStyle={{translate: 100}}
-  mountedStyle={{translate: 0}}
-  crumbStyle={{translate: -10}}
-  renderMotion={(style, scene, key) => (
-    &lt;div
-      key={key}
-      style={{
-        ...sceneStyle,
-        transform: `translate(${style.translate}%)`
-      }}>
-      {scene}
-    &lt;/div>
-  )}></code></pre>
+            <pre><code class="language-jsx">&lt;NavigationStack
+  unmountStyle={[
+    {transform: 'translateX(100%)'},
+    {transform: 'translateX(0)'}
+  ]}
+  crumbStyle={[
+    {transform: 'translateX(-10%)'},
+    {transform: 'translateX(0)'}
+  ]}></code></pre>
             <h2>Breadcrumbs</h2>
             <p>
-                You'll remember that the Navigation router drops a breadcrumb when we click the 'hello' Hyperlink. We can use this crumb to build a Hyperlink that returns us to the 'hello' scene. We'll replace the div in the 'world' scene with a <code>NavigationBackLink</code> component that navigates back a distance of 1 breadcrumb along the trail. When we click this Hyperlink, the <code>NavigationMotion</code> component plays the animations in reverse as the 'home' scene mounts and the 'world' scene unmounts.
+                You'll remember that the Navigation router drops a breadcrumb when we click the 'hello' Hyperlink. We can use this crumb to build a Hyperlink that returns us to the 'hello' scene. We'll replace the div in the 'world' scene with a <code>NavigationBackLink</code> component that navigates back a distance of 1 breadcrumb along the trail. When we click this Hyperlink, the <code>NavigationStack</code> component reverses the unmount keyframe animation and slides the 'world' scene off to the right.
             </p>
             <pre><code class="language-jsx">import {NavigationBackLink} from 'navigation-react';
 

--- a/documentation/mobile/setup.html
+++ b/documentation/mobile/setup.html
@@ -57,35 +57,29 @@
             <pre><code class="language-jsx">import {createRoot} from 'react-dom/client';
 import {StateNavigator} from 'navigation';
 import {NavigationHandler} from 'navigation-react';
-import {NavigationMotion} from 'navigation-react-mobile';
+import {NavigationStack} from 'navigation-react-mobile';
 
 const stateNavigator = new StateNavigator([
 ]);
 
 stateNavigator.start();
 
+const App = () => (
+  &lt;NavigationHandler stateNavigator={stateNavigator}>
+    &lt;NavigationStack style={sceneStyle}>
+    &lt;/NavigationStack>
+  &lt;/NavigationHandler>
+);
+
 const sceneStyle = {
   position: 'fixed',
-  overflow: 'auto',
+  overflow: 'hidden',
   backgroundColor: '#fff',
   top: 0, right: 0, bottom: 0, left: 0
 }
 
-const App = () => (
-  &lt;NavigationHandler stateNavigator={stateNavigator}>
-    &lt;NavigationMotion
-      renderMotion={(style, scene, key) => (
-        &lt;div key={key} style={sceneStyle}>
-          {scene}
-        &lt;/div>
-      )}>
-    &lt;/NavigationMotion>
-  &lt;/NavigationHandler>
-);
-
 const rootElement = document.getElementById('root');
 const root = createRoot(rootElement);
-
 root.render(&lt;App />);</code></pre>
         </div>
     </div>

--- a/documentation/mobile/shared-element-navigation.html
+++ b/documentation/mobile/shared-element-navigation.html
@@ -49,79 +49,25 @@
             <h1>Shared Element Navigation</h1>
             <h2>Sharing Elements</h2>
             <p>
-                The Navigation router lets you smoothly transition between elements that are shared across two scenes when the user navigates from one scene to the other. It's a technique common to native apps, for example, zooming into an enlarged image when a user clicks on a thumbnail in a gallery. To identify elements you want to share across two scenes, you wrap each one in a <code>SharedElement</code> component and give them both the same <code>name</code>. You pass in a <code>prop</code> holding the data you want to animate as one element transitions to the other.
+                The Navigation router lets you smoothly transition between elements that are shared across two scenes when the user navigates from one scene to the other. It's a technique common to native apps, for example, zooming into an enlarged image when a user clicks on a thumbnail in a gallery. To identify elements you want to share across two scenes, you wrap each one in a <code>SharedElement</code> component and give them both the same <code>name</code>.
             </p>
             <p>
-                In our email example app, we can smooth out the navigation when a user opens an email by sharing the subject of the email between the 'inbox' scene and the 'mail' scene. We wrap the subject elements on each scene inside a <code>SharedElement</code>. The font size of the subject is smaller in the inbox than on the open email, 14px as compared to 20px. Because we need to scale the text during the navigation, we pass these font sizes, along with the subject line, into the <code>data props</code>.
+                In our email example app, we can smooth out the navigation when a user opens an email by sharing the subject of the email between the 'inbox' scene and the 'mail' scene. We wrap the subject elements on each scene inside a <code>SharedElement</code> and name them the same.
             </p>
             <pre><code class="language-jsx">import {SharedElement} from 'navigation-react-mobile';
 
 // The 'inbox' scene
-&lt;SharedElement
-  data={{size: 14, subject: mail.subject}}
-  name={`mail${mail.id}`}>
+&lt;SharedElement name={`mail${mail.id}`}>
   &lt;span>{mail.subject}&lt;/span>
 &lt;/SharedElement></code></pre>
             <pre><code class="language-jsx">// The 'mail' scene
-&lt;SharedElement
-  data={{size: 20, subject: mail.subject}}
-  name={`mail${mail.id}`}>
+&lt;SharedElement name={`mail${mail.id}`}>
   &lt;span>{mail.subject}&lt;/span>
 &lt;/SharedElement></code></pre>
-            <h2>Animating</h2>
             <p>
-                During a navigation, the <code>SharedElementMotion</code> component keeps track of elements that are shared between the two scenes. For each pair it finds, as the navigation progresses, it interpolates between the source and target element screen positions. It calls you back with a <code>style</code> parameter containing these interpolated values so you can animate the shared element. The <code>SharedElementMotion</code> component also accepts <code>onAnimating</code> and <code>onAnimated props</code> so you can style the source and target elements when the navigation starts and finishes.
+                When you navigate between two <code>States</code>, the Navigation router calls the function you assign to the <code>sharedElements</code> prop of the destination <code>Scene</code> component. You return the shared names of the views that will participate in the transition. In our email example, we return the name we gave to the selected email.
             </p>
-            <p>
-                Returning to the email example, we create a <code>MailShared</code> component that renders a <code>SharedElementMotion</code> component. Inside the child callback function we render the email subject inside a <code>div</code>. We style the <code>div</code> using the interpolated coordinates. To make it look like the subject is moving out of the 'inbox' scene and into the 'mail' scene, we supply an <code>onAnimating prop</code> that hides the subject on these scenes when the navigation begins. An <code>onAnimated prop</code> restores their visibility when the navigation completes.
-            </p>
-            <pre><code class="language-jsx">import {SharedElementMotion} from 'navigation-react-mobile';
-
-const MailShared = (props) => (
-  &lt;SharedElementMotion
-    onAnimating={(name, ref) => {ref.style.opacity = 0}}
-    onAnimated={(name, ref) => {ref.style.opacity = 1}}
-    {...props}>
-    {(style, name, data) => (
-      &lt;div
-        key={name}
-        style={{
-          position: 'absolute',
-          fontSize: `${data.size}px`,
-          left: data.left,
-          top: data.top,
-          width: data.width,
-          height: data.height,
-          transformOrigin: 'top left',
-          transform: `
-            translate(${style.left - data.left}px, ${style.top - data.top}px)
-            scale(${style.width / data.width}, ${style.height / data.height})
-          `
-        }}>
-        {data.subject}
-      &lt;/div>
-    )}
-  &lt;/SharedElementMotion>
-);</code></pre>
-            <p>
-                We assign our <code>MailShared</code> component to the <code>sharedElementMotion prop</code> of the <code>NavigationMotion</code> component because the shared element animation has to run as part of the overall scene animation.
-            </p>
-            <pre><code class="language-jsx">&lt;NavigationMotion
-  unmountedStyle={{opacity: 0}}
-  mountedStyle={{opacity: 1}}
-  crumbStyle={{opacity: 0}}
-  sharedElementMotion={props => &lt;MailShared {...props} />}
-  renderMotion={(style, scene, key) => (
-    &lt;div
-      key={key}
-      style={{opacity: style.opacity}}>
-      {scene}
-    &lt;/div>
-  )}></code></pre>
-            <div class="Note">
-                <h2>Note</h2>
-                The <code>style</code> parameter of the callback contains the interpolated <code>data props</code> and screen positions. You can directly set them onto the shared element's <code>style props</code> instead of using <code>transform</code>, but the animation might be jankier.
-            </div>
+            <pre><code class="language-jsx">&lt;Scene stateKey="mail" sharedElements={data => [`mail${data.id}`]}>&lt;Mail />&lt;/Scene></code></pre>
         </div>
     </div>
     <script type="text/javascript" src="../../js/prism.js"></script>


### PR DESCRIPTION
See #808 and #812

Replaced `NavigationMotion` with `NavigationStack` and removed `SharedElementMotion`.
Will update the sandbox examples once navigaton-react-motion is released.