### PR TITLE
Removed RSC refetch on history navigation

### DIFF
--- a/NavigationReact/src/NavigationHandler.tsx
+++ b/NavigationReact/src/NavigationHandler.tsx
@@ -27,16 +27,9 @@ class NavigationHandler extends Component<{ stateNavigator: StateNavigator, chil
         const { stateNavigator } = this.props;
         const { stateContext } = stateNavigator;
         if (this.state.context.stateNavigator.stateContext !== stateContext) {
-            const { history, oldState, state, data, asyncData } = stateContext;
+            const { oldState, state, data, asyncData } = stateContext;
             const asyncNavigator = new AsyncStateNavigator(this, stateNavigator, stateContext);
-            const startTransition = React.startTransition || ((transition) => transition());
-            this.setState({ context: { oldState, state, data, asyncData, stateNavigator: asyncNavigator } }, () => {
-                if (stateNavigator.stateContext === stateContext && history) {
-                    startTransition(() => {
-                        this.setState({ context: { ignoreCache: true, oldState, state, data, asyncData, stateNavigator: asyncNavigator } });
-                    });
-                }
-            });
+            this.setState({ context: { oldState, state, data, asyncData, stateNavigator: asyncNavigator } });
         }
     }
 


### PR DESCRIPTION
Take a master/details scene where the details opens in a modal. It's common to programmatically pop browser history to close the details modal. If refetch the scene then there's a possibility the master list has changed and the selected record isn't in the list anymore. Safest to not refetch on history navigation. This is also better for mobile where the refetch was redundant anyway because the crumb scenes are already rendered.