### PR TITLE
fix crash on applaunch when using tabs with trackCrumbtrail disabled

### DIFF
--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -188,8 +188,12 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                 fragment.setReturnTransition(scene.exitTrans);
                 fragment.returnAnimator = scene.exitAnimator;
                 fragmentTransaction.replace(getId(), fragment, key);
-                if (nextCrumb > 0) fragmentTransaction.addToBackStack(String.valueOf(nextCrumb));
-                fragmentTransaction.commit();
+                if (nextCrumb > 0) {
+                    fragmentTransaction.addToBackStack(String.valueOf(nextCrumb));
+                    fragmentTransaction.commit();
+                } else {
+                    fragmentTransaction.commitNowAllowingStateLoss();
+                }
                 prevFragment = fragment;
             }
         }


### PR DESCRIPTION
_ISSUE:_  Experiencing a crash when the app is launched when tabView trackcrumbtrail is marked as false, while opening the app from app info the app crashed randomly, instead of resuming from the last screen, i.e tabView.

_Demo:_
Open the app info then go to the app. Swipe back from the tabs scene to close the app and bring up the app info. Then open the app from the app info. This fails which kills the app. Then open the app from the app info again and it works.

This problem only happened on a physical device (only tested on Poco F4 5g and Moto Edge 40 Neo and it happened on both) - couldn't recreate on a simulator (only tried Pixel).

[376014216-51121a66-b926-419b-bdfa-1691d440f34d.webm](https://github.com/user-attachments/assets/cf06acd2-3806-4ab3-adc4-148f4fe9ae2c)

_Stracktrace:_ 

```java
Process: codes.afk.habit.tracker, PID: 16588
java.lang.IllegalStateException: FragmentManager is already executing transactions
	at androidx.fragment.app.FragmentManager.ensureExecReady(FragmentManager.java:1876)
	at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:1935)
	at androidx.fragment.app.FragmentManager.executePendingTransactions(FragmentManager.java:737)
	at com.navigation.reactnative.NavigationStackView.onAfterUpdateTransaction(NavigationStackView.java:99)
	at com.navigation.reactnative.NavigationStackView.onAttachedToWindow(NavigationStackView.java:326)
	at android.view.View.dispatchAttachedToWindow(View.java:22663)
	at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3495)
	at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3502)
	at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3502)
	at android.view.ViewGroup.addViewInner(ViewGroup.java:5344)
	at android.view.ViewGroup.addView(ViewGroup.java:5130)
	at android.view.ViewGroup.addView(ViewGroup.java:5070)
	at androidx.fragment.app.FragmentStateManager.addViewToContainer(FragmentStateManager.java:893)
	at androidx.fragment.app.FragmentStateManager.createView(FragmentStateManager.java:577)
	at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:278)
	at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:2103)
	at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:2004)
	at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:1941)
	at androidx.fragment.app.FragmentManager$5.run(FragmentManager.java:661)
	at android.os.Handler.handleCallback(Handler.java:959)
	at android.os.Handler.dispatchMessage(Handler.java:100)
	at android.os.Looper.loopOnce(Looper.java:232)
	at android.os.Looper.loop(Looper.java:317)
	at android.app.ActivityThread.main(ActivityThread.java:8592)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:878)
```