### PR TITLE
Supported HMR in Vite RSC example

### DIFF
--- a/NavigationReact/sample/rsc-parcel/src/HmrProvider.tsx
+++ b/NavigationReact/sample/rsc-parcel/src/HmrProvider.tsx
@@ -13,9 +13,9 @@ const HmrProvider = ({children}: any) => {
           method: 'put',
           headers: {'Content-Type': 'application/json'},
           body: {
-              crumbs: crumbs.map(({state, data}) => ({state: state.key, data})),
-              state: state.key,
-              data
+            crumbs: crumbs.map(({state, data}) => ({state: state.key, data})),
+            state: state.key,
+            data
           }
       });
       stateNavigator.historyManager.stop();

--- a/NavigationReact/sample/rsc-vite/src/App.tsx
+++ b/NavigationReact/sample/rsc-vite/src/App.tsx
@@ -23,7 +23,7 @@ const App = async ({ url }: any) => {
         </NavigationProvider>
       </body>
     </html>
-  )
+  );
 }
 
 export default App;

--- a/NavigationReact/sample/rsc-vite/src/Filter.tsx
+++ b/NavigationReact/sample/rsc-vite/src/Filter.tsx
@@ -1,38 +1,27 @@
 'use client'
-import { startTransition, useOptimistic } from 'react'
-import { RefreshLink, useNavigationEvent } from 'navigation-react'
+import { startTransition, useOptimistic } from 'react';
+import { RefreshLink, useNavigationEvent } from 'navigation-react';
 
 const Filter = () => {
-  const { data, stateNavigator } = useNavigationEvent()
-  const { name } = data
-  const [optimisticName, setOptimisticName] = useOptimistic(
-    name || '',
-    (_, newName) => newName,
-  )
-  return (
-    <div>
-      <div>
-        <label htmlFor="name">Name</label>
-        <input
-          id="name"
-          value={optimisticName}
-          onChange={({ target: { value } }) => {
-            startTransition(() => {
-              setOptimisticName(value)
-              stateNavigator.refresh({ ...data, name: value, page: null })
-            })
-          }}
-        />
-      </div>
-      Page size
-      <RefreshLink navigationData={{ size: 5, page: null }} includeCurrentData>
-        5
-      </RefreshLink>
-      <RefreshLink navigationData={{ size: 10, page: null }} includeCurrentData>
-        10
-      </RefreshLink>
-    </div>
-  )
+    const {data, stateNavigator} = useNavigationEvent();
+    const {name} = data;
+    const [optimisticName, setOptimisticName] = useOptimistic(name || '', (_, newName) => newName);
+    return (
+        <div>
+            <div>
+                <label htmlFor="name">Name</label>
+                <input id="name" value={optimisticName} onChange={({target: {value}}) => {
+                    startTransition(() => {
+                        setOptimisticName(value);
+                        stateNavigator.refresh({...data, name: value, page: null});
+                    });
+                }} />
+            </div>
+            Page size
+            <RefreshLink navigationData={{size: 5, page: null}} includeCurrentData>5</RefreshLink>
+            <RefreshLink navigationData={{size: 10, page: null}} includeCurrentData>10</RefreshLink>
+        </div>
+    );
 }
 
-export default Filter
+export default Filter;

