### PR TITLE
Supported `startTransition` in userland when navigating with interception (RSC)

### DIFF
--- a/NavigationReact/src/NavigationHandler.tsx
+++ b/NavigationReact/src/NavigationHandler.tsx
@@ -173,6 +173,11 @@ const NavigationHandler = ({stateNavigator, children}: {stateNavigator: StateNav
             const title = typeof document !== 'undefined' ? document.title : null;
             const oldTitle = navigationEvent.intercept?.title;
             if (typeof document !== 'undefined' && oldTitle) document.title = oldTitle;
+            if (typeof window !== 'undefined' && window.navigation?.transition) {
+                const state = {...window.navigation.currentEntry.getState()};
+                window.history.replaceState({...window.history.state}, null);
+                window.navigation.updateCurrentEntry({state});
+            }
             navigationEvent.intercept?.resume?.();
             if (typeof document !== 'undefined' && document.title === oldTitle && title) document.title = title;
             if (navigationEvent.intercept?.hasUAVisualTransition)
@@ -189,11 +194,6 @@ const NavigationHandler = ({stateNavigator, children}: {stateNavigator: StateNav
             historyUrls[url] = true;
             for(let i =0; i < historyKeys.length; i ++) {
                 if (!historyUrls[historyKeys[i]]) delete historyCacheRef.current[url];
-            }
-            if (window.navigation.transition) {
-                const state = {...window.navigation.currentEntry.getState()};
-                window.history.replaceState({...window.history.state}, null);
-                window.navigation.updateCurrentEntry({state});
             }
         }
     }, [isPending, navigationEvent, navigationDeferredEvent]);

--- a/NavigationReact/src/NavigationHandler.tsx
+++ b/NavigationReact/src/NavigationHandler.tsx
@@ -6,7 +6,7 @@ import RefetchContext from './RefetchContext.js';
 import HistoryCacheContext from './HistoryCacheContext.js';
 import NavigationDeferredContext from './NavigationDeferredContext.js';
 import BundlerContext from './BundlerContext.js';
-type Intercept = {resume?: () => void, commit?: () => void, signal?: AbortSignal, title?: string, startTran?: (fn: () => void) => void, controller?: NavigationPrecommitController, hasUAVisualTransition?: boolean};
+type Intercept = {resume?: () => void, commit?: () => void, signal?: AbortSignal, title?: string, controller?: NavigationPrecommitController, hasUAVisualTransition?: boolean};
 type NavigationHandlerState = { ignoreCache?: boolean | string, rscCache?: any, hasUAVisualTransition?: boolean, oldState: State, state: State, data: any, asyncData: any, stateNavigator: StateNavigator & { navigateLink: (...args: [...Parameters<StateNavigator['navigateLink']>, Intercept?]) => void } };
 
 const supportsPrecommitNavigation = typeof window !== 'undefined' && !!window.NavigationPrecommitController
@@ -51,10 +51,12 @@ const NavigationHandler = ({stateNavigator, children}: {stateNavigator: StateNav
                         navigating = true;
                         const {oldState, state, crumbs} = stateContext;
                         const refresh = oldState === state && crumbs.length === this.stateContext.crumbs.length;
-                        const startTran = !refresh ? startTransition : null;
+                        const startTran = (!refresh && startTransition) || ((transition) => transition());
                         intercept.title = typeof document !== 'undefined' && createFromFetch ? document.title : null;
                         intercept.resume = resumeNavigation;
-                        intercept.startTran = startTran;
+                        startTran(() => {
+                            raiseNavigationEvent(stateContext, intercept, this.stateContext['rscCache']);
+                        });
                         raiseNavigationEvent(stateContext, intercept, this.stateContext['rscCache']);
                     })
                 }, currentContext);
@@ -63,10 +65,7 @@ const NavigationHandler = ({stateNavigator, children}: {stateNavigator: StateNav
         }
         const asyncNavigator = new AsyncStateNavigator()
         const {url, oldState, state, data, asyncData, historyAction, history} = asyncNavigator.stateContext;
-        const startTran = intercept.startTran || ((transition) => transition());
-        const startNavigation = () => startTran(() => {
-            setNavigationEvent({data: {oldState, state, data, asyncData, stateNavigator: asyncNavigator, rscCache, ignoreCache: !!rscCache, hasUAVisualTransition: intercept.hasUAVisualTransition}, stateNavigator, intercept});
-        });
+        setNavigationEvent({data: {oldState, state, data, asyncData, stateNavigator: asyncNavigator, rscCache, ignoreCache: !!rscCache, hasUAVisualTransition: intercept.hasUAVisualTransition}, stateNavigator, intercept});
         if (typeof window !== 'undefined' && intercept.resume && supportsPrecommitNavigation && createFromFetch && historyAction !== 'none' && !history && (!intercept.commit || intercept.controller)) {
             if (!intercept.controller) {
                 window.navigation.addEventListener('navigate', e => {
@@ -75,7 +74,6 @@ const NavigationHandler = ({stateNavigator, children}: {stateNavigator: StateNav
                         focusReset: 'manual',
                         scroll: 'manual',
                         async precommitHandler(controller) {
-                            startNavigation();
                             return new Promise((resolve, reject) => {
                                 intercept.commit = resolve;
                                 intercept.signal = e.signal;
@@ -85,15 +83,11 @@ const NavigationHandler = ({stateNavigator, children}: {stateNavigator: StateNav
                         }
                     });
                 }, {once: true});
-            } else {
-                startNavigation();
             }
             const res = stateNavigator.historyManager.navigate(url, historyAction === 'replace', intercept.controller, asyncNavigator.stateContext);
             res?.committed.catch((e) => {
                 if (!intercept?.signal?.aborted) throw e;
             });
-        } else {
-            startNavigation();
         }
     }, [stateNavigator, createFromFetch]);
     if (!navigationEvent) raiseNavigationEvent();

--- a/NavigationReact/src/NavigationHandler.tsx
+++ b/NavigationReact/src/NavigationHandler.tsx
@@ -57,7 +57,6 @@ const NavigationHandler = ({stateNavigator, children}: {stateNavigator: StateNav
                         startTran(() => {
                             raiseNavigationEvent(stateContext, intercept, this.stateContext['rscCache']);
                         });
-                        raiseNavigationEvent(stateContext, intercept, this.stateContext['rscCache']);
                     })
                 }, currentContext);
                 if (!navigating) intercept?.commit?.();


### PR DESCRIPTION
In https://github.com/grahammendick/navigation/commit/a2c67b1894598079ba2a63c09b44f07000025a2a, accidentally lost support for `startTransition` prop on navigation links and wrapping programmatic navigation in `startTransition`. The change moved `setNavigationEvent` into the precommit handler, making it async and so it happened outside of any `startTransition` supplied in userland.

Reverted the change and reinvestigated the original issue - on mobile, navigate from People to Person then navigate back to People and the url didn't update. Misdiagnosed the issue the first time around because the interception does happen before React commits the background render. The problem was that `MobileHistoryManager` encountered an ‘invalid key’ error when trying to `traverseTo` previous scene in browser history. 

Not fully sure why but obviously some kind of timing error (which is why the original ‘fix’ worked by changing the timing). The browser transition was still ongoing when `traverseTo` was called (`window.navigation.transition` wasn’t null). So moved the `replaceState` before history added in `resume` to kill off the transition which allowed the `transitionTo` to work.
