### PR TITLE
Prevented error when foregrounding with modal Sheet open

### DIFF
--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/BottomSheetDialogView.java
@@ -106,7 +106,8 @@ public class BottomSheetDialogView extends ReactViewGroup {
 
     public static class BottomSheetFragment extends BottomSheetDialogFragment implements DialogFragmentController {
         private BottomSheetDialogView dialogView;
-        BottomSheetBehavior.BottomSheetCallback bottomSheetCallback;
+        private BottomSheetBehavior.BottomSheetCallback bottomSheetCallback;
+        private boolean hostAttached = false;
 
         @SuppressLint({"Range", "WrongConstant"})
         @Nullable
@@ -150,7 +151,8 @@ public class BottomSheetDialogView extends ReactViewGroup {
             assert window != null : "Window is null";
             window.setLayout(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
             window.setBackgroundDrawable(null);
-            if (dialogView != null) {
+            if (!hostAttached && dialogView != null) {
+                hostAttached = true;
                 ((View) dialogView.dialogRootView.getParent()).setBackgroundColor(Color.TRANSPARENT);
                 dialogView.dialogRootView.fragmentController.attachHost(null);
                 dialogView.dialogRootView.fragmentController.dispatchStart();

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/DialogView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/DialogView.java
@@ -107,6 +107,7 @@ public class DialogView extends ReactViewGroup {
     {
         private DialogView dialogView;
         private boolean edgeToEdge;
+        private boolean hostAttached = false;
 
         @Nullable
         @Override
@@ -129,7 +130,8 @@ public class DialogView extends ReactViewGroup {
             setEdgeToEdge(this.edgeToEdge);
             window.setLayout(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
             window.setBackgroundDrawable(null);
-            if (dialogView != null) {
+            if (!hostAttached && dialogView != null) {
+                hostAttached = true;
                 dialogView.dialogRootView.fragmentController.attachHost(null);
                 dialogView.dialogRootView.fragmentController.dispatchStart();
                 dialogView.dialogRootView.lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START);


### PR DESCRIPTION
Fixes #859

In #787 the Navigation router attached host to the `FragmentManager` so that predictive back supports a `NavigationStack` inside a modal `Sheet`.

When foregrounding an app with an open modal `Sheet` the Navigation router tries to attach the host again and gets an error. Added check so host only attached the first time the modal Sheet is opened.