--- a/NavigationReact/sample/rsc-vite/src/Friends.tsx
+++ b/NavigationReact/sample/rsc-vite/src/Friends.tsx
@@ -1,34 +1,26 @@
-import { RefreshLink, useNavigationEvent } from 'navigation-react'
-import { getFriends } from './data'
-import Gender from './Gender'
+'use server-entry'
+import { RefreshLink, useNavigationEvent } from 'navigation-react';
+import { getFriends } from './data';
+import Gender from './Gender';
 
 const Friends = async () => {
-  const {
-    data: { show, id, gender },
-  } = useNavigationEvent()
-  const friends = show ? await getFriends(id, gender) : null
+  const {data: {show, id, gender}} = useNavigationEvent();
+  const friends = show ? await getFriends(id, gender) : null;
   return (
     <>
-      <RefreshLink
-        navigationData={{ show: !show }}
-        includeCurrentData
-      >{`${!show ? 'Show' : 'Hide'} Friends`}</RefreshLink>
+      <RefreshLink navigationData={{show: !show}} includeCurrentData>{`${!show ? 'Show' : 'Hide'} Friends`}</RefreshLink>
       {show && (
         <>
           <Gender />
           <ul>
-            {friends?.map(({ id, name }) => (
-              <li key={id}>
-                <RefreshLink navigationData={{ id }} includeCurrentData>
-                  {name}
-                </RefreshLink>
-              </li>
+            {friends?.map(({id, name}) => (
+              <li key={id}><RefreshLink navigationData={{id}} includeCurrentData>{name}</RefreshLink></li>
             ))}
           </ul>
         </>
       )}
     </>
-  )
+  );
 }
 
-export default Friends
+export default Friends;

--- a/NavigationReact/sample/rsc-vite/src/Gender.tsx
+++ b/NavigationReact/sample/rsc-vite/src/Gender.tsx
@@ -1,35 +1,28 @@
 'use client'
-import { startTransition } from 'react'
-import { useNavigationEvent } from 'navigation-react'
-import { useOptimistic } from 'react'
+import { startTransition } from 'react';
+import { useNavigationEvent } from 'navigation-react';
+import { useOptimistic } from 'react';
 
 const Gender = () => {
-  const { data, stateNavigator } = useNavigationEvent()
-  const { gender } = data
-  const [optimisticGender, setOptimisticGender] = useOptimistic(
-    gender || '',
-    (_, newGender) => newGender,
-  )
-  return (
-    <div>
-      <label htmlFor="gender">Gender</label>
-      <select
-        id="gender"
-        value={optimisticGender}
-        onChange={({ target: { value } }) => {
-          startTransition(() => {
-            setOptimisticGender(value)
-            stateNavigator.refresh({ ...data, gender: value })
-          })
-        }}
-      >
-        <option value=""></option>
-        <option value="male">Male</option>
-        <option value="female">Female</option>
-        <option value="other">Other</option>
-      </select>
-    </div>
-  )
+    const {data, stateNavigator} = useNavigationEvent();
+    const {gender} = data;
+    const [optimisticGender, setOptimisticGender] = useOptimistic(gender || '', (_, newGender) => newGender);
+    return (
+        <div>
+            <label htmlFor="gender">Gender</label>
+            <select id="gender" value={optimisticGender} onChange={({target: {value}}) => {
+                startTransition(() => {
+                    setOptimisticGender(value);
+                    stateNavigator.refresh({...data, gender: value});
+                });
+            }}>
+                <option value=""></option>
+                <option value="male">Male</option>
+                <option value="female">Female</option>
+                <option value="other">Other</option>
+            </select>
+        </div>
+    );
 }
 
-export default Gender
+export default Gender;

--- a/NavigationReact/sample/rsc-vite/src/HmrProvider.tsx
+++ b/NavigationReact/sample/rsc-vite/src/HmrProvider.tsx
@@ -2,41 +2,29 @@
 import { useContext, useEffect } from 'react'
 import { BundlerContext, useNavigationEvent } from 'navigation-react'
 
-const HmrProvider = ({ children }: any) => {
-  const { setRoot, deserialize } = useContext(BundlerContext)
-  const { stateNavigator } = useNavigationEvent()
+const HmrProvider = ({children}: any) => {
+  const {setRoot, deserialize} = useContext(BundlerContext);
+  const {stateNavigator} = useNavigationEvent();
   useEffect(() => {
     const onHmrReload = () => {
-      const {
-        stateContext: {
-          state,
-          data,
-          crumbs,
-          nextCrumb: { crumblessUrl },
-        },
-      } = stateNavigator
-      const root = deserialize(
-        stateNavigator.historyManager.getHref(crumblessUrl),
-        {
+      const {stateContext: {state, data, crumbs, nextCrumb: {crumblessUrl}}} = stateNavigator;
+      const root = deserialize(stateNavigator.historyManager.getHref(crumblessUrl), {
           method: 'put',
           headers: { 'Content-Type': 'application/json' },
           body: {
-            crumbs: crumbs.map(({ state, data }) => ({
-              state: state.key,
-              data,
-            })),
+            crumbs: crumbs.map(({state, data}) => ({state: state.key, data})),
             state: state.key,
-            data,
+            data
           },
         },
       )
-      stateNavigator.historyManager.stop()
-      setRoot(root)
+      stateNavigator.historyManager.stop();
+      setRoot(root);
     }
     import.meta.hot?.on("rsc:update", onHmrReload);
     return () => import.meta.hot?.off("rsc:update", onHmrReload);
   })
-  return children
+  return children;
 }
 
-export default HmrProvider
+export default HmrProvider;

--- a/NavigationReact/sample/rsc-vite/src/NavigationProvider.tsx
+++ b/NavigationReact/sample/rsc-vite/src/NavigationProvider.tsx
@@ -1,21 +1,21 @@
 'use client'
-import { useMemo } from 'react'
-import { StateNavigator, HTML5HistoryManager } from 'navigation'
-import { NavigationHandler } from 'navigation-react'
-import stateNavigator from './stateNavigator'
+import { useMemo } from 'react';
+import { StateNavigator, HTML5HistoryManager } from 'navigation';
+import { NavigationHandler } from 'navigation-react';
+import stateNavigator from './stateNavigator';
 
-const historyManager = new HTML5HistoryManager()
+const historyManager = new HTML5HistoryManager();
 
-const NavigationProvider = ({ url, children }: any) => {
+const NavigationProvider = ({url, children}: any) => {
   const clientNavigator = useMemo(() => {
-    historyManager.stop()
-    const clientNavigator = new StateNavigator(stateNavigator, historyManager)
+    historyManager.stop();
+    const clientNavigator = new StateNavigator(stateNavigator, historyManager);
     try {
       clientNavigator.navigateLink(url);
     } catch(e) {
     }
-    return clientNavigator
-  }, [])
+    return clientNavigator;
+  }, []);
   return (
     <NavigationHandler stateNavigator={clientNavigator}>
       {children}
@@ -23,4 +23,4 @@ const NavigationProvider = ({ url, children }: any) => {
   )
 }
 
-export default NavigationProvider
+export default NavigationProvider;

--- a/NavigationReact/sample/rsc-vite/src/NavigationProvider.tsx
+++ b/NavigationReact/sample/rsc-vite/src/NavigationProvider.tsx
@@ -10,7 +10,10 @@ const NavigationProvider = ({ url, children }: any) => {
   const clientNavigator = useMemo(() => {
     historyManager.stop()
     const clientNavigator = new StateNavigator(stateNavigator, historyManager)
-    clientNavigator.navigateLink(url)
+    try {
+      clientNavigator.navigateLink(url);
+    } catch(e) {
+    }
     return clientNavigator
   }, [])
   return (

--- a/NavigationReact/sample/rsc-vite/src/Pager.tsx
+++ b/NavigationReact/sample/rsc-vite/src/Pager.tsx
@@ -1,64 +1,26 @@
-import { RefreshLink, useNavigationEvent } from 'navigation-react'
+import { RefreshLink, useNavigationEvent } from 'navigation-react';
 
-const Pager = ({ totalRowCount }: { totalRowCount: number }) => {
-  const {
-    data: { page, size },
-  } = useNavigationEvent()
-  const lastPage = Math.ceil(totalRowCount / size)
+const Pager = ({totalRowCount}: {totalRowCount: number}) => {
+  const {data: {page, size} } = useNavigationEvent();
+  const lastPage = Math.ceil(totalRowCount / size);
   return (
     <div>
       <ul>
-        {totalRowCount ? (
+        {totalRowCount ?
           <>
-            <li>
-              <RefreshLink
-                navigationData={{ page: 1 }}
-                includeCurrentData
-                disableActive
-              >
-                First
-              </RefreshLink>
-            </li>
-            <li>
-              <RefreshLink
-                navigationData={{ page: Math.max(page - 1, 1) }}
-                includeCurrentData
-                disableActive
-              >
-                Previous
-              </RefreshLink>
-            </li>
-            <li>
-              <RefreshLink
-                navigationData={{ page: Math.min(lastPage, page + 1) }}
-                includeCurrentData
-                disableActive
-              >
-                Next
-              </RefreshLink>
-            </li>
-            <li>
-              <RefreshLink
-                navigationData={{ page: lastPage }}
-                includeCurrentData
-                disableActive
-              >
-                Last
-              </RefreshLink>
-            </li>
-          </>
-        ) : (
+            <li><RefreshLink navigationData={{page: 1}} includeCurrentData disableActive>First</RefreshLink></li>
+            <li><RefreshLink navigationData={{page: Math.max(page - 1, 1)}} includeCurrentData disableActive>Previous</RefreshLink></li>
+            <li><RefreshLink navigationData={{page: Math.min(lastPage, page + 1)}} includeCurrentData disableActive>Next</RefreshLink></li>
+            <li><RefreshLink navigationData={{page: lastPage}} includeCurrentData disableActive>Last</RefreshLink></li>
+          </> :
           <>
-            <li>First</li>
-            <li>Previous</li>
-            <li>Next</li>
-            <li>Last</li>
+            <li>First</li><li>Previous</li><li>Next</li><li>Last</li>
           </>
-        )}
+        }
       </ul>
       Total Count {totalRowCount}
     </div>
-  )
+  );
 }
 
-export default Pager
+export default Pager;

--- a/NavigationReact/sample/rsc-vite/src/People.tsx
+++ b/NavigationReact/sample/rsc-vite/src/People.tsx
@@ -1,17 +1,12 @@
-import { searchPeople } from './data'
-import {
-  NavigationLink,
-  RefreshLink,
-  useNavigationEvent,
-} from 'navigation-react'
-import Filter from './Filter'
-import Pager from './Pager'
+'use server-entry'
+import { searchPeople } from './data';
+import { NavigationLink, RefreshLink, useNavigationEvent } from 'navigation-react';
+import Filter from './Filter';
+import Pager from './Pager';
 
 const People = async () => {
-  const {
-    data: { name, page, size, sort },
-  } = useNavigationEvent()
-  const { people, count } = await searchPeople(name, page, size, sort)
+  const {data: {name, page, size, sort}} = useNavigationEvent();
+  const {people, count} = await searchPeople(name, page, size, sort);
   return (
     <>
       <h1>People</h1>
@@ -20,23 +15,16 @@ const People = async () => {
         <thead>
           <tr>
             <th>
-              <RefreshLink
-                navigationData={{ sort: sort === 'asc' ? 'desc' : 'asc' }}
-                includeCurrentData
-              >
-                Name
-              </RefreshLink>
+              <RefreshLink navigationData={{sort: sort === 'asc' ? 'desc' : 'asc'}} includeCurrentData>Name</RefreshLink>
             </th>
             <th>Date of Birth</th>
           </tr>
         </thead>
         <tbody>
-          {people.map(({ id, name, dateOfBirth }) => (
+          {people.map(({id, name, dateOfBirth}) => (
             <tr key={id}>
               <td>
-                <NavigationLink stateKey="person" navigationData={{ id: id }}>
-                  {name}
-                </NavigationLink>
+                <NavigationLink stateKey="person" navigationData={{id: id}}>{name}</NavigationLink>
               </td>
               <td>{dateOfBirth}</td>
             </tr>
@@ -45,7 +33,7 @@ const People = async () => {
       </table>
       <Pager totalRowCount={count} />
     </>
-  )
+  );
 }
 
-export default People
+export default People;

--- a/NavigationReact/sample/rsc-vite/src/Person.tsx
+++ b/NavigationReact/sample/rsc-vite/src/Person.tsx
@@ -1,14 +1,11 @@
-import {
-  SceneView,
-  NavigationBackLink,
-  useNavigationEvent,
-} from 'navigation-react'
-import { getPerson } from './data'
-import Friends from './Friends'
+'use server-entry'
+import { SceneView, NavigationBackLink, useNavigationEvent } from 'navigation-react';
+import { getPerson } from './data';
+import Friends from './Friends';
 
 const Person = async () => {
-  const { data } = useNavigationEvent()
-  const { name, dateOfBirth, email, phone } = await getPerson(data.id)
+  const {data} = useNavigationEvent();
+  const {name, dateOfBirth, email, phone} = await getPerson(data.id);
   return (
     <>
       <h1>Person</h1>
@@ -31,4 +28,4 @@ const Person = async () => {
   )
 }
 
-export default Person
+export default Person;

--- a/NavigationReact/sample/rsc-vite/src/data.ts
+++ b/NavigationReact/sample/rsc-vite/src/data.ts
@@ -1,175 +1,54 @@
-type Person = {
-  id: number
-  name: string
-  gender: 'male' | 'female' | 'other'
-  dateOfBirth: string
-  email: string
-  phone: string
-  friends: number[]
-}
+type Person = {id: number, name: string, gender: 'male' | 'female' | 'other', dateOfBirth: string, email: string, phone: string, friends: number[]};
 
 var people: Person[] = [
-  {
-    id: 1,
-    name: 'Bell Halvorson',
-    gender: 'female',
-    dateOfBirth: '01/01/1980',
-    email: 'bell@navigation.com',
-    phone: '555 0001',
-    friends: [2, 3, 4, 5],
-  },
-  {
-    id: 2,
-    name: 'Aditya Larson',
-    gender: 'male',
-    dateOfBirth: '01/02/1980',
-    email: 'aditya@navigation.com',
-    phone: '555 0002',
-    friends: [3, 4, 5, 6],
-  },
-  {
-    id: 3,
-    name: 'Rashawn Schamberger',
-    gender: 'male',
-    dateOfBirth: '01/03/1980',
-    email: 'rashawn@navigation.com',
-    phone: '555 0003',
-    friends: [4, 5, 6, 7],
-  },
-  {
-    id: 4,
-    name: 'Rupert Grant',
-    gender: 'male',
-    dateOfBirth: '01/04/1980',
-    email: 'rupert@navigation.com',
-    phone: '555 0004',
-    friends: [5, 6, 7, 8],
-  },
-  {
-    id: 5,
-    name: 'Opal Carter',
-    gender: 'female',
-    dateOfBirth: '01/05/1980',
-    email: 'opal@navigation.com',
-    phone: '555 0005',
-    friends: [6, 7, 8, 9],
-  },
-  {
-    id: 6,
-    name: 'Candida Christiansen',
-    gender: 'female',
-    dateOfBirth: '01/06/1980',
-    email: 'candida@navigation.com',
-    phone: '555 0006',
-    friends: [7, 8, 9, 10],
-  },
-  {
-    id: 7,
-    name: 'Haven Stroman',
-    gender: 'other',
-    dateOfBirth: '01/07/1980',
-    email: 'haven@navigation.com',
-    phone: '555 0007',
-    friends: [8, 9, 10, 11],
-  },
-  {
-    id: 8,
-    name: 'Celine Leannon',
-    gender: 'female',
-    dateOfBirth: '01/08/1980',
-    email: 'celine@navigation.com',
-    phone: '555 0008',
-    friends: [9, 10, 11, 12],
-  },
-  {
-    id: 9,
-    name: 'Ryan Ruecker',
-    gender: 'male',
-    dateOfBirth: '01/09/1980',
-    email: 'ryan@navigation.com',
-    phone: '555 0009',
-    friends: [10, 11, 12, 1],
-  },
-  {
-    id: 10,
-    name: 'Kaci Hoppe',
-    gender: 'other',
-    dateOfBirth: '01/10/1980',
-    email: 'kaci@navigation.com',
-    phone: '555 0010',
-    friends: [11, 12, 1, 2],
-  },
-  {
-    id: 11,
-    name: 'Fernando Dietrich',
-    gender: 'male',
-    dateOfBirth: '01/11/1980',
-    email: 'fernando@navigation.com',
-    phone: '555 0011',
-    friends: [12, 1, 2, 3],
-  },
-  {
-    id: 12,
-    name: 'Emelie Lueilwitz',
-    gender: 'female',
-    dateOfBirth: '01/12/1980',
-    email: 'emelie@navigation.com',
-    phone: '555 0012',
-    friends: [1, 2, 3, 4],
-  },
-]
+    {id: 1, name: 'Bell Halvorson', gender: 'female', dateOfBirth: '01/01/1980', email: 'bell@navigation.com', phone: '555 0001', friends: [2,3,4,5]},
+    {id: 2, name: 'Aditya Larson', gender: 'male', dateOfBirth: '01/02/1980', email: 'aditya@navigation.com', phone: '555 0002', friends: [3,4,5,6]},
+    {id: 3, name: 'Rashawn Schamberger', gender: 'male', dateOfBirth: '01/03/1980', email: 'rashawn@navigation.com', phone: '555 0003', friends: [4,5,6,7]},
+    {id: 4, name: 'Rupert Grant', gender: 'male', dateOfBirth: '01/04/1980', email: 'rupert@navigation.com', phone: '555 0004', friends: [5,6,7,8]},
+    {id: 5, name: 'Opal Carter', gender: 'female', dateOfBirth: '01/05/1980', email: 'opal@navigation.com', phone: '555 0005', friends: [6,7,8,9]},
+    {id: 6, name: 'Candida Christiansen', gender: 'female', dateOfBirth: '01/06/1980', email: 'candida@navigation.com', phone: '555 0006', friends: [7,8,9,10]},
+    {id: 7, name: 'Haven Stroman', gender: 'other', dateOfBirth: '01/07/1980', email: 'haven@navigation.com', phone: '555 0007', friends: [8,9,10,11]},
+    {id: 8, name: 'Celine Leannon', gender: 'female', dateOfBirth: '01/08/1980', email: 'celine@navigation.com', phone: '555 0008', friends: [9,10,11,12]},
+    {id: 9, name: 'Ryan Ruecker', gender: 'male', dateOfBirth: '01/09/1980', email: 'ryan@navigation.com', phone: '555 0009', friends: [10,11,12,1]},
+    {id: 10, name: 'Kaci Hoppe', gender: 'other', dateOfBirth: '01/10/1980', email: 'kaci@navigation.com', phone: '555 0010', friends: [11,12,1,2]},
+    {id: 11, name: 'Fernando Dietrich', gender: 'male', dateOfBirth: '01/11/1980', email: 'fernando@navigation.com', phone: '555 0011', friends: [12,1,2,3]},
+    {id: 12, name: 'Emelie Lueilwitz', gender: 'female', dateOfBirth: '01/12/1980', email: 'emelie@navigation.com', phone: '555 0012', friends: [1,2,3,4]}
+];
 
-const searchPeople = async (
-  name: string,
-  pageNumber: number,
-  pageSize: number,
-  sortExpression: string,
-) => {
-  return new Promise(
-    (res: (data: { people: Person[]; count: number }) => void) => {
-      var start = (pageNumber - 1) * pageSize
-      var filteredPeople = people
-        .sort((personA, personB) => {
-          var mult = sortExpression.indexOf('desc') === -1 ? -1 : 1
-          return mult * (personA.name < personB.name ? 1 : -1)
-        })
-        .filter(
-          (person) =>
-            !name ||
-            person.name.toUpperCase().indexOf(name.toUpperCase()) !== -1,
-        )
-      setTimeout(() => {
-        res({
-          people: filteredPeople.slice(start, start + pageSize),
-          count: filteredPeople.length,
-        })
-      }, 10)
-    },
-  )
-}
+const searchPeople = async (name: string, pageNumber: number, pageSize: number, sortExpression: string) => {
+    return new Promise((res: ((data: {people: Person[], count: number}) => void)) => {
+        var start = (pageNumber - 1) * pageSize;
+        var filteredPeople = people.sort((personA, personB) => {
+            var mult = sortExpression.indexOf('desc') === -1 ? -1 : 1;
+            return mult * (personA.name < personB.name ? 1 : -1);
+        }).filter(person => !name || person.name.toUpperCase().indexOf(name.toUpperCase()) !== -1)
+        setTimeout(() => {
+            res({
+                people: filteredPeople.slice(start, start + pageSize),
+                count: filteredPeople.length
+            });
+        }, 10);
+    })
+};
 
 const getPerson = async (id: number) => {
-  return new Promise((res: (person: Person) => void) => {
-    const person = people.find(({ id: personId }) => personId === id)!
-    setTimeout(() => {
-      res(person)
-    }, 10)
-  })
+    return new Promise((res: ((person: Person) => void)) => {
+        const person = people.find(({id: personId}) => personId === id)!
+        setTimeout(() => {
+            res(person);
+        }, 10);
+    })
 }
 
 const getFriends = async (id: number, gender: 'male' | 'female' | 'other') => {
-  return new Promise((res: (friends: Person[]) => void) => {
-    const person = people.find(({ id: personId }) => personId == id)!
-    setTimeout(() => {
-      res(
-        person.friends
-          .map((id) => people.find(({ id: personId }) => personId === id)!)
-          .filter(
-            ({ gender: personGender }) => !gender || personGender === gender,
-          ),
-      )
-    }, 10)
-  })
+    return new Promise((res: ((friends: Person[]) => void)) => {
+        const person = people.find(({id: personId}) => personId == id)!
+        setTimeout(() => {
+            res(person.friends.map((id) => (
+                people.find(({id: personId}) => personId === id)!
+            )).filter(({gender: personGender}) => !gender || personGender === gender));
+        }, 10);
+    })
 }
 
-export { searchPeople, getPerson, getFriends }
+export {searchPeople, getPerson, getFriends};

--- a/NavigationReact/sample/rsc-vite/src/stateNavigator.ts
+++ b/NavigationReact/sample/rsc-vite/src/stateNavigator.ts
@@ -1,18 +1,9 @@
-import { StateNavigator } from 'navigation'
+import { StateNavigator } from 'navigation';
 
 const stateNavigator = new StateNavigator([
-  {
-    key: 'people',
-    route: '{page?}',
-    defaults: { page: 1, sort: 'asc', size: 10 },
-  },
-  {
-    key: 'person',
-    route: 'person/{id}+/{show}',
-    defaults: { id: 0, show: false },
-    trackCrumbTrail: true,
-  },
-])
-stateNavigator.historyManager.stop()
+  {key: 'people', route: '{page?}', defaults: {page: 1, sort: 'asc', size: 10}},
+  {key: 'person', route: 'person/{id}+/{show}', defaults: {id: 0, show: false}, trackCrumbTrail: true}
+]);
+stateNavigator.historyManager.stop();
 
-export default stateNavigator
+export default stateNavigator;

--- a/NavigationReact/sample/rsc-webpack/src/HmrProvider.js
+++ b/NavigationReact/sample/rsc-webpack/src/HmrProvider.js
@@ -14,9 +14,9 @@ const HmrProvider = ({children}) => {
           method: 'put',
           headers: {'Content-Type': 'application/json'},
           body: {
-              crumbs: crumbs.map(({state, data}) => ({state: state.key, data})),
-              state: state.key,
-              data
+            crumbs: crumbs.map(({state, data}) => ({state: state.key, data})),
+            state: state.key,
+            data
           }
       });
       stateNavigator.historyManager.stop();

--- a/NavigationReact/src/NavigationHandler.tsx
+++ b/NavigationReact/src/NavigationHandler.tsx
@@ -21,6 +21,15 @@ class NavigationHandler extends Component<{ stateNavigator: StateNavigator, chil
         this.props.stateNavigator.onNavigate(this.onNavigate);
     }
 
+    componentDidUpdate({ stateNavigator: prevStateNavigator }: { stateNavigator: StateNavigator }) {
+        const { stateNavigator } = this.props;
+        if (stateNavigator !== prevStateNavigator) {
+            const { oldState, state, data, asyncData } = stateNavigator.stateContext;
+            const asyncNavigator = new AsyncStateNavigator(this, stateNavigator, stateNavigator.stateContext);
+            this.setState({ context: { oldState, state, data, asyncData, stateNavigator: asyncNavigator } });
+        }
+    }
+
     componentWillUnmount() {
         this.props.stateNavigator.offNavigate(this.onNavigate);
     }

--- a/NavigationReact/src/SceneRSCView.tsx
+++ b/NavigationReact/src/SceneRSCView.tsx
@@ -15,7 +15,8 @@ const SceneRSCView = ({active, name, refetch: serverRefetch, errorFallback, chil
     const navigationEvent = useNavigationEvent();
     const refetchRef = useRef(serverRefetch);
     const {state, oldState, data, stateNavigator: {stateContext, historyManager}} = navigationEvent;
-    const {crumbs, nextCrumb: {crumblessUrl: url}, oldUrl, oldData, history, historyAction} = stateContext;
+    const {crumbs, nextCrumb, oldUrl, oldData, history, historyAction} = stateContext;
+    const url = nextCrumb?.crumblessUrl;
     const {deserialize} = useContext(BundlerContext);
     const rscContext = useContext(RSCContext);
     const sceneViewKey = name || (typeof active === 'string' ? active : active[0]);
@@ -24,7 +25,7 @@ const SceneRSCView = ({active, name, refetch: serverRefetch, errorFallback, chil
             typeof active === 'string' ? stateKey === active : active.indexOf(stateKey) !== -1
         )
     );
-    const show = getShow(state.key);
+    const show = getShow(state?.key);
     const refetcherState = {ancestorFetching: rscContext.fetching, ignoreCache: !!navigationEvent['ignoreCache']};
     const [{ancestorFetching, ignoreCache}, refetcher] = useOptimistic<any, void>(refetcherState, () => ({ancestorFetching: false, ignoreCache: true}));
     const cachedHistory = !ignoreCache && history && !!historyCache[url]?.[sceneViewKey];

--- a/NavigationReact/test/FluentLinkTest.tsx
+++ b/NavigationReact/test/FluentLinkTest.tsx
@@ -1104,4 +1104,43 @@ describe('FluentLinkTest', function () {
             assert.equal(context.data.y, 'b');
         })
     });
+
+    describe('Change State Navigator Fluent Link', function () {
+        it('should update', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            var container = document.createElement('div');
+            var root = createRoot(container);
+            var updateStateNavigator;
+            var App = () => {
+                var [_stateNavigator, setStateNavigator] = useState(stateNavigator);
+                updateStateNavigator = setStateNavigator;
+                return (
+                    <NavigationHandler stateNavigator={_stateNavigator}>
+                        <FluentLink
+                            withContext={true}
+                            navigate={fluentNavigator => (
+                            fluentNavigator
+                                .navigate('s1')
+                        )}>
+                            link text
+                        </FluentLink>
+                    </NavigationHandler>
+                );
+            }
+            act(() => {
+                root.render(<App />);
+            });
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            assert.equal(link.hash, '#/r1');
+            act(() => {
+                var anotherStateNavigator = new StateNavigator(stateNavigator);
+                anotherStateNavigator.navigate('s0');
+                updateStateNavigator(anotherStateNavigator);
+            });
+            assert.equal(link.hash, '#/r1?crumb=%2Fr0');
+        })
+    });
 });

--- a/NavigationReact/test/NavigationBackLinkTest.tsx
+++ b/NavigationReact/test/NavigationBackLinkTest.tsx
@@ -1044,4 +1044,42 @@ describe('NavigationBackLinkTest', function () {
             assert.equal(context.data.y, undefined);
         })
     });
+
+    describe('Change State Navigator Navigation Back Link', function () {
+        it('should update', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1', trackCrumbTrail: true }
+            ]);
+            stateNavigator.navigate('s0');
+            stateNavigator.navigate('s1');
+            var container = document.createElement('div');
+            var root = createRoot(container);
+            var updateStateNavigator;
+            var App = () => {
+                var [_stateNavigator, setStateNavigator] = useState(stateNavigator);
+                updateStateNavigator = setStateNavigator;
+                return (
+                    <NavigationHandler stateNavigator={_stateNavigator}>
+                        <NavigationBackLink distance={1}>
+                            link text
+                        </NavigationBackLink>
+                    </NavigationHandler>
+                );
+            }
+            act(() => {
+                root.render(<App />);
+            });
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            assert.equal(link.hash, '#/r0');
+            act(() => {
+                var anotherStateNavigator = new StateNavigator(stateNavigator);
+                anotherStateNavigator.navigate('s0');
+                anotherStateNavigator.navigate('s1');
+                anotherStateNavigator.navigate('s1');
+                updateStateNavigator(anotherStateNavigator);
+            });
+            assert.equal(link.hash, '#/r1?crumb=%2Fr0');
+        })
+    });
 });

--- a/NavigationReact/test/NavigationLinkTest.tsx
+++ b/NavigationReact/test/NavigationLinkTest.tsx
@@ -3380,4 +3380,42 @@ describe('NavigationLinkTest', function () {
             assert.equal(context.data.y, 'b');
         })
     });
