### PR TITLE
Restored back navigation on Android <= 33

### DIFF
--- a/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
+++ b/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java
@@ -131,7 +131,7 @@ public class NavigationStackView extends ViewGroup implements LifecycleEventList
                         int popCrumb = ((SceneFragment) sceneFragment).getScene().crumb;
                         int crumb = fragment.getChildFragmentManager().getBackStackEntryCount();
                         if (Build.VERSION.SDK_INT > Build.VERSION_CODES.TIRAMISU) crumb--;
-                        if (popCrumb <= crumb + 1) {
+                        if (popCrumb <= crumb + 1 && crumb + 1 < oldKeys.size()) {
                             FragmentManager fragmentManager = fragment.getChildFragmentManager();
                             SceneFragment fragment = (SceneFragment) fragmentManager.findFragmentByTag(oldKeys.getString(crumb + 1));
                             ArrayList<Pair<SharedElementView, String>> sharedElements = fragment != null ? getOldSharedElements(crumb + 1, popCrumb, fragment) : null;


### PR DESCRIPTION
Thanks to @afkcodes for raising.

On Android <= 33, back navigation in JavaScript was broken. The only back navigation that worked was hardware back on Android 33 when `enableOnBackInvokedCallback` is true where the navigation happens on native side.

The error is that the JavaScript does the back first then `onBackStackChangeStarted` runs and tries to do the back again. It falls over accessing `crumb + 1` from `oldKeys` with `ArrayIndexOutOfBoundsException`. This error doesn't happen on Android > 33 because the `crumb--` 'correction' doesn't happen so the back doesn't run (this `crumb--` correction was put in for predictive back on Android 33 because it returned the wrong value).
