### PR TITLE
Added support for React Native 0.77

### DIFF
--- a/NavigationReactNative/src/BackButton.tsx
+++ b/NavigationReactNative/src/BackButton.tsx
@@ -1,30 +1,16 @@
-import React from 'react';
-import { BackHandler } from 'react-native';
+import { useContext, useEffect } from 'react';
 import BackHandlerContext from './BackHandlerContext';
 
-class BackButton extends React.Component<{backHandler: BackHandler, onPress: () => boolean}> {
-    constructor(props) {
-        super(props);
-        this.handleBack = this.handleBack.bind(this);
-    }
-    componentDidMount() {
-        this.props.backHandler.addEventListener('hardwareBackPress', this.handleBack);
-    }
-    componentWillUnmount() {
-        this.props.backHandler.removeEventListener('hardwareBackPress', this.handleBack);
-    }
-    handleBack() {
-        return this.props.onPress();
-    }
-    render() {
-        return null;
-    }
+const BackButton = ({onPress}: { onPress: () => boolean }) => {
+  const backHandler = useContext(BackHandlerContext);
+
+  useEffect(() => {
+    const subscription = backHandler.addEventListener('hardwareBackPress', onPress);
+
+    return () => subscription.remove();
+  }, [onPress])
+
+  return null;
 }
 
-export default props => (
-    <BackHandlerContext.Consumer>
-        {backHandler => (
-            <BackButton {...props} backHandler={backHandler} />
-        )}
-    </BackHandlerContext.Consumer>
-);
+export default BackButton;


### PR DESCRIPTION
Fixes #853

In React Native `v0.77`, [the removeEventListener](https://github.com/facebook/react-native/commit/44d619414c1de3dbf17a421afa8dbcec7cdab025) has been removed from `BackHandler`. This PR implements the suggested fix by calling `remove` on the subscription returned by `addEventListener`.