### PR TITLE
Ensured NavigationStack retains scene on browser forward (Mobile)

### DIFF
--- a/NavigationReactMobile/src/NavigationAnimation.tsx
+++ b/NavigationReactMobile/src/NavigationAnimation.tsx
@@ -38,6 +38,11 @@ const NavigationAnimation  = ({children, data: nextScenes, history, onRest, oldS
                     if (!oldState) scene.pushEnter.finish();
                 }
                 if (popExit && prevNavState !== 'popExit') {
+                    if (prevNavState === 'pushExit') {
+                        scene.prevNavState = 'popEnter';
+                        scene.popEnter.cancel();
+                        scene.popEnter = null;
+                    }
                     scene.navState = 'popExit';
                     scene.pushEnter.reverse();
                 }
@@ -111,7 +116,7 @@ const NavigationAnimation  = ({children, data: nextScenes, history, onRest, oldS
                         if (!history && scene?.unmounted) subkey += 1;
                         const wasMounted = !!scene?.pushEnter || !!scene?.popEnter;
                         const noAnimScene = {...scene, ...nextScene, ...noAnim, unmounted: false, subkey};
-                        if (!scene) return {...noAnimScene, pushEnter: true, count};
+                        if (!scene || scene.unmounted) return {...noAnimScene, pushEnter: true, count};
                         if (nextScene.mount && !wasMounted) return {...noAnimScene, popEnter: !scene.popExit, pushEnter: scene.popExit};
                         if (!nextScene.mount && wasMounted) return {...noAnimScene, pushExit: true};
                         return {...scene, ...nextScene, unmounted: false, subkey};

--- a/NavigationReactMobile/src/NavigationAnimation.tsx
+++ b/NavigationReactMobile/src/NavigationAnimation.tsx
@@ -23,7 +23,7 @@ const NavigationAnimation  = ({children, data: nextScenes, history, onRest, oldS
                 if (!scene.pushEnter) {
                     const {duration = defaultDuration, keyframes = unmountStyle} = unmountStyle;
                     if (!duration || !keyframes) return;
-                    scene.pushEnter = scene.animate(keyframes, {duration, fill: 'forwards'});
+                    scene.pushEnter = scene.animate(keyframes, {duration, fill: 'both'});
                     scene.pushEnter.persist();
                 }
                 if (pushEnter && prevNavState !== 'pushEnter') {

--- a/NavigationReactMobile/src/NavigationAnimation.tsx
+++ b/NavigationReactMobile/src/NavigationAnimation.tsx
@@ -5,11 +5,15 @@ const NavigationAnimation  = ({children, data: nextScenes, history, onRest, oldS
     const container = useRef(null);
     useLayoutEffect(() => {
         let cancel = false;
-        scenes.all.forEach(({key, url, pushEnter, popExit, pushExit, popEnter, unmountStyle, crumbStyle}, i) => {
+        scenes.all.forEach(({key, url, pushEnter, popExit, pushExit, popEnter, unmountStyle, crumbStyle, unmounted}, i) => {
             const scene = container.current.children[i];
             const prevNavState = scene.navState || scene.prevNavState;
             if (!scene.animate) {
-                if (popExit) setScenes(({all, ...rest}) => ({all: all.filter((_s, index) => index !== i), ...rest}));
+                if (popExit && !unmounted) {
+                    setScenes(({all, ...rest}) => (
+                        {all: all.map((s, index) => index !== i ? s : {...s, unmounted: true}), ...rest}
+                    ));
+                }
                 if ((pushEnter && prevNavState !== 'pushEnter') || (popEnter && prevNavState !== 'popEnter')) onRest({key, url});
                 scene.prevNavState = pushEnter ? 'pushEnter' : popExit ? 'popExit' : pushExit ? 'pushExit' : 'popEnter';
                 return;

--- a/NavigationReactMobile/src/NavigationAnimation.tsx
+++ b/NavigationReactMobile/src/NavigationAnimation.tsx
@@ -39,8 +39,11 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
                 }
                 scene.pushEnter?.finished.then(() => {
                     if (cancel || !scene.navState) return;
-                    if (popExit)
-                        setScenes(({all, ...rest}) => ({all: all.filter((_s, index) => index !== i), ...rest}))
+                    if (popExit) {
+                        setScenes(({all, ...rest}) => (
+                            {all: all.map((s, index) => index !== i ? s : {...s, unmounted: true}), ...rest}
+                        ));
+                    }
                     if (pushEnter || popExit) {
                         onRest({key, url});
                         scene.prevNavState = scene.navState;
@@ -101,11 +104,11 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
                     .map((nextScene) => {
                         const scene = scenesByKey[nextScene.key];
                         const wasMounted = !!scene?.pushEnter || !!scene?.popEnter;
-                        const noAnimScene = {...scene, ...nextScene, ...noAnim};
+                        const noAnimScene = {...scene, ...nextScene, ...noAnim, unmounted: false};
                         if (!scene) return {...noAnimScene, pushEnter: true, count};
                         if (nextScene.mount && !wasMounted) return {...noAnimScene, popEnter: !scene.popExit, pushEnter: scene.popExit};
                         if (!nextScene.mount && wasMounted) return {...noAnimScene, pushExit: true};
-                        return {...scene, ...nextScene};
+                        return {...scene, ...nextScene, unmounted: false};
                     })
                     .concat(scenes
                         .filter(({key, unmountStyle}) => (

--- a/NavigationReactMobile/src/NavigationAnimation.tsx
+++ b/NavigationReactMobile/src/NavigationAnimation.tsx
@@ -103,12 +103,14 @@ const NavigationAnimation  = ({children, data: nextScenes, history, onRest, oldS
                 all: nextScenes
                     .map((nextScene) => {
                         const scene = scenesByKey[nextScene.key];
+                        let subkey = scene?.subkey || 0;
+                        if (!history && scene?.unmounted) subkey += 1;
                         const wasMounted = !!scene?.pushEnter || !!scene?.popEnter;
-                        const noAnimScene = {...scene, ...nextScene, ...noAnim, unmounted: false};
+                        const noAnimScene = {...scene, ...nextScene, ...noAnim, unmounted: false, subkey};
                         if (!scene) return {...noAnimScene, pushEnter: true, count};
                         if (nextScene.mount && !wasMounted) return {...noAnimScene, popEnter: !scene.popExit, pushEnter: scene.popExit};
                         if (!nextScene.mount && wasMounted) return {...noAnimScene, pushExit: true};
-                        return {...scene, ...nextScene, unmounted: false};
+                        return {...scene, ...nextScene, unmounted: false, subkey};
                     })
                     .concat(scenes
                         .filter(({key}) => !nextScenesByKey[key])

--- a/NavigationReactMobile/src/NavigationAnimation.tsx
+++ b/NavigationReactMobile/src/NavigationAnimation.tsx
@@ -120,7 +120,7 @@ const NavigationAnimation  = ({children, data: nextScenes, history, onRest, oldS
                             return {...scene, ...noAnim, popExit: !scene.pushExit, popEnter: scene.pushExit, unmounted};
                         })
                     )
-                    .filter(({unmounted}) => history || nextScenes.length <= (prev?.length || 0) || !unmounted)
+                    .filter(({unmounted, index}) => history || nextScenes.length <= (prev?.length || 0) || !unmounted || index < nextScenes.length - 1)
                     .sort((a, b) => a.index !== b.index ? a.index - b.index : a.count - b.count)
             };
         });

--- a/NavigationReactMobile/src/NavigationAnimation.tsx
+++ b/NavigationReactMobile/src/NavigationAnimation.tsx
@@ -112,6 +112,7 @@ const NavigationAnimation  = ({children, data: nextScenes, onRest, oldState, dur
                     })
                     .concat(scenes
                         .filter(({key, unmountStyle}) => (
+                            // don't filter out if there's no unmount animation - suspend instead
                             !nextScenesByKey[key] && Array.isArray(unmountStyle?.keyframes || unmountStyle) && (unmountStyle.duration ?? defaultDuration)
                         ))
                         .map(scene => ({...scene, ...noAnim, popExit: !scene.pushExit, popEnter: scene.pushExit}))

--- a/NavigationReactMobile/src/NavigationStack.tsx
+++ b/NavigationReactMobile/src/NavigationStack.tsx
@@ -125,8 +125,8 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
         <SharedElementContext.Provider value={sharedElementRegistry as any}>
             <NavigationAnimation data={sceneData} onRest={clearScene} oldState={oldState} duration={duration} pause={!ignorePause && pause !== null}>
                 {scenes => (
-                    scenes.map(({key, index: crumb, url, className, style}) => (
-                        <Freeze key={key} enabled={rest && crumb < sceneData.length - 1}>
+                    scenes.map(({key, index: crumb, url, unmounted, className, style}) => (
+                        <Freeze key={key} enabled={(rest && crumb < sceneData.length - 1) || unmounted}>
                             <Scene crumb={crumb} url={url} rest={rest} className={className} style={style} wrap renderScene={renderScene} />
                         </Freeze>
                     )).concat(

--- a/NavigationReactMobile/src/NavigationStack.tsx
+++ b/NavigationReactMobile/src/NavigationStack.tsx
@@ -99,10 +99,7 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
             const {keys: prevKeys, stateNavigator: prevStateNavigator} = prevStackState;
             const {state, crumbs, nextCrumb} = stateNavigator.stateContext;
             const prevState = prevStateNavigator && prevStateNavigator.stateContext.state;
-            const currentKeys = crumbs.concat(nextCrumb).reduce((arr, {state: {key}}) => {
-                const prevKey = arr[arr.length - 1];
-                return [...arr, `${prevKey ? `${prevKey}->` : ''}${key.replace(/-/g, '-|')}`]
-            }, []);
+            const currentKeys = crumbs.concat(nextCrumb).map(({state: {key}}, i) => `${key}-${i}`);
             const newKeys = currentKeys.slice(prevKeys.length);
             const keys = prevKeys.slice(0, currentKeys.length).concat(newKeys);
             if (prevKeys.length === keys.length && prevState !== state)

--- a/NavigationReactMobile/src/NavigationStack.tsx
+++ b/NavigationReactMobile/src/NavigationStack.tsx
@@ -127,7 +127,7 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
                             <Scene key={subkey} crumb={crumb} url={url} rest={rest} className={className} style={style} wrap renderScene={renderScene} />
                         </Freeze>
                     )).concat(
-                        <SharedElementAnimation key="sharedElements-" sharedElements={!rest ? sharedEls : []}
+                        <SharedElementAnimation key="sharedElements" sharedElements={!rest ? sharedEls : []}
                             unmountStyle={sceneData[sceneData.length - 1].unmountStyle} duration={duration} />
                     )
                 )}

--- a/NavigationReactMobile/src/NavigationStack.tsx
+++ b/NavigationReactMobile/src/NavigationStack.tsx
@@ -125,9 +125,9 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
         <SharedElementContext.Provider value={sharedElementRegistry as any}>
             <NavigationAnimation data={sceneData} history={stateContext.history} onRest={clearScene} oldState={oldState} duration={duration} pause={!ignorePause && pause !== null}>
                 {scenes => (
-                    scenes.map(({key, index: crumb, url, unmounted, className, style}) => (
+                    scenes.map(({key, subkey, index: crumb, url, unmounted, className, style}) => (
                         <Freeze key={key} enabled={(rest && crumb < sceneData.length - 1) || unmounted}>
-                            <Scene crumb={crumb} url={url} rest={rest} className={className} style={style} wrap renderScene={renderScene} />
+                            <Scene key={subkey} crumb={crumb} url={url} rest={rest} className={className} style={style} wrap renderScene={renderScene} />
                         </Freeze>
                     )).concat(
                         <SharedElementAnimation key="sharedElements-" sharedElements={!rest ? sharedEls : []}

--- a/NavigationReactMobile/src/NavigationStack.tsx
+++ b/NavigationReactMobile/src/NavigationStack.tsx
@@ -123,7 +123,7 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
     const sceneData = getScenes();
     return (stateContext.state &&
         <SharedElementContext.Provider value={sharedElementRegistry as any}>
-            <NavigationAnimation data={sceneData} onRest={clearScene} oldState={oldState} duration={duration} pause={!ignorePause && pause !== null}>
+            <NavigationAnimation data={sceneData} history={stateContext.history} onRest={clearScene} oldState={oldState} duration={duration} pause={!ignorePause && pause !== null}>
                 {scenes => (
                     scenes.map(({key, index: crumb, url, unmounted, className, style}) => (
                         <Freeze key={key} enabled={(rest && crumb < sceneData.length - 1) || unmounted}>

--- a/NavigationReactMobile/test/NavigationMotionKeyTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionKeyTest.tsx
@@ -122,4 +122,118 @@ describe('NavigationMotionKey', function () {
             }
         };
     });
+
+    describe('A to A -> B to A -> B -> C to A -> B to A', function () {
+        var stateNavigator, root, container, updateA, updateB;
+        var SceneA = () => {
+            var [updated, setUpdated] = useState('0')
+            updateA = setUpdated;
+            return <div id="sceneA" data-updated={updated} />;
+        };
+        var SceneB = () => {
+            var [updated, setUpdated] = useState('0')
+            updateB = setUpdated;
+            return <div id="sceneB" data-updated={updated} />;
+        };
+        var SceneC = () => <div id="sceneC" />;
+        beforeEach(() => {
+            updateA = null;
+            updateB = null;
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+                { key: 'sceneC', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
+        describe('Static', () => {
+            it('should remember state', async function(){
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationMotion>
+                                {(_style, scene, key) =>  (
+                                    <div className="scene" id={key} key={key}>{scene}</div>
+                                )}
+                            </NavigationMotion>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic', () => {
+            it('should remember state', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationMotion
+                                renderMotion={(_style, scene, key) =>  (
+                                    <div className="scene" id={key} key={key}>{scene}</div>
+                                )}>
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                                <Scene stateKey="sceneC"><SceneC /></Scene>
+                            </NavigationMotion>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Static Stack', () => {
+            it('should remember state', async function(){
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should remember state', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                                <Scene stateKey="sceneC"><SceneC /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        const test = async () => {
+            act(() => updateA('1'));
+            await act(async () => stateNavigator.navigate('sceneB'));
+            act(() => updateB('2'));
+            await act(async () => stateNavigator.navigate('sceneC'));
+            await act(async () => stateNavigator.navigateBack(1));
+            try {
+                var scene = container.querySelector('#sceneB');
+                assert.strictEqual(scene.dataset.updated, '2');
+                await act(async () => stateNavigator.navigateBack(1));
+                var scene = container.querySelector('#sceneA');
+                assert.strictEqual(scene.dataset.updated, '1');
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
 });

--- a/NavigationReactMobile/test/NavigationMotionKeyTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionKeyTest.tsx
@@ -772,4 +772,82 @@ describe('NavigationMotionKey', function () {
             }
         };
     });
+
+    describe('A to A -> B to A -> B -> C to A history to A -> B history to A -> B -> C', function () {
+        var stateNavigator, root, container, updateB, updateC;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => {
+            var [updated, setUpdated] = useState('0')
+            updateB = setUpdated;
+            return <div id="sceneB" data-updated={updated} />;
+        };
+        var SceneC = () => {
+            var [updated, setUpdated] = useState('0')
+            updateC = setUpdated;
+            return <div id="sceneC" data-updated={updated} />;
+        };
+        beforeEach(() => {
+            updateB = null;
+            updateC = null;
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+                { key: 'sceneC', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
+        describe('Static Stack', () => {
+            it('should remember state', async function(){
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should remember state', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                                <Scene stateKey="sceneC"><SceneC /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        const test = async () => {
+            await act(async () => stateNavigator.navigate('sceneB'));
+            var historyForwardB = stateNavigator.stateContext.url;
+            act(() => updateB('1'));
+            await act(async () => stateNavigator.navigate('sceneC'));
+            var historyForwardC = stateNavigator.stateContext.url;
+            act(() => updateC('2'));
+            await act(async () => stateNavigator.navigateBack(2));
+            await act(async () => stateNavigator.navigateLink(historyForwardB, undefined, true));
+            try {
+                var scene = container.querySelector('#sceneB');
+                assert.strictEqual(scene.dataset.updated, '1');
+                await act(async () => stateNavigator.navigateLink(historyForwardC, undefined, true));
+                scene = container.querySelector('#sceneC');
+                assert.strictEqual(scene.dataset.updated, '2');
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
 });

--- a/NavigationReactMobile/test/NavigationMotionKeyTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionKeyTest.tsx
@@ -1,9 +1,9 @@
 import assert from 'assert';
 import 'mocha';
 import { StateNavigator } from 'navigation';
-import { NavigationHandler } from 'navigation-react';
+import { NavigationContext, NavigationHandler } from 'navigation-react';
 import { NavigationMotion, NavigationStack, Scene } from 'navigation-react-mobile';
-import React, {useState} from 'react';
+import React, {useContext, useState} from 'react';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
 import { JSDOM } from 'jsdom';
@@ -109,9 +109,8 @@ describe('NavigationMotionKey', function () {
             });
         });
         const test = async () => {
-            act(() => {
-                update(true);
-            });
+            act(() => update(true));
+            await act(async () => stateNavigator.navigate('sceneB'));
             await act(async () => stateNavigator.navigate('sceneB'));
             await act(async () => stateNavigator.navigateBack(1));
             try {
@@ -336,6 +335,106 @@ describe('NavigationMotionKey', function () {
             try {
                 var scene = container.querySelector('#sceneA');
                 assert.strictEqual(scene.dataset.updated, 'true');
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
+
+    describe('A to A* to A -> B to A*', function () {
+        var stateNavigator, root, container, update;
+        var SceneA = () => {
+            var [updated, setUpdated] = useState(false);
+            var {data: {x}} = useContext(NavigationContext);
+            update = setUpdated;
+            return <div id="sceneA" data-updated={updated + (x ?? '')} />;
+        };
+        var SceneB = () => <div id="sceneB" />;
+        beforeEach(() => {
+            update = null;
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
+        describe('Static', () => {
+            it('should remember state', async function(){
+                var {sceneA, sceneB} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationMotion>
+                                {(_style, scene, key) =>  (
+                                    <div className="scene" id={key} key={key}>{scene}</div>
+                                )}
+                            </NavigationMotion>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic', () => {
+            it('should remember state', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationMotion
+                                renderMotion={(_style, scene, key) =>  (
+                                    <div className="scene" id={key} key={key}>{scene}</div>
+                                )}>
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                            </NavigationMotion>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Static Stack', () => {
+            it('should remember state', async function(){
+                var {sceneA, sceneB} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should remember state', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        const test = async () => {
+            act(() => update(true));
+            await act(async () => stateNavigator.navigate('sceneA', {x: '1'}));
+            await act(async () => stateNavigator.navigate('sceneB'));
+            await act(async () => stateNavigator.navigateBack(1));
+            try {
+                var scene = container.querySelector('#sceneA');
+                assert.strictEqual(scene.dataset.updated, 'true1');
             } finally {
                 act(() => root.unmount());
             }

--- a/NavigationReactMobile/test/NavigationMotionKeyTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionKeyTest.tsx
@@ -512,7 +512,7 @@ describe('NavigationMotionKey', function () {
         };
     });
 
-    describe('A to A -> B to A -> C to A -> B', function () {
+    describe('A to A -> B to A -> C link to A -> B', function () {
         var stateNavigator, root, container, update;
         var SceneA = () => <div id="sceneA" />;
         var SceneB = () => {
@@ -647,7 +647,7 @@ describe('NavigationMotionKey', function () {
         };
     });
 
-    describe('A to A -> B to A to A -> B', function () {
+    describe('A to A -> B to A link to A -> B', function () {
         var stateNavigator, root, container, update;
         var SceneA = () => <div id="sceneA" />;
         var SceneB = () => {
@@ -701,6 +701,69 @@ describe('NavigationMotionKey', function () {
             act(() => update(true));
             await act(async () => stateNavigator.navigateBack(1));
             await act(async () => stateNavigator.navigateLink(historyForward));
+            try {
+                var scene = container.querySelector('#sceneB');
+                assert.strictEqual(scene.dataset.updated, 'false');
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
+
+    describe('A to A -> B to A to A -> B', function () {
+        var stateNavigator, root, container, update;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => {
+            var [updated, setUpdated] = useState(false)
+            update = setUpdated;
+            return <div id="sceneB" data-updated={updated} />;
+        };
+        beforeEach(() => {
+            update = null;
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
+        describe('Static Stack', () => {
+            it('should remember state', async function(){
+                var {sceneA, sceneB} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should remember state', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        const test = async () => {
+            await act(async () => stateNavigator.navigate('sceneB'));
+            const historyForward = stateNavigator.stateContext.url;
+            act(() => update(true));
+            await act(async () => stateNavigator.navigateBack(1));
+            await act(async () => stateNavigator.navigate('sceneB'));
             try {
                 var scene = container.querySelector('#sceneB');
                 assert.strictEqual(scene.dataset.updated, 'false');

--- a/NavigationReactMobile/test/NavigationMotionKeyTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionKeyTest.tsx
@@ -1006,4 +1006,81 @@ describe('NavigationMotionKey', function () {
             }
         };
     });
+
+    describe('A to A -> B to A -> B -> C to A history to A -> B -> C to A -> B', function () {
+        var stateNavigator, root, container, updateB, updateC;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => {
+            var [updated, setUpdated] = useState('0')
+            updateB = setUpdated;
+            return <div id="sceneB" data-updated={updated} />;
+        };
+        var SceneC = () => {
+            var [updated, setUpdated] = useState('0')
+            updateC = setUpdated;
+            return <div id="sceneC" data-updated={updated} />;
+        };
+        beforeEach(() => {
+            updateB = null;
+            updateC = null;
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+                { key: 'sceneC', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
+        describe('Static Stack', () => {
+            it('should remember state', async function(){
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should remember state', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                                <Scene stateKey="sceneC"><SceneC /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        const test = async () => {
+            await act(async () => stateNavigator.navigate('sceneB'));
+            act(() => updateB('1'));
+            await act(async () => stateNavigator.navigate('sceneC'));
+            var historyForwardC = stateNavigator.stateContext.url;
+            act(() => updateC('2'));
+            await act(async () => stateNavigator.navigateBack(2));
+            await act(async () => stateNavigator.navigateLink(historyForwardC, undefined, true));
+            try {
+                scene = container.querySelector('#sceneC');
+                assert.strictEqual(scene.dataset.updated, '2');
+                await act(async () => stateNavigator.navigateBack(1));
+                var scene = container.querySelector('#sceneB');
+                assert.strictEqual(scene.dataset.updated, '1');
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
 });

--- a/NavigationReactMobile/test/NavigationMotionKeyTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionKeyTest.tsx
@@ -1,0 +1,125 @@
+import assert from 'assert';
+import 'mocha';
+import { StateNavigator } from 'navigation';
+import { NavigationHandler } from 'navigation-react';
+import { NavigationMotion, NavigationStack, Scene } from 'navigation-react-mobile';
+import React, {useState} from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import { JSDOM } from 'jsdom';
+
+declare var global: any;
+global.IS_REACT_ACT_ENVIRONMENT = true;
+var { window } = new JSDOM('<!doctype html><html><body></body></html>');
+window.addEventListener = () => {};
+global.window = window;
+global.document = window.document;
+var now = window.performance.now()
+window.performance.now = () => now+=500;
+window.requestAnimationFrame = callback => {
+    callback(window.performance.now())
+};
+window.cancelAnimationFrame = () => {};
+React.useLayoutEffect = React.useEffect;
+
+describe('NavigationMotionKey', function () {
+    describe('A to A -> B to A', function () {
+        var stateNavigator, root, container, update;
+        var SceneA = () => {
+            var [updated, setUpdated] = useState(false)
+            update = setUpdated;
+            return <div id="sceneA" data-updated={updated} />;
+        };
+        var SceneB = () => <div id="sceneB" />;
+        beforeEach(() => {
+            update = null;
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
+        describe('Static', () => {
+            it('should remember state', async function(){
+                var {sceneA, sceneB} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationMotion>
+                                {(_style, scene, key) =>  (
+                                    <div className="scene" id={key} key={key}>{scene}</div>
+                                )}
+                            </NavigationMotion>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic', () => {
+            it('should remember state', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationMotion
+                                renderMotion={(_style, scene, key) =>  (
+                                    <div className="scene" id={key} key={key}>{scene}</div>
+                                )}>
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                            </NavigationMotion>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Static Stack', () => {
+            it('should remember state', async function(){
+                var {sceneA, sceneB} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should remember state', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        const test = async () => {
+            act(() => {
+                update(true);
+            });
+            await act(async () => stateNavigator.navigate('sceneB'));
+            await act(async () => stateNavigator.navigateBack(1));
+            try {
+                var scene = container.querySelector('#sceneA');
+                assert.strictEqual(scene.dataset.updated, 'true');
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
+});

--- a/NavigationReactMobile/test/NavigationMotionKeyTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionKeyTest.tsx
@@ -512,4 +512,76 @@ describe('NavigationMotionKey', function () {
             }
         };
     });
+
+    describe('A to A -> B to A -> C to A -> B', function () {
+        var stateNavigator, root, container, update;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => {
+            var [updated, setUpdated] = useState(false)
+            update = setUpdated;
+            return <div id="sceneB" data-updated={updated} />;
+        };
+        var SceneC = () => <div id="sceneC" />;
+        beforeEach(() => {
+            update = null;
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+                { key: 'sceneC', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
+        describe('Static Stack', () => {
+            it('should not remember state', async function(){
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should not remember state', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                                <Scene stateKey="sceneC"><SceneC /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        const test = async () => {
+            await act(async () => stateNavigator.navigate('sceneB'));
+            const historyBack = stateNavigator.stateContext.url;
+            act(() => update(true));
+            await act(async () => {
+                var url = stateNavigator.fluent(true)
+                    .navigateBack(1)
+                    .navigate('sceneC').url;
+                stateNavigator.navigateLink(url);
+            });
+            await act(async () => stateNavigator.navigateLink(historyBack));
+            try {
+                var scene = container.querySelector('#sceneB');
+                assert.strictEqual(scene.dataset.updated, 'false');
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
 });

--- a/NavigationReactMobile/test/NavigationMotionKeyTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionKeyTest.tsx
@@ -1083,4 +1083,81 @@ describe('NavigationMotionKey', function () {
             }
         };
     });
+
+    describe('A to A -> B to A -> B -> C to A link to A -> B -> C to A -> B', function () {
+        var stateNavigator, root, container, updateB, updateC;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => {
+            var [updated, setUpdated] = useState('0')
+            updateB = setUpdated;
+            return <div id="sceneB" data-updated={updated} />;
+        };
+        var SceneC = () => {
+            var [updated, setUpdated] = useState('0')
+            updateC = setUpdated;
+            return <div id="sceneC" data-updated={updated} />;
+        };
+        beforeEach(() => {
+            updateB = null;
+            updateC = null;
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+                { key: 'sceneC', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
+        describe('Static Stack', () => {
+            it('should not remember state', async function(){
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should not remember state', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                                <Scene stateKey="sceneC"><SceneC /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        const test = async () => {
+            await act(async () => stateNavigator.navigate('sceneB'));
+            act(() => updateB('1'));
+            await act(async () => stateNavigator.navigate('sceneC'));
+            var historyForwardC = stateNavigator.stateContext.url;
+            act(() => updateC('2'));
+            await act(async () => stateNavigator.navigateBack(2));
+            await act(async () => stateNavigator.navigateLink(historyForwardC));
+            try {
+                scene = container.querySelector('#sceneC');
+                assert.strictEqual(scene.dataset.updated, '0');
+                await act(async () => stateNavigator.navigateBack(1));
+                var scene = container.querySelector('#sceneB');
+                assert.strictEqual(scene.dataset.updated, '0');
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
 });

--- a/NavigationReactMobile/test/NavigationMotionKeyTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionKeyTest.tsx
@@ -440,150 +440,6 @@ describe('NavigationMotionKey', function () {
         };
     });
 
-    describe('A to A -> B to A -> C history to A -> B', function () {
-        var stateNavigator, root, container, update;
-        var SceneA = () => <div id="sceneA" />;
-        var SceneB = () => {
-            var [updated, setUpdated] = useState(false)
-            update = setUpdated;
-            return <div id="sceneB" data-updated={updated} />;
-        };
-        var SceneC = () => <div id="sceneC" />;
-        beforeEach(() => {
-            update = null;
-            stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC', trackCrumbTrail: true },
-            ]);
-            stateNavigator.navigate('sceneA');
-            container = document.createElement('div');
-            root = createRoot(container)
-        });
-        describe('Static Stack', () => {
-            it('should remember state', async function(){
-                var {sceneA, sceneB, sceneC} = stateNavigator.states;
-                sceneA.renderScene = () => <SceneA />;
-                sceneB.renderScene = () => <SceneB />;
-                sceneC.renderScene = () => <SceneC />;
-                act(() => {
-                    root.render(
-                        <NavigationHandler stateNavigator={stateNavigator}>
-                            <NavigationStack className="scene" />
-                        </NavigationHandler>
-                    );
-                });
-                await test();
-            });
-        });
-        describe('Dynamic Stack', () => {
-            it('should remember state', async function(){
-                act(() => {
-                    root.render(
-                        <NavigationHandler stateNavigator={stateNavigator}>
-                            <NavigationStack className="scene">
-                                <Scene stateKey="sceneA"><SceneA /></Scene>
-                                <Scene stateKey="sceneB"><SceneB /></Scene>
-                                <Scene stateKey="sceneC"><SceneC /></Scene>
-                            </NavigationStack>
-                        </NavigationHandler>
-                    );
-                });
-                await test();
-            });
-        });
-        const test = async () => {
-            await act(async () => stateNavigator.navigate('sceneB'));
-            const historyBack = stateNavigator.stateContext.url;
-            act(() => update(true));
-            await act(async () => {
-                var url = stateNavigator.fluent(true)
-                    .navigateBack(1)
-                    .navigate('sceneC').url;
-                stateNavigator.navigateLink(url);
-            });
-            await act(async () => stateNavigator.navigateLink(historyBack, undefined, true));
-            try {
-                var scene = container.querySelector('#sceneB');
-                assert.strictEqual(scene.dataset.updated, 'true');
-            } finally {
-                act(() => root.unmount());
-            }
-        };
-    });
-
-    describe('A to A -> B to A -> C link to A -> B', function () {
-        var stateNavigator, root, container, update;
-        var SceneA = () => <div id="sceneA" />;
-        var SceneB = () => {
-            var [updated, setUpdated] = useState(false)
-            update = setUpdated;
-            return <div id="sceneB" data-updated={updated} />;
-        };
-        var SceneC = () => <div id="sceneC" />;
-        beforeEach(() => {
-            update = null;
-            stateNavigator = new StateNavigator([
-                { key: 'sceneA' },
-                { key: 'sceneB', trackCrumbTrail: true },
-                { key: 'sceneC', trackCrumbTrail: true },
-            ]);
-            stateNavigator.navigate('sceneA');
-            container = document.createElement('div');
-            root = createRoot(container)
-        });
-        describe('Static Stack', () => {
-            it('should not remember state', async function(){
-                var {sceneA, sceneB, sceneC} = stateNavigator.states;
-                sceneA.renderScene = () => <SceneA />;
-                sceneB.renderScene = () => <SceneB />;
-                sceneC.renderScene = () => <SceneC />;
-                act(() => {
-                    root.render(
-                        <NavigationHandler stateNavigator={stateNavigator}>
-                            <NavigationStack className="scene" />
-                        </NavigationHandler>
-                    );
-                });
-                await test();
-            });
-        });
-        describe('Dynamic Stack', () => {
-            it('should not remember state', async function(){
-                act(() => {
-                    root.render(
-                        <NavigationHandler stateNavigator={stateNavigator}>
-                            <NavigationStack className="scene">
-                                <Scene stateKey="sceneA"><SceneA /></Scene>
-                                <Scene stateKey="sceneB"><SceneB /></Scene>
-                                <Scene stateKey="sceneC"><SceneC /></Scene>
-                            </NavigationStack>
-                        </NavigationHandler>
-                    );
-                });
-                await test();
-            });
-        });
-        const test = async () => {
-            await act(async () => stateNavigator.navigate('sceneB'));
-            const historyBack = stateNavigator.stateContext.url;
-            act(() => update(true));
-            await act(async () => {
-                var url = stateNavigator.fluent(true)
-                    .navigateBack(1)
-                    .navigate('sceneC').url;
-                stateNavigator.navigateLink(url);
-            });
-            await act(async () => stateNavigator.navigateLink(historyBack));
-            try {
-                var scene = container.querySelector('#sceneB');
-                assert.strictEqual(scene.dataset.updated, 'false');
-            } finally {
-                act(() => root.unmount());
-            }
-        };
-    });
-
     describe('A to A -> B to A history to A -> B', function () {
         var stateNavigator, root, container, update;
         var SceneA = () => <div id="sceneA" />;
@@ -764,6 +620,150 @@ describe('NavigationMotionKey', function () {
             act(() => update(true));
             await act(async () => stateNavigator.navigateBack(1));
             await act(async () => stateNavigator.navigate('sceneB'));
+            try {
+                var scene = container.querySelector('#sceneB');
+                assert.strictEqual(scene.dataset.updated, 'false');
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
+
+    describe('A to A -> B to A -> C history to A -> B', function () {
+        var stateNavigator, root, container, update;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => {
+            var [updated, setUpdated] = useState(false)
+            update = setUpdated;
+            return <div id="sceneB" data-updated={updated} />;
+        };
+        var SceneC = () => <div id="sceneC" />;
+        beforeEach(() => {
+            update = null;
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+                { key: 'sceneC', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
+        describe('Static Stack', () => {
+            it('should remember state', async function(){
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should remember state', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                                <Scene stateKey="sceneC"><SceneC /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        const test = async () => {
+            await act(async () => stateNavigator.navigate('sceneB'));
+            const historyBack = stateNavigator.stateContext.url;
+            act(() => update(true));
+            await act(async () => {
+                var url = stateNavigator.fluent(true)
+                    .navigateBack(1)
+                    .navigate('sceneC').url;
+                stateNavigator.navigateLink(url);
+            });
+            await act(async () => stateNavigator.navigateLink(historyBack, undefined, true));
+            try {
+                var scene = container.querySelector('#sceneB');
+                assert.strictEqual(scene.dataset.updated, 'true');
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
+
+    describe('A to A -> B to A -> C link to A -> B', function () {
+        var stateNavigator, root, container, update;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => {
+            var [updated, setUpdated] = useState(false)
+            update = setUpdated;
+            return <div id="sceneB" data-updated={updated} />;
+        };
+        var SceneC = () => <div id="sceneC" />;
+        beforeEach(() => {
+            update = null;
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+                { key: 'sceneC', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
+        describe('Static Stack', () => {
+            it('should not remember state', async function(){
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should not remember state', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                                <Scene stateKey="sceneC"><SceneC /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        const test = async () => {
+            await act(async () => stateNavigator.navigate('sceneB'));
+            const historyBack = stateNavigator.stateContext.url;
+            act(() => update(true));
+            await act(async () => {
+                var url = stateNavigator.fluent(true)
+                    .navigateBack(1)
+                    .navigate('sceneC').url;
+                stateNavigator.navigateLink(url);
+            });
+            await act(async () => stateNavigator.navigateLink(historyBack));
             try {
                 var scene = container.querySelector('#sceneB');
                 assert.strictEqual(scene.dataset.updated, 'false');

--- a/NavigationReactMobile/test/NavigationMotionKeyTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionKeyTest.tsx
@@ -646,4 +646,67 @@ describe('NavigationMotionKey', function () {
             }
         };
     });
+
+    describe('A to A -> B to A to A -> B', function () {
+        var stateNavigator, root, container, update;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => {
+            var [updated, setUpdated] = useState(false)
+            update = setUpdated;
+            return <div id="sceneB" data-updated={updated} />;
+        };
+        beforeEach(() => {
+            update = null;
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
+        describe('Static Stack', () => {
+            it('should remember state', async function(){
+                var {sceneA, sceneB} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should remember state', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        const test = async () => {
+            await act(async () => stateNavigator.navigate('sceneB'));
+            const historyForward = stateNavigator.stateContext.url;
+            act(() => update(true));
+            await act(async () => stateNavigator.navigateBack(1));
+            await act(async () => stateNavigator.navigateLink(historyForward));
+            try {
+                var scene = container.querySelector('#sceneB');
+                assert.strictEqual(scene.dataset.updated, 'false');
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
 });

--- a/NavigationReactMobile/test/NavigationMotionKeyTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionKeyTest.tsx
@@ -440,4 +440,76 @@ describe('NavigationMotionKey', function () {
             }
         };
     });
+
+    describe('A to A -> B to A -> C history to A -> B', function () {
+        var stateNavigator, root, container, update;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => {
+            var [updated, setUpdated] = useState(false)
+            update = setUpdated;
+            return <div id="sceneB" data-updated={updated} />;
+        };
+        var SceneC = () => <div id="sceneC" />;
+        beforeEach(() => {
+            update = null;
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+                { key: 'sceneC', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
+        describe('Static Stack', () => {
+            it('should remember state', async function(){
+                var {sceneA, sceneB, sceneC} = stateNavigator.states;
+                sceneA.renderScene = () => <SceneA />;
+                sceneB.renderScene = () => <SceneB />;
+                sceneC.renderScene = () => <SceneC />;
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene" />
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        describe('Dynamic Stack', () => {
+            it('should remember state', async function(){
+                act(() => {
+                    root.render(
+                        <NavigationHandler stateNavigator={stateNavigator}>
+                            <NavigationStack className="scene">
+                                <Scene stateKey="sceneA"><SceneA /></Scene>
+                                <Scene stateKey="sceneB"><SceneB /></Scene>
+                                <Scene stateKey="sceneC"><SceneC /></Scene>
+                            </NavigationStack>
+                        </NavigationHandler>
+                    );
+                });
+                await test();
+            });
+        });
+        const test = async () => {
+            await act(async () => stateNavigator.navigate('sceneB'));
+            const historyBack = stateNavigator.stateContext.url;
+            act(() => update(true));
+            await act(async () => {
+                var url = stateNavigator.fluent(true)
+                    .navigateBack(1)
+                    .navigate('sceneC').url;
+                stateNavigator.navigateLink(url);
+            });
+            await act(async () => stateNavigator.navigateLink(historyBack, undefined, true));
+            try {
+                var scene = container.querySelector('#sceneB');
+                assert.strictEqual(scene.dataset.updated, 'true');
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
 });

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -3669,7 +3669,7 @@ describe('NavigationMotion', function () {
                 update = setUpdated;
                 return (
                     <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationStack>
+                        <NavigationStack className="scene">
                             <Scene stateKey="sceneA"><SceneA /></Scene>
                             <Scene stateKey="sceneB"><SceneB /></Scene>
                             {!updated && <Scene stateKey="sceneC"><SceneC /></Scene>}
@@ -3684,9 +3684,13 @@ describe('NavigationMotion', function () {
             act(() => stateNavigator.navigate('sceneC'));
             await act(async () => update(true));
             try {
+                var scenes = container.querySelectorAll<HTMLDivElement>(".scene");
                 assert.notEqual(container.querySelector("#sceneA"), null);
-                assert.equal(container.querySelector("#sceneB"), null);
-                assert.equal(container.querySelector("#sceneC"), null);
+                assert.notEqual(scenes[0].style.display, 'none');
+                assert.notEqual(container.querySelector("#sceneB"), null);
+                assert.equal(scenes[1].style.display, 'none');
+                assert.notEqual(container.querySelector("#sceneC"), null);
+                assert.equal(scenes[2].style.display, 'none');
             } finally {
                 act(() => root.unmount());
             }

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -4498,7 +4498,7 @@ describe('NavigationMotion', function () {
                 update = setUpdated;
                 return (
                     <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationStack stackInvalidatedLink="/sceneC">
+                        <NavigationStack stackInvalidatedLink="/sceneC" className="scene">
                                 {!updated && <Scene stateKey="sceneA"><SceneA /></Scene>}
                                 <Scene stateKey="sceneB"><SceneB /></Scene>
                                 <Scene stateKey="sceneC"><SceneC /></Scene>
@@ -4512,9 +4512,12 @@ describe('NavigationMotion', function () {
             act(() => stateNavigator.navigate('sceneB'));
             await act(async () => update(true));
             try {
+                var scenes = container.querySelectorAll<HTMLDivElement>(".scene");
+                assert.notEqual(scenes[0].querySelector("#sceneC"), null);
+                assert.notEqual(scenes[0].style.display, 'none');
+                assert.notEqual(scenes[1].querySelector("#sceneB"), null);
+                assert.equal(scenes[1].style.display, 'none');
                 assert.equal(container.querySelector("#sceneA"), null);
-                assert.equal(container.querySelector("#sceneB"), null);
-                assert.notEqual(container.querySelector("#sceneC"), null);
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states.sceneC)
                 assert.equal(stateNavigator.stateContext.crumbs.length, 0)
             } finally {

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -494,6 +494,33 @@ describe('NavigationMotion', function () {
                 await test();
             });
         });
+        const test = async () => {
+            await act(async () => stateNavigator.navigateBack(1));
+            try {
+                var scenes = container.querySelectorAll(".scene");
+                assert.equal(scenes.length, 1);
+                assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+                assert.equal(container.querySelector("#sceneB"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        }
+    });
+
+    describe('A -> B to A', function () {
+        var stateNavigator, root, container;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => <div id="sceneB" />;
+        beforeEach(() => {
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            stateNavigator.navigate('sceneB');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
         describe('Static Stack', () => {
             it('should render A', async function(){
                 var {sceneA, sceneB} = stateNavigator.states;
@@ -528,9 +555,11 @@ describe('NavigationMotion', function () {
             await act(async () => stateNavigator.navigateBack(1));
             try {
                 var scenes = container.querySelectorAll(".scene");
-                assert.equal(scenes.length, 1);
+                assert.equal(scenes.length, 2);
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
-                assert.equal(container.querySelector("#sceneB"), null);
+                assert.notEqual(scenes[0].style.display, 'none');
+                assert.notEqual(scenes[1].querySelector("#sceneB"), null);
+                assert.equal(scenes[1].style.display, 'none');
             } finally {
                 act(() => root.unmount());
             }

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -2122,6 +2122,51 @@ describe('NavigationMotion', function () {
                 await test();
             });
         });
+        const test = async () => {
+            await act(async () => {
+                var url = stateNavigator.fluent(true)
+                    .navigate('sceneB')
+                    .navigate('sceneC').url;
+                stateNavigator.navigateLink(url);
+                url = stateNavigator.fluent(true)
+                    .navigateBack(2)
+                    .navigate('sceneD')
+                    .navigate('sceneC').url;
+                stateNavigator.navigateLink(url);
+            });
+            await act(async () => {
+                stateNavigator.navigateBack(1);
+            });
+            try {
+                var scenes = container.querySelectorAll(".scene");
+                assert.equal(scenes.length, 2);
+                assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+                assert.notEqual(scenes[1].querySelector("#sceneD"), null);
+                assert.equal(container.querySelector("#sceneB"), null);
+                assert.equal(container.querySelector("#sceneC"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
+
+    describe('A to A -> B -> C to A -> D -> C to A -> D', function () {
+        var stateNavigator, root, container;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => <div id="sceneB" />;
+        var SceneC = () => <div id="sceneC" />;
+        var SceneD = () => <div id="sceneD" />;
+        beforeEach(() => {
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+                { key: 'sceneC', trackCrumbTrail: true },
+                { key: 'sceneD', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
         describe('Static Stack', () => {
             it('should render A -> D', async function(){
                 var {sceneA, sceneB, sceneC, sceneD} = stateNavigator.states;
@@ -2167,15 +2212,20 @@ describe('NavigationMotion', function () {
                     .navigate('sceneD')
                     .navigate('sceneC').url;
                 stateNavigator.navigateLink(url);
+            });
+            await act(async () => {
                 stateNavigator.navigateBack(1);
             });
             try {
                 var scenes = container.querySelectorAll(".scene");
-                assert.equal(scenes.length, 2);
+                assert.equal(scenes.length, 3);
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+                assert.equal(scenes[0].style.display, 'none');
                 assert.notEqual(scenes[1].querySelector("#sceneD"), null);
+                assert.notEqual(scenes[1].style.display, 'none');
+                assert.notEqual(scenes[2].querySelector("#sceneC"), null);
+                assert.equal(scenes[2].style.display, 'none');
                 assert.equal(container.querySelector("#sceneB"), null);
-                assert.equal(container.querySelector("#sceneC"), null);
             } finally {
                 act(() => root.unmount());
             }

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -958,6 +958,36 @@ describe('NavigationMotion', function () {
                 test();
             });
         });
+        const test = () => {
+            act(() => stateNavigator.navigate('sceneB'));
+            act(() => stateNavigator.navigate('sceneC'));
+            try {
+                var scenes = container.querySelectorAll(".scene");
+                assert.equal(scenes.length, 1);
+                assert.notEqual(scenes[0].querySelector("#sceneC"), null);
+                assert.equal(container.querySelector("#sceneA"), null);
+                assert.equal(container.querySelector("#sceneB"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
+
+    describe('A to B to C', function () {
+        var stateNavigator, root, container;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => <div id="sceneB" />;
+        var SceneC = () => <div id="sceneC" />;
+        beforeEach(() => {
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB' },
+                { key: 'sceneC' },
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
         describe('Static Stack', () => {
             it('should render C++', function(){
                 var {sceneA, sceneB, sceneC} = stateNavigator.states;
@@ -995,10 +1025,13 @@ describe('NavigationMotion', function () {
             act(() => stateNavigator.navigate('sceneC'));
             try {
                 var scenes = container.querySelectorAll(".scene");
-                assert.equal(scenes.length, 1);
-                assert.notEqual(scenes[0].querySelector("#sceneC"), null);
-                assert.equal(container.querySelector("#sceneA"), null);
-                assert.equal(container.querySelector("#sceneB"), null);
+                assert.equal(scenes.length, 3);
+                assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+                assert.equal(scenes[0].style.display, 'none');
+                assert.notEqual(scenes[1].querySelector("#sceneB"), null);
+                assert.equal(scenes[1].style.display, 'none');
+                assert.notEqual(scenes[2].querySelector("#sceneC"), null);
+                assert.notEqual(scenes[2].style.display, 'none');
             } finally {
                 act(() => root.unmount());
             }

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -1199,6 +1199,42 @@ describe('NavigationMotion', function () {
                 await test();
             });
         });
+        const test = async () => {
+            await act(async () => {
+                var url = stateNavigator.fluent()
+                    .navigate('sceneC')
+                    .navigate('sceneB').url;
+                stateNavigator.navigateLink(url);
+                stateNavigator.navigateBack(1)
+            });
+            try {
+                var scenes = container.querySelectorAll(".scene");
+                assert.equal(scenes.length, 1);
+                assert.notEqual(scenes[0].querySelector("#sceneC"), null);
+                assert.equal(container.querySelector("#sceneA"), null);
+                assert.equal(container.querySelector("#sceneB"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        }
+    });
+
+    describe('A -> B to C -> B to C', function () {
+        var stateNavigator, root, container;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => <div id="sceneB" />;
+        var SceneC = () => <div id="sceneC" />;
+        beforeEach(() => {
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+                { key: 'sceneC' },
+            ]);
+            stateNavigator.navigate('sceneA');
+            stateNavigator.navigate('sceneB');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
         describe('Static Stack', () => {
             it('should render C', async function(){
                 var {sceneA, sceneB, sceneC} = stateNavigator.states;
@@ -1241,10 +1277,12 @@ describe('NavigationMotion', function () {
             });
             try {
                 var scenes = container.querySelectorAll(".scene");
-                assert.equal(scenes.length, 1);
+                assert.equal(scenes.length, 2);
                 assert.notEqual(scenes[0].querySelector("#sceneC"), null);
+                assert.notEqual(scenes[0].style.display, 'none');
+                assert.notEqual(scenes[1].querySelector("#sceneB"), null);
+                assert.equal(scenes[1].style.display, 'none');
                 assert.equal(container.querySelector("#sceneA"), null);
-                assert.equal(container.querySelector("#sceneB"), null);
             } finally {
                 act(() => root.unmount());
             }

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -3685,11 +3685,11 @@ describe('NavigationMotion', function () {
             await act(async () => update(true));
             try {
                 var scenes = container.querySelectorAll<HTMLDivElement>(".scene");
-                assert.notEqual(container.querySelector("#sceneA"), null);
+                assert.notEqual(scenes[0].querySelector("#sceneA"), null);
                 assert.notEqual(scenes[0].style.display, 'none');
-                assert.notEqual(container.querySelector("#sceneB"), null);
+                assert.notEqual(scenes[1].querySelector("#sceneB"), null);
                 assert.equal(scenes[1].style.display, 'none');
-                assert.notEqual(container.querySelector("#sceneC"), null);
+                assert.notEqual(scenes[2].querySelector("#sceneC"), null);
                 assert.equal(scenes[2].style.display, 'none');
             } finally {
                 act(() => root.unmount());
@@ -3774,11 +3774,11 @@ describe('NavigationMotion', function () {
             await act(async () => update(true));
             try {
                 var scenes = container.querySelectorAll<HTMLDivElement>(".scene");
-                assert.notEqual(container.querySelector("#sceneA"), null);
+                assert.notEqual(scenes[0].querySelector("#sceneA"), null);
                 assert.notEqual(scenes[0].style.display, 'none');
-                assert.notEqual(container.querySelector("#sceneB"), null);
+                assert.notEqual(scenes[1].querySelector("#sceneB"), null);
                 assert.equal(scenes[1].style.display, 'none');
-                assert.notEqual(container.querySelector("#sceneC"), null);
+                assert.notEqual(scenes[2].querySelector("#sceneC"), null);
                 assert.equal(scenes[2].style.display, 'none');
             } finally {
                 act(() => root.unmount());

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -2572,6 +2572,41 @@ describe('NavigationMotion', function () {
                 await test();
             });
         });
+        const test = async () => {
+            await act(async () => {
+                var url = stateNavigator.fluent()
+                    .navigate('sceneB').url;
+                stateNavigator.navigateLink(url);
+            });
+            try {
+                var scenes = container.querySelectorAll(".scene");
+                assert.equal(scenes.length, 1);
+                assert.notEqual(scenes[0].querySelector("#sceneB"), null);
+                assert.equal(container.querySelector("#sceneA"), null);
+                assert.equal(container.querySelector("#sceneC"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
+
+    describe('A -> B -> C to B', function () {
+        var stateNavigator, root, container;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => <div id="sceneB" />;
+        var SceneC = () => <div id="sceneC" />;
+        beforeEach(() => {
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+                { key: 'sceneC', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            stateNavigator.navigate('sceneB');
+            stateNavigator.navigate('sceneC');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
         describe('Static Stack', () => {
             it('should render B', async function(){
                 var {sceneA, sceneB, sceneC} = stateNavigator.states;
@@ -2612,10 +2647,13 @@ describe('NavigationMotion', function () {
             });
             try {
                 var scenes = container.querySelectorAll(".scene");
-                assert.equal(scenes.length, 1);
+                assert.equal(scenes.length, 3);
                 assert.notEqual(scenes[0].querySelector("#sceneB"), null);
+                assert.notEqual(scenes[0].style.display, 'none');
+                assert.equal(scenes[1].style.display, 'none');
+                assert.notEqual(scenes[2].querySelector("#sceneC"), null);
+                assert.equal(scenes[2].style.display, 'none');
                 assert.equal(container.querySelector("#sceneA"), null);
-                assert.equal(container.querySelector("#sceneC"), null);
             } finally {
                 act(() => root.unmount());
             }

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -4589,7 +4589,7 @@ describe('NavigationMotion', function () {
                 update = setUpdated;
                 return (
                     <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationStack stackInvalidatedLink={null}>
+                        <NavigationStack stackInvalidatedLink={null} className="scene">
                                 <Scene stateKey="sceneA"><SceneA /></Scene>
                                 {!updated && <Scene stateKey="sceneB"><SceneB /></Scene>}
                                 <Scene stateKey="sceneC"><SceneC /></Scene>
@@ -4603,8 +4603,11 @@ describe('NavigationMotion', function () {
             act(() => stateNavigator.navigate('sceneB'));
             await act(async () => update(true));
             try {
-                assert.notEqual(container.querySelector("#sceneA"), null);
-                assert.equal(container.querySelector("#sceneB"), null);
+                var scenes = container.querySelectorAll<HTMLDivElement>(".scene");
+                assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+                assert.notEqual(scenes[0].style.display, 'none');
+                assert.notEqual(scenes[1].querySelector("#sceneB"), null);
+                assert.equal(scenes[1].style.display, 'none');
                 assert.equal(container.querySelector("#sceneC"), null);
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states.sceneA)
                 assert.equal(stateNavigator.stateContext.crumbs.length, 0)

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -616,6 +616,37 @@ describe('NavigationMotion', function () {
                 await test();
             });
         });
+        const test = async () => {
+            await act(async () => {
+                stateNavigator.navigate('sceneB');
+            });
+            await act(async () => {
+                stateNavigator.navigateBack(1);
+            });
+            try {
+                var scenes = container.querySelectorAll(".scene");
+                assert.equal(scenes.length, 1);
+                assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+                assert.equal(container.querySelector("#sceneB"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
+
+    describe('A to A -> B to A', function () {
+        var stateNavigator, root, container;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => <div id="sceneB" />;
+        beforeEach(() => {
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
         describe('Static Stack', () => {
             it('should render A', async function(){
                 var {sceneA, sceneB} = stateNavigator.states;
@@ -649,13 +680,17 @@ describe('NavigationMotion', function () {
         const test = async () => {
             await act(async () => {
                 stateNavigator.navigate('sceneB');
+            });
+            await act(async () => {
                 stateNavigator.navigateBack(1);
             });
             try {
                 var scenes = container.querySelectorAll(".scene");
-                assert.equal(scenes.length, 1);
+                assert.equal(scenes.length, 2);
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
-                assert.equal(container.querySelector("#sceneB"), null);
+                assert.notEqual(scenes[0].style.display, 'none');
+                assert.notEqual(scenes[1].querySelector("#sceneB"), null);
+                assert.equal(scenes[1].style.display, 'none');
             } finally {
                 act(() => root.unmount());
             }

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -2436,6 +2436,37 @@ describe('NavigationMotion', function () {
                 await test();
             });
         });
+        const test = async () => {
+            await act(async () => stateNavigator.navigateBack(2));
+            try {
+                var scenes = container.querySelectorAll(".scene");
+                assert.equal(scenes.length, 1);
+                assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+                assert.equal(container.querySelector("#sceneB"), null);
+                assert.equal(container.querySelector("#sceneC"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
+
+    describe('A -> B -> C to A', function () {
+        var stateNavigator, root, container;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => <div id="sceneB" />;
+        var SceneC = () => <div id="sceneC" />;
+        beforeEach(() => {
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+                { key: 'sceneC', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            stateNavigator.navigate('sceneB');
+            stateNavigator.navigate('sceneC');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
         describe('Static Stack', () => {
             it('should render A', async function(){
                 var {sceneA, sceneB, sceneC} = stateNavigator.states;
@@ -2472,10 +2503,13 @@ describe('NavigationMotion', function () {
             await act(async () => stateNavigator.navigateBack(2));
             try {
                 var scenes = container.querySelectorAll(".scene");
-                assert.equal(scenes.length, 1);
+                assert.equal(scenes.length, 3);
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+                assert.notEqual(scenes[0].style.display, 'none');
+                assert.equal(scenes[1].style.display, 'none');
+                assert.notEqual(scenes[2].querySelector("#sceneC"), null);
+                assert.equal(scenes[2].style.display, 'none');
                 assert.equal(container.querySelector("#sceneB"), null);
-                assert.equal(container.querySelector("#sceneC"), null);
             } finally {
                 act(() => root.unmount());
             }

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -4407,7 +4407,7 @@ describe('NavigationMotion', function () {
                 update = setUpdated;
                 return (
                     <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationStack stackInvalidatedLink="/sceneC">
+                        <NavigationStack stackInvalidatedLink="/sceneC" className="scene">
                                 <Scene stateKey="sceneA"><SceneA /></Scene>
                                 {!updated && <Scene stateKey="sceneB"><SceneB /></Scene>}
                                 <Scene stateKey="sceneC"><SceneC /></Scene>
@@ -4421,9 +4421,12 @@ describe('NavigationMotion', function () {
             act(() => stateNavigator.navigate('sceneB'));
             await act(async () => update(true));
             try {
+                var scenes = container.querySelectorAll<HTMLDivElement>(".scene");
+                assert.notEqual(scenes[0].querySelector("#sceneC"), null);
+                assert.notEqual(scenes[0].style.display, 'none');
+                assert.notEqual(scenes[1].querySelector("#sceneB"), null);
+                assert.equal(scenes[1].style.display, 'none');
                 assert.equal(container.querySelector("#sceneA"), null);
-                assert.equal(container.querySelector("#sceneB"), null);
-                assert.notEqual(container.querySelector("#sceneC"), null);
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states.sceneC)
                 assert.equal(stateNavigator.stateContext.crumbs.length, 0)
             } finally {

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -4695,7 +4695,7 @@ describe('NavigationMotion', function () {
                     <NavigationHandler stateNavigator={stateNavigator}>
                         <NavigationStack stackInvalidatedLink={stateNavigator.fluent()
                                 .navigate('sceneC')
-                                .navigate('sceneD').url}>
+                                .navigate('sceneD').url} className="scene">
                             {!updated ? (
                                 <>
                                     <Scene stateKey="sceneA"><SceneA /></Scene>
@@ -4717,8 +4717,14 @@ describe('NavigationMotion', function () {
             act(() => stateNavigator.navigate('sceneB'));
             await act(async () => update(true));
             try {
-                assert.equal(container.querySelector("#sceneB"), null);
-                assert.notEqual(container.querySelector("#sceneD"), null);
+                var scenes = container.querySelectorAll<HTMLDivElement>(".scene");
+                assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+                assert.equal(scenes[0].style.display, 'none');
+                assert.notEqual(scenes[1].querySelector("#sceneB"), null);
+                assert.equal(scenes[1].style.display, 'none');
+                assert.notEqual(scenes[2].querySelector("#sceneD"), null);
+                assert.notEqual(scenes[2].style.display, 'none');
+                assert.equal(container.querySelector("#sceneC"), null);
                 assert.equal(stateNavigator.stateContext.state, stateNavigator.states.sceneD)
                 assert.equal(stateNavigator.stateContext.crumbs.length, 1)
             } finally {

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -2797,6 +2797,38 @@ describe('NavigationMotion', function () {
                 await test();
             });
         });
+        const test = async () => {
+            act(() => stateNavigator.navigate('sceneA'));
+            await act(async () => {
+                var url = stateNavigator.fluent(true)
+                    .navigateBack(1)
+                    .navigate('sceneB').url;
+                stateNavigator.navigateLink(url);
+            });
+            try {
+                var scenes = container.querySelectorAll(".scene");
+                assert.equal(scenes.length, 2);
+                assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+                assert.notEqual(scenes[1].querySelector("#sceneB"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
+
+    describe('A to A -> A to A -> B', function () {
+        var stateNavigator, root, container;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => <div id="sceneB" />;
+        beforeEach(() => {
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA', trackCrumbTrail: true },
+                { key: 'sceneB', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
         describe('Static Stack', () => {
             it('should render A -> B+', async function(){
                 var {sceneA, sceneB} = stateNavigator.states;
@@ -2837,9 +2869,13 @@ describe('NavigationMotion', function () {
             });
             try {
                 var scenes = container.querySelectorAll(".scene");
-                assert.equal(scenes.length, 2);
+                assert.equal(scenes.length, 3);
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
-                assert.notEqual(scenes[1].querySelector("#sceneB"), null);
+                assert.equal(scenes[0].style.display, 'none');
+                assert.notEqual(scenes[1].querySelector("#sceneA"), null);
+                assert.equal(scenes[1].style.display, 'none');
+                assert.notEqual(scenes[2].querySelector("#sceneB"), null);
+                assert.notEqual(scenes[2].style.display, 'none');
             } finally {
                 act(() => root.unmount());
             }

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -3949,7 +3949,7 @@ describe('NavigationMotion', function () {
                 update = setUpdated;
                 return (
                     <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationStack>
+                        <NavigationStack className="scene">
                             {!updated ? (
                                 <>
                                     <Scene stateKey="sceneA"><SceneA /></Scene>
@@ -3971,9 +3971,12 @@ describe('NavigationMotion', function () {
             act(() => stateNavigator.navigate('sceneB'));
             await act(async () => update(true));
             try {
+                var scenes = container.querySelectorAll<HTMLDivElement>(".scene");
+                assert.notEqual(scenes[0].querySelector("#sceneC"), null);
+                assert.notEqual(scenes[0].style.display, 'none');
+                assert.notEqual(scenes[1].querySelector("#sceneB"), null);
+                assert.equal(scenes[1].style.display, 'none');
                 assert.equal(container.querySelector("#sceneA"), null);
-                assert.equal(container.querySelector("#sceneB"), null);
-                assert.notEqual(container.querySelector("#sceneC"), null);
             } finally {
                 act(() => root.unmount());
             }

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -833,42 +833,31 @@ describe('NavigationMotion', function () {
                 test();
             });
         });
-        describe('Static', () => {
-            it('should render B+', function(){
-                var {sceneA, sceneB} = stateNavigator.states;
-                sceneA.renderScene = () => <SceneA />;
-                sceneB.renderScene = () => <SceneB />;
-                act(() => {
-                    root.render(
-                        <NavigationHandler stateNavigator={stateNavigator}>
-                            <NavigationMotion>
-                                {(_style, scene, key) =>  (
-                                    <div className="scene" id={key} key={key}>{scene}</div>
-                                )}
-                            </NavigationMotion>
-                        </NavigationHandler>
-                    );
-                });
-                test();
-            });
-        });
-        describe('Dynamic', () => {
-            it('should render B+', function(){
-                act(() => {
-                    root.render(
-                        <NavigationHandler stateNavigator={stateNavigator}>
-                            <NavigationMotion
-                                renderMotion={(_style, scene, key) =>  (
-                                    <div className="scene" id={key} key={key}>{scene}</div>
-                                )}>
-                                <Scene stateKey="sceneA"><SceneA /></Scene>
-                                <Scene stateKey="sceneB"><SceneB /></Scene>
-                            </NavigationMotion>
-                        </NavigationHandler>
-                    );
-                });
-                test();
-            });
+        const test = () => {
+            act(() => stateNavigator.navigate('sceneB'));
+            try {
+                var scenes = container.querySelectorAll(".scene");
+                assert.equal(scenes.length, 1);
+                assert.notEqual(scenes[0].querySelector("#sceneB"), null);
+                assert.equal(container.querySelector("#sceneA"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
+
+    describe('A to B', function () {
+        var stateNavigator, root, container;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => <div id="sceneB" />;
+        beforeEach(() => {
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB' },
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
         });
         describe('Static Stack', () => {
             it('should render B+', function(){
@@ -904,9 +893,11 @@ describe('NavigationMotion', function () {
             act(() => stateNavigator.navigate('sceneB'));
             try {
                 var scenes = container.querySelectorAll(".scene");
-                assert.equal(scenes.length, 1);
-                assert.notEqual(scenes[0].querySelector("#sceneB"), null);
-                assert.equal(container.querySelector("#sceneA"), null);
+                assert.equal(scenes.length, 2);
+                assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+                assert.equal(scenes[0].style.display, 'none');
+                assert.notEqual(scenes[1].querySelector("#sceneB"), null);
+                assert.notEqual(scenes[1].style.display, 'none');
             } finally {
                 act(() => root.unmount());
             }

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -3758,7 +3758,7 @@ describe('NavigationMotion', function () {
                 update = setUpdated;
                 return (
                     <NavigationHandler stateNavigator={stateNavigator}>
-                        <NavigationStack>
+                        <NavigationStack className="scene">
                             <Scene stateKey="sceneA"><SceneA /></Scene>
                             {!updated && <Scene stateKey="sceneB"><SceneB /></Scene>}
                             <Scene stateKey="sceneC"><SceneC /></Scene>
@@ -3773,9 +3773,13 @@ describe('NavigationMotion', function () {
             act(() => stateNavigator.navigate('sceneC'));
             await act(async () => update(true));
             try {
+                var scenes = container.querySelectorAll<HTMLDivElement>(".scene");
                 assert.notEqual(container.querySelector("#sceneA"), null);
-                assert.equal(container.querySelector("#sceneB"), null);
-                assert.equal(container.querySelector("#sceneC"), null);
+                assert.notEqual(scenes[0].style.display, 'none');
+                assert.notEqual(container.querySelector("#sceneB"), null);
+                assert.equal(scenes[1].style.display, 'none');
+                assert.notEqual(container.querySelector("#sceneC"), null);
+                assert.equal(scenes[2].style.display, 'none');
             } finally {
                 act(() => root.unmount());
             }

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -2286,6 +2286,43 @@ describe('NavigationMotion', function () {
                 await test();
             })
         });
+        const test = async () => {
+            await act(async () => {
+                var url = stateNavigator.fluent(true)
+                    .navigate('sceneB')
+                    .navigate('sceneC').url;
+                stateNavigator.navigateLink(url);
+            });
+            await act(async () => {
+                stateNavigator.navigateBack(2);
+            });
+            try {
+                var scenes = container.querySelectorAll(".scene");
+                assert.equal(scenes.length, 1);
+                assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+                assert.equal(container.querySelector("#sceneB"), null);
+                assert.equal(container.querySelector("#sceneC"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
+
+    describe('A to A -> B -> C to A', function () {
+        var stateNavigator, root, container;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => <div id="sceneB" />;
+        var SceneC = () => <div id="sceneC" />;
+        beforeEach(() => {
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+                { key: 'sceneC', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
         describe('Static Stack', () => {            
             it('should render A', async function(){
                 var {sceneA, sceneB, sceneC} = stateNavigator.states;
@@ -2324,14 +2361,19 @@ describe('NavigationMotion', function () {
                     .navigate('sceneB')
                     .navigate('sceneC').url;
                 stateNavigator.navigateLink(url);
+            });
+            await act(async () => {
                 stateNavigator.navigateBack(2);
             });
             try {
                 var scenes = container.querySelectorAll(".scene");
-                assert.equal(scenes.length, 1);
+                assert.equal(scenes.length, 3);
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+                assert.notEqual(scenes[0].style.display, 'none');
+                assert.equal(scenes[1].style.display, 'none');
+                assert.notEqual(scenes[2].querySelector("#sceneC"), null);
+                assert.equal(scenes[2].style.display, 'none');
                 assert.equal(container.querySelector("#sceneB"), null);
-                assert.equal(container.querySelector("#sceneC"), null);
             } finally {
                 act(() => root.unmount());
             }

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -1853,6 +1853,43 @@ describe('NavigationMotion', function () {
                 await test();
             });
         });
+        const test = async () => {
+            await act(async () => {
+                var url = stateNavigator.fluent(true)
+                    .navigate('sceneB')
+                    .navigate('sceneC').url;
+                stateNavigator.navigateLink(url);
+            });
+            await act(async () => {
+                stateNavigator.navigateBack(1);
+            });
+            try {
+                var scenes = container.querySelectorAll(".scene");
+                assert.equal(scenes.length, 2);
+                assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+                assert.notEqual(scenes[1].querySelector("#sceneB"), null);
+                assert.equal(container.querySelector("#sceneC"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
+
+    describe('A to A -> B -> C to A -> B', function () {
+        var stateNavigator, root, container;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => <div id="sceneB" />;
+        var SceneC = () => <div id="sceneC" />;
+        beforeEach(() => {
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+                { key: 'sceneC', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
         describe('Static Stack', () => {
             it('should render A -> B', async function(){
                 var {sceneA, sceneB, sceneC} = stateNavigator.states;
@@ -1891,14 +1928,19 @@ describe('NavigationMotion', function () {
                     .navigate('sceneB')
                     .navigate('sceneC').url;
                 stateNavigator.navigateLink(url);
+            });
+            await act(async () => {
                 stateNavigator.navigateBack(1);
             });
             try {
                 var scenes = container.querySelectorAll(".scene");
-                assert.equal(scenes.length, 2);
+                assert.equal(scenes.length, 3);
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+                assert.equal(scenes[0].style.display, 'none');
                 assert.notEqual(scenes[1].querySelector("#sceneB"), null);
-                assert.equal(container.querySelector("#sceneC"), null);
+                assert.notEqual(scenes[1].style.display, 'none');
+                assert.notEqual(scenes[2].querySelector("#sceneC"), null);
+                assert.equal(scenes[2].style.display, 'none');
             } finally {
                 act(() => root.unmount());
             }

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -1598,6 +1598,44 @@ describe('NavigationMotion', function () {
                 await test();
             });
         });
+        const test = async () => {
+            act(() => stateNavigator.navigate('sceneB'));
+            await act(async () => {
+                var url = stateNavigator.fluent()
+                    .navigate('sceneC')
+                    .navigate('sceneD').url;
+                stateNavigator.navigateLink(url);
+            });
+            try {
+                var scenes = container.querySelectorAll(".scene");
+                assert.equal(scenes.length, 2);
+                assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+                assert.notEqual(scenes[1].querySelector("#sceneD"), null);
+                assert.equal(container.querySelector("#sceneB"), null);
+                assert.equal(container.querySelector("#sceneC"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        }
+    });
+
+    describe('A to A -> B to C -> D', function () {
+        var stateNavigator, root, container;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => <div id="sceneB" />;
+        var SceneC = () => <div id="sceneC" />;
+        var SceneD = () => <div id="sceneD" />;
+        beforeEach(() => {
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+                { key: 'sceneC' },
+                { key: 'sceneD', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
         describe('Static Stack', () => {
             it('should render A -> D+', async function(){
                 var {sceneA, sceneB, sceneC, sceneD} = stateNavigator.states;
@@ -1642,10 +1680,13 @@ describe('NavigationMotion', function () {
             });
             try {
                 var scenes = container.querySelectorAll(".scene");
-                assert.equal(scenes.length, 2);
+                assert.equal(scenes.length, 3);
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
-                assert.notEqual(scenes[1].querySelector("#sceneD"), null);
-                assert.equal(container.querySelector("#sceneB"), null);
+                assert.equal(scenes[0].style.display, 'none');
+                assert.notEqual(scenes[1].querySelector("#sceneB"), null);
+                assert.equal(scenes[1].style.display, 'none');
+                assert.notEqual(scenes[2].querySelector("#sceneD"), null);
+                assert.notEqual(scenes[2].style.display, 'none');
                 assert.equal(container.querySelector("#sceneC"), null);
             } finally {
                 act(() => root.unmount());

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -1449,6 +1449,42 @@ describe('NavigationMotion', function () {
                 await test();
             });
         });
+        const test = async () => {
+            act(() => stateNavigator.navigate('sceneB'));
+            act(() => {
+                var url = stateNavigator.fluent()
+                    .navigate('sceneC')
+                    .navigate('sceneB').url;
+                stateNavigator.navigateLink(url);
+            });
+            await act(async () => stateNavigator.navigateBack(1));
+            try {
+                var scenes = container.querySelectorAll(".scene");
+                assert.equal(scenes.length, 1);
+                assert.notEqual(scenes[0].querySelector("#sceneC"), null);
+                assert.equal(container.querySelector("#sceneA"), null);
+                assert.equal(container.querySelector("#sceneB"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        }
+    });
+
+    describe('A to A -> B to C -> B to C', function () {
+        var stateNavigator, root, container;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => <div id="sceneB" />;
+        var SceneC = () => <div id="sceneC" />;
+        beforeEach(() => {
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA' },
+                { key: 'sceneB', trackCrumbTrail: true },
+                { key: 'sceneC' },
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
         describe('Static Stack', () => {
             it('should render C', async function(){
                 var {sceneA, sceneB, sceneC} = stateNavigator.states;
@@ -1492,10 +1528,12 @@ describe('NavigationMotion', function () {
             await act(async () => stateNavigator.navigateBack(1));
             try {
                 var scenes = container.querySelectorAll(".scene");
-                assert.equal(scenes.length, 1);
+                assert.equal(scenes.length, 2);
                 assert.notEqual(scenes[0].querySelector("#sceneC"), null);
+                assert.notEqual(scenes[0].style.display, 'none');
+                assert.notEqual(scenes[1].querySelector("#sceneB"), null);
+                assert.equal(scenes[1].style.display, 'none');
                 assert.equal(container.querySelector("#sceneA"), null);
-                assert.equal(container.querySelector("#sceneB"), null);
             } finally {
                 act(() => root.unmount());
             }

--- a/NavigationReactMobile/test/NavigationMotionTest.tsx
+++ b/NavigationReactMobile/test/NavigationMotionTest.tsx
@@ -2936,6 +2936,49 @@ describe('NavigationMotion', function () {
                 await test();
             });
         });
+        const test = async () => {
+            act(() => stateNavigator.navigate('sceneA'));
+            await act(async () => {
+                var url = stateNavigator.fluent(true)
+                    .navigateBack(1)
+                    .navigate('sceneB').url;
+                stateNavigator.navigateLink(url);
+            });
+            act(() => stateNavigator.navigate('sceneC'));
+            await act(async () => stateNavigator.navigateBack(1));
+            await act(async () => {
+                var url = stateNavigator.fluent(true)
+                    .navigateBack(1)
+                    .navigate('sceneC').url;
+                stateNavigator.navigateLink(url);
+            });
+            try {
+                var scenes = container.querySelectorAll(".scene");
+                assert.equal(scenes.length, 2);
+                assert.notEqual(scenes[0].querySelector("#sceneA"), null);
+                assert.notEqual(scenes[1].querySelector("#sceneC"), null);
+                assert.equal(container.querySelector("#sceneB"), null);
+            } finally {
+                act(() => root.unmount());
+            }
+        };
+    });
+
+    describe('A to A -> A to A -> B to A -> B -> C to A -> B to A -> C', function () {
+        var stateNavigator, root, container;
+        var SceneA = () => <div id="sceneA" />;
+        var SceneB = () => <div id="sceneB" />;
+        var SceneC = () => <div id="sceneC" />;
+        beforeEach(() => {
+            stateNavigator = new StateNavigator([
+                { key: 'sceneA', trackCrumbTrail: true },
+                { key: 'sceneB', trackCrumbTrail: true },
+                { key: 'sceneC', trackCrumbTrail: true },
+            ]);
+            stateNavigator.navigate('sceneA');
+            container = document.createElement('div');
+            root = createRoot(container)
+        });
         describe('Static Stack', () => {            
             it('should render A -> C++', async function(){
                 var {sceneA, sceneB, sceneC} = stateNavigator.states;
@@ -2986,10 +3029,17 @@ describe('NavigationMotion', function () {
             });
             try {
                 var scenes = container.querySelectorAll(".scene");
-                assert.equal(scenes.length, 2);
+                assert.equal(scenes.length, 5);
                 assert.notEqual(scenes[0].querySelector("#sceneA"), null);
-                assert.notEqual(scenes[1].querySelector("#sceneC"), null);
-                assert.equal(container.querySelector("#sceneB"), null);
+                assert.equal(scenes[0].style.display, 'none');
+                assert.notEqual(scenes[1].querySelector("#sceneA"), null);
+                assert.equal(scenes[1].style.display, 'none');
+                assert.notEqual(scenes[2].querySelector("#sceneB"), null);
+                assert.equal(scenes[2].style.display, 'none');
+                assert.notEqual(scenes[3].querySelector("#sceneC"), null);
+                assert.notEqual(scenes[3].style.display, 'none');
+                assert.notEqual(scenes[4].querySelector("#sceneC"), null);
+                assert.equal(scenes[4].style.display, 'none');
             } finally {
                 act(() => root.unmount());
             }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -119,7 +119,8 @@ var tests = [
     { name: 'NavigatedHook', to: 'navigatedHook.test.js', folder: 'ReactMobile', ext: 'tsx' },
     { name: 'UnloadingHook', to: 'unloadingHook.test.js', folder: 'ReactMobile', ext: 'tsx' },
     { name: 'UnloadedHook', to: 'unloadedHook.test.js', folder: 'ReactMobile', ext: 'tsx' },
-    { name: 'NavigationMotion', to: 'navigationMotion.test.js', folder: 'ReactMobile', ext: 'tsx' }
+    { name: 'NavigationMotion', to: 'navigationMotion.test.js', folder: 'ReactMobile', ext: 'tsx' },
+    { name: 'NavigationMotionKey', to: 'navigationMotionKey.test.js', folder: 'ReactMobile', ext: 'tsx' }
 ];
 function testTask(name, input, file) {
     var globals = [


### PR DESCRIPTION
The `NavigationStack` retained the scene when browser back but not browser forward. Navigate from A → B then browser back to A and the React state and scroll position are remembered. But then browser forward to B and React state and scroll position were lost. This PR ensures the `NavigationStack` retains the state and scroll position on browser forward, too.

The `NavigationStack` also retains replaced scenes. For example, navigate fluently from A → B to A → C and browser back to B and its state and scroll position are remembered.

Kept the 'unmounted' scenes in the stack but suspended them so they're hidden and don’t re-render. Then revive them when using browser history to navigate to them.
