### PR TITLE
Ensured BarButton onPress works with auto navigation (Android)

### DIFF
--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomAppBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomAppBarView.java
@@ -90,20 +90,7 @@ public class BottomAppBarView extends BottomAppBar implements ActionView, Drawer
             }
         };
         setNavigationOnClickListener(this::onNavigationClick);
-        setOnMenuItemClickListener(new OnMenuItemClickListener() {
-            @Override
-            public boolean onMenuItemClick(MenuItem item) {
-                for (int i = 0; i < children.size(); i++) {
-                    if (children.get(i) instanceof BarButtonView barButtonView) {
-                        if (barButtonView.getMenuItem() != item)
-                            barButtonView.getMenuItem().collapseActionView();
-                        else
-                            barButtonView.press();
-                    }
-                }
-                return true;
-            }
-        });
+        setOnMenuItemClickListener(this::onMenuItemClick);
     }
 
     @Override
@@ -233,12 +220,14 @@ public class BottomAppBarView extends BottomAppBar implements ActionView, Drawer
                 activity.getSupportActionBar().setDisplayHomeAsUpEnabled(true);
                 activity.setSupportActionBar(null);
                 setNavigationOnClickListener(this::onNavigationClick);
+                setOnMenuItemClickListener(this::onMenuItemClick);
             } else {
                 registerDrawerToggleHandler();
             }
         } else {
             setNavigationIcon(navigationIcon);
             setNavigationOnClickListener(this::onNavigationClick);
+            setOnMenuItemClickListener(this::onMenuItemClick);
         }
         setTintColor(getNavigationIcon());
         setTestID();
@@ -260,6 +249,18 @@ public class BottomAppBarView extends BottomAppBar implements ActionView, Drawer
         ReactContext reactContext = (ReactContext) (getContext() instanceof ReactContext ? getContext() : ((ContextWrapper) getContext()).getBaseContext());
         EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
         eventDispatcher.dispatchEvent(new BottomAppBarView.NavigationPressEvent(getId()));
+    }
+
+    private boolean onMenuItemClick(MenuItem item) {
+        for (int i = 0; i < children.size(); i++) {
+            if (children.get(i) instanceof BarButtonView barButtonView) {
+                if (barButtonView.getMenuItem() != item)
+                    barButtonView.getMenuItem().collapseActionView();
+                else
+                    barButtonView.press();
+            }
+        }
+        return true;
     }
 
     public void setOnSearchListener(OnSearchListener onSearchListener) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchToolbarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/SearchToolbarView.java
@@ -84,13 +84,7 @@ public class SearchToolbarView extends SearchBar implements DrawerToggleHandler 
             setOverflowIcon(d);
             setTintColor(getOverflowIcon());
         };
-        setOnMenuItemClickListener(item -> {
-            for (int i = 0; i < children.size(); i++) {
-                if (children.get(i).getMenuItem() == item)
-                    children.get(i).press();
-            }
-            return true;
-        });
+        setOnMenuItemClickListener(this::onMenuItemClick);
     }
 
     void setFontFamily(String fontFamily) {
@@ -197,6 +191,7 @@ public class SearchToolbarView extends SearchBar implements DrawerToggleHandler 
                 defaultNavigationIcon = getNavigationIcon();
                 activity.setSupportActionBar(null);
                 addNavigationListener();
+                setOnMenuItemClickListener(this::onMenuItemClick);
             } else {
                 registerDrawerToggleHandler();
             }
@@ -204,6 +199,7 @@ public class SearchToolbarView extends SearchBar implements DrawerToggleHandler 
             defaultNavigationIcon = searchDefaultNavigationIcon;
             setNavigationIcon(navigationIcon != null ? navigationIcon : defaultNavigationIcon);
             addNavigationListener();
+            setOnMenuItemClickListener(this::onMenuItemClick);
         }
         setTintColor(getNavigationIcon());
         setTestID();
@@ -232,6 +228,14 @@ public class SearchToolbarView extends SearchBar implements DrawerToggleHandler 
             EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
             eventDispatcher.dispatchEvent(new SearchToolbarView.NavigationPressEvent(getId()));
         });
+    }
+
+    private boolean onMenuItemClick(MenuItem item) {
+        for (int i = 0; i < children.size(); i++) {
+            if (children.get(i).getMenuItem() == item)
+                children.get(i).press();
+        }
+        return true;
     }
 
     void setNavigationTestID(String navigationTestID) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/ToolbarView.java
@@ -88,17 +88,7 @@ public class ToolbarView extends MaterialToolbar implements ActionView, DrawerTo
             setTintColor(getOverflowIcon());
         };
         setNavigationOnClickListener(this::onNavigationClick);
-        setOnMenuItemClickListener(item -> {
-            for (int i = 0; i < children.size(); i++) {
-                if (children.get(i) instanceof BarButtonView barButtonView) {
-                    if (barButtonView.getMenuItem() != item)
-                        barButtonView.getMenuItem().collapseActionView();
-                    else
-                        barButtonView.press();
-                }
-            }
-            return true;
-        });
+        setOnMenuItemClickListener(this::onMenuItemClick);
     }
 
     private int getDefaultTitleTextColor() {
@@ -267,12 +257,14 @@ public class ToolbarView extends MaterialToolbar implements ActionView, DrawerTo
                 activity.getSupportActionBar().setDisplayHomeAsUpEnabled(true);
                 activity.setSupportActionBar(null);
                 setNavigationOnClickListener(this::onNavigationClick);
+                setOnMenuItemClickListener(this::onMenuItemClick);
             } else {
                 registerDrawerToggleHandler();
             }
         } else {
             setNavigationIcon(navigationIcon);
             setNavigationOnClickListener(this::onNavigationClick);
+            setOnMenuItemClickListener(this::onMenuItemClick);
         }
         setTintColor(getNavigationIcon());
         setTestID();
@@ -319,6 +311,18 @@ public class ToolbarView extends MaterialToolbar implements ActionView, DrawerTo
         ReactContext reactContext = (ReactContext) getContext();
         EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
         eventDispatcher.dispatchEvent(new NavigationPressEvent(getId()));
+    }
+
+    private boolean onMenuItemClick(MenuItem item) {
+        for (int i = 0; i < children.size(); i++) {
+            if (children.get(i) instanceof BarButtonView barButtonView) {
+                if (barButtonView.getMenuItem() != item)
+                    barButtonView.getMenuItem().collapseActionView();
+                else
+                    barButtonView.press();
+            }
+        }
+        return true;
     }
 
     public void setOnSearchListener(OnSearchListener onSearchListener) {


### PR DESCRIPTION
With auto navigation on (no `onNavigationPress` listener) a `BarButton's` `onPress` didn't fire when not on the first scene. Android's support action bar steals the menu item click listener. Added the listener back after setting up the support action bar.
```jsx
<NavigationBar>
  <RightBar>
     <BarButton onPress={() =>{/* only fired on the first scene */}} />
  </RightBar>
</NavigationBar>
```