### PR TITLE
Supported Pressables with a scrolling NavigationBar (Android Fabric)

### DIFF
--- a/NavigationReactNative/sample/fabric/Timeline.js
+++ b/NavigationReactNative/sample/fabric/Timeline.js
@@ -22,7 +22,7 @@ export default () => {
         barTintColor={Platform.OS === 'android' ? standard => standard ? colors[0] : colors[1] : 'rgb(247,247,247)'}
         tintColor={Platform.OS === 'android' ? "#fff" : null}
         titleColor={Platform.OS === 'android' ? "#fff" : null}
-        style={{height: 120}}>
+        style={{height: 140}}>
         <CollapsingBar />
       </NavigationBar>
       <Tweets

--- a/NavigationReactNative/sample/twitter/Timeline.js
+++ b/NavigationReactNative/sample/twitter/Timeline.js
@@ -22,7 +22,7 @@ export default () => {
         barTintColor={Platform.OS === 'android' ? standard => standard ? colors[0] : colors[1] : 'rgb(247,247,247)'}
         tintColor={Platform.OS === 'android' ? "#fff" : null}
         titleColor={Platform.OS === 'android' ? "#fff" : null}
-        style={{height: 120}}>
+        style={{height: 140}}>
         <CollapsingBar />
       </NavigationBar>
       <Tweets

--- a/NavigationReactNative/src/CoordinatorLayout.tsx
+++ b/NavigationReactNative/src/CoordinatorLayout.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
 import { requireNativeComponent, Platform } from 'react-native';
+import OverlapContext from './OverlapContext';
 
 const CoordinatorLayout = ({overlap, children}) => (
-    <NVCoordinatorLayout overlap={overlap} style={{flex: 1}}>{children}</NVCoordinatorLayout>
+    <NVCoordinatorLayout overlap={overlap} style={{flex: 1}}>
+        <OverlapContext.Provider value={overlap || 0}>{children}</OverlapContext.Provider>
+    </NVCoordinatorLayout>
 );
 const NVCoordinatorLayout = global.nativeFabricUIManager ? require('./CoordinatorLayoutNativeComponent').default : requireNativeComponent('NVCoordinatorLayout');
 

--- a/NavigationReactNative/src/NavigationBar.tsx
+++ b/NavigationReactNative/src/NavigationBar.tsx
@@ -10,6 +10,7 @@ import TabBar from './TabBar';
 import StatusBar from './StatusBar';
 import BottomAppBar from './BottomAppBar';
 import InsetsContext from './InsetsContext';
+import OverlapContext from './OverlapContext';
 
 class NavigationBar extends React.Component<any, any> {
     constructor(props) {
@@ -33,7 +34,7 @@ class NavigationBar extends React.Component<any, any> {
         }
     }
     render() {
-        var {navigationEvent, bottomBar, hidden, logo, navigationImage, overflowImage, backTitle, backImage, titleCentered, shadowColor, insets, children, onNavigationPress, style = {height: undefined}, ...otherProps} = this.props;
+        var {navigationEvent, bottomBar, hidden, logo, navigationImage, overflowImage, backTitle, backImage, titleCentered, shadowColor, insets, overlap, children, onNavigationPress, style = {height: undefined}, ...otherProps} = this.props;
         const Material3 = global.__turboModuleProxy != null ? require("./NativeMaterial3Module").default : NativeModules.Material3;
         const { on: material3 } = Platform.OS === 'android' ? Material3.getConstants() : { on: false };
         var scrollEdgeProps = this.getScrollEdgeProps()
@@ -65,7 +66,9 @@ class NavigationBar extends React.Component<any, any> {
                     backTitleOn={backTitle !== undefined}
                     backImage={Image.resolveAssetSource(backImage)}
                     barHeight={!!collapsingBar ? style.height : barHeight}
-                    style={{height: !!collapsingBar ? style.height : Platform.OS === 'android' ? barHeight + insets.top : null}}
+                    includeInset={!collapsingBar}
+                    overlap={overlap}
+                    style={{height: !!collapsingBar ? style.height - overlap : Platform.OS === 'android' ? barHeight + insets.top : null}}
                     {...otherProps}
                     {...scrollEdgeProps}
                     shadowColor={shadowColor}
@@ -130,9 +133,16 @@ const AnimatedNavigationBar =  Animated.createAnimatedComponent(NavigationBar);
 export default props => (
     <InsetsContext.Consumer>
         {(insets) => (
-            <NavigationContext.Consumer>
-                {(navigationEvent) => <AnimatedNavigationBar navigationEvent={navigationEvent} insets={insets} {...props} />}
-            </NavigationContext.Consumer>
+            <OverlapContext.Consumer>
+                {(overlap) => (
+                    <NavigationContext.Consumer>
+                        {(navigationEvent) => (
+                            <AnimatedNavigationBar
+                                navigationEvent={navigationEvent} insets={insets} overlap={overlap} {...props} />
+                        )}
+                    </NavigationContext.Consumer>
+                )}
+            </OverlapContext.Consumer>
         )}
     </InsetsContext.Consumer>
 );

--- a/NavigationReactNative/src/NavigationBar.tsx
+++ b/NavigationReactNative/src/NavigationBar.tsx
@@ -59,7 +59,7 @@ class NavigationBar extends React.Component<any, any> {
         var crumb = stateNavigator.stateContext.crumbs.length;
         const toolbarHeight = !material3 || searchToolbar ? 56 : 64;
         const barHeight = toolbarHeight + (searchToolbar ? 32 : 0);
-        const overlapRatio = Math.round(1 + (this.totalScrollRange ? this.offset / (this.totalScrollRange * PixelRatio.getPixelSizeForLayoutSize(1)) : 0) * (overlap || 0));
+        const overlapRatio = Math.round((1 + (this.totalScrollRange ? this.offset / this.totalScrollRange : 0)) * (overlap || 0) / PixelRatio.getPixelSizeForLayoutSize(1));
         return (
             <>
                 <NVNavigationBar

--- a/NavigationReactNative/src/NavigationBar.tsx
+++ b/NavigationReactNative/src/NavigationBar.tsx
@@ -59,7 +59,7 @@ class NavigationBar extends React.Component<any, any> {
         var crumb = stateNavigator.stateContext.crumbs.length;
         const toolbarHeight = !material3 || searchToolbar ? 56 : 64;
         const barHeight = toolbarHeight + (searchToolbar ? 32 : 0);
-        const overlapRatio = Math.round(1 + this.offset / (this.totalScrollRange * PixelRatio.getPixelSizeForLayoutSize(1))) * overlap;
+        const overlapRatio = Math.round(1 + (this.totalScrollRange ? this.offset / (this.totalScrollRange * PixelRatio.getPixelSizeForLayoutSize(1)) : 0) * (overlap || 0));
         return (
             <>
                 <NVNavigationBar
@@ -68,10 +68,10 @@ class NavigationBar extends React.Component<any, any> {
                     backTitle={backTitle}
                     backTitleOn={backTitle !== undefined}
                     backImage={Image.resolveAssetSource(backImage)}
-                    barHeight={!!collapsingBar ? style.height : barHeight}
+                    barHeight={!!collapsingBar ? style.height || 0 : barHeight}
                     includeInset={!collapsingBar}
                     overlap={overlap}
-                    style={{height: !!collapsingBar ? style.height - overlapRatio + this.offset : Platform.OS === 'android' ? barHeight + insets.top + this.offset : null}}
+                    style={{height: !!collapsingBar ? (style.height || 0) - overlapRatio + this.offset : Platform.OS === 'android' ? barHeight + insets.top + this.offset : null}}
                     {...otherProps}
                     {...scrollEdgeProps}
                     shadowColor={shadowColor}

--- a/NavigationReactNative/src/NavigationBarNativeComponent.js
+++ b/NavigationReactNative/src/NavigationBarNativeComponent.js
@@ -38,6 +38,8 @@ type NativeProps = $ReadOnly<{|
   |}>,
   backTestID: string,
   barHeight: Double,
+  includeInset: boolean,
+  overlap: Int32,
   onOffsetChanged: DirectEventHandler<$ReadOnly<{|
     offset: Double
   |}>>,

--- a/NavigationReactNative/src/NavigationBarNativeComponent.js
+++ b/NavigationReactNative/src/NavigationBarNativeComponent.js
@@ -41,7 +41,8 @@ type NativeProps = $ReadOnly<{|
   includeInset: boolean,
   overlap: Int32,
   onOffsetChanged: DirectEventHandler<$ReadOnly<{|
-    offset: Double
+    offset: Double,
+    totalScrollRange: Double,
   |}>>,
 |}>;
 

--- a/NavigationReactNative/src/OverlapContext.ts
+++ b/NavigationReactNative/src/OverlapContext.ts
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export default createContext(0);

--- a/NavigationReactNative/src/Scene.tsx
+++ b/NavigationReactNative/src/Scene.tsx
@@ -1,9 +1,10 @@
 import React, { ReactNode } from 'react';
 import { requireNativeComponent, StyleSheet } from 'react-native';
-import { StateNavigator, StateContext, State, Crumb } from 'navigation';
+import { StateNavigator, State } from 'navigation';
 import { NavigationContext, NavigationEvent } from 'navigation-react';
 import BackButton from './BackButton';
 import Freeze from './Freeze';
+import OverlapContext from './OverlapContext';
 type SceneProps = { crumb: number, url: string, sceneKey: string, rest: boolean, renderScene: (state: State, data: any) => ReactNode, customAnimation: boolean, crumbStyle: any, unmountStyle: any, hidesTabBar: any, backgroundColor: any, landscape: any, title: (state: State, data: any) => string, popped: (key: string) => void, navigationEvent: NavigationEvent };
 type SceneState = { navigationEvent: NavigationEvent };
 
@@ -159,7 +160,9 @@ class Scene extends React.Component<SceneProps, SceneState> {
                     onPopped={() => popped(sceneKey)}>
                     <BackButton onPress={this.handleBack} />
                     <NavigationContext.Provider value={navigationEvent}>
-                        {navigationEvent && this.props.renderScene(state, data)}
+                        <OverlapContext.Provider value={0}>
+                            {navigationEvent && this.props.renderScene(state, data)}
+                        </OverlapContext.Provider>
                     </NavigationContext.Provider>
                 </NVScene>
             </Freeze>

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CoordinatorLayoutManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CoordinatorLayoutManager.java
@@ -3,6 +3,7 @@ package com.navigation.reactnative;
 import android.view.View;
 import android.widget.ScrollView;
 
+import androidx.annotation.NonNull;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.viewpager.widget.ViewPager;
 import androidx.viewpager2.widget.ViewPager2;
@@ -39,7 +40,7 @@ public class CoordinatorLayoutManager extends ViewGroupManager<CoordinatorLayout
     }
 
     @Override
-    public void addView(CoordinatorLayoutView parent, View child, int index) {
+    public void addView(@NonNull CoordinatorLayoutView parent, @NonNull View child, int index) {
         super.addView(parent, child, index);
         if (child instanceof ScrollView || child instanceof ViewPager || child instanceof ViewPager2) {
             CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) child.getLayoutParams();

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CoordinatorLayoutViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/CoordinatorLayoutViewManager.java
@@ -3,6 +3,7 @@ package com.navigation.reactnative;
 import android.view.View;
 import android.widget.ScrollView;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.viewpager.widget.ViewPager;
@@ -54,7 +55,7 @@ public class CoordinatorLayoutViewManager extends ViewGroupManager<CoordinatorLa
     }
 
     @Override
-    public void addView(CoordinatorLayoutView parent, View child, int index) {
+    public void addView(@NonNull CoordinatorLayoutView parent, @NonNull View child, int index) {
         super.addView(parent, child, index);
         if (child instanceof ScrollView || child instanceof ViewPager || child instanceof ViewPager2) {
             CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) child.getLayoutParams();

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarManager.java
@@ -66,6 +66,16 @@ public class NavigationBarManager extends ViewGroupManager<NavigationBarView> {
         }
     }
 
+    @ReactProp(name = "includeInset")
+    public void setIncludeInset(NavigationBarView view, boolean includeInset) {
+        view.includeInset = includeInset;
+    }
+
+    @ReactProp(name = "overlap")
+    public void setOverlap(NavigationBarView view, int overlap) {
+        view.overlap = overlap;
+    }
+
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarView.java
@@ -30,6 +30,8 @@ public class NavigationBarView extends AppBarLayout {
     final ViewOutlineProvider defaultOutlineProvider;
     final Drawable defaultBackground;
     final int defaultShadowColor;
+    boolean includeInset;
+    int overlap = 0;
     private boolean layoutRequested = false;
     private int topInset = 0;
     private final SceneView.WindowInsetsListener windowInsetsListener;
@@ -53,7 +55,7 @@ public class NavigationBarView extends AppBarLayout {
             int newTopInset = insets.getSystemWindowInsetTop();
             if (topInset != newTopInset) {
                 topInset = newTopInset;
-                final int newHeight = getLayoutParams().height + topInset;
+                final int newHeight = getLayoutParams().height + (includeInset ? topInset : 0) - this.overlap;
                 if (stateWrapper != null) {
                     updateState(-1, newHeight);
                 } else {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarView.java
@@ -82,7 +82,8 @@ public class NavigationBarView extends AppBarLayout {
     }
 
     private void resize() {
-        final int newHeight = getLayoutParams().height + (includeInset ? topInset : 0) - ((int) (1f + (float) offset / getTotalScrollRange())) * overlap + offset;
+        int overlapRatio = (int) ((1f + (getTotalScrollRange() > 0 ? (float) offset / getTotalScrollRange() : 0)) * overlap);
+        final int newHeight = getLayoutParams().height + (includeInset ? topInset : 0) - overlapRatio + offset;
         if (stateWrapper != null) {
             updateState(-1, newHeight);
         } else {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarView.java
@@ -58,7 +58,7 @@ public class NavigationBarView extends AppBarLayout {
                 eventDispatcher.dispatchEvent(OffsetChangedEvent.obtain(getId(), offset, getTotalScrollRange()));
                 handler.removeCallbacks(afterOffsetChangedRunnable);
                 afterOffsetChangedRunnable = this::resize;
-                handler.postDelayed(afterOffsetChangedRunnable, 100);
+                handler.postDelayed(afterOffsetChangedRunnable, 200);
             }
         });
         windowInsetsListener = insets -> {
@@ -82,7 +82,7 @@ public class NavigationBarView extends AppBarLayout {
     }
 
     private void resize() {
-        final int newHeight = getLayoutParams().height + (includeInset ? topInset : 0) - ((int) (1f + (float) offset * overlap / getTotalScrollRange())) + offset;
+        final int newHeight = getLayoutParams().height + (includeInset ? topInset : 0) - ((int) (1f + (float) offset / getTotalScrollRange())) * overlap + offset;
         if (stateWrapper != null) {
             updateState(-1, newHeight);
         } else {

--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarViewManager.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationBarViewManager.java
@@ -88,6 +88,16 @@ public class NavigationBarViewManager extends ViewGroupManager<NavigationBarView
         }
     }
 
+    @ReactProp(name = "includeInset")
+    public void setIncludeInset(NavigationBarView view, boolean includeInset) {
+        view.includeInset = includeInset;
+    }
+
+    @ReactProp(name = "overlap")
+    public void setOverlap(NavigationBarView view, int overlap) {
+        view.overlap = overlap;
+    }
+
     @Override
     public void setCrumb(NavigationBarView view, int value) {
     }

--- a/NavigationReactNativeWeb/sample/twitter/Timeline.js
+++ b/NavigationReactNativeWeb/sample/twitter/Timeline.js
@@ -29,7 +29,7 @@ export default () => {
         navigationHref={stateNavigator.historyManager.getHref(
           stateNavigator.getNavigationBackLink(1)
         )}
-        style={{height: 120}}
+        style={{height: 140}}
         onNavigationPress={() => stateNavigator.navigateBack(1)}>
         <CollapsingBar>
           <View style={{backgroundColor: colors[1], flex: 1}} />


### PR DESCRIPTION
On a physical Android device, the `onPress` of the `Touchables` in the fabric sample didn't reliably fire. On the 'Home' and 'Timeline' scenes, when scrolled, React Native cancelled any press originating from the bottom half of a tweet. The press fires the `onTouchMove` and React Native doesn't think the move is in the region of the `Touchable` and so cancels it. 

The new React Native architecture has changed the way it measures nodes. It measures them from the Shadow Tree (c++) instead of the Host Tree (native). When the 'Home' or 'Timeline' scene is scrolled the `NavigationBar` collapses but the new height isn't communicated to the Shadow Tree. So the Shadow Nodes aren't in the correct position and React Native thinks the press on the bottom of a tweet is off target and cancels it.

The problem only happens on a physical device because on a simulator the press doesn't fire the `onTouchMove`. The problem only happens on the new architecture because the old architecture measures nodes from the Host Tree.

Fixed by updating the `NavigationBar` Shadow Node height when the `AppBarLayout` offset changes. There's a slight flicker when using the 'overlap' prop of the `CoordinatorLayout` but suspect this will have to wait until React Native supports sync resize on the new architecture.
