### PR TITLE
Prevented flicker when navigating to nested `NavigationStack`

### DIFF
--- a/NavigationReact/src/AsyncStateNavigator.ts
+++ b/NavigationReact/src/AsyncStateNavigator.ts
@@ -62,8 +62,8 @@ class AsyncStateNavigator extends StateNavigator {
         this.stateNavigator.navigateLink(url, historyAction, history, (stateContext, resumeNavigation) => {
             suspendNavigation(stateContext, () => {
                 var asyncNavigator = new AsyncStateNavigator(this.navigationHandler, this.stateNavigator, stateContext);
-                var { oldState, state, data, asyncData } = asyncNavigator.stateContext;
-                const startTransition = React.startTransition || ((transition) => transition());
+                var { oldState, state, data, asyncData, history } = asyncNavigator.stateContext;
+                const startTransition = (!history && React.startTransition) || ((transition) => transition());
                 startTransition(() => {
                     this.navigationHandler.setState({ context: { oldState, state, data, asyncData, stateNavigator: asyncNavigator } }, () => {
                         if (stateContext === this.navigationHandler.state.context.stateNavigator.stateContext)

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -71,41 +71,13 @@ class Scene extends React.Component<SceneProps, SceneState> {
     }
     peekNavigate() {
         var {crumb, navigationEvent} = this.props;
-        var {crumbs, nextCrumb} = navigationEvent.stateNavigator.stateContext;
+        var {crumbs} = navigationEvent.stateNavigator.stateContext;
         var {stateNavigator} = navigationEvent;
         var peekNavigator = new StateNavigator(stateNavigator, stateNavigator.historyManager);
-        peekNavigator.stateContext = Scene.createStateContext(crumbs, nextCrumb, crumb, navigationEvent);
-        peekNavigator.configure = stateNavigator.configure;
-        peekNavigator.onBeforeNavigate = stateNavigator.onBeforeNavigate;
-        peekNavigator.offBeforeNavigate = stateNavigator.offBeforeNavigate;
-        peekNavigator.onNavigate = stateNavigator.onNavigate;
-        peekNavigator.offNavigate = stateNavigator.offNavigate;
-        peekNavigator.navigateLink = stateNavigator.navigateLink.bind(stateNavigator);
+        peekNavigator.navigateLink(crumbs[crumb].url);
+        peekNavigator.stateContext['peek'] = navigationEvent;
         var {oldState, state, data, asyncData} = peekNavigator.stateContext;
         this.setState({navigationEvent: {oldState, state, data, asyncData, stateNavigator: peekNavigator}});
-    }
-    static createStateContext(crumbs: Crumb[], nextCrumb: Crumb, crumb: number, navigationEvent: NavigationEvent) {
-        var stateContext = new StateContext();
-        var {state, data, url, title} = crumbs[crumb];
-        stateContext['peek'] = navigationEvent;
-        stateContext.state = state;
-        stateContext.data = data;
-        stateContext.url = url;
-        stateContext.title = title;
-        stateContext.history = true;
-        stateContext.crumbs = crumbs.slice(0, crumb);
-        stateContext.nextCrumb = crumbs[crumb];
-        var {state, data, url} = nextCrumb;
-        stateContext.oldState = state;
-        stateContext.oldData = data;
-        stateContext.oldUrl = url;
-        if (crumb > 1) {
-            var {state, data, url} = crumbs[crumb - 1];
-            stateContext.previousState = state;
-            stateContext.previousData = data;
-            stateContext.previousUrl = url;
-        }
-        return stateContext;
     }
     getAnimation() {
         var {crumb, navigationEvent, customAnimation, unmountStyle, crumbStyle, hidesTabBar, backgroundColor, landscape} = this.props;


### PR DESCRIPTION
Navigate from A -> B where B has a `TabBar` with a nested `NavigationStack` per tab. The tab content is blank when  the transition starts and the transition stutters when the content appears. Thanks to @afkcodes for showing me the problem over twitter.

The problem is that, on the very first render, the `NavigationStack` doesn't show any content. It's not until the `useEffect` runs that it returns the first scene. The `NavigationStack` has to trigger a navigation, before it shows content, which it can't do synchronously (because navigating triggers a state update in the ancestor `NavigationHandler`). The transition is interrupted when the content loads in (probably need 4 tabs with heavy scenes to see the stutter).

Can workaround by priming the `stateNavigator` of each `NavigationStack`. Priming populates the `NavigationContext` immediately so the `NavigationStack` returns a scene on the very first render.
```jsx
const {stateNavigator} = useContext(NavigationContext);
const tabNavigator = useMemo(() => {
  const newNavigator = new StateNavigator(stateNavigator);
  // prime with an initial navigation
  newNavigator.navigate('home');
  return newNavigator;
}, []);
```
Fixed by creating a dummy `NavigationContext` on the first render. The same idea as the `peekNavigator` already in place for fluent navigation. Found a tidier way to do it than the peek approach. Instead of manually building a `StateContext`, called `navigateLink` so the context is built automatically. Decided to not allow navigation from the dummy `NavigationContext`. It makes the code simpler because don't have to hook up the navigation functions from the `AsyncStateNavigator`. Also it doesn't matter because the real `NavigationContext` will be along very shortly. Rewrote  peek to use this simpler approach.

While testing on iOS found a [regression with fluent navigation introduced with RSCs](https://github.com/grahammendick/navigation/pull/863). Navigate fluently from A to A -> B -> C -> D then fluently again to A -> B -> C -> D -> E -> F -> G. Then tap/swipe back to F. Then tap/swipe back again and nothing happens. Scene E wasn't populated so the native `shouldPopItem` in `NavigationStackView` prevents the back from happening. The swipe back was wrapped in a `startTransition` (#863) and the suspended scenes weren't unsuspended so React couldn't apply the peek state update (same as 0e09b3aeac39bff0054482b0996572b23f91915c). Fixed by removing the `startTransition` if navigating history - history has already happened so no point suspending anyway.

