### PR TITLE
Supported React Native 0.76

### DIFF
--- a/NavigationReactNative/src/cpp/CMakeLists.txt
+++ b/NavigationReactNative/src/cpp/CMakeLists.txt
@@ -28,27 +28,36 @@ target_include_directories(
   ../android/build/generated/source/codegen/jni/react/renderer/components/navigationreactnative
 )
 
-target_link_libraries(
-  react_codegen_navigationreactnative
-  fbjni
-  folly_runtime
-  glog
-  jsi
-  react_codegen_rncore
-  react_debug
-  react_nativemodule_core
-  react_render_core
-  react_render_mapbuffer
-  react_render_imagemanager
-  react_render_componentregistry
-  react_render_debug
-  react_render_graphics
-  react_utils
-  rrc_image
-  rrc_view
-  turbomodulejsijni
-  yoga
-)
+if (REACTNATIVE_MERGED_SO)
+  target_link_libraries(
+    react_codegen_navigationreactnative
+    ReactAndroid::reactnative
+    ReactAndroid::jsi
+    fbjni::fbjni
+  )
+else()
+  target_link_libraries(
+    react_codegen_navigationreactnative
+    fbjni
+    folly_runtime
+    glog
+    jsi
+    react_codegen_rncore
+    react_debug
+    react_nativemodule_core
+    react_render_core
+    react_render_mapbuffer
+    react_render_imagemanager
+    react_render_componentregistry
+    react_render_debug
+    react_render_graphics
+    react_utils
+    rrc_image
+    rrc_view
+    turbomodulejsijni
+    yoga
+  )
+endif()
 
 target_compile_options(
   react_codegen_navigationreactnative


### PR DESCRIPTION
Followed [the React Native guidance](https://github.com/react-native-community/discussions-and-proposals/discussions/816) but also used a [couple of other](https://github.com/callstack/react-native-slider/pull/660/files) [PRs](https://github.com/software-mansion/react-native-screens/pull/2415/files) to compile the new link library list
