### PR TITLE
Prevented primary TabBar jump when edge-to-edge (Android)

### DIFF
--- a/NavigationReactNative/sample/fabric/Tabs.js
+++ b/NavigationReactNative/sample/fabric/Tabs.js
@@ -2,7 +2,7 @@ import React, {useState, useMemo, useContext} from 'react';
 import {Platform} from 'react-native';
 import {StateNavigator} from 'navigation';
 import {NavigationHandler, NavigationContext} from 'navigation-react';
-import {NavigationStack, Scene, TabBar, TabBarItem, NavigationBar} from 'navigation-react-native';
+import {NavigationStack, Scene, TabBar, TabBarItem, NavigationBar, CoordinatorLayout} from 'navigation-react-native';
 import Home from './Home';
 import Notifications from './Notifications';
 import Tweet from './Tweet';
@@ -19,9 +19,9 @@ export default () => {
   const homeNavigator = useStateNavigator();
   const notificationsNavigator = useStateNavigator();
   return (
-    <>
+    <CoordinatorLayout>
       <NavigationBar hidden={true} />
-      <TabBar primary={true} barTintColor={Platform.OS === 'android' ? null : 'rgb(247,247,247)'} selectedTintColor={Platform.OS === 'android' ? '#1da1f2' : null}>
+      <TabBar primary={true} barTintColor={Platform.OS === 'android' ? 'white' : 'rgb(247,247,247)'} selectedTintColor={Platform.OS === 'android' ? '#1da1f2' : null}>
         <TabBarItem title="Home" image={require('./home.png')}>
           {Platform.OS === 'ios'
             ? (<NavigationHandler stateNavigator={homeNavigator}>
@@ -49,6 +49,6 @@ export default () => {
             : <Notifications />}
         </TabBarItem>
       </TabBar>
-    </>
+    </CoordinatorLayout>
   );
 }

--- a/NavigationReactNative/sample/fabric/Tabs.js
+++ b/NavigationReactNative/sample/fabric/Tabs.js
@@ -2,7 +2,7 @@ import React, {useState, useMemo, useContext} from 'react';
 import {Platform} from 'react-native';
 import {StateNavigator} from 'navigation';
 import {NavigationHandler, NavigationContext} from 'navigation-react';
-import {NavigationStack, Scene, TabBar, TabBarItem, NavigationBar, CoordinatorLayout} from 'navigation-react-native';
+import {NavigationStack, Scene, TabBar, TabBarItem, NavigationBar} from 'navigation-react-native';
 import Home from './Home';
 import Notifications from './Notifications';
 import Tweet from './Tweet';
@@ -19,9 +19,9 @@ export default () => {
   const homeNavigator = useStateNavigator();
   const notificationsNavigator = useStateNavigator();
   return (
-    <CoordinatorLayout>
+    <>
       <NavigationBar hidden={true} />
-      <TabBar primary={true} barTintColor={Platform.OS === 'android' ? 'white' : 'rgb(247,247,247)'} selectedTintColor={Platform.OS === 'android' ? '#1da1f2' : null}>
+      <TabBar primary={true} barTintColor={Platform.OS === 'android' ? null : 'rgb(247,247,247)'} selectedTintColor={Platform.OS === 'android' ? '#1da1f2' : null}>
         <TabBarItem title="Home" image={require('./home.png')}>
           {Platform.OS === 'ios'
             ? (<NavigationHandler stateNavigator={homeNavigator}>
@@ -49,6 +49,6 @@ export default () => {
             : <Notifications />}
         </TabBarItem>
       </TabBar>
-    </CoordinatorLayout>
+    </>
   );
 }

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
@@ -202,7 +202,6 @@ public class TabNavigationView extends BottomNavigationView implements TabView {
         layout(getLeft(), getTop(), getRight(), getBottom());
     };
 
-
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         heightMeasureSpec = MeasureSpec.makeMeasureSpec(MeasureSpec.getSize(heightMeasureSpec), MeasureSpec.UNSPECIFIED);

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
@@ -5,6 +5,7 @@ import android.content.ContextWrapper;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -12,6 +13,7 @@ import android.view.ViewGroup;
 import android.view.ViewParent;
 
 import androidx.annotation.UiThread;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
 import com.facebook.react.bridge.GuardedRunnable;
 import com.facebook.react.bridge.ReactContext;
@@ -47,6 +49,9 @@ public class TabNavigationView extends BottomNavigationView implements TabView {
         defaultActiveIndicatorColor = getItemActiveIndicatorColor() != null ? getItemActiveIndicatorColor().getDefaultColor() : Color.WHITE;
         defaultRippleColor = getItemRippleColor() != null ? getItemRippleColor().getColorForState(new int[]{ android.R.attr.state_pressed }, Color.WHITE) : Color.WHITE;
         defaultShadowColor = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P ? getOutlineAmbientShadowColor() : Color.WHITE;
+        CoordinatorLayout.LayoutParams params = new CoordinatorLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        setLayoutParams(params);
+        params.gravity = Gravity.BOTTOM;
         setOnItemSelectedListener(menuItem -> {
             TabBarView tabBar = getTabBar();
             if (!autoSelected && tabBar != null && tabBar.selectedTab == menuItem.getOrder())
@@ -189,6 +194,13 @@ public class TabNavigationView extends BottomNavigationView implements TabView {
         }
     }
 
+    @Override
+    public void setPaddingRelative(int start, int top, int end, int bottom) {
+        super.setPaddingRelative(start, top, end, bottom);
+        if (getParent() instanceof CoordinatorLayoutView coordinatorLayoutView)
+            coordinatorLayoutView.measureAndLayout.run();
+    }
+
     private final Runnable measureAndLayout = () -> {
         layoutRequested = false;
         measure(
@@ -196,6 +208,14 @@ public class TabNavigationView extends BottomNavigationView implements TabView {
             MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
         layout(getLeft(), getTop(), getRight(), getBottom());
     };
+
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        heightMeasureSpec = MeasureSpec.makeMeasureSpec(MeasureSpec.getSize(heightMeasureSpec), MeasureSpec.UNSPECIFIED);
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+    }
+
 
     @Override
     public void setTitle(int index, CharSequence title) {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/TabNavigationView.java
@@ -50,8 +50,8 @@ public class TabNavigationView extends BottomNavigationView implements TabView {
         defaultRippleColor = getItemRippleColor() != null ? getItemRippleColor().getColorForState(new int[]{ android.R.attr.state_pressed }, Color.WHITE) : Color.WHITE;
         defaultShadowColor = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P ? getOutlineAmbientShadowColor() : Color.WHITE;
         CoordinatorLayout.LayoutParams params = new CoordinatorLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
-        setLayoutParams(params);
         params.gravity = Gravity.BOTTOM;
+        setLayoutParams(params);
         setOnItemSelectedListener(menuItem -> {
             TabBarView tabBar = getTabBar();
             if (!autoSelected && tabBar != null && tabBar.selectedTab == menuItem.getOrder())
@@ -194,13 +194,6 @@ public class TabNavigationView extends BottomNavigationView implements TabView {
         }
     }
 
-    @Override
-    public void setPaddingRelative(int start, int top, int end, int bottom) {
-        super.setPaddingRelative(start, top, end, bottom);
-        if (getParent() instanceof CoordinatorLayoutView coordinatorLayoutView)
-            coordinatorLayoutView.measureAndLayout.run();
-    }
-
     private final Runnable measureAndLayout = () -> {
         layoutRequested = false;
         measure(
@@ -216,6 +209,12 @@ public class TabNavigationView extends BottomNavigationView implements TabView {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
     }
 
+    @Override
+    public void setPaddingRelative(int start, int top, int end, int bottom) {
+        super.setPaddingRelative(start, top, end, bottom);
+        if (getParent() instanceof CoordinatorLayoutView coordinatorLayoutView)
+            coordinatorLayoutView.measureAndLayout.run();
+    }
 
     @Override
     public void setTitle(int index, CharSequence title) {


### PR DESCRIPTION
The `TabBar` jumped when edge-to-edge because it resizes asynchronously on first load. React Native doesn't support sync resizing yet.

Got the resize to happen on the native side by wrapping the `TabBar` in a `CoordinatorLayout`. The `CoordinatorLayout` returns true from `needsCustomLayoutForChildren` so React Native doesn't try to size its children. Once the edge-to-edge insets are applied, trigger a sync measure and layout of the `CoordinatorLayout` which ensures the `BottomNavigationView` is sized correctly (changed the measure spec to UNSPECIFIED so the insets are included).

Thanks to @afkcodes for raising the issue and testing the fix.

```jsx
<CoordinatorLayout>
  <TabBar primary>
    ...
  </TabBar>
</CoordinatorLayout>
```
