### PR TITLE
Supported collapsing non-primary TabBar on Material 3

### DIFF
--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarView.java
@@ -32,6 +32,7 @@ public class NavigationBarView extends AppBarLayout {
         defaultOutlineProvider = getOutlineProvider();
         defaultBackground = getBackground();
         defaultShadowColor = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P ? getOutlineAmbientShadowColor() : -16777216;
+        setLiftOnScroll(false);
         addOnOffsetChangedListener((appBarLayout, offset) -> {
             ReactContext reactContext = (ReactContext) getContext();
             EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());


### PR DESCRIPTION
Adding a Material 3 theme to the Twitter sample stopped the collapsing TabBar on Notifications scene from working. 
Turning off `liftOnScroll` on the NavigationBar (AppBarLayout) gets it working again.

Would be a lot of work [to get liftOnScroll to work with the ViewPager](https://github.com/material-components/material-components-android/issues/163). Not worth it until support turning off scroll on the Toolbar (`SCROLL_FLAG_NO_SCROLL` flag) and even then Android Material doesn't allow programmatic setting of `liftOnScroll` colors.