### PR TITLE
Supported navigation precommit on Opera (RSC)

### DIFF
--- a/NavigationReact/src/NavigationHandler.tsx
+++ b/NavigationReact/src/NavigationHandler.tsx
@@ -10,7 +10,7 @@ type Intercept = {resume?: () => void, commit?: () => void, signal?: AbortSignal
 type NavigationHandlerState = { ignoreCache?: boolean | string, rscCache?: any, hasUAVisualTransition?: boolean, oldState: State, state: State, data: any, asyncData: any, stateNavigator: StateNavigator & { navigateLink: (...args: [...Parameters<StateNavigator['navigateLink']>, Intercept?]) => void } };
 
 const supportsPrecommitNavigation = typeof window !== 'undefined' && !!window.NavigationPrecommitController
-    && !!(window.navigator as any).userAgentData?.brands?.some(({brand}) => brand === 'Microsoft Edge' || brand === 'Google Chrome');
+    && !!(window.navigator as any).userAgentData?.brands?.some(({brand}) => brand === 'Microsoft Edge' || brand === 'Google Chrome' || brand === 'Opera' || brand === 'Opera GX');
 
 const NavigationHandler = ({stateNavigator, children}: {stateNavigator: StateNavigator, children: any}) => {
     const [navigationEvent, setNavigationEvent] = useState<{data: NavigationHandlerState, stateNavigator: StateNavigator, intercept?: Intercept}>();


### PR DESCRIPTION
As mentioned in https://github.com/grahammendick/navigation/pull/906, retested precommit navigation on Opera after they [fixed history back while another precommitHandler interception is running and the browser crashes](https://issues.chromium.org/issues/511525672). All working so releasing precommit navigation on Opera.