+
+    describe('Change State Navigator Navigation Link', function () {
+        it('should update', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' }
+            ]);
+            stateNavigator.navigate('s0');
+            var container = document.createElement('div');
+            var root = createRoot(container);
+            var updateStateNavigator;
+            var App = () => {
+                var [_stateNavigator, setStateNavigator] = useState(stateNavigator);
+                updateStateNavigator = setStateNavigator;
+                return (
+                    <NavigationHandler stateNavigator={_stateNavigator}>
+                        <NavigationLink
+                            stateKey="s0"
+                            navigationData={{x: 'a'}}
+                            includeCurrentData={true}>
+                            link text
+                        </NavigationLink>
+                    </NavigationHandler>
+                );
+            }
+            act(() => {
+                root.render(<App />);
+            });
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            assert.equal(link.hash, '#/r0?x=a');
+            act(() => {
+                var anotherStateNavigator = new StateNavigator(stateNavigator);
+                anotherStateNavigator.navigate('s1', {y: 'b'});
+                updateStateNavigator(anotherStateNavigator);
+            });
+            assert.equal(link.hash, '#/r0?y=b&x=a');
+        })
+    });
 });

--- a/NavigationReact/test/RefreshLinkTest.tsx
+++ b/NavigationReact/test/RefreshLinkTest.tsx
@@ -3294,4 +3294,41 @@ describe('RefreshLinkTest', function () {
             assert.equal(context.data.y, 'b');
         })
     });
