### PR TITLE
Cleared RSC cache

### DIFF
--- a/NavigationReact/src/SceneRSCView.tsx
+++ b/NavigationReact/src/SceneRSCView.tsx
@@ -77,6 +77,12 @@ const SceneRSCView = ({active, name, dataKeyDeps, errorFallback, children}: Scen
         window.addEventListener('popstate', cacheHistory);
         return () => window.removeEventListener('popstate', cacheHistory);
     });
+    useEffect(() => {
+        return () => {
+            delete cachedSceneViews[sceneViewKey];
+            if (Object.keys(cachedSceneViews).length <= 1) rscCache.delete(navigationEvent);
+        };
+    }, [])
     if (!fetchedSceneView && !cachedHistory && !firstScene && show && !ancestorFetching && dataChanged()) {
         cachedSceneViews[sceneViewKey] = fetchRSC(historyManager.getHref(url), {
             method: 'post',


### PR DESCRIPTION
Only need to keep the RSC that React commits in the cache because React throws away all the others. In the people search example, add a delay to the search, then sort and, before it returns, click the next page. React only commits the next page and throws away the sort.

Unfortunately, React doesn't notify when it discards a background render. Added a `__committed` flag to the cached item when the `useEffect` runs so it's only set for items that React commits. Then discard everything without a `__committed` flag. Also discard the committed item when the last `SceneRSCView` unmounts.
