### PR TITLE
Supported browser history on mobile for refresh navigation without interception (RSC)

### DIFF
--- a/NavigationReact/src/HistoryCacheContext.ts
+++ b/NavigationReact/src/HistoryCacheContext.ts
@@ -1,4 +1,4 @@
 import { createContext, RefObject } from 'react';
 import { StateNavigator } from 'navigation';
 
-export default createContext<{instance: RefObject<any>, get: (navigationEvent: {stateNavigator: StateNavigator}, sceneViewKey: string) => any, set: (navigationEvent: {stateNavigator: StateNavigator}, sceneViewKey: string, sceneView: any) => void}>({instance: {current:{}}, get: () => {}, set: () => {}});
+export default createContext<{instance: RefObject<any>, supportsPrecommitNavigation: boolean, get: (navigationEvent: {stateNavigator: StateNavigator}, sceneViewKey: string) => any, set: (navigationEvent: {stateNavigator: StateNavigator}, sceneViewKey: string, sceneView: any) => void}>({instance: {current:{}}, supportsPrecommitNavigation: false, get: () => {}, set: () => {}});

--- a/NavigationReact/src/NavigationHandler.tsx
+++ b/NavigationReact/src/NavigationHandler.tsx
@@ -19,6 +19,7 @@ const NavigationHandler = ({stateNavigator, children}: {stateNavigator: StateNav
     const historyCacheRef = useRef({});
     const historyCache = useMemo(() => ({
         instance: historyCacheRef,
+        supportsPrecommitNavigation,
         get: ({hasUAVisualTransition, stateNavigator: {stateContext: {url, history}}}: NavigationHandlerState, sceneViewKey: string) => {
             return (history && (!supportsPrecommitNavigation || !!hasUAVisualTransition)) ? historyCacheRef.current[url]?.[sceneViewKey] : null;
         },

--- a/NavigationReactMobile/src/NavigationStack.tsx
+++ b/NavigationReactMobile/src/NavigationStack.tsx
@@ -136,9 +136,11 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
             else registerSceneViews(children);
         }
     }, [registerRootView, allScenes]);
-    const {instance: historyCacheInstance, set: setHistory} = useContext(HistoryCacheContext);
+    const defaultHistoryCache = useContext(HistoryCacheContext);
+    const {instance: historyCacheInstance, supportsPrecommitNavigation, set: setHistory} = defaultHistoryCache;
     const historyCache = useMemo(() => ({
         instance: historyCacheInstance,
+        supportsPrecommitNavigation,
         get: ({stateNavigator: {stateContext: {url, history, crumbs, oldUrl}}}: NavigationEvent, sceneViewKey: string) => {
             if (!oldUrl) return null;
             const {crumbs: oldCrumbs} = stateNavigator.parseLink(oldUrl);
@@ -148,7 +150,7 @@ const NavigationStack = ({unmountStyle: unmountStyleStack, crumbStyle: crumbStyl
     }), [historyCacheInstance, setHistory]);
     const sceneData = getScenes();
     return (stateContext.state &&
-        <HistoryCacheContext.Provider value={historyCache}>
+        <HistoryCacheContext.Provider value={!supportsPrecommitNavigation ? defaultHistoryCache : historyCache}>
             <SharedElementContext.Provider value={sharedElementRegistry as any}>
                 <NavigationAnimation data={sceneData} history={stateContext.history} onRest={clearScene} oldState={oldState} duration={duration} pause={!ignorePause && pause !== null} hasUAVisualTransition={!!navigationEvent['hasUAVisualTransition']}>
                     {scenes => (

--- a/build/npm/navigation-react/navigation.react.d.ts
+++ b/build/npm/navigation-react/navigation.react.d.ts
@@ -62,7 +62,7 @@ export var BundlerContext: Context<{
 /**
  * The history cache context
  */
-export var HistoryCacheContext: Context<{instance: RefObject<any>, get: (navigationEvent: NavigationEvent<any, any>, sceneViewKey: string) => any, set: (navigationEvent: NavigationEvent<any, any>, sceneViewKey: string, sceneView: any) => void}>;
+export var HistoryCacheContext: Context<{instance: RefObject<any>, supportsPrecommitNavigation: boolean, get: (navigationEvent: NavigationEvent<any, any>, sceneViewKey: string) => any, set: (navigationEvent: NavigationEvent<any, any>, sceneViewKey: string, sceneView: any) => void}>;
 
 /**
  * The hook that provides the current navigation event data

--- a/types/navigation-react.d.ts
+++ b/types/navigation-react.d.ts
@@ -62,7 +62,7 @@ export var BundlerContext: Context<{
 /**
  * The history cache context
  */
-export var HistoryCacheContext: Context<{instance: RefObject<any>, get: (navigationEvent: NavigationEvent<any, any>, sceneViewKey: string) => any, set: (navigationEvent: NavigationEvent<any, any>, sceneViewKey: string, sceneView: any) => void}>;
+export var HistoryCacheContext: Context<{instance: RefObject<any>, supportsPrecommitNavigation: boolean, get: (navigationEvent: NavigationEvent<any, any>, sceneViewKey: string) => any, set: (navigationEvent: NavigationEvent<any, any>, sceneViewKey: string, sceneView: any) => void}>;
 
 /**
  * The hook that provides the current navigation event data


### PR DESCRIPTION
In https://github.com/grahammendick/navigation/pull/907, overrode the history cache to ignore cache for refresh navigation. This was only intended for browsers that support interception because they can delay the url change until React commits the renders. Accidentally overrode for browsers that don’t support interception and can’t delay the url change. This PR restores the default history cache for those browsers.