+
+    describe('Change State Navigator Refresh Link', function () {
+        it('should update', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0', route: 'r0' },
+                { key: 's1', route: 'r1' }
+            ]);
+            stateNavigator.navigate('s0');
+            var container = document.createElement('div');
+            var root = createRoot(container);
+            var updateStateNavigator;
+            var App = () => {
+                var [_stateNavigator, setStateNavigator] = useState(stateNavigator);
+                updateStateNavigator = setStateNavigator;
+                return (
+                    <NavigationHandler stateNavigator={_stateNavigator}>
+                        <RefreshLink
+                            navigationData={{x: 'a'}}
+                            includeCurrentData={true}>
+                            link text
+                        </RefreshLink>
+                    </NavigationHandler>
+                );
+            }
+            act(() => {
+                root.render(<App />);
+            });
+            var link = container.querySelector<HTMLAnchorElement>('a');
+            assert.equal(link.hash, '#/r0?x=a');
+            act(() => {
+                var anotherStateNavigator = new StateNavigator(stateNavigator);
+                anotherStateNavigator.navigate('s1', {y: 'b'})
+                updateStateNavigator(anotherStateNavigator);
+            });
+            assert.equal(link.hash, '#/r1?y=b&x=a');
+        })
+    });
 });

--- a/NavigationReact/test/SceneViewTest.tsx
+++ b/NavigationReact/test/SceneViewTest.tsx
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as mocha from 'mocha';
 import { StateNavigator } from 'navigation';
 import { SceneView, NavigationHandler, useNavigationEvent } from 'navigation-react';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { act, Simulate } from 'react-dom/test-utils';
 import { JSDOM } from 'jsdom';
