### PR TITLE
Supported navigation precommit on Chrome (RSC) 

### DIFF
--- a/NavigationReact/src/NavigationHandler.tsx
+++ b/NavigationReact/src/NavigationHandler.tsx
@@ -10,7 +10,7 @@ type Intercept = {resume?: () => void, commit?: () => void, signal?: AbortSignal
 type NavigationHandlerState = { ignoreCache?: boolean | string, rscCache?: any, hasUAVisualTransition?: boolean, oldState: State, state: State, data: any, asyncData: any, stateNavigator: StateNavigator & { navigateLink: (...args: [...Parameters<StateNavigator['navigateLink']>, Intercept?]) => void } };
 
 const supportsPrecommitNavigation = typeof window !== 'undefined' && !!window.NavigationPrecommitController
-    && !!(window.navigator as any).userAgentData?.brands?.some(({brand}) => brand === 'Microsoft Edge');
+    && !!(window.navigator as any).userAgentData?.brands?.some(({brand}) => brand === 'Microsoft Edge' || brand === 'Google Chrome');
 
 const NavigationHandler = ({stateNavigator, children}: {stateNavigator: StateNavigator, children: any}) => {
     const [navigationEvent, setNavigationEvent] = useState<{data: NavigationHandlerState, stateNavigator: StateNavigator, intercept?: Intercept}>();


### PR DESCRIPTION
As mentioned in https://github.com/grahammendick/navigation/pull/906, retested precommit navigation on Chrome now they've released the following chromium bugs.

- [Do a history back while another precommitHandler interception is running and the browser crashes](https://issues.chromium.org/issues/511525672) - retested by pressing back then pressing back again while the first is in progress
- [Run a pushState during an intercepted navigation and browser progress button stays on 'X' forever](https://issues.chromium.org/issues/515480635) - retested by updating person's name then clicking people link while update is in progress and check the 'X' disappears when the update completes

They're both working so releasing precommit navigation on Chrome.