### PR TITLE
Prevented primary TabBar flicker when changing tabs (Android)

### DIFF
--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemView.java
@@ -124,13 +124,15 @@ public class TabBarItemView extends ViewGroup {
     }
 
     void setTabView(TabView tabView, int index) {
-        this.tabView = tabView;
         this.index = index;
-        if (icon != null)
-            tabView.setIcon(index, icon);
-        setBadge(badge);
-        tabView.setTitle(index, styledTitle);
-        tabView.setTestID(index, testID);
+        if (this.tabView != tabView) {
+            this.tabView = tabView;
+            if (icon != null)
+                tabView.setIcon(index, icon);
+            setBadge(badge);
+            tabView.setTitle(index, styledTitle);
+            tabView.setTestID(index, testID);
+        }
     }
 
     void styleTitle() {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabBarItemView.java
@@ -4,7 +4,7 @@ import android.os.Build;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.text.SpannableString;
-import android.text.style.AbsoluteSizeSpan;
+import android.text.style.RelativeSizeSpan;
 import android.text.style.StyleSpan;
 import android.text.style.TypefaceSpan;
 import android.view.View;
@@ -151,7 +151,7 @@ public class TabBarItemView extends ViewGroup {
                 if (fontStyle != null)
                     titleSpannable.setSpan(new StyleSpan(ReactTypefaceUtils.parseFontStyle(fontStyle)), 0, title.length(), 0);
                 if (fontSize != null)
-                    titleSpannable.setSpan(new AbsoluteSizeSpan(fontSize, true), 0, title.length(), 0);
+                    titleSpannable.setSpan(new RelativeSizeSpan(fontSize / 14f), 0, title.length(), 0);
             }
             styledTitle = titleSpannable;
             if (tabView != null)

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -50,9 +51,10 @@ public class TabNavigationView extends BottomNavigationView implements TabView {
         TabBarView tabBar = getTabBar();
         for (int i = 0; tabBar != null && i < tabBar.tabFragments.size(); i++) {
             CharSequence title = getTabBar().tabFragments.get(i).tabBarItem.styledTitle;
-            if (getMenu().findItem(i) != null)
-                getMenu().findItem(i).setTitle(title);
-            else
+            MenuItem item = getMenu().findItem(i);
+            if (item != null && item.getTitle() != title)
+                item.setTitle(title);
+            if (item == null)
                 getMenu().add(Menu.NONE, i, i, title);
         }
         assert tabBar != null;


### PR DESCRIPTION
Updating the `MenuItems` caused flickering when changing tabs so avoided updating when `TabBarItem` props haven't changed. Also changed from `Absolute` to `RelativeSizeSpan` so that font resizing is smooth when changing tabs on old Material theme.

Thanks to @afkcodes for identifying and working through the problem.