@@ -578,6 +578,42 @@ describe('SceneViewTest', function () {
                 );
             });
             console.error = err;
+            assert.equal(container.innerHTML, '<div>scene 1</div>');
+        })
+    });
+
+    describe('Scene View Change State Navigator', function () {
+        it('should render', function(){
+            var stateNavigator = new StateNavigator([
+                { key: 's0'},
+                { key: 's1'},
+            ]);
+            stateNavigator.navigate('s0');
+            var container = document.createElement('div');
+            var root = createRoot(container);
+            var updateStateNavigator;
+            var App = () => {
+                var [_stateNavigator, setStateNavigator] = useState(stateNavigator);
+                updateStateNavigator = setStateNavigator;
+                return (
+                    <NavigationHandler stateNavigator={_stateNavigator}>
+                        <SceneView active="s0">
+                            <div>scene 0</div>
+                        </SceneView>
+                        <SceneView active="s1">
+                            <div>scene 1</div>
+                        </SceneView>
+                    </NavigationHandler>
+                );
+            }
+            act(() => {
+                root.render(<App />);
+            });
+            act(() => {
+                var anotherStateNavigator = new StateNavigator(stateNavigator);
+                anotherStateNavigator.navigate('s1');
+                updateStateNavigator(anotherStateNavigator);
+            });
             assert.equal(container.innerHTML, '<div>scene 1</div>');
         })
     });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -128,23 +128,7 @@ var itemTasks = items.reduce((tasks, item) => {
 }, { buildTasks: [], packageTasks: [] });
 
 var tests = [
-    { name: 'NavigationRouting', to: 'navigationRouting.test.js' },
-    { name: 'StateConfig', to: 'stateConfig.test.js' },
-    { name: 'Navigation', to: 'navigation.test.js' },
-    { name: 'NavigationData', to: 'navigationData.test.js' },
-    { name: 'FluentNavigation', to: 'fluentNavigation.test.js' },
-    { name: 'RewriteNavigation', to: 'rewriteNavigation.test.js' },
-    { name: 'NavigationLink', to: 'navigationLink.test.js', folder: 'React', ext: 'tsx' },
-    { name: 'NavigationBackLink', to: 'navigationBackLink.test.js', folder: 'React', ext: 'tsx' },
-    { name: 'RefreshLink', to: 'refreshLink.test.js', folder: 'React', ext: 'tsx' },
-    { name: 'FluentLink', to: 'fluentLink.test.js', folder: 'React', ext: 'tsx' },
-    { name: 'SceneView', to: 'sceneView.test.js', folder: 'React', ext: 'tsx' },
-    { name: 'NavigatingHook', to: 'navigatingHook.test.js', folder: 'ReactMobile', ext: 'tsx' },
-    { name: 'NavigatedHook', to: 'navigatedHook.test.js', folder: 'ReactMobile', ext: 'tsx' },
-    { name: 'UnloadingHook', to: 'unloadingHook.test.js', folder: 'ReactMobile', ext: 'tsx' },
-    { name: 'UnloadedHook', to: 'unloadedHook.test.js', folder: 'ReactMobile', ext: 'tsx' },
-    { name: 'NavigationMotion', to: 'navigationMotion.test.js', folder: 'ReactMobile', ext: 'tsx' },
-    { name: 'NavigationMotionKey', to: 'navigationMotionKey.test.js', folder: 'ReactMobile', ext: 'tsx' }
+    { name: 'SceneView', to: 'sceneView.test.js', folder: 'React', ext: 'tsx' }
 ];
 function testTask(name, input, file) {
     var globals = [

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -128,7 +128,23 @@ var itemTasks = items.reduce((tasks, item) => {
 }, { buildTasks: [], packageTasks: [] });
 
 var tests = [
-    { name: 'SceneView', to: 'sceneView.test.js', folder: 'React', ext: 'tsx' }
+    { name: 'NavigationRouting', to: 'navigationRouting.test.js' },
+    { name: 'StateConfig', to: 'stateConfig.test.js' },
+    { name: 'Navigation', to: 'navigation.test.js' },
+    { name: 'NavigationData', to: 'navigationData.test.js' },
+    { name: 'FluentNavigation', to: 'fluentNavigation.test.js' },
+    { name: 'RewriteNavigation', to: 'rewriteNavigation.test.js' },
+    { name: 'NavigationLink', to: 'navigationLink.test.js', folder: 'React', ext: 'tsx' },
+    { name: 'NavigationBackLink', to: 'navigationBackLink.test.js', folder: 'React', ext: 'tsx' },
+    { name: 'RefreshLink', to: 'refreshLink.test.js', folder: 'React', ext: 'tsx' },
+    { name: 'FluentLink', to: 'fluentLink.test.js', folder: 'React', ext: 'tsx' },
+    { name: 'SceneView', to: 'sceneView.test.js', folder: 'React', ext: 'tsx' },
+    { name: 'NavigatingHook', to: 'navigatingHook.test.js', folder: 'ReactMobile', ext: 'tsx' },
+    { name: 'NavigatedHook', to: 'navigatedHook.test.js', folder: 'ReactMobile', ext: 'tsx' },
+    { name: 'UnloadingHook', to: 'unloadingHook.test.js', folder: 'ReactMobile', ext: 'tsx' },
+    { name: 'UnloadedHook', to: 'unloadedHook.test.js', folder: 'ReactMobile', ext: 'tsx' },
+    { name: 'NavigationMotion', to: 'navigationMotion.test.js', folder: 'ReactMobile', ext: 'tsx' },
+    { name: 'NavigationMotionKey', to: 'navigationMotionKey.test.js', folder: 'ReactMobile', ext: 'tsx' }
 ];
 function testTask(name, input, file) {
     var globals = [


### PR DESCRIPTION
On the people list edit the route in `stateNavigator.tsx` and the hyperlinks should all update but didn't. Vite HMR creates a new `stateNavigator` and the `NavigationHandler` didn't handle it. It doesn't expect the `stateNavigator` prop to ever change. Updated `NavigationHandler` to change the navigation context when the prop changes and the HMR works and updates the hyperlinks.

However there is a Vite HMR bug that happens if edit the route a second time. Vite HMR calls the `NavigationProvider` with the latest url but the old `stateNavigator`. It throws trying to parse the latest url. Wrapped the `navigateLink` call in a try/catch and this works because eventually Vite HMR calls with the latest `stateNavigator`. Will [raise on Vite](https://github.com/vitejs/vite-plugin-react/pull/567) and see what they say.
