### PR TITLE
Supported full screen swipe pop gesture (iOS 26)

### DIFF
--- a/NavigationReactNative/sample/fabric/Home.js
+++ b/NavigationReactNative/sample/fabric/Home.js
@@ -6,7 +6,7 @@ import {getHome} from './data';
 
 export default ({tweets}) => (
   <CoordinatorLayout>
-    <NavigationBar title="Home" barTintColor={Platform.OS === 'android' ? '#fff' : 'rgb(247,247,247)'} />
+    <NavigationBar title="Home" barTintColor={Platform.OS === 'android' ? '#fff' : null} />
     <Tweets tweets={getHome()} />
   </CoordinatorLayout>
 );

--- a/NavigationReactNative/sample/fabric/Notifications.js
+++ b/NavigationReactNative/sample/fabric/Notifications.js
@@ -22,7 +22,7 @@ export default () => {
       <CoordinatorLayout>
         <NavigationBar
           title="Notifications"
-          barTintColor={Platform.OS === 'android' ? 'rgba(255,255,255, 0)' : 'rgb(247,247,247)'}>
+          barTintColor={Platform.OS === 'android' ? 'rgba(255,255,255, 0)' : null}>
           <TabBar selectedTintColor="#1da1f2" />
         </NavigationBar>
         <TabBar primary={false}>

--- a/NavigationReactNative/sample/fabric/Notifications.js
+++ b/NavigationReactNative/sample/fabric/Notifications.js
@@ -7,7 +7,11 @@ import TweetItem from './TweetItem';
 import {getNotifications} from './data';
 
 const Container = ({children}) => (
-  Platform.OS === 'ios' ? <SafeAreaProvider><SafeAreaView style={{flex: 1}}>{children}</SafeAreaView></SafeAreaProvider> : children
+  Platform.OS === 'ios' ? (
+    <SafeAreaProvider>
+      <SafeAreaView style={{flex: 1}} edges={+Platform.Version >= 26 ? ['top'] : ['top', 'bottom']}>{children}</SafeAreaView>
+    </SafeAreaProvider>
+   ) : children
 );
 
 export default () => {

--- a/NavigationReactNative/sample/fabric/Timeline.js
+++ b/NavigationReactNative/sample/fabric/Timeline.js
@@ -19,7 +19,7 @@ export default () => {
       <NavigationBar
         title={name}
         onOffsetChanged={Animated.event([{nativeEvent:{offset}}], {useNativeDriver: true})}
-        barTintColor={Platform.OS === 'android' ? standard => standard ? colors[0] : colors[1] : 'rgb(247,247,247)'}
+        barTintColor={Platform.OS === 'android' ? standard => standard ? colors[0] : colors[1] : null}
         tintColor={Platform.OS === 'android' ? "#fff" : null}
         titleColor={Platform.OS === 'android' ? "#fff" : null}
         style={{height: 140}}>

--- a/NavigationReactNative/sample/fabric/Tweet.js
+++ b/NavigationReactNative/sample/fabric/Tweet.js
@@ -13,7 +13,7 @@ export default () => {
     <>
       <NavigationBar
         title="Tweet"
-        barTintColor={Platform.OS === 'android' ? '#fff' : 'rgb(247,247,247)'}
+        barTintColor={Platform.OS === 'android' ? '#fff' : null}
         tintColor={Platform.OS === 'android' ? "#1da1f2" : null} />
       <Tweets tweets={replies} renderHeader={(
         <View>

--- a/NavigationReactNative/sample/twitter/Home.js
+++ b/NavigationReactNative/sample/twitter/Home.js
@@ -6,7 +6,7 @@ import {getHome} from './data';
 
 export default ({tweets}) => (
   <CoordinatorLayout>
-    <NavigationBar title="Home" barTintColor={Platform.OS === 'android' ? '#fff' : 'rgb(247,247,247)'} />
+    <NavigationBar title="Home" barTintColor={Platform.OS === 'android' ? '#fff' : null} />
     <Tweets tweets={getHome()} />
   </CoordinatorLayout>
 );

--- a/NavigationReactNative/sample/twitter/Notifications.js
+++ b/NavigationReactNative/sample/twitter/Notifications.js
@@ -13,7 +13,7 @@ export default () => {
       <CoordinatorLayout>
         <NavigationBar
           title="Notifications"
-          barTintColor={Platform.OS === 'android' ? 'rgba(255,255,255, 0)' : 'rgb(247,247,247)'}>
+          barTintColor={Platform.OS === 'android' ? 'rgba(255,255,255, 0)' : null}>
           <TabBar selectedTintColor="#1da1f2" />
         </NavigationBar>
         <TabBar primary={false}>

--- a/NavigationReactNative/sample/twitter/Timeline.js
+++ b/NavigationReactNative/sample/twitter/Timeline.js
@@ -19,7 +19,7 @@ export default () => {
       <NavigationBar
         title={name}
         onOffsetChanged={Animated.event([{nativeEvent:{offset}}], {useNativeDriver: true})}
-        barTintColor={Platform.OS === 'android' ? standard => standard ? colors[0] : colors[1] : 'rgb(247,247,247)'}
+        barTintColor={Platform.OS === 'android' ? standard => standard ? colors[0] : colors[1] : null}
         tintColor={Platform.OS === 'android' ? "#fff" : null}
         titleColor={Platform.OS === 'android' ? "#fff" : null}
         style={{height: 140}}>

--- a/NavigationReactNative/sample/twitter/Tweet.js
+++ b/NavigationReactNative/sample/twitter/Tweet.js
@@ -13,7 +13,7 @@ export default () => {
     <>
       <NavigationBar
         title="Tweet"
-        barTintColor={Platform.OS === 'android' ? '#fff' : 'rgb(247,247,247)'}
+        barTintColor={Platform.OS === 'android' ? '#fff' : null}
         tintColor={Platform.OS === 'android' ? "#1da1f2" : null} />
       <Tweets tweets={replies} renderHeader={(
         <View>


### PR DESCRIPTION
On iOS 26 can swipe anywhere on the screen to pop, not just the left edge.

Followed the pattern that was already in place for the `interactivePopGestureRecognizer` (left edge) and applied it to the iOS 26's new `interactiveContentPopGestureRecognizer` (full screen).

Also added custom `UIPanGestureRecognizer` so can swipe full screen with custom animations. There was already a custom `UIScreenEdgePanGestureRecognizer` in place for the left edge with custom animations so followed the same pattern.

The Navigation router already supports interacting during transition that's new in iOS 26, for example, clicking back button multiple times. But couldn't find a way to enable this for custom animations - assume it's not possible.

Didn't find anything else not working in iOS 26.

